### PR TITLE
fix: preserve nested list structure in VLM pipeline (#2301)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,7 @@ dev = [
     "pytest-dependency~=0.6",
     "pytest-durations~=1.6.1",
     "pytest-xdist~=3.3",
+    "requests-mock~=1.12",
     "ipykernel~=6.29",
     "ipywidgets~=8.1",
     "nbqa~=1.9",

--- a/tests/test_vlm_pipeline.py
+++ b/tests/test_vlm_pipeline.py
@@ -1,0 +1,240 @@
+"""
+Tests for VLM pipeline functionality.
+
+Includes tests for handling nested lists in Markdown responses,
+which previously caused: ValueError: Can not append a child with children
+See: https://github.com/docling-project/docling/issues/2301
+
+Test structure based on reproducer code contributed by @amomra in issue #2301.
+"""
+
+import time
+
+import pytest
+import requests_mock
+from docling_core.types.doc import GroupItem, ListItem
+
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.pipeline_options import VlmPipelineOptions
+from docling.datamodel.pipeline_options_vlm_model import (
+    ApiVlmOptions,
+    ResponseFormat,
+)
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.pipeline.vlm_pipeline import VlmPipeline
+
+
+@pytest.fixture
+def mock_api_endpoint():
+    """Create a mock API endpoint for VLM responses."""
+    with requests_mock.Mocker() as m:
+        yield m
+
+
+# Dummy file needs to exist even though its not processed by the VLM
+TEST_PDF = "tests/data/pdf/code_and_formula.pdf"
+
+
+def create_vlm_converter(mock_endpoint, markdown_response):
+    """Helper to create a DocumentConverter with mocked VLM API."""
+    test_url = "http://test-vlm-api.com"
+
+    mock_endpoint.post(
+        test_url,
+        json={
+            "id": "test-123",
+            "choices": [
+                {
+                    "index": 0,
+                    "message": {"role": "assistant", "content": markdown_response},
+                    "finish_reason": "stop",
+                }
+            ],
+            "created": int(time.time()),
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1, "total_tokens": 2},
+        },
+    )
+
+    pipeline_options = VlmPipelineOptions(enable_remote_services=True)
+    pipeline_options.vlm_options = ApiVlmOptions(
+        url=test_url,
+        headers={"Authorization": "Bearer test"},
+        params=dict(model="test-model"),
+        prompt="Convert to markdown",
+        timeout=90,
+        scale=1.0,
+        response_format=ResponseFormat.MARKDOWN,
+    )
+
+    return DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(
+                pipeline_options=pipeline_options,
+                pipeline_cls=VlmPipeline,
+            ),
+        }
+    )
+
+
+def test_nested_list_with_html_tag(mock_api_endpoint):
+    """Test the original failing case: nested list with HTML tag."""
+    markdown = """- item 1
+- item 2
+  - sub item 1 <text>
+  - sub item 2"""
+
+    converter = create_vlm_converter(mock_api_endpoint, markdown)
+
+    # Should not raise ValueError
+    result = converter.convert(TEST_PDF)
+
+    assert result.document is not None
+    output = result.document.export_to_markdown()
+
+    # Verify content is present (order may vary due to flattening)
+    assert "item 1" in output
+    assert "item 2" in output
+    assert "sub item 1" in output
+    assert "sub item 2" in output
+
+
+def test_simple_nested_list(mock_api_endpoint):
+    """Test simple nested list without special characters."""
+    markdown = """- item 1
+- item 2
+  - sub item 1
+  - sub item 2"""
+
+    converter = create_vlm_converter(mock_api_endpoint, markdown)
+
+    result = converter.convert(TEST_PDF)
+
+    assert result.document is not None
+    output = result.document.export_to_markdown()
+
+    assert "item 1" in output
+    assert "item 2" in output
+    assert "sub item 1" in output
+    assert "sub item 2" in output
+
+
+def test_parent_item_with_text_and_children(mock_api_endpoint):
+    """Test that parent item text is preserved when it has children."""
+    markdown = """- item 1
+- item 2 has some text
+  - sub item 1
+  - sub item 2
+- item 3"""
+
+    converter = create_vlm_converter(mock_api_endpoint, markdown)
+
+    result = converter.convert(TEST_PDF)
+
+    assert result.document is not None
+    output = result.document.export_to_markdown()
+
+    # Verify parent text is preserved
+    assert "item 1" in output
+    assert "item 2 has some text" in output  # Parent text must not be lost
+    assert "sub item 1" in output
+    assert "sub item 2" in output
+    assert "item 3" in output
+
+
+def test_deeply_nested_list(mock_api_endpoint):
+    """Test deeply nested lists (3+ levels)."""
+    markdown = """- level 1 item 1
+  - level 2 item 1
+    - level 3 item 1
+  - level 2 item 2"""
+
+    converter = create_vlm_converter(mock_api_endpoint, markdown)
+
+    result = converter.convert(TEST_PDF)
+
+    assert result.document is not None
+    output = result.document.export_to_markdown()
+
+    assert "level 1 item 1" in output
+    assert "level 2 item 1" in output
+    assert "level 3 item 1" in output
+    assert "level 2 item 2" in output
+
+
+def test_flat_list_still_works(mock_api_endpoint):
+    """Ensure flat lists (no nesting) continue to work correctly."""
+    markdown = """- item 1
+- item 2
+- item 3"""
+
+    converter = create_vlm_converter(mock_api_endpoint, markdown)
+
+    result = converter.convert(TEST_PDF)
+
+    assert result.document is not None
+    output = result.document.export_to_markdown()
+
+    assert "item 1" in output
+    assert "item 2" in output
+    assert "item 3" in output
+
+
+# Structure Preservation Tests (added for comprehensive fix of issue #2301)
+def test_nested_list_structure_preserved(mock_api_endpoint):
+    """Verify nested list structure is correctly preserved with proper levels."""
+    markdown = """- item 1
+- item 2
+  - sub item 1
+  - sub item 2
+- item 3"""
+
+    converter = create_vlm_converter(mock_api_endpoint, markdown)
+    result = converter.convert(TEST_PDF)
+
+    assert result.document is not None
+
+    # Verify structure using iterate_items without groups (user view)
+    # Note: PDF may have multiple pages, so get items from first page only
+    all_items = list(result.document.iterate_items(with_groups=False))
+
+    # Filter to first page's items (page_no=1 in prov)
+    page1_items = [
+        (item, level)
+        for item, level in all_items
+        if hasattr(item, "prov") and len(item.prov) > 0 and item.prov[0].page_no == 1
+    ]
+
+    # Expected: at least 5 items (item 1, item 2, sub item 1, sub item 2, item 3)
+    assert len(page1_items) >= 5, (
+        f"Expected at least 5 items on page 1, got {len(page1_items)}"
+    )
+
+    # Check first 5 items (our list)
+    first_5_items = page1_items[:5]
+    levels = [level for _, level in first_5_items]
+
+    # Verify relative structure: sub-items should be deeper than parents, siblings same level
+    assert levels[0] == levels[1], (
+        "item 1 and item 2 should be at same level (siblings)"
+    )
+    assert levels[2] > levels[1], "sub item 1 should be deeper than item 2 (nested)"
+    assert levels[2] == levels[3], (
+        "sub item 1 and sub item 2 should be at same level (siblings)"
+    )
+    assert levels[4] == levels[0], "item 3 should be at same level as item 1 (siblings)"
+    assert levels[2] == levels[1] + 2, (
+        "Nested items should be 2 levels deeper (without groups: 2→4)"
+    )
+
+    # Verify text content
+    item1, _ = first_5_items[0]
+    item2, _ = first_5_items[1]
+    sub1, _ = first_5_items[2]
+    sub2, _ = first_5_items[3]
+    item3, _ = first_5_items[4]
+
+    assert "item 1" in getattr(item1, "text", "")
+    assert "item 2" in getattr(item2, "text", "")
+    assert "sub item 1" in getattr(sub1, "text", "")
+    assert "sub item 2" in getattr(sub2, "text", "")
+    assert "item 3" in getattr(item3, "text", "")

--- a/uv.lock
+++ b/uv.lock
@@ -1166,6 +1166,7 @@ dev = [
     { name = "pytest-durations" },
     { name = "pytest-xdist" },
     { name = "python-semantic-release" },
+    { name = "requests-mock" },
     { name = "types-openpyxl" },
     { name = "types-requests" },
     { name = "types-setuptools" },
@@ -1252,6 +1253,7 @@ dev = [
     { name = "pytest-durations", specifier = "~=1.6.1" },
     { name = "pytest-xdist", specifier = "~=3.3" },
     { name = "python-semantic-release", specifier = "~=7.32" },
+    { name = "requests-mock", specifier = "~=1.12" },
     { name = "types-openpyxl", specifier = "~=3.1" },
     { name = "types-requests", specifier = "~=2.31" },
     { name = "types-setuptools", specifier = "~=70.3" },
@@ -6225,6 +6227,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "requests-mock"
+version = "1.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/32/587625f91f9a0a3d84688bf9cfc4b2480a7e8ec327cefd0ff2ac891fd2cf/requests-mock-1.12.1.tar.gz", hash = "sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401", size = 60901, upload-time = "2024-03-29T03:54:29.446Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/ec/889fbc557727da0c34a33850950310240f2040f3b1955175fdb2b36a8910/requests_mock-1.12.1-py2.py3-none-any.whl", hash = "sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563", size = 27695, upload-time = "2024-03-29T03:54:27.64Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Use iterate_items(with_groups=True) to reveal ListGroup containers
- Track parent relationships with level-based stack
- Copy and clear children before append to satisfy constraints
- Include tests suite for nested list structures taken from #2301

The VLM pipeline previously crashed with nested Markdown lists. This fix properly preserves hierarchy by tracking parent-child relationships through ListGroup containers.

**Issue resolved by this Pull Request:**
Resolves #2301

**Checklist:**

- [X] Tests have been added, if necessary.
