### PR TITLE
docs: make navigation menus collapse and expand

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -46,7 +46,7 @@ theme:
     # - navigation.instant.preview
     - navigation.instant.progress
     - navigation.path
-    # - navigation.sections  # <=
+    # - navigation.sections  # <= if set, navigation menus will not collapse and expand
     - navigation.top
     - navigation.tracking
     - search.suggest


### PR DESCRIPTION
Remove navigations.sections feature so that navigation menus will collapse and expand. Ensure they are collapsed by default.

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #2572 
<img width="1324" height="631" alt="Screenshot 2025-11-03 at 11 56 49 AM" src="https://github.com/user-attachments/assets/4448b0c2-de9a-407e-953b-f4dfc169d10d" />
<img width="1336" height="742" alt="Screenshot 2025-11-03 at 11 57 05 AM" src="https://github.com/user-attachments/assets/ee5b9787-3557-44a8-9503-10f629e0b18a" />

--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
