### PR TITLE
fix(cli): Add Layout and Table models to --show-external-plugins

### DIFF
--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -100,7 +100,12 @@ from docling.document_converter import (
     PowerpointFormatOption,
     WordFormatOption,
 )
-from docling.models.factories import get_ocr_factory
+from docling.models.factories import (
+    get_layout_factory,
+    get_ocr_factory,
+    get_table_structure_factory,
+)
+from docling.models.factories.base_factory import BaseFactory
 from docling.pipeline.asr_pipeline import AsrPipeline
 from docling.pipeline.vlm_pipeline import VlmPipeline
 
@@ -182,18 +187,27 @@ def version_callback(value: bool):
 def show_external_plugins_callback(value: bool):
     if value:
         ocr_factory_all = get_ocr_factory(allow_external_plugins=True)
-        table = rich.table.Table(title="Available OCR engines")
-        table.add_column("Name", justify="right")
-        table.add_column("Plugin")
-        table.add_column("Package")
-        for meta in ocr_factory_all.registered_meta.values():
-            if not meta.module.startswith("docling."):
-                table.add_row(
-                    f"[bold]{meta.kind}[/bold]",
-                    meta.plugin_name,
-                    meta.module.split(".")[0],
-                )
-        rich.print(table)
+        layout_factory_all = get_layout_factory(allow_external_plugins=True)
+        table_factory_all = get_table_structure_factory(allow_external_plugins=True)
+
+        def print_external_plugins(factory: BaseFactory, factory_name: str):
+            table = rich.table.Table(title=f"Available {factory_name} engines")
+            table.add_column("Name", justify="right")
+            table.add_column("Plugin")
+            table.add_column("Package")
+            for meta in factory.registered_meta.values():
+                if not meta.module.startswith("docling."):
+                    table.add_row(
+                        f"[bold]{meta.kind}[/bold]",
+                        meta.plugin_name,
+                        meta.module.split(".")[0],
+                    )
+            rich.print(table)
+
+        print_external_plugins(ocr_factory_all, "OCR")
+        print_external_plugins(layout_factory_all, "layout")
+        print_external_plugins(table_factory_all, "table")
+
         raise typer.Exit()
 
 


### PR DESCRIPTION
Since the introduction of factory and plugin-capability for Layout and Table models in #2637, the `--show-external-plugins` CLI option should return the available engines for Layout and Table models in addition to the OCR ones. This was missed at the time and the option remained showing only external OCR engines.

This pull request updates the CLI program to fix it.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
