### PR TITLE
fix(html): Parse rawspan and colspan when they include non numerical values

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -512,8 +512,10 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
             str(cell.get("rowspan", "1")),
         )
         int_spans: tuple[int, int] = (
-            int(raw_spans[0]) if raw_spans[0].isnumeric() else 1,
-            int(raw_spans[1]) if raw_spans[0].isnumeric() else 1,
+            # Rawspan could have  number followed by non-digit. e.g:  rowspan=2;align="left" 
+            # prevent ValueError: invalid literal for int() by extracting the starting digits only
+            int(re.search(r'\d+', raw_spans[0]).group()) if raw_spans[0].isnumeric() else 1,
+            int(re.search(r'\d+', raw_spans[1]).group())  if raw_spans[0].isnumeric() else 1,
         )
 
         return int_spans

--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -511,10 +511,17 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
             str(cell.get("colspan", "1")),
             str(cell.get("rowspan", "1")),
         )
+
+        def _extract_num(s: str) -> int:
+            if s and s[0].isnumeric():
+                match = re.search(r"\d+", s)
+                if match:
+                    return int(match.group())
+            return 1
+
         int_spans: tuple[int, int] = (
-            # colspan could have number followed by non-digit. e.g:  2;align="left"
-            int(re.search(r'\d+', raw_spans[0]).group()) if raw_spans[0][0].isnumeric() else 1,
-            int(re.search(r'\d+', raw_spans[1]).group()) if raw_spans[1][0].isnumeric() else 1,
+            _extract_num(raw_spans[0]),
+            _extract_num(raw_spans[1]),
         )
 
         return int_spans

--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -512,10 +512,9 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
             str(cell.get("rowspan", "1")),
         )
         int_spans: tuple[int, int] = (
-            # Rawspan could have  number followed by non-digit. e.g:  rowspan=2;align="left" 
-            # prevent ValueError: invalid literal for int() by extracting the starting digits only
-            int(re.search(r'\d+', raw_spans[0]).group()) if raw_spans[0].isnumeric() else 1,
-            int(re.search(r'\d+', raw_spans[1]).group())  if raw_spans[0].isnumeric() else 1,
+            # colspan could have number followed by non-digit. e.g:  2;align="left"
+            int(re.search(r'\d+', raw_spans[0]).group()) if raw_spans[0][0].isnumeric() else 1,
+            int(re.search(r'\d+', raw_spans[1]).group()) if raw_spans[1][0].isnumeric() else 1,
         )
 
         return int_spans


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Fix ValueError Exception when colspan or raw span include a number followed by a string (such as 2;aligh="left")

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
