### PR TITLE
fix: allow custom torch_dtype in vlm models

### DIFF
--- a/docling/datamodel/pipeline_options_vlm_model.py
+++ b/docling/datamodel/pipeline_options_vlm_model.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Dict, List, Literal
+from typing import Any, Dict, List, Literal, Optional, Union
 
 from pydantic import AnyUrl, BaseModel
 from typing_extensions import deprecated
@@ -42,6 +42,7 @@ class InlineVlmOptions(BaseVlmOptions):
     transformers_model_type: TransformersModelType = TransformersModelType.AUTOMODEL
     response_format: ResponseFormat
 
+    torch_dtype: Optional[str] = None
     supported_devices: List[AcceleratorDevice] = [
         AcceleratorDevice.CPU,
         AcceleratorDevice.CUDA,

--- a/docling/models/vlm_models_inline/hf_transformers_model.py
+++ b/docling/models/vlm_models_inline/hf_transformers_model.py
@@ -99,6 +99,7 @@ class HuggingFaceTransformersVlmModel(BasePageModel, HuggingFaceModelDownloadMix
             self.vlm_model = model_cls.from_pretrained(
                 artifacts_path,
                 device_map=self.device,
+                torch_dtype=self.vlm_options.torch_dtype,
                 _attn_implementation=(
                     "flash_attention_2"
                     if self.device.startswith("cuda")


### PR DESCRIPTION
Once we get a few more running experience, we could set the `torch_dtype` automatically when flash_attention is activated. For the moment, let's make sure users can experiment with the correct setting of their choice.

**Issue resolved by this Pull Request:**
Resolves #1730

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
