### PR TITLE
docs: fixed a few typos

### DIFF
--- a/docs/usage/enrichments.md
+++ b/docs/usage/enrichments.md
@@ -16,7 +16,7 @@ The following table provides an overview of the default enrichment models availa
 
 ### Code understanding
 
-The code understanding step allows to use advance parsing for code blocks found in the document.
+The code understanding step allows to use advanced parsing for code blocks found in the document.
 This enrichment model also set the `code_language` property of the `CodeItem`.
 
 Model specs: see the [`CodeFormula` model card](https://huggingface.co/ds4sd/CodeFormula).
@@ -168,7 +168,7 @@ from docling.datamodel.pipeline_options import PictureDescriptionVlmOptions
 
 pipeline_options.picture_description_options = PictureDescriptionVlmOptions(
     repo_id="",  # <-- add here the Hugging Face repo_id of your favorite VLM
-    prompt="Describe the image in three sentences. Be consise and accurate.",
+    prompt="Describe the image in three sentences. Be concise and accurate.",
 )
 ```
 
@@ -209,7 +209,7 @@ End-to-end code snippets for cloud providers are available in the examples secti
 
 ## Develop new enrichment models
 
-Beside looking at the implementation of all the models listed above, the Docling documentation has a few examples
+Besides looking at the implementation of all the models listed above, the Docling documentation has a few examples
 dedicated to the implementation of enrichment models.
 
 - [Develop picture enrichment](../examples/develop_picture_enrichment.py)


### PR DESCRIPTION
**Description:**

Hi, I found a few typos that I fixed in [this page](https://docling-project.github.io/docling/usage/enrichments/#develop-new-enrichment-models).

- `consise` → `concise`
- `advance` → `advanced`
- `Beside` → `Besides`

**Checklist:**

- [x] Documentation has been updated.
