### PR TITLE
fix(docx): handle missing value in paragraph style name

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -25,6 +25,7 @@ from docx import Document
 from docx.document import Document as DocxDocument
 from docx.oxml.table import CT_Tc
 from docx.oxml.xmlchemy import BaseOxmlElement
+from docx.styles.style import ParagraphStyle
 from docx.table import Table, _Cell
 from docx.text.hyperlink import Hyperlink
 from docx.text.paragraph import Paragraph
@@ -511,15 +512,17 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         if paragraph.style is None:
             return "Normal", None
 
-        label = paragraph.style.style_id
-        name = paragraph.style.name
-        base_style_label = None
-        base_style_name = None
-        if base_style := getattr(paragraph.style, "base_style", None):
+        label: str = paragraph.style.style_id
+        name: str = paragraph.style.name or ""
+        base_style_label: Optional[str] = None
+        base_style_name: Optional[str] = None
+        if isinstance(
+            base_style := getattr(paragraph.style, "base_style", None), ParagraphStyle
+        ):
             base_style_label = base_style.style_id
             base_style_name = base_style.name
 
-        if label is None:
+        if not label:
             return "Normal", None
 
         if ":" in label:


### PR DESCRIPTION
The `MsWordDocumentBackend` implements the function `_get_label_and_level` to extract the style label and name of paragraphs. It tries to find out if those paragraphs represent a document heading.
However, the current implementation assumes that the style name will always be a string, which may trigger an `AttributeError` in case it is `None`.

This PR adds a defensive type check on the paragraph style name and other variables in `_get_label_and_level`.

Resolves #2759

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
