### PR TITLE
fix(logging): include page numbers in preprocess error messages

### DIFF
--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -390,7 +390,10 @@ class PreprocessThreadedStage(ThreadedPipelineStage):
                 page_numbers = [it.page_no for it in good]
                 _log.error(
                     "Stage preprocess failed for run %d, pages %s: %s",
-                    rid, page_numbers, exc
+                    rid,
+                    page_numbers,
+                    exc,
+                    exc_info=False,  # Put to True if you want detailed exception info
                 )
                 for it in good:
                     it.is_failed = True


### PR DESCRIPTION
## Description

Previously, when a page failed to parse, only the run ID was logged:

`ERROR - Stage preprocess failed for run 1: Invalid code point`

Users had no way to identify which specific page caused the failure, making debugging difficult. Now the error message includes the page number(s) that failed:

`ERROR - Stage preprocess failed for run 1, pages [79]: Invalid code point`

This makes it much easier to identify and investigate problematic pages in large documents.

## Changes

- Modified `docling/pipeline/standard_pdf_pipeline.py` to extract and log page numbers from failed items in the exception handler

## Issue resolved by this Pull Request:
Resolves #2857

## Checklist:

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
