### PR TITLE
fix: Treat overflowing -v flags as DEBUG

### DIFF
--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -421,7 +421,7 @@ def convert(  # noqa: C901
         logging.basicConfig(level=logging.WARNING)
     elif verbose == 1:
         logging.basicConfig(level=logging.INFO)
-    elif verbose == 2:
+    else:
         logging.basicConfig(level=logging.DEBUG)
 
     settings.debug.visualize_cells = debug_visualize_cells


### PR DESCRIPTION
Fixes: #1417 

This is how most software handles it. Users dont always know how many verbosity levels there are 

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
