### PR TITLE
fix: off-by-one error for page indexing in vlm_pipeline

### DIFF
--- a/docling/experimental/pipeline/threaded_layout_vlm_pipeline.py
+++ b/docling/experimental/pipeline/threaded_layout_vlm_pipeline.py
@@ -235,7 +235,7 @@ class ThreadedLayoutVlmPipeline(BasePipeline):
         images_scale = self.pipeline_options.images_scale
         for i in range(conv_res.input.page_count):
             if start_page - 1 <= i <= end_page - 1:
-                page = Page(page_no=i)
+                page = Page(page_no=i + 1)
                 if images_scale is not None:
                     page._default_image_scale = images_scale
                 page._backend = backend.load_page(i)

--- a/docling/pipeline/vlm_pipeline.py
+++ b/docling/pipeline/vlm_pipeline.py
@@ -124,7 +124,7 @@ class VlmPipeline(PaginatedPipeline):
             images_scale = self.pipeline_options.images_scale
             if images_scale is not None:
                 page._default_image_scale = images_scale
-            page._backend = conv_res.input._backend.load_page(page.page_no)  # type: ignore
+            page._backend = conv_res.input._backend.load_page(page.page_no - 1)  # type: ignore
             if page._backend is not None and page._backend.is_valid():
                 page.size = page._backend.get_size()
 


### PR DESCRIPTION
Fixes an off-by-one error for page indexing in the VLM pipeline, introduced with docling 2.69.0.

**Issue resolved by this Pull Request:**
Resolves #2901


**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
