### PR TITLE
fix: updated the time-recorder label for reading order

### DIFF
--- a/docling/models/readingorder_model.py
+++ b/docling/models/readingorder_model.py
@@ -344,9 +344,9 @@ class ReadingOrderModel:
         new_item.text += f" {merged_elem.text}"
         new_item.orig += f" {merged_elem.text}"  # TODO: This is incomplete, we don't have the `orig` field of the merged element.
         new_item.prov.append(prov)
-
+        
     def __call__(self, conv_res: ConversionResult) -> DoclingDocument:
-        with TimeRecorder(conv_res, "glm", scope=ProfilingScope.DOCUMENT):
+        with TimeRecorder(conv_res, "reading_order", scope=ProfilingScope.DOCUMENT):
             page_elements = self._assembled_to_readingorder_elements(conv_res)
 
             # Apply reading order

--- a/docling/models/readingorder_model.py
+++ b/docling/models/readingorder_model.py
@@ -344,7 +344,7 @@ class ReadingOrderModel:
         new_item.text += f" {merged_elem.text}"
         new_item.orig += f" {merged_elem.text}"  # TODO: This is incomplete, we don't have the `orig` field of the merged element.
         new_item.prov.append(prov)
-        
+
     def __call__(self, conv_res: ConversionResult) -> DoclingDocument:
         with TimeRecorder(conv_res, "reading_order", scope=ProfilingScope.DOCUMENT):
             page_elements = self._assembled_to_readingorder_elements(conv_res)


### PR DESCRIPTION
Updated the time-recorder label for reading order: `glm` -> `reading_order`
