### PR TITLE
chore: `mkdocstring` python handler to render pydantic field

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -197,9 +197,9 @@ plugins:
             extensions:
               - griffe_pydantic:
                   schema: true
-          preload_modules:
-            - docling
-            - docling_core
+            preload_modules:
+              - docling
+              - docling_core
 
 extra_css:
   - stylesheets/extra.css


### PR DESCRIPTION
Prerequisite for #2747

This will make `griffe_pydantic` work

Unfortunately this will only work when the Field is defined like:

```python
class A(BaseModel):
    a: bool = Field(False, description="Text that renders")
```

It won't work with Annotated fields :(

```python
class A(BaseModel):
    a: Annotated[bool, Field(False, description="Text that does NOT render")]
```

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
