### PR TITLE
fix: AsciiDoc header identification (#1562)

### DIFF
--- a/docling/backend/asciidoc_backend.py
+++ b/docling/backend/asciidoc_backend.py
@@ -287,7 +287,7 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
 
     #   =========   Section headers
     def _is_section_header(self, line):
-        return re.match(r"^==+", line)
+        return re.match(r"^==+\s+", line)
 
     def _parse_section_header(self, line):
         match = re.match(r"^(=+)\s+(.*)", line)


### PR DESCRIPTION
Fix regular expression to identify header lines in AsciiDoc avoiding to match defined blocks.

Resolves #1562 

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
