### PR TITLE
docs: DPK pipeline example using docling library 

### DIFF
--- a/docs/examples/dpk-ingest-chunck-tokenize.ipynb
+++ b/docs/examples/dpk-ingest-chunck-tokenize.ipynb
@@ -19,7 +19,7 @@
    "source": [
     "## 🔍 Why DPK Pipelines\n",
     "\n",
-    "DPK transform pipelines are intended to simplify how any number of transforms can be executed in a sequence to ingest, annotage, filter and create embedding used for LLM post-training and RAG applications. \n"
+    "DPK transform pipelines are intended to simplify how any number of transforms can be executed in a sequence to ingest, annotate, filter and create embedding used for LLM post-training and RAG applications. \n"
    ]
   },
   {
@@ -31,7 +31,7 @@
     "\n",
     "We will use the following transforms from DPK:\n",
     "\n",
-    "- `DocLing2Parquet`: Injest one or more HTML document and turn it into a parquet file.\n",
+    "- `Docling2Parquet`: Ingest one or more HTML document and turn it into a parquet file.\n",
     "- `Doc_Chunk`: Create chunks from one more more ducment.\n",
     "- `Tokenization`: Create embedding for document chunks.\n"
    ]
@@ -56,7 +56,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "d8e34691-3b14-4796-847d-f07132bbca00",
    "metadata": {},
    "outputs": [],
@@ -64,6 +64,7 @@
     "%%capture\n",
     "%pip install \"data-prep-toolkit-transforms[docling2parquet,doc_chunk,tokenization]\"\n",
     "%pip install pandas\n",
+    "%pip install \"numpy<2.0\"\n",
     "from dotenv import load_dotenv\n",
     "\n",
     "load_dotenv(\".env\", override=True)"
@@ -81,7 +82,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": null,
    "id": "ec0f6f63-9c4b-400d-af10-0ce9f805d6f9",
    "metadata": {},
    "outputs": [],
@@ -122,7 +123,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": null,
    "id": "712befc1-7b3b-4949-9c5b-84e434c1ff60",
    "metadata": {},
    "outputs": [],
@@ -147,7 +148,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "fd453793-8f68-440c-a08a-8a6a16f3de04",
    "metadata": {
     "scrolled": true
@@ -177,7 +178,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "8db5da67-4797-4b85-b83c-3347e8852611",
    "metadata": {
     "scrolled": true
@@ -203,12 +204,12 @@
    "source": [
     "### 🔗 Tokenization\n",
     "\n",
-    "Invoke Tokenization tansform to create embedding of various chunks"
+    "Invoke Tokenization transform to create embedding of various chunks"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "93be7a31-d13c-4345-861c-6654aea4f680",
    "metadata": {},
    "outputs": [],
@@ -237,7 +238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "997003fc-ba1a-4ebf-a37d-4419bcaf5389",
    "metadata": {
     "scrolled": true

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,6 +96,8 @@ nav:
       - examples/serialization.ipynb
       - examples/hybrid_chunking.ipynb
       - examples/advanced_chunking_and_serialization.ipynb
+    - ✂️ Data Preparation and Embedding Pipeline:
+      - examples/dpk-ingest-chunck-tokenize.ipynb
     - 🤖 RAG with AI dev frameworks:
       - examples/rag_haystack.ipynb
       - examples/rag_langchain.ipynb


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

In this PR we show an example of a notebook that implements a DPK pipeline that consists of: 1) ingesting HTML documents using docling, 2) chunking the ingested document using docling and then 3) creating the embedding.

Pre-requisite 1: The HTML content used in this example is loaded using the Wikimedia API for retrieving wikipedia articles and require a ACCESS TOKEN that can be obtained from Wikimedia Enterprise web site (Pointer to instructions are in the notebook)

Pre-requisite 2: The embedding uses llama tokenizer and requires a HuggingFace ACCESS TOKEN for downloading the model

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
