### PR TITLE
docs: correct broken link to supported formats

### DIFF
--- a/docs/getting_started/quickstart.md
+++ b/docs/getting_started/quickstart.md
@@ -19,7 +19,7 @@ doc = converter.convert(source).document
 print(doc.export_to_markdown())  # output: "### Docling Technical Report[...]"
 ```
 
-Docling supports a wide array of [file formats](./supported_formats.md) and, as outlined in the
+Docling supports a wide array of [file formats](../usage/supported_formats.md) and, as outlined in the
 [architecture](../concepts/architecture.md) guide, provides a versatile document model along with a full suite of
 supported operations.
 


### PR DESCRIPTION
Correct broken link to supported formats