### PR TITLE
feat(retry): add retry feature

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -40,6 +40,7 @@ from docling.datamodel.backend_options import HTMLBackendOptions
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
 from docling.exceptions import OperationNotAllowed
+from docling.utils.http_client import request_with_retry
 
 _log = logging.getLogger(__name__)
 
@@ -1256,9 +1257,9 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
                     "Fetching remote resources is only allowed when set explicitly. "
                     "Set options.enable_remote_fetch=True."
                 )
-            response = requests.get(src_loc, stream=True)
-            response.raise_for_status()
-            return response.content
+            with request_with_retry("GET", src_loc, stream=True) as response:
+                response.raise_for_status()
+                return response.content
         elif src_loc.startswith("data:"):
             data = re.sub(r"^data:image/.+;base64,", "", src_loc)
             return base64.b64decode(data)

--- a/docling/utils/http_client.py
+++ b/docling/utils/http_client.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+import requests
+from requests import Response, Session
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
+
+# Status codes worth retrying because they are transient or throttling related.
+_DEFAULT_STATUS_FORCELIST = (408, 425, 429, 500, 502, 503, 504)
+
+# Methods that are safe or idempotent enough for retries in our usage.
+_DEFAULT_ALLOWED_METHODS = frozenset(
+    ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
+)
+
+
+def _build_retry(
+    *,
+    total: int = 5,
+    backoff_factor: float = 0.2,
+    status_forcelist: Iterable[int] = _DEFAULT_STATUS_FORCELIST,
+    allowed_methods: Iterable[str] | None = _DEFAULT_ALLOWED_METHODS,
+) -> Retry:
+    return Retry(
+        total=total,
+        read=total,
+        connect=total,
+        status=total,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+        allowed_methods=frozenset(allowed_methods) if allowed_methods else None,
+        raise_on_status=False,
+    )
+
+
+def create_retry_session(
+    *,
+    total: int = 5,
+    backoff_factor: float = 0.2,
+    status_forcelist: Iterable[int] = _DEFAULT_STATUS_FORCELIST,
+    allowed_methods: Iterable[str] | None = _DEFAULT_ALLOWED_METHODS,
+) -> Session:
+    """Return a requests Session configured with retry/backoff handling."""
+    session = requests.Session()
+    retry = _build_retry(
+        total=total,
+        backoff_factor=backoff_factor,
+        status_forcelist=status_forcelist,
+        allowed_methods=allowed_methods,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
+
+
+_DEFAULT_SESSION: Session | None = None
+
+
+def get_retry_session() -> Session:
+    """Return the lazily-created default retry-enabled Session."""
+    global _DEFAULT_SESSION
+    if _DEFAULT_SESSION is None:
+        _DEFAULT_SESSION = create_retry_session()
+    return _DEFAULT_SESSION
+
+
+def request_with_retry(
+    method: str,
+    url: str,
+    *,
+    session: Session | None = None,
+    **kwargs,
+) -> Response:
+    """Perform an HTTP request using a retry-enabled Session."""
+    sess = session or get_retry_session()
+    return sess.request(method=method, url=url, **kwargs)

--- a/docling/utils/http_client.py
+++ b/docling/utils/http_client.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Collection, Iterable
 
 import requests
 from requests import Response, Session
@@ -20,7 +20,7 @@ def _build_retry(
     *,
     total: int = 5,
     backoff_factor: float = 0.2,
-    status_forcelist: Iterable[int] = _DEFAULT_STATUS_FORCELIST,
+    status_forcelist: Collection[int] = _DEFAULT_STATUS_FORCELIST,
     allowed_methods: Iterable[str] | None = _DEFAULT_ALLOWED_METHODS,
 ) -> Retry:
     return Retry(
@@ -39,7 +39,7 @@ def create_retry_session(
     *,
     total: int = 5,
     backoff_factor: float = 0.2,
-    status_forcelist: Iterable[int] = _DEFAULT_STATUS_FORCELIST,
+    status_forcelist: Collection[int] = _DEFAULT_STATUS_FORCELIST,
     allowed_methods: Iterable[str] | None = _DEFAULT_ALLOWED_METHODS,
 ) -> Session:
     """Return a requests Session configured with retry/backoff handling."""

--- a/docling/utils/utils.py
+++ b/docling/utils/utils.py
@@ -4,8 +4,9 @@ from itertools import islice
 from pathlib import Path
 from typing import List, Union
 
-import requests
 from tqdm import tqdm
+
+from docling.utils.http_client import request_with_retry
 
 
 def chunkify(iterator, chunk_size):
@@ -46,7 +47,7 @@ def create_hash(string: str):
 
 def download_url_with_progress(url: str, progress: bool = False) -> BytesIO:
     buf = BytesIO()
-    with requests.get(url, stream=True, allow_redirects=True) as response:
+    with request_with_retry("GET", url, stream=True, allow_redirects=True) as response:
         total_size = int(response.headers.get("content-length", 0))
         progress_bar = tqdm(
             total=total_size,

--- a/tests/test_backend_html.py
+++ b/tests/test_backend_html.py
@@ -1,6 +1,6 @@
 from io import BytesIO
 from pathlib import Path, PurePath
-from unittest.mock import Mock, mock_open, patch
+from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import pytest
 from docling_core.types.doc import PictureItem
@@ -279,7 +279,7 @@ def test_e2e_html_conversion_with_images(mock_local, mock_remote):
     assert num_pic == 1, "No embedded picture was found in the converted file"
 
     # fetching image remotely
-    mock_resp = Mock()
+    mock_resp = MagicMock()
     mock_resp.status_code = 200
     mock_resp.content = img_bytes
     mock_resp.__enter__.return_value = mock_resp

--- a/tests/test_backend_html.py
+++ b/tests/test_backend_html.py
@@ -249,7 +249,7 @@ def test_e2e_html_conversions(html_paths):
         assert verify_document(doc, str(gt_path) + ".json", GENERATE)
 
 
-@patch("docling.backend.html_backend.requests.get")
+@patch("docling.backend.html_backend.request_with_retry")
 @patch("docling.backend.html_backend.open", new_callable=mock_open)
 def test_e2e_html_conversion_with_images(mock_local, mock_remote):
     source = "tests/data/html/example_01.html"
@@ -282,6 +282,8 @@ def test_e2e_html_conversion_with_images(mock_local, mock_remote):
     mock_resp = Mock()
     mock_resp.status_code = 200
     mock_resp.content = img_bytes
+    mock_resp.__enter__.return_value = mock_resp
+    mock_resp.__exit__.return_value = False
     mock_remote.return_value = mock_resp
     source_location = "https://example.com/example_01.html"
 
@@ -296,7 +298,7 @@ def test_e2e_html_conversion_with_images(mock_local, mock_remote):
     )
     res_remote = converter.convert(source)
     mock_remote.assert_called_once_with(
-        "https://example.com/example_image_01.png", stream=True
+        "GET", "https://example.com/example_image_01.png", stream=True
     )
     assert res_remote.document
     num_pic = 0


### PR DESCRIPTION
**Issue resolved by this Pull Request:** 
Resolves #2465 

Introduced a reusable retry-enabled HTTP helper (`docling.utils.http_client`) and refactored all existing remote `requests` calls to use it. This makes download helpers, HTML backend image fetches, and OpenAI-compatible image requests more resilient to transient errors and rate limiting without duplicating retry configuration.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
