### PR TITLE
feat: Add uspto backend meta-data extraction

### DIFF
--- a/docling/backend/abstract_backend.py
+++ b/docling/backend/abstract_backend.py
@@ -38,6 +38,10 @@ class AbstractDocumentBackend(ABC):
     def supported_formats(cls) -> Set["InputFormat"]:
         pass
 
+    @abstractmethod
+    def extract_metadata(self) -> Dict[str, Any]:
+        return {}
+
 
 class PaginatedDocumentBackend(AbstractDocumentBackend):
     """DeclarativeDocumentBackend.

--- a/docling/backend/xml/uspto_backend.py
+++ b/docling/backend/xml/uspto_backend.py
@@ -147,6 +147,10 @@ class PatentUsptoDocumentBackend(DeclarativeDocumentBackend):
                 f"Cannot convert doc (hash={self.document_hash}, "
                 f"name={self.file.name}) because the backend failed to init."
             )
+    
+    @override
+    def extract_metadata(self) -> Dict[str, Any]:
+        return {}
 
 
 class PatentUspto(ABC):

--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -207,6 +207,7 @@ class ConversionResult(BaseModel):
     confidence: ConfidenceReport = Field(default_factory=ConfidenceReport)
 
     document: DoclingDocument = _EMPTY_DOCLING_DOC
+    metadata: Dict[str, Any] = {}
 
     @property
     @deprecated("Use document instead.")

--- a/docling/pipeline/simple_pipeline.py
+++ b/docling/pipeline/simple_pipeline.py
@@ -38,6 +38,7 @@ class SimplePipeline(ConvertPipeline):
         # a DoclingDocument straight.
         with TimeRecorder(conv_res, "doc_build", scope=ProfilingScope.DOCUMENT):
             conv_res.document = conv_res.input._backend.convert()
+            conv_res.metadata = conv_res.input._backend.extract_metadata()
         return conv_res
 
     def _determine_status(self, conv_res: ConversionResult) -> ConversionStatus:


### PR DESCRIPTION
Adds extraction of the meta-data for uspto-backend that handles parsing of uspto patents in xml form.


**Issue resolved by this Pull Request:**
Resolves #2273 

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
