### PR TITLE
fix: handles line breaks in pptx table cells to markdown

### DIFF
--- a/docling/backend/mspowerpoint_backend.py
+++ b/docling/backend/mspowerpoint_backend.py
@@ -339,7 +339,7 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
                         col_span = int(col_span)
 
                     icell = TableCell(
-                        text=cell.text.strip(),
+                        text=cell.text.replace("\n", "<br>").strip(),
                         row_span=row_span,
                         col_span=col_span,
                         start_row_offset_idx=row_idx,


### PR DESCRIPTION
fix: handles line breaks in table cells
Resolves #539 (for pptx)

Example:
![image](https://github.com/user-attachments/assets/fdec5c46-0c52-4af0-b164-5df53ae1593a)

