### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -16,11 +16,11 @@ jobs:
     outputs:
       TARGET_TAG_V: ${{ steps.version_check.outputs.TRGT_VERSION }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # for fetching tags, required for semantic-release
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install dependencies
@@ -40,17 +40,17 @@ jobs:
     runs-on: ubuntu-latest
     concurrency: release
     steps:
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@v2
         id: app-token
         with:
           app-id: ${{ vars.CI_APP_ID }}
           private-key: ${{ secrets.CI_PRIVATE_KEY }}
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0  # for fetching tags, required for semantic-release
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
       - name: Install dependencies

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -30,10 +30,10 @@ jobs:
       matrix:
         python-version: ["3.12"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -42,7 +42,7 @@ jobs:
         run: echo "PY=$(python -VV | sha256sum | cut -d' ' -f1)" >> "$GITHUB_ENV"
 
       - name: Cache pre-commit environments
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/pre-commit
           key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
@@ -64,14 +64,14 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Grant permissions to APT cache directory # allows restore
         run: sudo chown -R $USER:$USER /var/cache/apt/archives
 
       - name: Cache APT packages
         id: apt-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /var/cache/apt/archives
           key: apt-packages-${{ runner.os }}-${{ hashFiles('.github/workflows/checks.yml') }}
@@ -87,7 +87,7 @@ jobs:
         run: echo "TESSDATA_PREFIX=$(dpkg -L tesseract-ocr-eng | grep tessdata$)" >> "$GITHUB_ENV"
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -95,7 +95,7 @@ jobs:
         run: uv sync --frozen --all-extras
 
       - name: Cache Models
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/huggingface
@@ -131,14 +131,14 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Grant permissions to APT cache directory # allows restore
         run: sudo chown -R $USER:$USER /var/cache/apt/archives
 
       - name: Cache APT packages
         id: apt-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /var/cache/apt/archives
           key: apt-packages-${{ runner.os }}-${{ hashFiles('.github/workflows/checks.yml') }}
@@ -154,7 +154,7 @@ jobs:
         run: echo "TESSDATA_PREFIX=$(dpkg -L tesseract-ocr-eng | grep tessdata$)" >> "$GITHUB_ENV"
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -162,7 +162,7 @@ jobs:
         run: uv sync --frozen --all-extras
 
       - name: Cache Models
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/huggingface
@@ -203,14 +203,14 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Grant permissions to APT cache directory # allows restore
         run: sudo chown -R $USER:$USER /var/cache/apt/archives
 
       - name: Cache APT packages
         id: apt-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /var/cache/apt/archives
           key: apt-packages-${{ runner.os }}-${{ hashFiles('.github/workflows/checks.yml') }}
@@ -226,7 +226,7 @@ jobs:
         run: echo "TESSDATA_PREFIX=$(dpkg -L tesseract-ocr-eng | grep tessdata$)" >> "$GITHUB_ENV"
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -234,7 +234,7 @@ jobs:
         run: uv sync --frozen --all-extras
 
       - name: Cache Models
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/huggingface
@@ -293,10 +293,10 @@ jobs:
       matrix:
         python-version: ["3.12"]
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true
@@ -311,7 +311,7 @@ jobs:
         run: unzip -l dist/*.whl
 
       - name: Store the distribution packages
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: python-package-distributions
           path: dist/
@@ -325,13 +325,13 @@ jobs:
         python-version: ["3.12"]
     steps:
       - name: Download all the dists
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           name: python-package-distributions
           path: dist/
 
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
           activate-environment: true

--- a/.github/workflows/dco-advisor.yml
+++ b/.github/workflows/dco-advisor.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Handle DCO check result
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,9 +13,9 @@ jobs:
     run-docs:
         runs-on: ubuntu-latest
         steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - name: Install uv and set the python version
-          uses: astral-sh/setup-uv@v5
+          uses: astral-sh/setup-uv@v7
           with:
             python-version: ${{ matrix.python-version }}
             enable-cache: true

--- a/.github/workflows/pr-reminders.yml
+++ b/.github/workflows/pr-reminders.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Check PRs blocked by workflow approval
         id: filter
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,9 +22,9 @@ jobs:
     permissions:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install uv and set the python version
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           python-version: ${{ matrix.python-version }}
           enable-cache: true


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

**Commit Message Formatting:**  
Updates GitHub Action versions  

**Checklist:**  
- [ ] Documentation has been updated, if necessary.  
- [ ] Examples have been added, if necessary.  
- [ ] Tests have been added, if necessary.  

**Issue resolved by this Pull Request:**  
Resolves # (if applicable)  

**Description:**  
This PR updates outdated GitHub Action versions across multiple workflows:  
- `actions/github-script` (v7 → v8)  
- `astral-sh/setup-uv` (v5 → v7)  
- `actions/upload-artifact` (v4 → v6)  
- `actions/checkout` (v4 → v6, v5 → v6)  
- `actions/cache` (v4 → v5)  
- `actions/download-artifact` (v4 → v7)  
- `actions/checkout` (v5 → v6)  
- `astral-sh/setup-uv` (v5 → v7)  
- `actions/checkout` (v4 → v6)  
- `astral-sh/setup-uv` (v5 → v7)  
- `actions/checkout` (v4 → v6)  
- `actions/checkout` (v4 → v6)  

The changes ensure compatibility with newer GitHub Actions versions while maintaining stability. The PR title follows conventional commit message formatting.