### PR TITLE
fix(asciidoc): set default size when missing in image directive

### DIFF
--- a/tests/data/asciidoc/test_03.asciidoc
+++ b/tests/data/asciidoc/test_03.asciidoc
@@ -1,0 +1,29 @@
+:_mod-docs-content-type: PROCEDURE
+:experimental:
+
+[id="renaming-a-bookmark_{context}"]
+= Renaming a bookmark
+
+You can rename a bookmark to distinguish it from other bookmarks. If you have bookmarks to several folders that all share the same name, you can tell the bookmarks apart if you rename them.
+
+Renaming the bookmark does not rename the folder.
+
+.Procedure
+
+. Right-click the bookmark in the side bar.
+
+. Select *Rename…*.
++
+image::rename-bookmark-menu.png[Rename bookmark menu]
+
+. In the *Name* field, enter the new name for the bookmark.
++
+image::rename-bookmark-text.png[Bookmark name field]
+
+. Click btn:[Rename].
+
+.Verification
+
+* Check that the side bar lists the bookmark under the new name.
++
+image::renamed-bookmark.png[Renamed bookmark]

--- a/tests/data/groundtruth/docling_v2/test_03.asciidoc.md
+++ b/tests/data/groundtruth/docling_v2/test_03.asciidoc.md
@@ -1,0 +1,23 @@
+:\_mod-docs-content-type: PROCEDURE :experimental:
+
+# Renaming a bookmark
+
+[id="renaming-a-bookmark\_{context}"]
+
+You can rename a bookmark to distinguish it from other bookmarks. If you have bookmarks to several folders that all share the same name, you can tell the bookmarks apart if you rename them.
+
+Renaming the bookmark does not rename the folder.
+
+- Check that the side bar lists the bookmark under the new name.
+
+Procedure . Right-click the bookmark in the side bar. . Select *Rename…*. +
+
+<!-- image -->
+
+ In the *Name* field, enter the new name for the bookmark. +
+
+<!-- image -->
+
+ Click btn:[Rename]. .Verification
+
+<!-- image -->

--- a/tests/test_backend_asciidoc.py
+++ b/tests/test_backend_asciidoc.py
@@ -2,7 +2,11 @@ import glob
 import os
 from pathlib import Path
 
-from docling.backend.asciidoc_backend import AsciiDocBackend
+from docling.backend.asciidoc_backend import (
+    DEFAULT_IMAGE_HEIGHT,
+    DEFAULT_IMAGE_WIDTH,
+    AsciiDocBackend,
+)
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
 
@@ -16,6 +20,24 @@ def _get_backend(fname):
 
     doc_backend = in_doc._backend
     return doc_backend
+
+
+def test_parse_picture():
+    line = (
+        "image::images/example1.png[Example Image, width=200, height=150, align=center]"
+    )
+    res = AsciiDocBackend._parse_picture(line)
+    assert res
+    assert res.get("width", 0) == "200"
+    assert res.get("height", 0) == "150"
+    assert res.get("uri", "") == "images/example1.png"
+
+    line = "image::renamed-bookmark.png[Renamed bookmark]"
+    res = AsciiDocBackend._parse_picture(line)
+    assert res
+    assert "width" not in res
+    assert "height" not in res
+    assert res.get("uri", "") == "renamed-bookmark.png"
 
 
 def test_asciidocs_examples():


### PR DESCRIPTION
- The AsciiDoc backend should not create an `ImageRef` with `Size` equal to `None` (invalid), instead it should use default size values.
- Refactor static methods as such and add the `staticmethod` decorator.
- Extend the regression test for this fix.

**Issue resolved by this Pull Request:**
Resolves #1768 

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
