### PR TITLE
docs: improve introduction page with clearer examples

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -1,6 +1,13 @@
 To use Docling, simply install `docling` from your Python package manager, e.g. pip:
+
 ```bash
 pip install docling
+```
+
+Or using Astral `uv`:
+
+```bash
+uv add docling
 ```
 
 Works on macOS, Linux, and Windows, with support for both x86_64 and arm64 architectures.
@@ -39,39 +46,74 @@ Works on macOS, Linux, and Windows, with support for both x86_64 and arm64 archi
     poetry add docling
     ```
 
+## CPU-only setup with uv
+
+When using `uv` for dependency management, you can configure CPU-only PyTorch builds through your `pyproject.toml`. This is particularly useful for server deployments or environments without GPU support.
+
+Add the following configuration to your `pyproject.toml`:
+
+```toml
+[project]
+name = "your-project"
+version = "0.1.0"
+requires-python = ">=3.11"
+dependencies = [
+    "docling>=2.71.0",
+    "torch>=2.0.0",
+    "torchvision>=0.15.0",
+    # ... other dependencies
+]
+
+[tool.uv.sources]
+# Force PyTorch packages to use CPU-only builds
+torch = { index = "pytorch-cpu" }
+torchvision = { index = "pytorch-cpu" }
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+```
+
+Then sync your dependencies:
+
+```bash
+uv lock
+uv sync
+```
+
+This configuration ensures that `torch` and `torchvision` are installed from the CPU-only PyTorch index, significantly reducing installation size and avoiding CUDA dependencies.
+
 ## Available extras
 
 The `docling` package is designed to offer a working solution for the Docling default options.
 Some Docling functionalities require additional third-party packages and are therefore installed only if selected as extras (or installed independently).
 
 The following table summarizes the extras available in the `docling` package. They can be activated with:
-`pip install "docling[NAME1,NAME2]"`
+`pip install "docling[NAME1,NAME2]"` or `uv add "docling[NAME1,NAME2]"`
 
-
-| Extra | Description |
-| - | - |
-| `asr` | Installs dependencies for running the ASR pipeline. |
-| `vlm` | Installs dependencies for running the VLM pipeline. |
-| `easyocr` | Installs the [EasyOCR](https://github.com/JaidedAI/EasyOCR) OCR engine. |
-| `tesserocr` | Installs the Tesseract binding for using it as OCR engine. |
-| `ocrmac` | Installs the OcrMac OCR engine. |
-| `rapidocr` | Installs the [RapidOCR](https://github.com/RapidAI/RapidOCR) OCR engine with [onnxruntime](https://github.com/microsoft/onnxruntime/) backend. |
-
+| Extra       | Description                                                                                                                                    |
+| ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| `asr`       | Installs dependencies for running the ASR pipeline.                                                                                            |
+| `vlm`       | Installs dependencies for running the VLM pipeline.                                                                                            |
+| `easyocr`   | Installs the [EasyOCR](https://github.com/JaidedAI/EasyOCR) OCR engine.                                                                        |
+| `tesserocr` | Installs the Tesseract binding for using it as OCR engine.                                                                                     |
+| `ocrmac`    | Installs the OcrMac OCR engine.                                                                                                                |
+| `rapidocr`  | Installs the [RapidOCR](https://github.com/RapidAI/RapidOCR) OCR engine with [onnxruntime](https://github.com/microsoft/onnxruntime/) backend. |
 
 ### OCR engines
-
 
 Docling supports multiple OCR engines for processing scanned documents. The current version provides
 the following engines.
 
-| Engine | Installation | Usage |
-| ------ | ------------ | ----- |
-| [EasyOCR](https://github.com/JaidedAI/EasyOCR) | `easyocr` extra or via `pip install easyocr`. | `EasyOcrOptions` |
-| Tesseract | System dependency. See description for Tesseract and Tesserocr below.  | `TesseractOcrOptions` |
-| Tesseract CLI | System dependency. See description below. | `TesseractCliOcrOptions` |
-| OcrMac | System dependency. See description below. | `OcrMacOptions` |
-| [RapidOCR](https://github.com/RapidAI/RapidOCR) | `rapidocr` extra can or via `pip install rapidocr onnxruntime` | `RapidOcrOptions` |
-| [OnnxTR](https://github.com/felixdittrich92/OnnxTR) | Can be installed via the plugin system `pip install "docling-ocr-onnxtr[cpu]"`. Please take a look at [docling-OCR-OnnxTR](https://github.com/felixdittrich92/docling-OCR-OnnxTR).| `OnnxtrOcrOptions` |
+| Engine                                              | Installation                                                                                                                                                                       | Usage                    |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------ |
+| [EasyOCR](https://github.com/JaidedAI/EasyOCR)      | `easyocr` extra or via `pip install easyocr`.                                                                                                                                      | `EasyOcrOptions`         |
+| Tesseract                                           | System dependency. See description for Tesseract and Tesserocr below.                                                                                                              | `TesseractOcrOptions`    |
+| Tesseract CLI                                       | System dependency. See description below.                                                                                                                                          | `TesseractCliOcrOptions` |
+| OcrMac                                              | System dependency. See description below.                                                                                                                                          | `OcrMacOptions`          |
+| [RapidOCR](https://github.com/RapidAI/RapidOCR)     | `rapidocr` extra can or via `pip install rapidocr onnxruntime`                                                                                                                     | `RapidOcrOptions`        |
+| [OnnxTR](https://github.com/felixdittrich92/OnnxTR) | Can be installed via the plugin system `pip install "docling-ocr-onnxtr[cpu]"`. Please take a look at [docling-OCR-OnnxTR](https://github.com/felixdittrich92/docling-OCR-OnnxTR). | `OnnxtrOcrOptions`       |
 
 The Docling `DocumentConverter` allows to choose the OCR engine with the `ocr_options` settings. For example
 
@@ -128,15 +170,32 @@ doc_converter = DocumentConverter(
     If you get into installation issues of Tesserocr, we suggest using the following
     installation options:
 
+    **pip:**
+
     ```console
     pip uninstall tesserocr
     pip install --no-binary :all: tesserocr
+    ```
+
+    **uv:**
+
+    ```console
+    uv pip uninstall tesserocr
+    uv pip install --no-binary :all: tesserocr
     ```
 
 ## Development setup
 
 To develop Docling features, bugfixes etc., install as follows from your local clone's root dir:
 
+**uv:**
+
 ```bash
 uv sync --all-extras
+```
+
+**pip:**
+
+```bash
+pip install -e ".[all]"
 ```


### PR DESCRIPTION
Added uv specific examples to the installation documentation and a new detailed section about CPU only usage with uv as pytorch is a transitive dependency and can be hard to configure for new developpers.