### PR TITLE
perf(msexcel): _find_table_bounds use iter_rows/iter_cols instead of Worksheet.cell

### DIFF
--- a/docling/backend/msexcel_backend.py
+++ b/docling/backend/msexcel_backend.py
@@ -337,13 +337,16 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         # Collect the data within the bounds
         data = []
         visited_cells: set[tuple[int, int]] = set()
-        for ri, row in enumerate(sheet.iter_rows(
+        for ri, row in enumerate(
+            sheet.iter_rows(
                 min_row=start_row + 1,  # start_row is 0-based but iter_rows is 1-based
                 max_row=max_row + 1,
                 min_col=start_col + 1,
                 max_col=max_col + 1,
-                values_only=False
-        ), start_row):
+                values_only=False,
+            ),
+            start_row,
+        ):
             for rj, cell in enumerate(row, start_col):
                 # Check if the cell belongs to a merged range
                 row_span = 1
@@ -401,13 +404,16 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         """
         max_row: int = start_row
 
-        for ri, (cell,) in enumerate(sheet.iter_rows(
+        for ri, (cell,) in enumerate(
+            sheet.iter_rows(
                 min_row=start_row + 2,
                 max_row=sheet.max_row,
                 min_col=start_col + 1,
                 max_col=start_col + 1,
-                values_only=False
-        ), start_row + 1):
+                values_only=False,
+            ),
+            start_row + 1,
+        ):
             # Check if the cell is part of a merged range
             merged_range = next(
                 (mr for mr in sheet.merged_cells.ranges if cell.coordinate in mr),
@@ -440,13 +446,16 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         """
         max_col: int = start_col
 
-        for rj, (cell,) in enumerate(sheet.iter_cols(
+        for rj, (cell,) in enumerate(
+            sheet.iter_cols(
                 min_row=start_row + 1,
                 max_row=start_row + 1,
                 min_col=start_col + 2,
                 max_col=sheet.max_column,
-                values_only=False
-        ), start_col + 1):
+                values_only=False,
+            ),
+            start_col + 1,
+        ):
             # Check if the cell is part of a merged range
             merged_range = next(
                 (mr for mr in sheet.merged_cells.ranges if cell.coordinate in mr),

--- a/docling/backend/msexcel_backend.py
+++ b/docling/backend/msexcel_backend.py
@@ -337,10 +337,14 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         # Collect the data within the bounds
         data = []
         visited_cells: set[tuple[int, int]] = set()
-        for ri in range(start_row, max_row + 1):
-            for rj in range(start_col, max_col + 1):
-                cell = sheet.cell(row=ri + 1, column=rj + 1)  # 1-based indexing
-
+        for ri, row in enumerate(sheet.iter_rows(
+                min_row=start_row + 1,  # start_row is 0-based but iter_rows is 1-based
+                max_row=max_row + 1,
+                min_col=start_col + 1,
+                max_col=max_col + 1,
+                values_only=False
+        ), start_row):
+            for rj, cell in enumerate(row, start_col):
                 # Check if the cell belongs to a merged range
                 row_span = 1
                 col_span = 1
@@ -397,10 +401,13 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         """
         max_row: int = start_row
 
-        while max_row < sheet.max_row - 1:
-            # Get the cell value or check if it is part of a merged cell
-            cell = sheet.cell(row=max_row + 2, column=start_col + 1)
-
+        for ri, (cell,) in enumerate(sheet.iter_rows(
+                min_row=start_row + 2,
+                max_row=sheet.max_row,
+                min_col=start_col + 1,
+                max_col=start_col + 1,
+                values_only=False
+        ), start_row + 1):
             # Check if the cell is part of a merged range
             merged_range = next(
                 (mr for mr in sheet.merged_cells.ranges if cell.coordinate in mr),
@@ -414,7 +421,7 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
             if merged_range:
                 max_row = max(max_row, merged_range.max_row - 1)
             else:
-                max_row += 1
+                max_row = ri
 
         return max_row
 
@@ -433,10 +440,13 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         """
         max_col: int = start_col
 
-        while max_col < sheet.max_column - 1:
-            # Get the cell value or check if it is part of a merged cell
-            cell = sheet.cell(row=start_row + 1, column=max_col + 2)
-
+        for rj, (cell,) in enumerate(sheet.iter_cols(
+                min_row=start_row + 1,
+                max_row=start_row + 1,
+                min_col=start_col + 2,
+                max_col=sheet.max_column,
+                values_only=False
+        ), start_col + 1):
             # Check if the cell is part of a merged range
             merged_range = next(
                 (mr for mr in sheet.merged_cells.ranges if cell.coordinate in mr),
@@ -450,7 +460,7 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
             if merged_range:
                 max_col = max(max_col, merged_range.max_col - 1)
             else:
-                max_col += 1
+                max_col = rj
 
         return max_col
 


### PR DESCRIPTION
Traverse cells in table bound finding by `Worksheet.cell` is low efficiency.

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
