### PR TITLE
fix: Sync page.parsed_page.textline_cells and page.cells with OCR cells

### DIFF
--- a/docling/models/easyocr_model.py
+++ b/docling/models/easyocr_model.py
@@ -177,7 +177,7 @@ class EasyOcrModel(BaseOcrModel):
                         all_ocr_cells.extend(cells)
 
                     # Post-process the cells
-                    page.cells = self.post_process_cells(all_ocr_cells, page.cells)
+                    self.post_process_cells(all_ocr_cells, page)
 
                 # DEBUG code:
                 if settings.debug.visualize_ocr:

--- a/docling/models/layout_model.py
+++ b/docling/models/layout_model.py
@@ -176,9 +176,9 @@ class LayoutModel(BasePageModel):
                     # Apply postprocessing
 
                     processed_clusters, processed_cells = LayoutPostprocessor(
-                        page.cells, clusters, page.size
+                        page, clusters
                     ).postprocess()
-                    # processed_clusters, processed_cells = clusters, page.cells
+                    # Note: LayoutPostprocessor updates page.cells and page.parsed_page internally
 
                     with warnings.catch_warnings():
                         warnings.filterwarnings(
@@ -198,7 +198,7 @@ class LayoutModel(BasePageModel):
                             )
                         )
 
-                    page.cells = processed_cells
+                    # page.cells is already updated by LayoutPostprocessor
                     page.predictions.layout = LayoutPrediction(
                         clusters=processed_clusters
                     )

--- a/docling/models/ocr_mac_model.py
+++ b/docling/models/ocr_mac_model.py
@@ -132,7 +132,7 @@ class OcrMacModel(BaseOcrModel):
                         all_ocr_cells.extend(cells)
 
                     # Post-process the cells
-                    page.cells = self.post_process_cells(all_ocr_cells, page.cells)
+                    self.post_process_cells(all_ocr_cells, page)
 
                 # DEBUG code:
                 if settings.debug.visualize_ocr:

--- a/docling/models/tesseract_ocr_cli_model.py
+++ b/docling/models/tesseract_ocr_cli_model.py
@@ -306,7 +306,7 @@ class TesseractOcrCliModel(BaseOcrModel):
                             all_ocr_cells.append(cell)
 
                     # Post-process the cells
-                    page.cells = self.post_process_cells(all_ocr_cells, page.cells)
+                    self.post_process_cells(all_ocr_cells, page)
 
                 # DEBUG code:
                 if settings.debug.visualize_ocr:

--- a/docling/models/tesseract_ocr_model.py
+++ b/docling/models/tesseract_ocr_model.py
@@ -235,7 +235,7 @@ class TesseractOcrModel(BaseOcrModel):
                         all_ocr_cells.extend(cells)
 
                     # Post-process the cells
-                    page.cells = self.post_process_cells(all_ocr_cells, page.cells)
+                    self.post_process_cells(all_ocr_cells, page)
 
                 # DEBUG code:
                 if settings.debug.visualize_ocr:

--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -194,11 +194,12 @@ class LayoutPostprocessor:
         DocItemLabel.TITLE: DocItemLabel.SECTION_HEADER,
     }
 
-    def __init__(self, cells: List[TextCell], clusters: List[Cluster], page_size: Size):
-        """Initialize processor with cells and clusters."""
-        """Initialize processor with cells and spatial indices."""
-        self.cells = cells
-        self.page_size = page_size
+    def __init__(self, page, clusters: List[Cluster]):
+        """Initialize processor with page and clusters."""
+        # Get cells from best available source (prefer parsed_page)
+        self.cells = self._get_page_cells(page)
+        self.page = page
+        self.page_size = page.size
         self.all_clusters = clusters
         self.regular_clusters = [
             c for c in clusters if c.label not in self.SPECIAL_TYPES
@@ -213,6 +214,24 @@ class LayoutPostprocessor:
         self.wrapper_index = SpatialClusterIndex(
             [c for c in self.special_clusters if c.label in self.WRAPPER_TYPES]
         )
+
+    def _get_page_cells(self, page):
+        """Get cells from best available source (prefer parsed_page)."""
+        return (
+            page.parsed_page.textline_cells
+            if page.parsed_page is not None
+            else page.cells
+        )
+
+    def _update_page_structures(self, final_cells):
+        """Update both page structures efficiently."""
+        if self.page.parsed_page is not None:
+            # Update parsed_page as primary source
+            self.page.parsed_page.textline_cells = final_cells
+            self.page.parsed_page.has_lines = len(final_cells) > 0
+
+        # Legacy fallback: only page.cells available
+        self.page.cells = final_cells
 
     def postprocess(self) -> Tuple[List[Cluster], List[TextCell]]:
         """Main processing pipeline."""
@@ -239,6 +258,9 @@ class LayoutPostprocessor:
             # Also sort cells in children if any
             for child in cluster.children:
                 child.cells = self._sort_cells(child.cells)
+
+        # Update page structures with processed cells
+        self._update_page_structures(self.cells)
 
         return final_clusters, self.cells
 


### PR DESCRIPTION
This fix ensures that if there is a `parsed_page` data structure available (from docling-parse v4 backend), text cells created in OCR are added to its `textline_cells`, and the regular `page.cells` data structure is kept in sync. 

The test ground truth does not change, proving that `page.cells` remains unaltered. 

**Issue resolved by this Pull Request:**
Resolves #1721

**TODO:**

- [ ] Add test that specifically proves parsed_page contains the OCR cells as expected.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
