### PR TITLE
chore: Add CI tests for pip install without lock file

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -339,14 +339,19 @@ jobs:
             uv venv /tmp/venv-nodev-${py_version} --python=${py_version}
             source /tmp/venv-nodev-${py_version}/bin/activate
             
-            # Find and remove Python.h from the uv-managed Python installation
-            echo "Removing Python development headers from uv Python installation..."
+            # Find and remove Python.h from the Python installation
+            echo "Removing Python development headers from Python installation..."
             python_include_dir=$(python -c "import sysconfig; print(sysconfig.get_path('include'))")
             echo "Python include directory: $python_include_dir"
             
             if [ -f "$python_include_dir/Python.h" ]; then
               echo "Found Python.h, removing it and other headers..."
-              rm -rf "$python_include_dir"/*
+              # Use sudo if the directory is system-owned
+              if [ -w "$python_include_dir" ]; then
+                rm -rf "$python_include_dir"/*
+              else
+                sudo rm -rf "$python_include_dir"/*
+              fi
               echo "✓ Headers removed"
             else
               echo "Warning: Python.h not found at expected location"


### PR DESCRIPTION
## Summary

Adds two new CI test jobs to validate that the package can be installed correctly using standard `pip install` without lock files, simulating real user installation scenarios.

## Changes

### 1. test-pip-install-no-lock
- Tests standard pip installation without lock file
- Installs all extras: `[easyocr,tesserocr,vlm,rapidocr,asr]`
- Runs across Python 3.10-3.14
- Verifies basic import functionality

### 2. test-pip-install-no-dev-headers
- Tests pip installation in environments without Python development components
- Removes Python development headers to simulate systems without build tools
- Uses `--only-binary=:all:` to force binary-only packages (prevents compilation)
- Excludes `tesserocr` extra which requires compilation
- Runs across Python 3.10-3.14
- Will fail if any dependency attempts to compile from source (e.g., missing Python.h)

## Motivation

These tests ensure that:
1. Users can install the package without needing lock files
2. The package works in environments without C/C++ build tools
3. All dependencies have binary wheels available for supported platforms