### PR TITLE
fix: guess HTML content starting with script tag

### DIFF
--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -412,7 +412,11 @@ class _DocumentConversionInput(BaseModel):
             else:
                 return "application/xml"
 
-        if re.match(r"<!doctype\s+html|<html|<head|<body", content_str):
+        if re.match(
+            r"(<script.*?>.*?</script>\s*)?(<!doctype\s+html|<html|<head|<body)",
+            content_str,
+            re.DOTALL,
+        ):
             return "text/html"
 
         p = re.compile(

--- a/tests/test_input_doc.py
+++ b/tests/test_input_doc.py
@@ -132,6 +132,13 @@ def test_guess_format(tmp_path):
     doc_path = Path("./tests/data/html/wiki_duck.html")
     assert dci._guess_format(doc_path) == InputFormat.HTML
 
+    html_str = (  # HTML starting with a script
+        "<script>\nconsole.log('foo');\n</script>"
+        '<!doctype html>\n<html lang="en-us class="no-js"></html>'
+    )
+    stream = DocumentStream(name="lorem_ipsum", stream=BytesIO(f"{html_str}".encode()))
+    assert dci._guess_format(stream) == InputFormat.HTML
+
     # Valid MD
     buf = BytesIO(Path("./tests/data/md/wiki.md").open("rb").read())
     stream = DocumentStream(name="wiki.md", stream=buf)


### PR DESCRIPTION
This PR improves the heuristic rule to detect the file type from the first section of its content. In particular, the function `docling.datamodel.document._DocumentConversionInput._detect_html_xhtml`.

Even though the HTML5 specification recommends HTML documents to start with `<!DOCTYPE html>`, some documents may have other HTML indicators like <html> or <head> at the beginning of the content.
Some documents may start with scripts (tag `<script>`), like in https://hometheaterhifi.com/reviews/headphone-earphone/hifiman-he1000-unveiled-planar-magnetic-headphone-review/. This PR addresses these cases.

Resolves #1535 

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
