### PR TITLE
fix: Edit bbox to to_bounding_box in PdfTextCell

### DIFF
--- a/docling/models/page_preprocessing_model.py
+++ b/docling/models/page_preprocessing_model.py
@@ -63,7 +63,12 @@ class PagePreprocessingModel(BasePageModel):
         def draw_text_boxes(image, cells, show: bool = False):
             draw = ImageDraw.Draw(image)
             for c in cells:
-                x0, y0, x1, y1 = c.to_bounding_box().l, c.to_bounding_box().t, c.to_bounding_box().r, c.to_bounding_box().b
+                x0, y0, x1, y1 = (
+                    c.to_bounding_box().l,
+                    c.to_bounding_box().t,
+                    c.to_bounding_box().r,
+                    c.to_bounding_box().b,
+                )
                 draw.rectangle([(x0, y0), (x1, y1)], outline="red")
             if show:
                 image.show()

--- a/docling/models/page_preprocessing_model.py
+++ b/docling/models/page_preprocessing_model.py
@@ -69,6 +69,7 @@ class PagePreprocessingModel(BasePageModel):
                     c.to_bounding_box().r,
                     c.to_bounding_box().b,
                 )
+
                 draw.rectangle([(x0, y0), (x1, y1)], outline="red")
             if show:
                 image.show()

--- a/docling/models/page_preprocessing_model.py
+++ b/docling/models/page_preprocessing_model.py
@@ -63,7 +63,7 @@ class PagePreprocessingModel(BasePageModel):
         def draw_text_boxes(image, cells, show: bool = False):
             draw = ImageDraw.Draw(image)
             for c in cells:
-                x0, y0, x1, y1 = c.bbox.as_tuple()
+                x0, y0, x1, y1 = c.to_bounding_box().l, c.to_bounding_box().t, c.to_bounding_box().r, c.to_bounding_box().b
                 draw.rectangle([(x0, y0), (x1, y1)], outline="red")
             if show:
                 image.show()


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Description:**
Resolved https://github.com/docling-project/docling/issues/1219 issue. 
Discovered that the `PdfTextCell` object was missing the `bbox` attribute/method during testing of the batch conversion functionality within the examples.

Resolution:

*   Renamed `bbox` to `to_bounding_box` and changed the code of line 66 in models\page_preprocessing_model.py file.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
