### PR TITLE
fix : Tesseract OCR CLI can't process images composed with numbers only

### DIFF
--- a/docling/models/tesseract_ocr_cli_model.py
+++ b/docling/models/tesseract_ocr_cli_model.py
@@ -247,7 +247,7 @@ class TesseractOcrCliModel(BaseOcrModel):
 
                             cell = TextCell(
                                 index=ix,
-                                text=text,
+                                text=str(text),
                                 orig=text,
                                 from_ocr=True,
                                 confidence=conf / 100.0,


### PR DESCRIPTION
### **Description:**

This fix resloves #1179 issue, by forcing text output tesseract cli ocr as string.

### **Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
