### PR TITLE
fix: Fixing Handling of Pictures PowerPoint Backend

### DIFF
--- a/docling/backend/mspowerpoint_backend.py
+++ b/docling/backend/mspowerpoint_backend.py
@@ -392,9 +392,10 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
                     self.handle_tables(shape, parent_slide, slide_ind, doc, slide_size)
                 if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
                     # Handle Pictures
-                    self.handle_pictures(
-                        shape, parent_slide, slide_ind, doc, slide_size
-                    )
+                    if hasattr(shape, "image"): # make sure the Picture shape has an image attribute
+                        image_part = shape.image
+                        if image_part.ext not in ["emf", "wmf"]: # all extensions except emf and wmf that lead to bug in adding picture to doc
+                            self.handle_pictures(shape, parent_slide, slide_ind, doc, slide_size)     
                 # If shape doesn't have any text, move on to the next shape
                 if not hasattr(shape, "text"):
                     return

--- a/docling/backend/mspowerpoint_backend.py
+++ b/docling/backend/mspowerpoint_backend.py
@@ -394,7 +394,7 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
                     # Handle Pictures
                     if hasattr(shape, "image"): # make sure the Picture shape has an image attribute
                         image_part = shape.image # get the image part
-                        if image_part.ext not in ["emf", "wmf"]: # all extensions except emf and wmf that lead to bug in adding picture to doc
+                        if image_part.ext not in ["emf", "wmf"]: # all extensions except emf and wmf 
                             self.handle_pictures(shape, parent_slide, slide_ind, doc, slide_size)     
                 # If shape doesn't have any text, move on to the next shape
                 if not hasattr(shape, "text"):

--- a/docling/backend/mspowerpoint_backend.py
+++ b/docling/backend/mspowerpoint_backend.py
@@ -393,7 +393,7 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
                 if shape.shape_type == MSO_SHAPE_TYPE.PICTURE:
                     # Handle Pictures
                     if hasattr(shape, "image"): # make sure the Picture shape has an image attribute
-                        image_part = shape.image
+                        image_part = shape.image # get the image part
                         if image_part.ext not in ["emf", "wmf"]: # all extensions except emf and wmf that lead to bug in adding picture to doc
                             self.handle_pictures(shape, parent_slide, slide_ind, doc, slide_size)     
                 # If shape doesn't have any text, move on to the next shape


### PR DESCRIPTION
## Bug Fix

Handling Pictures in PPTX with no "image" attributes or "emf"/"wmf" extensions in the Image parts.

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. So the change is minimal: Just making sure in the mspowerpoint backend that when handling pictures, we only process pictures that indeed have an image attribute (sometimes slide deck have images that look like images and are Picture Types but do not have an image attribute) and for which the Image part extension is not "emf" or "wmf"
  3. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  4. 1242
  5. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  6. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

## Change
So the change is minimal: Just making sure in the mspowerpoint backend that when handling pictures, we only process pictures that indeed have an image attribute (sometimes slide deck have images that look like images and are Picture Types but do not have an image attribute) and for which the Image part extension is not "emf" or "wmf"

## Issue resolved:
 1242

Areas that has been changed:

[MsPowerBackend Slight Change in handle_shapes](https://github.com/benichou/bugs/blob/main/docling/image_parsing/screenshot_errored_code/pushed_commit.png)

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->1242: https://github.com/docling-project/docling/issues/1242

**Checklist:**
Minimal change so no need to update the documentation, add example or adding tests
- [X] Documentation has been updated, if necessary.
- [X] Examples have been added, if necessary.
- [X] Tests have been added, if necessary.






