### PR TITLE
fix: standardize page_no to 1-based indexing

### DIFF
--- a/docling/models/base_model.py
+++ b/docling/models/base_model.py
@@ -213,7 +213,7 @@ class BaseItemAndImageEnrichmentModel(
             coord_origin=bbox.coord_origin,
         )
 
-        page_ix = element_prov.page_no - conv_res.pages[0].page_no - 1
+        page_ix = element_prov.page_no - conv_res.pages[0].page_no
         cropped_image = conv_res.pages[page_ix].get_image(
             scale=self.images_scale, cropbox=expanded_bbox
         )

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -81,7 +81,7 @@ class ReadingOrderModel:
         for child in element.cluster.children:
             c_label = child.label
             c_bbox = child.bbox.to_bottom_left_origin(
-                doc.pages[element.page_no + 1].size.height
+                doc.pages[element.page_no].size.height
             )
             c_text = " ".join(
                 [
@@ -92,7 +92,7 @@ class ReadingOrderModel:
             )
 
             c_prov = ProvenanceItem(
-                page_no=element.page_no + 1, charspan=(0, len(c_text)), bbox=c_bbox
+                page_no=element.page_no, charspan=(0, len(c_text)), bbox=c_bbox
             )
             if c_label == DocItemLabel.LIST_ITEM:
                 # TODO: Infer if this is a numbered or a bullet list item
@@ -142,7 +142,7 @@ class ReadingOrderModel:
         out_doc: DoclingDocument = DoclingDocument(name=doc_name, origin=origin)
 
         for page in conv_res.pages:
-            page_no = page.page_no + 1
+            page_no = page.page_no
             size = page.size
 
             assert size is not None, "Page size is not initialized."
@@ -174,7 +174,7 @@ class ReadingOrderModel:
                 if element.label == DocItemLabel.CODE:
                     cap_text = element.text
                     prov = ProvenanceItem(
-                        page_no=element.page_no + 1,
+                        page_no=element.page_no,
                         charspan=(0, len(cap_text)),
                         bbox=element.cluster.bbox.to_bottom_left_origin(page_height),
                     )
@@ -230,7 +230,7 @@ class ReadingOrderModel:
                     )
 
                 prov = ProvenanceItem(
-                    page_no=element.page_no + 1,
+                    page_no=element.page_no,
                     charspan=(0, 0),
                     bbox=element.cluster.bbox.to_bottom_left_origin(page_height),
                 )
@@ -286,7 +286,7 @@ class ReadingOrderModel:
             elif isinstance(element, FigureElement):
                 cap_text = ""
                 prov = ProvenanceItem(
-                    page_no=element.page_no + 1,
+                    page_no=element.page_no,
                     charspan=(0, len(cap_text)),
                     bbox=element.cluster.bbox.to_bottom_left_origin(page_height),
                 )
@@ -330,7 +330,7 @@ class ReadingOrderModel:
         assert isinstance(elem, TextElement)
         text = elem.text
         prov = ProvenanceItem(
-            page_no=elem.page_no + 1,
+            page_no=elem.page_no,
             charspan=(0, len(text)),
             bbox=elem.cluster.bbox.to_bottom_left_origin(page_height),
         )
@@ -343,7 +343,7 @@ class ReadingOrderModel:
         cap_text = element.text
 
         prov = ProvenanceItem(
-            page_no=element.page_no + 1,
+            page_no=element.page_no,
             charspan=(0, len(cap_text)),
             bbox=element.cluster.bbox.to_bottom_left_origin(page_height),
         )
@@ -391,7 +391,7 @@ class ReadingOrderModel:
             "Labels of merged elements must match."
         )
         prov = ProvenanceItem(
-            page_no=merged_elem.page_no + 1,
+            page_no=merged_elem.page_no,
             charspan=(
                 len(new_item.text) + 1,
                 len(new_item.text) + 1 + len(merged_elem.text),

--- a/docling/pipeline/base_pipeline.py
+++ b/docling/pipeline/base_pipeline.py
@@ -216,7 +216,7 @@ class PaginatedPipeline(ConvertPipeline):  # TODO this is a bad name.
             for i in range(conv_res.input.page_count):
                 start_page, end_page = conv_res.input.limits.page_range
                 if (start_page - 1) <= i <= (end_page - 1):
-                    conv_res.pages.append(Page(page_no=i))
+                    conv_res.pages.append(Page(page_no=i + 1))
 
             try:
                 total_pages_processed = 0

--- a/docling/pipeline/legacy_standard_pdf_pipeline.py
+++ b/docling/pipeline/legacy_standard_pdf_pipeline.py
@@ -145,7 +145,7 @@ class LegacyStandardPdfPipeline(PaginatedPipeline):
 
     def initialize_page(self, conv_res: ConversionResult, page: Page) -> Page:
         with TimeRecorder(conv_res, "page_init"):
-            page._backend = conv_res.input._backend.load_page(page.page_no)  # type: ignore
+            page._backend = conv_res.input._backend.load_page(page.page_no - 1)  # type: ignore
             if page._backend is not None and page._backend.is_valid():
                 page.size = page._backend.get_size()
 
@@ -176,7 +176,7 @@ class LegacyStandardPdfPipeline(PaginatedPipeline):
             if self.pipeline_options.generate_page_images:
                 for page in conv_res.pages:
                     assert page.image is not None
-                    page_no = page.page_no + 1
+                    page_no = page.page_no
                     conv_res.document.pages[page_no].image = ImageRef.from_pil(
                         page.image, dpi=int(72 * self.pipeline_options.images_scale)
                     )

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -372,7 +372,7 @@ class PreprocessThreadedStage(ThreadedPipelineStage):
                         assert isinstance(backend, PdfDocumentBackend), (
                             "Threaded pipeline only supports PdfDocumentBackend."
                         )
-                        page_backend = backend.load_page(page.page_no)
+                        page_backend = backend.load_page(page.page_no - 1)
                         page._backend = page_backend
                         if page_backend.is_valid():
                             page.size = page_backend.get_size()
@@ -603,7 +603,7 @@ class StandardPdfPipeline(ConvertPipeline):
         pages: list[Page] = []
         for i in range(conv_res.input.page_count):
             if start_page - 1 <= i <= end_page - 1:
-                page = Page(page_no=i)
+                page = Page(page_no=i + 1)
                 conv_res.pages.append(page)
                 pages.append(page)
 
@@ -717,7 +717,7 @@ class StandardPdfPipeline(ConvertPipeline):
         ]
         # Add error details from failed pages
         for page_no, error in proc.failed_pages:
-            page_label = f"Page {page_no + 1}" if page_no >= 0 else "Unknown page"
+            page_label = f"Page {page_no}" if page_no > 0 else "Unknown page"
             error_msg = str(error) if error else ""
             error_item = ErrorItem(
                 component_type=DoclingComponentType.PIPELINE,
@@ -762,7 +762,7 @@ class StandardPdfPipeline(ConvertPipeline):
             if self.pipeline_options.generate_page_images:
                 for page in conv_res.pages:
                     assert page.image is not None
-                    page_no = page.page_no + 1
+                    page_no = page.page_no
                     conv_res.document.pages[page_no].image = ImageRef.from_pil(
                         page.image, dpi=int(72 * self.pipeline_options.images_scale)
                     )
@@ -785,7 +785,7 @@ class StandardPdfPipeline(ConvertPipeline):
                             isinstance(element, TableItem)
                             and self.pipeline_options.generate_table_images
                         ):
-                            page_ix = element.prov[0].page_no - 1
+                            page_ix = element.prov[0].page_no
                             page = next(
                                 (p for p in conv_res.pages if p.page_no == page_ix),
                                 cast("Page", None),


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #2654

### Description
Standardizes `Page.page_no` to use 1-based indexing throughout the pipeline, ensuring consistency with `DoclingDocument.pages` keys and backend conventions.

**Changes:**
- Updated [StandardPdfPipeline](cci:2://file:///Users/danishkhan/Downloads/codes/contributions/docling/docling/pipeline/standard_pdf_pipeline.py:412:0-842:44) to initialize [Page](cci:2://file:///Users/danishkhan/Downloads/codes/contributions/docling/docling/datamodel/base_models.py:296:0-354:62) objects with 1-based `page_no`.
- Removed redundant page number adjustments/offsets in [ReadingOrderModel](cci:2://file:///Users/danishkhan/Downloads/codes/contributions/docling/docling/models/readingorder_model.py:41:0-430:26) and other pipeline stages to respect the canonical 1-based `page_no`.
- Ensures that `Page.page_no` aligns with `DoclingDocument.pages` keys (e.g., Page 1 is key 1).

**Checklist:**

- [ ] Documentation has been updated, if necessary. (Pending maintainer feedback on whether/where to document this change)
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary. (Verified locally; ready to add formal test case if requested)