### PR TITLE
Move expensive imports closer to usage

### DIFF
--- a/docling/models/base_ocr_model.py
+++ b/docling/models/base_ocr_model.py
@@ -10,7 +10,6 @@ from docling_core.types.doc import BoundingBox, CoordOrigin
 from docling_core.types.doc.page import TextCell
 from PIL import Image, ImageDraw
 from rtree import index
-from scipy.ndimage import binary_dilation, find_objects, label
 
 from docling.datamodel.accelerator_options import AcceleratorOptions
 from docling.datamodel.base_models import Page
@@ -31,6 +30,8 @@ class BaseOcrModel(BasePageModel, BaseModelWithOptions):
         options: OcrOptions,
         accelerator_options: AcceleratorOptions,
     ):
+        from scipy.ndimage import binary_dilation, find_objects, label
+
         self.enabled = enabled
         self.options = options
 

--- a/docling/models/layout_model.py
+++ b/docling/models/layout_model.py
@@ -7,7 +7,6 @@ from typing import Optional
 
 import numpy as np
 from docling_core.types.doc import DocItemLabel
-from docling_ibm_models.layoutmodel.layout_predictor import LayoutPredictor
 from PIL import Image
 
 from docling.datamodel.accelerator_options import AcceleratorOptions
@@ -51,6 +50,8 @@ class LayoutModel(BasePageModel):
     def __init__(
         self, artifacts_path: Optional[Path], accelerator_options: AcceleratorOptions
     ):
+        from docling_ibm_models.layoutmodel.layout_predictor import LayoutPredictor
+
         device = decide_device(accelerator_options.device)
 
         if artifacts_path is None:

--- a/docling/models/plugins/defaults.py
+++ b/docling/models/plugins/defaults.py
@@ -1,13 +1,12 @@
-from docling.models.easyocr_model import EasyOcrModel
-from docling.models.ocr_mac_model import OcrMacModel
-from docling.models.picture_description_api_model import PictureDescriptionApiModel
-from docling.models.picture_description_vlm_model import PictureDescriptionVlmModel
-from docling.models.rapid_ocr_model import RapidOcrModel
-from docling.models.tesseract_ocr_cli_model import TesseractOcrCliModel
-from docling.models.tesseract_ocr_model import TesseractOcrModel
 
 
 def ocr_engines():
+    from docling.models.easyocr_model import EasyOcrModel
+    from docling.models.ocr_mac_model import OcrMacModel
+    from docling.models.rapid_ocr_model import RapidOcrModel
+    from docling.models.tesseract_ocr_cli_model import TesseractOcrCliModel
+    from docling.models.tesseract_ocr_model import TesseractOcrModel
+
     return {
         "ocr_engines": [
             EasyOcrModel,
@@ -20,6 +19,9 @@ def ocr_engines():
 
 
 def picture_description():
+    from docling.models.picture_description_api_model import PictureDescriptionApiModel
+    from docling.models.picture_description_vlm_model import PictureDescriptionVlmModel
+
     return {
         "picture_description": [
             PictureDescriptionVlmModel,

--- a/docling/models/table_structure_model.py
+++ b/docling/models/table_structure_model.py
@@ -10,7 +10,6 @@ from docling_core.types.doc.page import (
     BoundingRectangle,
     TextCellUnit,
 )
-from docling_ibm_models.tableformer.data_management.tf_predictor import TFPredictor
 from PIL import ImageDraw
 
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
@@ -70,6 +69,9 @@ class TableStructureModel(BasePageModel):
 
             # Third Party
             import docling_ibm_models.tableformer.common as c
+            from docling_ibm_models.tableformer.data_management.tf_predictor import (
+                TFPredictor,
+            )
 
             device = decide_device(accelerator_options.device)
 

--- a/docling/utils/accelerator_utils.py
+++ b/docling/utils/accelerator_utils.py
@@ -1,8 +1,6 @@
 import logging
 from typing import List, Optional
 
-import torch
-
 from docling.datamodel.accelerator_options import AcceleratorDevice
 
 _log = logging.getLogger(__name__)
@@ -18,6 +16,7 @@ def decide_device(
     1. AUTO: Check for the best available device on the system.
     2. User-defined: Check if the device actually exists, otherwise fall-back to CPU
     """
+    import torch
     device = "cpu"
 
     has_cuda = torch.backends.cuda.is_built() and torch.cuda.is_available()


### PR DESCRIPTION
Fixes: https://github.com/docling-project/docling/issues/1862

Move the imports for the Layout Predictor, scipy, torch, and OCR models within the object initialization to eliminate expensive imports.

CLI `docling --version` goes from ~7s to <1s
`import docling` goes from ~7s to <1s

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.

