### PR TITLE
Fix: Hard‑coded fallback (add_level = 1) and Off‑by‑one for numbered headings in msword_backend.py

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -874,7 +874,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
 
             current_level = curr_level
             parent_level = curr_level - 1
-            add_level = curr_level
+            add_level = curr_level - 1
         else:
             current_level = self.level
             parent_level = self.level - 1

--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -878,7 +878,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         else:
             current_level = self.level
             parent_level = self.level - 1
-            add_level = 1
+            add_level = max(0, self.level - 1)
 
         if is_numbered_style:
             if add_level in self.numbered_headers:


### PR DESCRIPTION
Defect
Effect
Fix applied
A. Hard‑coded fallback (add_level = 1) when the style carries no explicit number
Flattens every “un‑numbered” heading into level 1; deeper levels never surface.
Derive the target level from the live hierarchy (self._get_level()/self.level) instead of hard‑coding.
B. Off‑by‑one for numbered headings (Heading 3 stored as internal level 3 instead of 2)
Makes Word one‑based while HTML/AsciiDoc are zero‑based, so the renderer silently suppresses anything beyond level 3.
Convert Word’s one‑based index to zero‑based (target_level = curr_level - 1).

Operational notes
	1.	Maximum depth is still governed by self.max_levels (10).
	2.	Custom style names – the existing _get_heading_and_level logic is untouched; if it yields None, the fallback rules above will still nest correctly.
	3.	Performance / memory – unchanged; only index arithmetic was corrected.

Cross checked by Gemini 2.5 Pro, o3-pro, Claude 4 Opus.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
