### PR TITLE
fix: Handle missing runs to avoid out of range exception

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -397,7 +397,11 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             if isinstance(c, Hyperlink):
                 text = c.text
                 hyperlink = Path(c.address)
-                format = self._get_format_from_run(c.runs[0])
+                format = (
+                    self._get_format_from_run(c.runs[0])
+                    if c.runs and len(c.runs) > 0
+                    else None
+                )
             elif isinstance(c, Run):
                 text = c.text
                 hyperlink = None


### PR DESCRIPTION
Small change to handle missing runs, which avoids the out of range exception on some docx files.

**Issue resolved by this Pull Request:**
Resolves #1681


**Checklist:**

- [ x] Documentation has been updated, if necessary.
- [x ] Examples have been added, if necessary.
- [x ] Tests have been added, if necessary.
