### PR TITLE
fix: docs are missing osd packages for tesseract on RHEL

### DIFF
--- a/docs/installation/index.md
+++ b/docs/installation/index.md
@@ -77,7 +77,7 @@ Works on macOS, Linux, and Windows, with support for both x86_64 and arm64 archi
     === "RHEL"
 
         ```console
-        dnf install tesseract tesseract-devel tesseract-langpack-eng leptonica-devel
+        dnf install tesseract tesseract-devel tesseract-langpack-eng tesseract-osd leptonica-devel
         TESSDATA_PREFIX=/usr/share/tesseract/tessdata/
         echo "Set TESSDATA_PREFIX=${TESSDATA_PREFIX}"
         ```


### PR DESCRIPTION
On RHEL the tesseract osd is installed as separate package, docs where missing it.


**Checklist:**

- [x] Documentation has been updated, if necessary.
