### PR TITLE
fix: Fixes tables when using OCR

### DIFF
--- a/docling/models/table_structure_model.py
+++ b/docling/models/table_structure_model.py
@@ -229,6 +229,9 @@ class TableStructureModel(BasePageModel):
                                     cell_unit=TextCellUnit.WORD,
                                     bbox=table_cluster.bbox,
                                 )
+                                if len(tcells) == 0:
+                                    # In case word-level cells yield empty
+                                    tcells = table_cluster.cells
                             else:
                                 # Otherwise - we use normal (line/phrase) cells
                                 tcells = table_cluster.cells


### PR DESCRIPTION
Afer latest update, when using backend that supports word-level cells, but at the same time using OCR - tableformer received empty text for cells as @KapyGenius noticed. This PR fixes the issue.
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
