### PR TITLE
docs: update export table function args

### DIFF
--- a/docs/examples/export_tables.py
+++ b/docs/examples/export_tables.py
@@ -40,12 +40,11 @@ def main():
         element_html_filename = output_dir / f"{doc_filename}-table-{table_ix + 1}.html"
         _log.info(f"Saving HTML table to {element_html_filename}")
         with element_html_filename.open("w") as fp:
-            fp.write(table.export_to_html(doc=conv_res.document))
+            fp.write(table.export_to_html())
 
     end_time = time.time() - start_time
 
     _log.info(f"Document converted and tables exported in {end_time:.2f} seconds.")
-
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This pull request includes a small change to the `docs/examples/export_tables.py` file. The change simplifies the `export_to_html` method call by removing the `doc` parameter, as it is no longer needed.

Before
![image](https://github.com/user-attachments/assets/047870e8-5f58-4101-b531-168721727e40)

After
![image](https://github.com/user-attachments/assets/a7da2b5e-5639-4d75-a95f-bd20d54b4c3d)


- [X] Documentation has been updated, if necessary.