### PR TITLE
docs: Remove deprecated call in custom_convert.py

### DIFF
--- a/docs/examples/custom_convert.py
+++ b/docs/examples/custom_convert.py
@@ -205,7 +205,7 @@ def main():
 
     # Export Document Tags format:
     with (output_dir / f"{doc_filename}.doctags").open("w", encoding="utf-8") as fp:
-        fp.write(conv_result.document.export_to_document_tokens())
+        fp.write(conv_result.document.export_to_doctags())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
export_to_document_tokens is deprecated so change it to export_to_doctags

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
