### PR TITLE
docs: Fix wrong output format in example code

### DIFF
--- a/docs/examples/minimal_vlm_pipeline.py
+++ b/docs/examples/minimal_vlm_pipeline.py
@@ -80,7 +80,7 @@ for source in sources:
         fp.write(json.dumps(res.document.export_to_dict()))
 
     res.document.save_as_json(
-        out_path / f"{res.input.file.stem}.md",
+        out_path / f"{res.input.file.stem}.json",
         image_mode=ImageRefMode.PLACEHOLDER,
     )
 


### PR DESCRIPTION
**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

fix: wrong output format in example code

The output format in example code (minimal_vlm_pipeline.py) is wrong, written to `.md` as it shoud be `.json`.
This PR fix that.