### PR TITLE
fix: add table raw content when no table structure model is used

### DIFF
--- a/docling/models/readingorder_model.py
+++ b/docling/models/readingorder_model.py
@@ -226,6 +226,9 @@ class ReadingOrderModel:
 
                         tbl.footnotes.append(new_footnote_item.get_ref())
 
+                if tbl.data.num_rows == 0 and tbl.data.num_cols == 0:
+                    self._add_child_elements(element, tbl, out_doc)
+
                 # TODO: Consider adding children of Table.
 
             elif isinstance(element, FigureElement):


### PR DESCRIPTION
This change will add the table text cells as children. The current serialization behavior are already exporting this content which ends up in the final markdown or html exports.

- [x] Add table text cells when no table structure model is used
- [ ] Make this content optional and not mixed with other content

---

We would like to provide this output as an opt-in capability, so we leave the PR as draft until we clarify the possible approaches for it.

For example, we could
1. Use a different `ContentLayer`
2. Add this type of content not in `.children` but something else. (not doable at the moment with the DoclingDoc API)
3. Add an option for the export functions which blocks table traversals

FYI @cau-git  @PeterStaar-IBM @vagenas  

---

**Issue resolved by this Pull Request:**
Resolves #1805 

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
