### PR TITLE
fix(ocr): orig field in TesseractOcrCliModel as str

### DIFF
--- a/docling/models/tesseract_ocr_cli_model.py
+++ b/docling/models/tesseract_ocr_cli_model.py
@@ -249,7 +249,7 @@ class TesseractOcrCliModel(BaseOcrModel):
                             cell = TextCell(
                                 index=ix,
                                 text=str(text),
-                                orig=text,
+                                orig=str(text),
                                 from_ocr=True,
                                 confidence=conf / 100.0,
                                 rect=BoundingRectangle.from_bounding_box(


### PR DESCRIPTION
Issue resolved by this Pull Request: #1552 

