### PR TITLE
docs: Add Hector as compatible AI agent platform integration

### DIFF
--- a/docs/integrations/hector.md
+++ b/docs/integrations/hector.md
@@ -1,0 +1,13 @@
+Docling is available in [Hector](https://gohector.dev) as an MCP-based document parser
+for RAG systems and document stores.
+
+Hector is a production-grade A2A-native agent platform that integrates with Docling via
+the [MCP server](../usage/mcp.md) for advanced document parsing capabilities.
+
+- 💻 [Hector GitHub][github]
+- 📖 [Hector Docs][docs]
+- 📖 [Using Docling with Hector][tutorial]
+
+[github]: https://github.com/kadirpekel/hector
+[docs]: https://gohector.dev
+[tutorial]: https://gohector.dev/blog/posts/using-docling-with-hector/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -134,6 +134,7 @@ nav:
       - "Bee Agent Framework": integrations/bee.md
       - "Crew AI": integrations/crewai.md
       - "Haystack": integrations/haystack.md
+      - "Hector": integrations/hector.md
       - "LangChain": integrations/langchain.md
       - "Langflow": integrations/langflow.md
       - "LlamaIndex": integrations/llamaindex.md


### PR DESCRIPTION
This PR adds [Hector](https://gohector.dev/) to the list of compatible AI agent platforms that integrate with Docling. Hector is a production-grade A2A-native agent platform that uses Docling via the MCP server for advanced document parsing in RAG systems and document stores. Changes:
Added docs/integrations/hector.md with integration details and links
Updated mkdocs.yml to include Hector in the "Agentic / AI dev frameworks" section

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
