### PR TITLE
fix: skip temporary docx files

### DIFF
--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -547,13 +547,25 @@ def convert(  # noqa: C901
                     if local_path.exists() and local_path.is_dir():
                         for fmt in from_formats:
                             for ext in FormatToExtensions[fmt]:
-                                input_doc_paths.extend(
-                                    list(local_path.glob(f"**/*.{ext}"))
-                                )
-                                input_doc_paths.extend(
-                                    list(local_path.glob(f"**/*.{ext.upper()}"))
-                                )
+                                for path in local_path.glob(f"**/*.{ext}"):
+                                    if path.name.startswith("~$") and ext == "docx":
+                                        _log.info(
+                                            f"Ignoring temporary Word file: {path}"
+                                        )
+                                        continue
+                                    input_doc_paths.append(path)
+
+                                for path in local_path.glob(f"**/*.{ext.upper()}"):
+                                    if path.name.startswith("~$") and ext == "docx":
+                                        _log.info(
+                                            f"Ignoring temporary Word file: {path}"
+                                        )
+                                        continue
+                                    input_doc_paths.append(path)
                     elif local_path.exists():
+                        if not local_path.name.startswith("~$") and ext == "docx":
+                            _log.info(f"Ignoring temporary Word file: {path}")
+                            continue
                         input_doc_paths.append(local_path)
                     else:
                         err_console.print(


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #2191  

**Solution Implemented:**
Now checks whether the file is a temporary .docx (starts with ~$); if so, it is ignored.

```python
for path in local_path.glob(f"**/*.{ext}"):
    if path.name.startswith("~$") and ext == "docx":
        _log.info(
            f"Ignoring temporary Word file: {path}"
        )
        continue
    input_doc_paths.append(path)

for path in local_path.glob(f"**/*.{ext.upper()}"):
    if path.name.startswith("~$") and ext == "docx":
        _log.info(
            f"Ignoring temporary Word file: {path}"
        )
        continue
    input_doc_paths.append(path)
```

and also here:

```python
if not local_path.name.startswith("~$") and ext == "docx":
    _log.info(f"Ignoring temporary Word file: {path}")
    continue
```

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.