### PR TITLE
feat: use `w:lastRenderedPageBreak` to get approximate pagination from docx

### DIFF
--- a/tests/data/groundtruth/docling_v2/unit_test_headers.docx.json
+++ b/tests/data/groundtruth/docling_v2/unit_test_headers.docx.json
@@ -56,7 +56,22 @@
         }
       ],
       "label": "title",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Test Document",
       "text": "Test Document"
     },
@@ -67,7 +82,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -100,7 +130,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            9
+          ]
+        }
+      ],
       "orig": "Section 1",
       "text": "Section 1",
       "level": 1
@@ -112,7 +157,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -123,7 +183,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Paragraph 1.1",
       "text": "Paragraph 1.1"
     },
@@ -134,7 +209,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -145,7 +235,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Paragraph 1.2",
       "text": "Paragraph 1.2"
     },
@@ -156,7 +261,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -183,7 +303,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "Section 1.1",
       "text": "Section 1.1",
       "level": 2
@@ -195,7 +330,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -206,7 +356,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Paragraph 1.1.1",
       "text": "Paragraph 1.1.1"
     },
@@ -217,7 +382,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -228,7 +408,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Paragraph 1.1.2",
       "text": "Paragraph 1.1.2"
     },
@@ -239,7 +434,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -269,7 +479,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "Section 1.2",
       "text": "Section 1.2",
       "level": 2
@@ -281,7 +506,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -292,7 +532,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Paragraph 1.1.1",
       "text": "Paragraph 1.1.1"
     },
@@ -303,7 +558,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -314,7 +584,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Paragraph 1.1.2",
       "text": "Paragraph 1.1.2"
     },
@@ -325,7 +610,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -355,7 +655,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Section 1.2.3",
       "text": "Section 1.2.3",
       "level": 3
@@ -367,7 +682,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -378,7 +708,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            17
+          ]
+        }
+      ],
       "orig": "Paragraph 1.2.3.1",
       "text": "Paragraph 1.2.3.1"
     },
@@ -389,7 +734,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -400,7 +760,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            17
+          ]
+        }
+      ],
       "orig": "Paragraph 1.2.3.1",
       "text": "Paragraph 1.2.3.1"
     },
@@ -411,7 +786,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -422,7 +812,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -455,7 +860,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            9
+          ]
+        }
+      ],
       "orig": "Section 2",
       "text": "Section 2",
       "level": 1
@@ -467,7 +887,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -478,7 +913,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Paragraph 2.1",
       "text": "Paragraph 2.1"
     },
@@ -489,7 +939,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -500,7 +965,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Paragraph 2.2",
       "text": "Paragraph 2.2"
     },
@@ -511,7 +991,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -538,7 +1033,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Section 2.1.1",
       "text": "Section 2.1.1",
       "level": 3
@@ -550,7 +1060,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -561,7 +1086,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            17
+          ]
+        }
+      ],
       "orig": "Paragraph 2.1.1.1",
       "text": "Paragraph 2.1.1.1"
     },
@@ -572,7 +1112,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -583,7 +1138,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            17
+          ]
+        }
+      ],
       "orig": "Paragraph 2.1.1.1",
       "text": "Paragraph 2.1.1.1"
     },
@@ -594,7 +1164,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -624,7 +1209,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "Section 2.1",
       "text": "Section 2.1",
       "level": 2
@@ -636,7 +1236,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -647,7 +1262,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Paragraph 2.1.1",
       "text": "Paragraph 2.1.1"
     },
@@ -658,7 +1288,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -669,7 +1314,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Paragraph 2.1.2",
       "text": "Paragraph 2.1.2"
     },
@@ -680,7 +1340,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -691,7 +1366,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     }
@@ -699,5 +1389,20 @@
   "pictures": [],
   "tables": [],
   "key_value_items": [],
-  "pages": {}
+  "pages": {
+    "1": {
+      "size": {
+        "width": 612.0,
+        "height": 792.0
+      },
+      "page_no": 1
+    },
+    "2": {
+      "size": {
+        "width": 612.0,
+        "height": 792.0
+      },
+      "page_no": 2
+    }
+  }
 }

--- a/tests/data/groundtruth/docling_v2/unit_test_headers_numbered.docx.json
+++ b/tests/data/groundtruth/docling_v2/unit_test_headers_numbered.docx.json
@@ -150,7 +150,22 @@
         }
       ],
       "label": "title",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Test Document",
       "text": "Test Document"
     },
@@ -161,7 +176,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -172,7 +202,22 @@
       },
       "children": [],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            9
+          ]
+        }
+      ],
       "orig": "Section 1",
       "text": "Section 1",
       "level": 1
@@ -184,7 +229,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -195,7 +255,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Paragraph 1.1",
       "text": "Paragraph 1.1"
     },
@@ -206,7 +281,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -217,7 +307,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Paragraph 1.2",
       "text": "Paragraph 1.2"
     },
@@ -228,7 +333,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -255,7 +375,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "Section 1.1",
       "text": "Section 1.1",
       "level": 2
@@ -267,7 +402,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -278,7 +428,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Paragraph 1.1.1",
       "text": "Paragraph 1.1.1"
     },
@@ -289,7 +454,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -300,7 +480,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Paragraph 1.1.2",
       "text": "Paragraph 1.1.2"
     },
@@ -311,7 +506,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -341,7 +551,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "Section 1.2",
       "text": "Section 1.2",
       "level": 2
@@ -353,7 +578,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -364,7 +604,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Paragraph 1.1.1",
       "text": "Paragraph 1.1.1"
     },
@@ -375,7 +630,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -386,7 +656,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Paragraph 1.1.2",
       "text": "Paragraph 1.1.2"
     },
@@ -397,7 +682,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -427,7 +727,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Section 1.2.3",
       "text": "Section 1.2.3",
       "level": 3
@@ -439,7 +754,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -450,7 +780,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            17
+          ]
+        }
+      ],
       "orig": "Paragraph 1.2.3.1",
       "text": "Paragraph 1.2.3.1"
     },
@@ -461,7 +806,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -472,7 +832,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            17
+          ]
+        }
+      ],
       "orig": "Paragraph 1.2.3.1",
       "text": "Paragraph 1.2.3.1"
     },
@@ -483,7 +858,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -494,7 +884,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -505,7 +910,22 @@
       },
       "children": [],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            9
+          ]
+        }
+      ],
       "orig": "Section 2",
       "text": "Section 2",
       "level": 1
@@ -517,7 +937,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -528,7 +963,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Paragraph 2.1",
       "text": "Paragraph 2.1"
     },
@@ -539,7 +989,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -550,7 +1015,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Paragraph 2.2",
       "text": "Paragraph 2.2"
     },
@@ -561,7 +1041,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -588,7 +1083,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Section 2.1.1",
       "text": "Section 2.1.1",
       "level": 3
@@ -600,7 +1110,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -611,7 +1136,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            17
+          ]
+        }
+      ],
       "orig": "Paragraph 2.1.1.1",
       "text": "Paragraph 2.1.1.1"
     },
@@ -622,7 +1162,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -633,7 +1188,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            17
+          ]
+        }
+      ],
       "orig": "Paragraph 2.1.1.1",
       "text": "Paragraph 2.1.1.1"
     },
@@ -644,7 +1214,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -674,7 +1259,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "Section 2.1",
       "text": "Section 2.1",
       "level": 2
@@ -686,7 +1286,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -697,7 +1312,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Paragraph 2.1.1",
       "text": "Paragraph 2.1.1"
     },
@@ -708,7 +1338,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -719,7 +1364,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Paragraph 2.1.2",
       "text": "Paragraph 2.1.2"
     },
@@ -730,7 +1390,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -741,7 +1416,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     }
@@ -749,5 +1439,20 @@
   "pictures": [],
   "tables": [],
   "key_value_items": [],
-  "pages": {}
+  "pages": {
+    "1": {
+      "size": {
+        "width": 612.0,
+        "height": 792.0
+      },
+      "page_no": 1
+    },
+    "2": {
+      "size": {
+        "width": 612.0,
+        "height": 792.0
+      },
+      "page_no": 2
+    }
+  }
 }

--- a/tests/data/groundtruth/docling_v2/unit_test_lists.docx.json
+++ b/tests/data/groundtruth/docling_v2/unit_test_lists.docx.json
@@ -309,7 +309,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Test Document",
       "text": "Test Document",
       "level": 1
@@ -321,7 +336,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -332,7 +362,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -343,7 +388,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Paragraph 2.1.1",
       "text": "Paragraph 2.1.1"
     },
@@ -354,7 +414,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -365,7 +440,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Paragraph 2.1.2",
       "text": "Paragraph 2.1.2"
     },
@@ -376,7 +466,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -394,7 +499,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            7
+          ]
+        }
+      ],
       "orig": "Test 1:",
       "text": "Test 1:",
       "level": 3
@@ -406,7 +526,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item 1",
       "text": "List item 1",
       "enumerated": false,
@@ -419,7 +554,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item 2",
       "text": "List item 2",
       "enumerated": false,
@@ -432,7 +582,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item 3",
       "text": "List item 3",
       "enumerated": false,
@@ -445,7 +610,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -463,7 +643,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            7
+          ]
+        }
+      ],
       "orig": "Test 2:",
       "text": "Test 2:",
       "level": 3
@@ -475,7 +670,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item a",
       "text": "List item a",
       "enumerated": false,
@@ -488,7 +698,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item b",
       "text": "List item b",
       "enumerated": false,
@@ -501,7 +726,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item c",
       "text": "List item c",
       "enumerated": false,
@@ -514,7 +754,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -532,7 +787,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            7
+          ]
+        }
+      ],
       "orig": "Test 3:",
       "text": "Test 3:",
       "level": 3
@@ -544,7 +814,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item 1",
       "text": "List item 1",
       "enumerated": false,
@@ -557,7 +842,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item 2",
       "text": "List item 2",
       "enumerated": false,
@@ -570,7 +870,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "List item 1.1",
       "text": "List item 1.1",
       "enumerated": false,
@@ -583,7 +898,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "List item 1.2",
       "text": "List item 1.2",
       "enumerated": false,
@@ -596,7 +926,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "List item 1.3",
       "text": "List item 1.3",
       "enumerated": false,
@@ -609,7 +954,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item 3",
       "text": "List item 3",
       "enumerated": false,
@@ -622,7 +982,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -640,7 +1015,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            7
+          ]
+        }
+      ],
       "orig": "Test 4:",
       "text": "Test 4:",
       "level": 3
@@ -652,7 +1042,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item 1",
       "text": "List item 1",
       "enumerated": false,
@@ -665,7 +1070,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "List item 1.1",
       "text": "List item 1.1",
       "enumerated": false,
@@ -678,7 +1098,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item 2",
       "text": "List item 2",
       "enumerated": false,
@@ -691,7 +1126,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -709,7 +1159,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            7
+          ]
+        }
+      ],
       "orig": "Test 5:",
       "text": "Test 5:",
       "level": 3
@@ -721,7 +1186,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item 1",
       "text": "List item 1",
       "enumerated": false,
@@ -734,7 +1214,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "List item 1.1",
       "text": "List item 1.1",
       "enumerated": false,
@@ -747,7 +1242,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "List item 1.1.1",
       "text": "List item 1.1.1",
       "enumerated": false,
@@ -760,7 +1270,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item 3",
       "text": "List item 3",
       "enumerated": false,
@@ -773,7 +1298,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -797,7 +1337,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            7
+          ]
+        }
+      ],
       "orig": "Test 6:",
       "text": "Test 6:",
       "level": 3
@@ -809,7 +1364,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item 1",
       "text": "List item 1",
       "enumerated": false,
@@ -822,7 +1392,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item 2",
       "text": "List item 2",
       "enumerated": false,
@@ -835,7 +1420,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "List item 1.1",
       "text": "List item 1.1",
       "enumerated": false,
@@ -848,7 +1448,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "List item 1.2",
       "text": "List item 1.2",
       "enumerated": false,
@@ -861,7 +1476,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "List item 1.2.1",
       "text": "List item 1.2.1",
       "enumerated": false,
@@ -874,7 +1504,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "List item 3",
       "text": "List item 3",
       "enumerated": false,
@@ -887,7 +1532,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -898,7 +1558,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -909,7 +1584,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     }
@@ -917,5 +1607,20 @@
   "pictures": [],
   "tables": [],
   "key_value_items": [],
-  "pages": {}
+  "pages": {
+    "1": {
+      "size": {
+        "width": 612.0,
+        "height": 792.0
+      },
+      "page_no": 1
+    },
+    "2": {
+      "size": {
+        "width": 612.0,
+        "height": 792.0
+      },
+      "page_no": 2
+    }
+  }
 }

--- a/tests/data/groundtruth/docling_v2/word_sample.docx.json
+++ b/tests/data/groundtruth/docling_v2/word_sample.docx.json
@@ -93,7 +93,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            17
+          ]
+        }
+      ],
       "orig": "Summer activities",
       "text": "Summer activities"
     },
@@ -117,7 +132,22 @@
         }
       ],
       "label": "title",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            20
+          ]
+        }
+      ],
       "orig": "Swimming in the lake",
       "text": "Swimming in the lake"
     },
@@ -128,7 +158,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            4
+          ]
+        }
+      ],
       "orig": "Duck",
       "text": "Duck"
     },
@@ -139,7 +184,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            33
+          ]
+        }
+      ],
       "orig": "Figure 1: This is a cute duckling",
       "text": "Figure 1: This is a cute duckling"
     },
@@ -169,7 +229,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            11
+          ]
+        }
+      ],
       "orig": "Let\u2019s swim!",
       "text": "Let\u2019s swim!",
       "level": 1
@@ -181,7 +256,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            77
+          ]
+        }
+      ],
       "orig": "To get started with swimming, first lay down in a water and try not to drown:",
       "text": "To get started with swimming, first lay down in a water and try not to drown:"
     },
@@ -192,7 +282,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            29
+          ]
+        }
+      ],
       "orig": "You can relax and look around",
       "text": "You can relax and look around",
       "enumerated": false,
@@ -205,7 +310,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            12
+          ]
+        }
+      ],
       "orig": "Paddle about",
       "text": "Paddle about",
       "enumerated": false,
@@ -218,7 +338,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            19
+          ]
+        }
+      ],
       "orig": "Enjoy summer warmth",
       "text": "Enjoy summer warmth",
       "enumerated": false,
@@ -231,7 +366,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            19
+          ]
+        }
+      ],
       "orig": "Also, don\u2019t forget:",
       "text": "Also, don\u2019t forget:"
     },
@@ -242,7 +392,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Wear sunglasses",
       "text": "Wear sunglasses",
       "enumerated": false,
@@ -255,7 +420,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            27
+          ]
+        }
+      ],
       "orig": "Don\u2019t forget to drink water",
       "text": "Don\u2019t forget to drink water",
       "enumerated": false,
@@ -268,7 +448,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            13
+          ]
+        }
+      ],
       "orig": "Use sun cream",
       "text": "Use sun cream",
       "enumerated": false,
@@ -281,7 +476,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            15
+          ]
+        }
+      ],
       "orig": "Hmm, what else\u2026",
       "text": "Hmm, what else\u2026"
     },
@@ -314,7 +524,22 @@
         }
       ],
       "label": "section_header",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            9
+          ]
+        }
+      ],
       "orig": "Let\u2019s eat",
       "text": "Let\u2019s eat",
       "level": 2
@@ -326,7 +551,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            85
+          ]
+        }
+      ],
       "orig": "After we had a good day of swimming in the lake, it\u2019s important to eat something nice",
       "text": "After we had a good day of swimming in the lake, it\u2019s important to eat something nice"
     },
@@ -337,7 +577,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            20
+          ]
+        }
+      ],
       "orig": "I like to eat leaves",
       "text": "I like to eat leaves"
     },
@@ -348,7 +603,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            61
+          ]
+        }
+      ],
       "orig": "Here are some interesting things a respectful duck could eat:",
       "text": "Here are some interesting things a respectful duck could eat:"
     },
@@ -359,7 +629,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "orig": "",
       "text": ""
     },
@@ -370,7 +655,22 @@
       },
       "children": [],
       "label": "paragraph",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            38
+          ]
+        }
+      ],
       "orig": "And let\u2019s add another list in the end:",
       "text": "And let\u2019s add another list in the end:"
     },
@@ -381,7 +681,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            6
+          ]
+        }
+      ],
       "orig": "Leaves",
       "text": "Leaves",
       "enumerated": false,
@@ -394,7 +709,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            7
+          ]
+        }
+      ],
       "orig": "Berries",
       "text": "Berries",
       "enumerated": false,
@@ -407,7 +737,22 @@
       },
       "children": [],
       "label": "list_item",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            5
+          ]
+        }
+      ],
       "orig": "Grain",
       "text": "Grain",
       "enumerated": false,
@@ -422,7 +767,22 @@
       },
       "children": [],
       "label": "picture",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 1,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 397.0,
+            "b": 397.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            0
+          ]
+        }
+      ],
       "captions": [],
       "references": [],
       "footnotes": [],
@@ -446,7 +806,22 @@
       },
       "children": [],
       "label": "table",
-      "prov": [],
+      "prov": [
+        {
+          "page_no": 2,
+          "bbox": {
+            "l": 0.0,
+            "t": 0.0,
+            "r": 0.0,
+            "b": 0.0,
+            "coord_origin": "TOPLEFT"
+          },
+          "charspan": [
+            0,
+            120
+          ]
+        }
+      ],
       "captions": [],
       "references": [],
       "footnotes": [],
@@ -757,5 +1132,20 @@
     }
   ],
   "key_value_items": [],
-  "pages": {}
+  "pages": {
+    "1": {
+      "size": {
+        "width": 612.0,
+        "height": 792.0
+      },
+      "page_no": 1
+    },
+    "2": {
+      "size": {
+        "width": 612.0,
+        "height": 792.0
+      },
+      "page_no": 2
+    }
+  }
 }

--- a/tests/test_backend_msword.py
+++ b/tests/test_backend_msword.py
@@ -6,9 +6,11 @@ from docling.backend.msword_backend import MsWordDocumentBackend
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import (
     ConversionResult,
+    DocItemLabel,
     DoclingDocument,
     InputDocument,
     SectionHeaderItem,
+    TextItem,
 )
 from docling.document_converter import DocumentConverter
 
@@ -38,6 +40,27 @@ def test_heading_levels():
                 found_lvl_2 = True
                 assert item.level == 2
     assert found_lvl_1 and found_lvl_2
+
+
+def test_page_breaks():
+    for name in "unit_test_headers.docx", "unit_test_lists.docx", "word_sample.docx":
+        in_path = Path("tests/data/docx") / name
+        in_doc = InputDocument(
+            path_or_stream=in_path,
+            format=InputFormat.DOCX,
+            backend=MsWordDocumentBackend,
+        )
+        backend = MsWordDocumentBackend(
+            in_doc=in_doc,
+            path_or_stream=in_path,
+        )
+        doc = backend.convert()
+        assert backend.has_pagination()
+        # These all have two pages
+        assert len(doc.pages) == 2
+        for item, _ in doc.iterate_items():
+            assert item.prov
+            assert item.prov[0].page_no
 
 
 def get_docx_paths():


### PR DESCRIPTION
Sometimes (very far from always) we can get pagination from a Word document using the `w:lastRenderedPageBreak` element (https://ooxml.info/docs/17/17.3/17.3.3/17.3.3.13/).  This supports that.  Note that the resulting pagination is very approximate, and the provenance ~and page~ objects created are known to be false.

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
