### PR TITLE
docs(example): fix update sample image path to be relative

### DIFF
--- a/docs/examples/experimental/process_table_crops.py
+++ b/docs/examples/experimental/process_table_crops.py
@@ -17,7 +17,9 @@ from docling.models.factories import get_layout_factory
 
 def main() -> None:
     # Go up 3 levels to escape 'docs' and reach the repo root
-    sample_image = Path(__file__).parent / "../../../tests/data/2305.03393v1-table_crop.png"
+    sample_image = (
+        Path(__file__).parent / "../../../tests/data/2305.03393v1-table_crop.png"
+    )
 
     pipeline_options = ThreadedPdfPipelineOptions(
         layout_options=TableCropsLayoutOptions(),


### PR DESCRIPTION
The example script currently uses a relative path (tests\data\...) to load the sample image. This causes a FileNotFoundError if the script is not executed strictly from the repository root (e.g., when running directly from an IDE or the script's own directory).

This change updates the script to determine the path dynamically using pathlib, ensuring the sample image is found regardless of the working directory from which the script is executed.
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->