### PR TITLE
fix(HTML): remove an unnecessary print command

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -1,6 +1,5 @@
 import logging
 import re
-import traceback
 from io import BytesIO
 from pathlib import Path
 from typing import Final, Optional, Union, cast
@@ -144,11 +143,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         )
         # reset context
         self.ctx = _Context()
-
-        try:
-            self._walk(content, doc)
-        except Exception:
-            print(traceback.format_exc())
+        self._walk(content, doc)
 
         return doc
 


### PR DESCRIPTION
This PR removes an unnecessary `print` command in the HTML backend.

Resolves #1987 

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
