### PR TITLE
fix: auto-recognize .xlsx, .docx and .pptx files

### DIFF
--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -283,6 +283,9 @@ class _DocumentConversionInput(BaseModel):
             if mime is None:  # must guess from
                 with obj.open("rb") as f:
                     content = f.read(1024)  # Read first 1KB
+            if mime is not None and mime.lower() == "application/zip" and obj.suffixes[-1].lower() == ".xlsx":
+                mime = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+
 
         elif isinstance(obj, DocumentStream):
             content = obj.stream.read(8192)

--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -283,9 +283,14 @@ class _DocumentConversionInput(BaseModel):
             if mime is None:  # must guess from
                 with obj.open("rb") as f:
                     content = f.read(1024)  # Read first 1KB
-            if mime is not None and mime.lower() == "application/zip" and obj.suffixes[-1].lower() == ".xlsx":
-                mime = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-
+            if (
+                mime is not None
+                and mime.lower() == "application/zip"
+                and obj.suffixes[-1].lower() == ".xlsx"
+            ):
+                mime = (
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                )
 
         elif isinstance(obj, DocumentStream):
             content = obj.stream.read(8192)

--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -283,14 +283,13 @@ class _DocumentConversionInput(BaseModel):
             if mime is None:  # must guess from
                 with obj.open("rb") as f:
                     content = f.read(1024)  # Read first 1KB
-            if (
-                mime is not None
-                and mime.lower() == "application/zip"
-                and obj.suffixes[-1].lower() == ".xlsx"
-            ):
-                mime = (
-                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
-                )
+            if mime is not None and mime.lower() == "application/zip":
+                if obj.suffixes[-1].lower() == ".xlsx":
+                    mime = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+                elif obj.suffixes[-1].lower() == ".docx":
+                    mime = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                elif obj.suffixes[-1].lower() == ".pptx":
+                    mime = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
 
         elif isinstance(obj, DocumentStream):
             content = obj.stream.read(8192)


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

This resolves an issue for me where it won't convert `.xlsx` files even though the readme advertises this. It's just a problem with recognizing the format. Without this change, the `filetype` library resolves it to `application/zip`. Once it gets past this check, it seems to work great.

I'm not super happy with the code of this change, but I don't feel like digging through the repo to figure out the right way to do it. Here's a bug and a fix.

**Checklist:**

- [n/a] Documentation has been updated, if necessary.
- [n/a] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
