### PR TITLE
fix: font download by passing font_path to RapidOcr

### DIFF
--- a/docling/models/rapid_ocr_model.py
+++ b/docling/models/rapid_ocr_model.py
@@ -181,7 +181,7 @@ class RapidOcrModel(BaseOcrModel):
             params = {
                 # Global settings (these are still correct)
                 "Global.text_score": self.options.text_score,
-                "Global.font_path": self.options.font_path,
+                "Global.font_path": font_path,
                 # "Global.verbose": self.options.print_verbose,
                 # Detection model settings
                 "Det.model_path": det_model_path,
@@ -195,7 +195,7 @@ class RapidOcrModel(BaseOcrModel):
                 "Cls.intra_op_num_threads": intra_op_num_threads,
                 # Recognition model settings
                 "Rec.model_path": rec_model_path,
-                "Rec.font_path": self.options.rec_font_path,
+                "Rec.font_path": font_path,
                 "Rec.rec_keys_path": rec_keys_path,
                 "Rec.use_cuda": use_cuda,
                 "Rec.use_dml": use_dml,


### PR DESCRIPTION
completing fix for https://github.com/docling-project/docling-serve/issues/464

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

Resolves
https://github.com/docling-project/docling-serve/issues/464 
https://github.com/docling-project/docling-serve/issues/375

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
