### PR TITLE
docs(style): fix link visibility in dark mode

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -60,10 +60,10 @@
 
 /* Links */
 [data-md-color-scheme="slate"] a {
-    color: rgba(233, 219, 189, 0.90) !important;
+    color: rgba(88, 166, 255, 0.90) !important;
 }
 [data-md-color-scheme="slate"] a:hover {
-    color: rgba(233, 219, 189, 0.90) !important;
+    color: rgba(121, 192, 255, 0.90) !important;
 }
 
 /* Code blocks */


### PR DESCRIPTION
Hello, I noticed that links were using the same color as regular text making them indistinguishable in dark mode (default). This PR changes the color of links to a different color for better accessibility in dark more. This has been bugging me for a while, so I am creating this PR to fix this 😅.

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
