### PR TITLE
fix: pyproject.toml uv default-groups expects a sequence, not a string

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,7 +143,7 @@ constraints = [
 
 [tool.uv]
 package = true
-default-groups = "all"
+default-groups = ["all"]
 
 [tool.setuptools.packages.find]
 include = ["docling*"]


### PR DESCRIPTION
default-groups expects a sequence, not a string