### PR TITLE
fix:missing elements in markdown lists

### DIFF
--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -247,7 +247,9 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
             self._process_inline_text(parent_item, doc)
             _log.debug(" - List item")
 
-            snippet_text = str(first_child.children[0].children)  # type: ignore
+            snippet_text = (
+                marko.md_renderer.MarkdownRenderer().render(first_child).strip()
+            )  # type: ignore
             is_numbered = False
             if (
                 parent_item is not None


### PR DESCRIPTION
It uses the marko MarkdownRenderer to ensure that no text is lost, when the structure is more complex than assumed (bold text for example)

Resolve: #1837 
