### PR TITLE
fix: Incorrect scaling of TableModel bboxes when do_cell_matching is False

### DIFF
--- a/docling/models/table_structure_model.py
+++ b/docling/models/table_structure_model.py
@@ -267,7 +267,7 @@ class TableStructureModel(BasePageModel):
                                     element["bbox"]["token"] = text_piece
 
                                 tc = TableCell.model_validate(element)
-                                if self.do_cell_matching and tc.bbox is not None:
+                                if tc.bbox is not None:
                                     tc.bbox = tc.bbox.scaled(1 / self.scale)
                                 table_cells.append(tc)
 


### PR DESCRIPTION
By default, value for `do_cell_matching = True`, and it should remain this way, as it works great with new PDF backend, etc.

However indeed we had a bug when `do_cell_matching = False`
This tiny PR, as suggested by @stestagg, fixes this issue in case someone needs it.
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #1453 

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
