### PR TITLE
feat(vlm): Ability to preprocess VLM response

### DIFF
--- a/docling/datamodel/pipeline_options_vlm_model.py
+++ b/docling/datamodel/pipeline_options_vlm_model.py
@@ -14,6 +14,7 @@ class BaseVlmOptions(BaseModel):
     scale: float = 2.0
     max_size: Optional[int] = None
     temperature: float = 0.0
+    decode_response: Optional[Callable[[str], str]] = None
 
 
 class ResponseFormat(str, Enum):

--- a/docling/datamodel/pipeline_options_vlm_model.py
+++ b/docling/datamodel/pipeline_options_vlm_model.py
@@ -1,5 +1,5 @@
 from enum import Enum
-from typing import Any, Callable, Dict, List, Literal, Optional, Union
+from typing import Any, Dict, List, Literal, Optional
 
 from docling_core.types.doc.page import SegmentedPage
 from pydantic import AnyUrl, BaseModel
@@ -10,11 +10,16 @@ from docling.datamodel.accelerator_options import AcceleratorDevice
 
 class BaseVlmOptions(BaseModel):
     kind: str
-    prompt: Union[str, Callable[[Optional[SegmentedPage]], str]]
+    prompt: str
     scale: float = 2.0
     max_size: Optional[int] = None
     temperature: float = 0.0
-    decode_response: Optional[Callable[[str], str]] = None
+
+    def build_prompt(self, page: Optional[SegmentedPage]) -> str:
+        return self.prompt
+
+    def decode_response(self, text: str) -> str:
+        return text
 
 
 class ResponseFormat(str, Enum):

--- a/docling/models/api_vlm_model.py
+++ b/docling/models/api_vlm_model.py
@@ -53,11 +53,7 @@ class ApiVlmModel(BasePageModel):
                         if hi_res_image.mode != "RGB":
                             hi_res_image = hi_res_image.convert("RGB")
 
-                    if callable(self.vlm_options.prompt):
-                        prompt = self.vlm_options.prompt(page.parsed_page)
-                    else:
-                        prompt = self.vlm_options.prompt
-
+                    prompt = self.vlm_options.build_prompt(page.parsed_page)
                     page_tags = api_image_request(
                         image=hi_res_image,
                         prompt=prompt,
@@ -67,8 +63,7 @@ class ApiVlmModel(BasePageModel):
                         **self.params,
                     )
 
-                    if self.vlm_options.decode_response:
-                        page_tags = self.vlm_options.decode_response(page_tags)
+                    page_tags = self.vlm_options.decode_response(page_tags)
                     page.predictions.vlm_response = VlmPrediction(text=page_tags)
 
                 return page

--- a/docling/models/api_vlm_model.py
+++ b/docling/models/api_vlm_model.py
@@ -67,6 +67,8 @@ class ApiVlmModel(BasePageModel):
                         **self.params,
                     )
 
+                    if self.vlm_options.decode_response:
+                        page_tags = self.vlm_options.decode_response(page_tags)
                     page.predictions.vlm_response = VlmPrediction(text=page_tags)
 
                 return page

--- a/docling/models/vlm_models_inline/hf_transformers_model.py
+++ b/docling/models/vlm_models_inline/hf_transformers_model.py
@@ -166,6 +166,10 @@ class HuggingFaceTransformersVlmModel(BasePageModel, HuggingFaceModelDownloadMix
                     _log.debug(
                         f"Generated {num_tokens} tokens in time {generation_time:.2f} seconds."
                     )
+                    if self.vlm_options.decode_response:
+                        generated_texts = self.vlm_options.decode_response(
+                            generated_texts
+                        )
                     page.predictions.vlm_response = VlmPrediction(
                         text=generated_texts,
                         generation_time=generation_time,

--- a/docling/models/vlm_models_inline/hf_transformers_model.py
+++ b/docling/models/vlm_models_inline/hf_transformers_model.py
@@ -135,10 +135,7 @@ class HuggingFaceTransformersVlmModel(BasePageModel, HuggingFaceModelDownloadMix
                     )
 
                     # Define prompt structure
-                    if callable(self.vlm_options.prompt):
-                        user_prompt = self.vlm_options.prompt(page.parsed_page)
-                    else:
-                        user_prompt = self.vlm_options.prompt
+                    user_prompt = self.vlm_options.build_prompt(page.parsed_page)
                     prompt = self.formulate_prompt(user_prompt)
 
                     inputs = self.processor(
@@ -166,10 +163,7 @@ class HuggingFaceTransformersVlmModel(BasePageModel, HuggingFaceModelDownloadMix
                     _log.debug(
                         f"Generated {num_tokens} tokens in time {generation_time:.2f} seconds."
                     )
-                    if self.vlm_options.decode_response:
-                        generated_texts = self.vlm_options.decode_response(
-                            generated_texts
-                        )
+                    generated_texts = self.vlm_options.decode_response(generated_texts)
                     page.predictions.vlm_response = VlmPrediction(
                         text=generated_texts,
                         generation_time=generation_time,

--- a/docling/models/vlm_models_inline/mlx_model.py
+++ b/docling/models/vlm_models_inline/mlx_model.py
@@ -142,6 +142,8 @@ class HuggingFaceMlxModel(BasePageModel, HuggingFaceModelDownloadMixin):
                     _log.debug(
                         f"{generation_time:.2f} seconds for {len(tokens)} tokens ({len(tokens) / generation_time} tokens/sec)."
                     )
+                    if self.vlm_options.decode_response:
+                        page_tags = self.vlm_options.decode_response(page_tags)
                     page.predictions.vlm_response = VlmPrediction(
                         text=page_tags,
                         generation_time=generation_time,

--- a/docling/models/vlm_models_inline/mlx_model.py
+++ b/docling/models/vlm_models_inline/mlx_model.py
@@ -84,10 +84,7 @@ class HuggingFaceMlxModel(BasePageModel, HuggingFaceModelDownloadMixin):
                         if hi_res_image.mode != "RGB":
                             hi_res_image = hi_res_image.convert("RGB")
 
-                    if callable(self.vlm_options.prompt):
-                        user_prompt = self.vlm_options.prompt(page.parsed_page)
-                    else:
-                        user_prompt = self.vlm_options.prompt
+                    user_prompt = self.vlm_options.build_prompt(page.parsed_page)
                     prompt = self.apply_chat_template(
                         self.processor, self.config, user_prompt, num_images=1
                     )
@@ -142,8 +139,7 @@ class HuggingFaceMlxModel(BasePageModel, HuggingFaceModelDownloadMixin):
                     _log.debug(
                         f"{generation_time:.2f} seconds for {len(tokens)} tokens ({len(tokens) / generation_time} tokens/sec)."
                     )
-                    if self.vlm_options.decode_response:
-                        page_tags = self.vlm_options.decode_response(page_tags)
+                    page_tags = self.vlm_options.decode_response(page_tags)
                     page.predictions.vlm_response = VlmPrediction(
                         text=page_tags,
                         generation_time=generation_time,

--- a/docs/examples/vlm_pipeline_api_model.py
+++ b/docs/examples/vlm_pipeline_api_model.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from pathlib import Path
@@ -83,6 +84,14 @@ def lms_olmocr_vlm_options(model: str):
             f"RAW_TEXT_START\n{base_text}\nRAW_TEXT_END"
         )
 
+    def _decode_olmocr_response(generated_text: str) -> str:
+        try:
+            generated_json = json.loads(generated_text)
+        except json.decoder.JSONDecodeError:
+            return ""
+
+        return generated_json["natural_text"]
+
     options = ApiVlmOptions(
         url="http://localhost:1234/v1/chat/completions",
         params=dict(
@@ -92,6 +101,7 @@ def lms_olmocr_vlm_options(model: str):
         timeout=90,
         scale=1.0,
         max_size=1024,  # from OlmOcr pipeline
+        decode_response=_decode_olmocr_response,
         response_format=ResponseFormat.MARKDOWN,
     )
     return options

--- a/docs/examples/vlm_pipeline_api_model.py
+++ b/docs/examples/vlm_pipeline_api_model.py
@@ -39,69 +39,66 @@ def lms_vlm_options(model: str, prompt: str, format: ResponseFormat):
 
 
 def lms_olmocr_vlm_options(model: str):
-    def _dynamic_olmocr_prompt(page: Optional[SegmentedPage]):
-        if page is None:
-            return (
-                "Below is the image of one page of a document. Just return the plain text"
-                " representation of this document as if you were reading it naturally.\n"
-                "Do not hallucinate.\n"
-            )
+    class OlmocrVlmOptions(ApiVlmOptions):
+        def build_prompt(self, page: Optional[SegmentedPage]) -> str:
+            if page is None:
+                return self.prompt.replace("#RAW_TEXT#", "")
 
-        anchor = [
-            f"Page dimensions: {int(page.dimension.width)}x{int(page.dimension.height)}"
-        ]
+            anchor = [
+                f"Page dimensions: {int(page.dimension.width)}x{int(page.dimension.height)}"
+            ]
 
-        for text_cell in page.textline_cells:
-            if not text_cell.text.strip():
-                continue
-            bbox = text_cell.rect.to_bounding_box().to_bottom_left_origin(
-                page.dimension.height
-            )
-            anchor.append(f"[{int(bbox.l)}x{int(bbox.b)}] {text_cell.text}")
+            for text_cell in page.textline_cells:
+                if not text_cell.text.strip():
+                    continue
+                bbox = text_cell.rect.to_bounding_box().to_bottom_left_origin(
+                    page.dimension.height
+                )
+                anchor.append(f"[{int(bbox.l)}x{int(bbox.b)}] {text_cell.text}")
 
-        for image_cell in page.bitmap_resources:
-            bbox = image_cell.rect.to_bounding_box().to_bottom_left_origin(
-                page.dimension.height
-            )
-            anchor.append(
-                f"[Image {int(bbox.l)}x{int(bbox.b)} to {int(bbox.r)}x{int(bbox.t)}]"
-            )
+            for image_cell in page.bitmap_resources:
+                bbox = image_cell.rect.to_bounding_box().to_bottom_left_origin(
+                    page.dimension.height
+                )
+                anchor.append(
+                    f"[Image {int(bbox.l)}x{int(bbox.b)} to {int(bbox.r)}x{int(bbox.t)}]"
+                )
 
-        if len(anchor) == 1:
-            anchor.append(
-                f"[Image 0x0 to {int(page.dimension.width)}x{int(page.dimension.height)}]"
-            )
+            if len(anchor) == 1:
+                anchor.append(
+                    f"[Image 0x0 to {int(page.dimension.width)}x{int(page.dimension.height)}]"
+                )
 
-        # Original prompt uses cells sorting. We are skipping it in this demo.
+            # Original prompt uses cells sorting. We are skipping it for simplicity.
 
-        base_text = "\n".join(anchor)
+            raw_text = "\n".join(anchor)
 
-        return (
-            f"Below is the image of one page of a document, as well as some raw textual"
-            f" content that was previously extracted for it. Just return the plain text"
-            f" representation of this document as if you were reading it naturally.\n"
-            f"Do not hallucinate.\n"
-            f"RAW_TEXT_START\n{base_text}\nRAW_TEXT_END"
-        )
+            return self.prompt.replace("#RAW_TEXT#", raw_text)
 
-    def _decode_olmocr_response(generated_text: str) -> str:
-        try:
-            generated_json = json.loads(generated_text)
-        except json.decoder.JSONDecodeError:
-            return ""
+        def decode_response(self, text: str) -> str:
+            # OlmOcr trained to generate json response with language, rotation and other info
+            try:
+                generated_json = json.loads(text)
+            except json.decoder.JSONDecodeError:
+                return ""
 
-        return generated_json["natural_text"]
+            return generated_json["natural_text"]
 
-    options = ApiVlmOptions(
+    options = OlmocrVlmOptions(
         url="http://localhost:1234/v1/chat/completions",
         params=dict(
             model=model,
         ),
-        prompt=_dynamic_olmocr_prompt,
+        prompt=(
+            "Below is the image of one page of a document, as well as some raw textual"
+            " content that was previously extracted for it. Just return the plain text"
+            " representation of this document as if you were reading it naturally.\n"
+            "Do not hallucinate.\n"
+            "RAW_TEXT_START\n#RAW_TEXT#\nRAW_TEXT_END"
+        ),
         timeout=90,
         scale=1.0,
         max_size=1024,  # from OlmOcr pipeline
-        decode_response=_decode_olmocr_response,
         response_format=ResponseFormat.MARKDOWN,
     )
     return options


### PR DESCRIPTION
This is the third and i hope the last PR to support models like OlmOcr ( 1 - https://github.com/docling-project/docling/pull/1802 , 2 - https://github.com/docling-project/docling/pull/1808 ).

VLM models may generate something more than just text or markdown.
E.g.:
* OlmOcr generates json with information about page language, rotation and recognized text
* Nanonets-OCR-s generates recognized text as markdown, but tables and some other elements as HTML.

For such models we need a way to decode vlm response (fully convert it to markdown).


**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
