### PR TITLE
docs: add Pydantic field documentation for PipelineOptions

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -2,7 +2,7 @@ import logging
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
-from typing import Any, ClassVar, Dict, List, Literal, Optional, Union
+from typing import Annotated, Any, ClassVar, Dict, List, Literal, Optional, Union
 
 from pydantic import (
     AnyUrl,
@@ -10,7 +10,7 @@ from pydantic import (
     ConfigDict,
     Field,
 )
-from typing_extensions import Annotated, deprecated
+from typing_extensions import deprecated
 
 from docling.datamodel import asr_model_specs, vlm_model_specs
 


### PR DESCRIPTION
Solved part of the issue #2747

This PR adds Pydantic Annotated + Field metadata for all configurable fields in Class PipelineOptions.
These additions improve schema clarity, autocompletion, and downstream documentation generation without changing any functional behavior.
