### PR TITLE
fix: Relax pypdfium2 dependency constraint

### DIFF
--- a/docling/backend/pypdfium2_backend.py
+++ b/docling/backend/pypdfium2_backend.py
@@ -104,6 +104,7 @@ _log = logging.getLogger(__name__)
 # pypdfium2 5.x renamed PdfObject.get_pos() -> get_bounds()
 _PYPDFIUM2_MAJOR_VERSION = int(version("pypdfium2").split(".")[0])
 
+
 class PyPdfiumPageBackend(PdfPageBackend):
     def __init__(
         self, pdfium_doc: pdfium.PdfDocument, document_hash: str, page_no: int

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ dependencies = [
   'docling-parse (>=4.7.0,<5.0.0)',
   "docling-ibm-models>=3.9.1,<4",
   'filetype (>=1.2.0,<2.0.0)',
-  'pypdfium2 (==5.3.0)',
+  'pypdfium2 (>=4.30.0,!=4.30.1,<6.0.0)',
   'pydantic-settings (>=2.3.0,<3.0.0)',
   'huggingface_hub (>=0.23,<1)',
   'requests (>=2.32.2,<3.0.0)',

--- a/uv.lock
+++ b/uv.lock
@@ -1643,7 +1643,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.3.0,<3.0.0" },
     { name = "pylatexenc", specifier = ">=2.10,<3.0" },
-    { name = "pypdfium2", specifier = "==5.3.0" },
+    { name = "pypdfium2", specifier = ">=4.30.0,!=4.30.1,<6.0.0" },
     { name = "python-docx", specifier = ">=1.1.2,<2.0.0" },
     { name = "python-pptx", specifier = ">=1.0.2,<2.0.0" },
     { name = "qwen-vl-utils", marker = "extra == 'vlm'", specifier = ">=0.0.11" },


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.

This PR relaxes the pypdfium2 dependency constraint from `<5.0.0` to `<6.0.0` while continuing to exclude the known `4.30.1` release. uv.lock updated accordingly.

Rationale:
- The APIs remain compatible with pypdfium2 5.x
- Improves compatibility with newer environments and provides stability.
- pypdfium2 >=5.2.0 now supports ppc64le.

Tests:
- Core and PDF backend tests pass

Fixes #2793 
