### PR TITLE
fix(models): correct parameter name from dtype to torch_dtype in VLM model

### DIFF
--- a/docling/models/picture_description_vlm_model.py
+++ b/docling/models/picture_description_vlm_model.py
@@ -68,7 +68,7 @@ class PictureDescriptionVlmModel(
                 self.model = AutoModelForImageTextToText.from_pretrained(
                     artifacts_path,
                     device_map=self.device,
-                    dtype=torch.bfloat16,
+                    torch_dtype=torch.bfloat16,
                     _attn_implementation=(
                         "flash_attention_2"
                         if self.device.startswith("cuda")


### PR DESCRIPTION
## Summary

Fixes incorrect parameter name when loading `AutoModelForImageTextToText` model. The Hugging Face transformers library expects `torch_dtype` instead of `dtype` for specifying the tensor data type during model initialization.

## Problem

The VLM picture description model initialization uses `dtype=torch.bfloat16` but the transformers `from_pretrained()` method expects `torch_dtype=torch.bfloat16`. This causes a `TypeError` when the parameter is passed through to the model's `__init__()` method.

**Error:**
```
TypeError: Idefics3ForConditionalGeneration.__init__() got an unexpected keyword argument 'dtype'
```

## Fix

Changed parameter name from `dtype` to `torch_dtype` in `docling/models/picture_description_vlm_model.py:71`.

## Testing

- Verified the fix resolves the TypeError when using VLM picture descriptions
- Confirmed `torch_dtype` is the correct parameter name per transformers documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)