### PR TITLE
feat(RapidOcr): Support generic extra arguments for RapidOcr

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -114,7 +114,7 @@ class RapidOcrOptions(OcrOptions):
     cls_model_path: Optional[str] = None  # same default as rapidocr
     rec_model_path: Optional[str] = None  # same default as rapidocr
     rec_keys_path: Optional[str] = None  # same default as rapidocr
-    rec_font_path: Optional[str] = None  # Deprecated with new RapidOCR Version please use font_path instead
+    rec_font_path: Optional[str] = None  # Deprecated, please use font_path instead
     font_path: Optional[str] = None  # same default as rapidocr
 
     # Dictionary to overwrite or pass-through additional parameters

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -114,7 +114,10 @@ class RapidOcrOptions(OcrOptions):
     cls_model_path: Optional[str] = None  # same default as rapidocr
     rec_model_path: Optional[str] = None  # same default as rapidocr
     rec_keys_path: Optional[str] = None  # same default as rapidocr
-    rec_font_path: Optional[str] = None  # same default as rapidocr
+    font_path: Optional[str] = None  # same default as rapidocr
+
+    # Dictionary to overwrite or pass-through additional parameters
+    rapidocr_params: Dict[str, Any] = Field(default_factory=dict)
 
     model_config = ConfigDict(
         extra="forbid",

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -114,6 +114,7 @@ class RapidOcrOptions(OcrOptions):
     cls_model_path: Optional[str] = None  # same default as rapidocr
     rec_model_path: Optional[str] = None  # same default as rapidocr
     rec_keys_path: Optional[str] = None  # same default as rapidocr
+    rec_font_path: Optional[str] = None  # Deprecated with new RapidOCR Version please use font_path instead
     font_path: Optional[str] = None  # same default as rapidocr
 
     # Dictionary to overwrite or pass-through additional parameters

--- a/docling/models/rapid_ocr_model.py
+++ b/docling/models/rapid_ocr_model.py
@@ -89,6 +89,10 @@ class RapidOcrModel(BaseOcrModel):
                 "Rec.engine_type": backend_enum,
             }
 
+            if self.options.rec_font_path is not None:
+                _log.warning(
+                    "The 'rec_font_path' option for RapidOCR is deprecated. Please use 'font_path' instead."
+                )
             user_params = self.options.rapidocr_params
             if user_params:
                 _log.debug("Overwriting RapidOCR params with user-provided values.")

--- a/docling/models/rapid_ocr_model.py
+++ b/docling/models/rapid_ocr_model.py
@@ -62,32 +62,40 @@ class RapidOcrModel(BaseOcrModel):
             }
             backend_enum = _ALIASES.get(self.options.backend, EngineType.ONNXRUNTIME)
 
+            params = {
+                # Global settings (these are still correct)
+                "Global.text_score": self.options.text_score,
+                "Global.font_path": self.options.font_path,
+                # "Global.verbose": self.options.print_verbose,
+                # Detection model settings
+                "Det.model_path": self.options.det_model_path,
+                "Det.use_cuda": use_cuda,
+                "Det.use_dml": use_dml,
+                "Det.intra_op_num_threads": intra_op_num_threads,
+                # Classification model settings
+                "Cls.model_path": self.options.cls_model_path,
+                "Cls.use_cuda": use_cuda,
+                "Cls.use_dml": use_dml,
+                "Cls.intra_op_num_threads": intra_op_num_threads,
+                # Recognition model settings
+                "Rec.model_path": self.options.rec_model_path,
+                "Rec.font_path": self.options.rec_font_path,
+                "Rec.keys_path": self.options.rec_keys_path,
+                "Rec.use_cuda": use_cuda,
+                "Rec.use_dml": use_dml,
+                "Rec.intra_op_num_threads": intra_op_num_threads,
+                "Det.engine_type": backend_enum,
+                "Cls.engine_type": backend_enum,
+                "Rec.engine_type": backend_enum,
+            }
+
+            user_params = self.options.rapidocr_params
+            if user_params:
+                _log.debug("Overwriting RapidOCR params with user-provided values.")
+                params.update(user_params)
+
             self.reader = RapidOCR(
-                params={
-                    # Global settings (these are still correct)
-                    "Global.text_score": self.options.text_score,
-                    # "Global.verbose": self.options.print_verbose,
-                    # Detection model settings
-                    "Det.model_path": self.options.det_model_path,
-                    "Det.use_cuda": use_cuda,
-                    "Det.use_dml": use_dml,
-                    "Det.intra_op_num_threads": intra_op_num_threads,
-                    # Classification model settings
-                    "Cls.model_path": self.options.cls_model_path,
-                    "Cls.use_cuda": use_cuda,
-                    "Cls.use_dml": use_dml,
-                    "Cls.intra_op_num_threads": intra_op_num_threads,
-                    # Recognition model settings
-                    "Rec.model_path": self.options.rec_model_path,
-                    "Rec.font_path": self.options.rec_font_path,
-                    "Rec.keys_path": self.options.rec_keys_path,
-                    "Rec.use_cuda": use_cuda,
-                    "Rec.use_dml": use_dml,
-                    "Rec.intra_op_num_threads": intra_op_num_threads,
-                    "Det.engine_type": backend_enum,
-                    "Cls.engine_type": backend_enum,
-                    "Rec.engine_type": backend_enum,
-                }
+                params=params,
             )
 
     def __call__(

--- a/tests/test_e2e_ocr_conversion.py
+++ b/tests/test_e2e_ocr_conversion.py
@@ -80,7 +80,7 @@ def test_e2e_conversions():
                     force_full_page_ocr=True,
                     rec_font_path="test",
                     rapidocr_params={
-                        "rec_font_path": None
+                        "Rec.font_path": None
                     },  # should overwrite rec_font_path
                 ),
                 False,

--- a/tests/test_e2e_ocr_conversion.py
+++ b/tests/test_e2e_ocr_conversion.py
@@ -79,9 +79,7 @@ def test_e2e_conversions():
                 RapidOcrOptions(
                     force_full_page_ocr=True,
                     rec_font_path="test",
-                    rapidocr_params={
-                        "Rec.font_path": None
-                    },  # should overwrite rec_font_path
+                    rapidocr_params={"Rec.font_path": None},  # overwrites rec_font_path
                 ),
                 False,
             )

--- a/tests/test_e2e_ocr_conversion.py
+++ b/tests/test_e2e_ocr_conversion.py
@@ -79,7 +79,9 @@ def test_e2e_conversions():
                 RapidOcrOptions(
                     force_full_page_ocr=True,
                     rec_font_path="test",
-                    rapidocr_params={"rec_font_path": None},
+                    rapidocr_params={
+                        "rec_font_path": None
+                    },  # should overwrite rec_font_path
                 ),
                 False,
             )

--- a/tests/test_e2e_ocr_conversion.py
+++ b/tests/test_e2e_ocr_conversion.py
@@ -74,6 +74,16 @@ def test_e2e_conversions():
     if sys.version_info < (3, 13):
         engines.append((RapidOcrOptions(), False))
         engines.append((RapidOcrOptions(force_full_page_ocr=True), False))
+        engines.append(
+            (
+                RapidOcrOptions(
+                    force_full_page_ocr=True,
+                    rec_font_path="test",
+                    rapidocr_params={"rec_font_path": None},
+                ),
+                False,
+            )
+        )
 
     # only works on mac
     if "darwin" == sys.platform:


### PR DESCRIPTION
Add support for additional parameters in RapidOcrOptions and fix the font_path parameter for RapidOCR.

previously it was rec.font_path but now it has to be Global.font_path


**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
