### PR TITLE
fix: enable cuda_use_flash_attention2 for PictureDescriptionVlmModel

### DIFF
--- a/docling/models/picture_description_vlm_model.py
+++ b/docling/models/picture_description_vlm_model.py
@@ -57,7 +57,10 @@ class PictureDescriptionVlmModel(PictureDescriptionBaseModel):
                 artifacts_path,
                 torch_dtype=torch.bfloat16,
                 _attn_implementation=(
-                    "flash_attention_2" if self.device.startswith("cuda") else "eager"
+                    "flash_attention_2"
+                    if self.device.startswith("cuda")
+                    and accelerator_options.cuda_use_flash_attention2
+                    else "eager"
                 ),
             ).to(self.device)
 


### PR DESCRIPTION
This PR ensures the `cuda_use_flash_attention2` flag is respected when using the `PictureDescriptionVlmModel`.

**Issue resolved by this Pull Request:**
Resolves #1495

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
