### PR TITLE
fix: Ensure that TesseractOcrModel does not crash in case OSD is not installed

### DIFF
--- a/docling/models/tesseract_ocr_model.py
+++ b/docling/models/tesseract_ocr_model.py
@@ -144,7 +144,10 @@ class TesseractOcrModel(BaseOcrModel):
 
                         local_reader = self.reader
                         self.osd_reader.SetImage(high_res_image)
+
+                        doc_orientation = 0
                         osd = self.osd_reader.DetectOrientationScript()
+
                         # No text, or Orientation and Script detection failure
                         if osd is None:
                             _log.error(
@@ -158,11 +161,14 @@ class TesseractOcrModel(BaseOcrModel):
                             # to OCR in the hope OCR will succeed while OSD failed
                             if self._is_auto:
                                 continue
-                        doc_orientation = parse_tesseract_orientation(osd["orient_deg"])
-                        if doc_orientation != 0:
-                            high_res_image = high_res_image.rotate(
-                                -doc_orientation, expand=True
+                        else:
+                            doc_orientation = parse_tesseract_orientation(
+                                osd["orient_deg"]
                             )
+                            if doc_orientation != 0:
+                                high_res_image = high_res_image.rotate(
+                                    -doc_orientation, expand=True
+                                )
                         if self._is_auto:
                             script = osd["script_name"]
                             script = map_tesseract_script(script)


### PR DESCRIPTION
This fix for `TesseractOcrModel` prevents an uncontrolled exception in case tesseract OSD is not installed in the system.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
