### PR TITLE
feat: add fallback_lang support in TesseractOcrCliModel

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -176,7 +176,7 @@ class TesseractCliOcrOptions(OcrOptions):
 
     kind: ClassVar[Literal["tesseract"]] = "tesseract"
     lang: List[str] = ["fra", "deu", "spa", "eng"]
-    fall_back_lang: List[str] = ["osd"]
+    fallback_lang: List[str] = ["osd"]
     tesseract_cmd: str = "tesseract"
     path: Optional[str] = None
 

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -176,6 +176,7 @@ class TesseractCliOcrOptions(OcrOptions):
 
     kind: ClassVar[Literal["tesseract"]] = "tesseract"
     lang: List[str] = ["fra", "deu", "spa", "eng"]
+    fall_back_lang: List[str] = ["osd"]
     tesseract_cmd: str = "tesseract"
     path: Optional[str] = None
 

--- a/docling/models/tesseract_ocr_cli_model.py
+++ b/docling/models/tesseract_ocr_cli_model.py
@@ -164,9 +164,24 @@ class TesseractOcrCliModel(BaseOcrModel):
 
         # Check if the detected language has been installed
         if lang not in self._tesseract_languages:
-            msg = f"Tesseract detected the script '{script}' and language '{lang}'."
-            msg += " However this language is not installed in your system and will be ignored."
-            _log.warning(msg)
+
+            fallback = [
+                fb for fb in self.options.fall_back_lang
+                if fb in self._tesseract_languages
+            ]
+
+            if fallback:
+                _log.warning(
+                    f"Tesseract detected the script '{script}' and language '{lang}', "
+                    f"but it is not installed. Falling back to: {', '.join(fallback)}"
+                )
+
+                return "+".join(fallback)
+
+            _log.warning(
+                f"Tesseract detected the script '{script}' and language '{lang}', "
+                "but it is not installed and no fall-back languages are available."
+            )
             return None
 
         _log.debug(

--- a/docling/models/tesseract_ocr_cli_model.py
+++ b/docling/models/tesseract_ocr_cli_model.py
@@ -166,7 +166,7 @@ class TesseractOcrCliModel(BaseOcrModel):
         if lang not in self._tesseract_languages:
 
             fallback = [
-                fb for fb in self.options.fall_back_lang
+                fb for fb in self.options.fallback_lang
                 if fb in self._tesseract_languages
             ]
 


### PR DESCRIPTION
Adds support for `fall_back_lang` in `TesseractOcrCliModel`. If the detected language is not installed in Tesseract, the model will now fall back to the languages coming from the `fallback_lang` list in options. This improves robustness in environments with limited language installations.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
