### PR TITLE
fix: Properly address page in pipeline _assemble_document when page_range is provided

### DIFF
--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -226,7 +226,10 @@ class StandardPdfPipeline(PaginatedPipeline):
                         and self.pipeline_options.generate_table_images
                     ):
                         page_ix = element.prov[0].page_no - 1
-                        page = conv_res.pages[page_ix]
+                        page = next(
+                            (p for p in conv_res.pages if p.page_no == page_ix), None
+                        )
+                        assert page is not None
                         assert page.size is not None
                         assert page.image is not None
 

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -2,7 +2,7 @@ import logging
 import sys
 import warnings
 from pathlib import Path
-from typing import Optional
+from typing import Optional, cast
 
 from docling_core.types.doc import DocItem, ImageRef, PictureItem, TableItem
 
@@ -227,7 +227,8 @@ class StandardPdfPipeline(PaginatedPipeline):
                     ):
                         page_ix = element.prov[0].page_no - 1
                         page = next(
-                            (p for p in conv_res.pages if p.page_no == page_ix), None
+                            (p for p in conv_res.pages if p.page_no == page_ix),
+                            cast("Page", None),
                         )
                         assert page is not None
                         assert page.size is not None


### PR DESCRIPTION
Fixes the bug #1333 (also fixes #1193 which is a duplicate of my bug, sorry about that)

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
