### PR TITLE
docs(examples): remove deprecation warnings with export_to_dataframe

### DIFF
--- a/docs/examples/export_tables.py
+++ b/docs/examples/export_tables.py
@@ -52,7 +52,7 @@ def main():
 
     # Export tables
     for table_ix, table in enumerate(conv_res.document.tables):
-        table_df: pd.DataFrame = table.export_to_dataframe()
+        table_df: pd.DataFrame = table.export_to_dataframe(doc=conv_res.document)
         print(f"## Table {table_ix}")
         print(table_df.to_markdown())
 

--- a/docs/v2.md
+++ b/docs/v2.md
@@ -146,6 +146,9 @@ is now available in conversion results as a `DoclingDocument` object.
 `DoclingDocument` provides a neat set of APIs to construct, iterate and export content in the document, as shown below.
 
 ```python
+import pandas as pd
+from docling_core.types.doc import TextItem, TableItem
+
 conv_result: ConversionResult = doc_converter.convert("https://arxiv.org/pdf/2408.09869") # previously `convert_single`
 
 ## Inspect the converted document:
@@ -156,7 +159,7 @@ for item, level in conv_result.document.iterate_items():
     if isinstance(item, TextItem):
         print(item.text)
     elif isinstance(item, TableItem):
-        table_df: pd.DataFrame = item.export_to_dataframe()
+        table_df: pd.DataFrame = item.export_to_dataframe(doc=conv_result.document)
         print(table_df.to_markdown())
     elif ...:
         #...

--- a/tests/verify_utils.py
+++ b/tests/verify_utils.py
@@ -171,9 +171,6 @@ def verify_table_v2(true_item: TableItem, pred_item: TableItem, fuzzy: bool):
     assert true_item.data is not None, "documents are expected to have table data"
     assert pred_item.data is not None, "documents are expected to have table data"
 
-    # print("True: \n", true_item.export_to_dataframe().to_markdown())
-    # print("Pred: \n", true_item.export_to_dataframe().to_markdown())
-
     for i, row in enumerate(true_item.data.grid):
         for j, col in enumerate(true_item.data.grid[i]):
             # print("true: ", true_item.data[i][j].text)


### PR DESCRIPTION
The usage of `TableItem.export_to_dataframe()` without `doc` argument is deprecated. However, some documentation is still showing the usage of `export_to_dataframe` function without the `doc` argument.

Resolves #2633 

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
