### PR TITLE
fix: Handle multiple formatted elements in list MD parsing

### DIFF
--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -247,7 +247,24 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
             self._process_inline_text(parent_item, doc)
             _log.debug(" - List item")
 
-            snippet_text = str(first_child.children[0].children)  # type: ignore
+            snippet_text = (
+                (lambda extractor:
+                 (lambda node: extractor(extractor, node))
+                 )
+                    (
+                    lambda self, node: (
+                        node.children
+                        if hasattr(node, 'children') and isinstance(node.children, str)
+                        else ''.join(
+                            self(self, child)
+                            for child in node.children
+                        )
+                        if hasattr(node, 'children')
+                        else str(node)
+                    )
+                )
+            )(first_child)  # type: ignore
+
             is_numbered = False
             if (
                 parent_item is not None


### PR DESCRIPTION
This PR fixes an issue with incorrect parsing of list items in Markdown files when those items contain formatting.

The current implementation handles simple lists without formatting correctly. For example:
```markdown
List example:
- First element
- Second item
```

After parsing and calling chunker.contextualize(), the expected output is:
```
List example:
First element
Second item
```

However, when list items include formatting, such as:
```markdown
List example:
- **First**: Lorem ipsum.
- **Second**: Dolor `sit` amet.
```

The parser fails to produce the correct result, even though the Markdown syntax is valid. The output becomes:
```
List example:
[<RawText children=First'>]
[<RawText children=Second'>]
```

This issue is caused by the Markdown backend code that retrieves only the first child of each list item and ignores any additional or nested children:
```python
snippet_text = str(first_child.children[0].children)
```

This PR fixes the behavior by traversing all children in the tree, resulting in correct string generation:
```
List example:
First: Lorem ipsum.
Second: Dolor sit amet.
```

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
