### PR TITLE
fix: Use model name for AutoProcessor to fix formula enrichment AttributeError

### DIFF
--- a/docling/models/code_formula_model.py
+++ b/docling/models/code_formula_model.py
@@ -105,8 +105,11 @@ class CodeFormulaModel(BaseItemAndImageEnrichmentModel):
             else:
                 artifacts_path = artifacts_path / self._model_repo_folder
 
+            # Use model name instead of local path to avoid transformers bug where
+            # config is loaded as dict but accessed as object attribute
+            # Transformers will automatically use the cached model from artifacts_path
             self._processor = AutoProcessor.from_pretrained(
-                artifacts_path,
+                "docling-project/CodeFormulaV2",
             )
             self._model_max_length = self._processor.tokenizer.model_max_length
             self._model = AutoModelForImageTextToText.from_pretrained(


### PR DESCRIPTION
Fixes #2681

## Problem
When `do_formula_enrichment=True` is set, Docling fails with:
```
AttributeError: 'dict' object has no attribute 'model_type'
```

## Root Cause
Passing a local `Path` object to `AutoProcessor.from_pretrained()` causes
transformers to load the tokenizer config as a dict, but then tries to access
`_config.model_type` as an object attribute.

## Solution
Use the model name (`'docling-project/CodeFormulaV2'`) instead of the local
path. Transformers will automatically use the cached model, and the config
will be properly loaded as an object.

## Testing
- [x] Tested with `do_formula_enrichment=True` - no longer throws AttributeError
- [x] Verified formulas are still extracted correctly
- [x] Confirmed cached model is still used (no re-download)