### PR TITLE
feat: Add option to control empty clusters in layout postprocessing

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -279,6 +279,9 @@ class LayoutOptions(BaseModel):
     """Options for layout processing."""
 
     create_orphan_clusters: bool = True  # Whether to create clusters for orphaned cells
+    keep_empty_clusters: bool = (
+        False  # Whether to keep clusters that contain no text cells
+    )
     model_spec: LayoutModelConfig = DOCLING_LAYOUT_V2
 
 

--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -267,8 +267,9 @@ class LayoutPostprocessor:
         # Initial cell assignment
         clusters = self._assign_cells_to_clusters(clusters)
 
-        # Remove clusters with no cells
-        clusters = [cluster for cluster in clusters if cluster.cells]
+        # Remove clusters with no cells (if keep_empty_clusters is False)
+        if not self.options.keep_empty_clusters:
+            clusters = [cluster for cluster in clusters if cluster.cells]
 
         # Handle orphaned cells
         unassigned = self._find_unassigned_cells(clusters)


### PR DESCRIPTION
Adds an option in layout postprocessing to allow empty clusters propagate the DoclingDocument output.

```
# used like this:
pipeline_options.layout_options.keep_empty_clusters = True # default is False.
```
<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
