### PR TITLE
chore: add deprecation flag for annotations

### DIFF
--- a/docling/datamodel/picture_classification_options.py
+++ b/docling/datamodel/picture_classification_options.py
@@ -28,7 +28,7 @@ class DocumentPictureClassifierOptions(
     # TODO: default should become False in a future release, and this field
     # may be removed entirely once docling-core drops the deprecated
     # `annotations` attribute from DoclingDocument items.
-    keep_deprecated_annotations: bool = True
+    _keep_deprecated_annotations: bool = True
 
     model_spec: ImageClassificationModelSpec = Field(
         default_factory=lambda: stage_model_specs.IMAGE_CLASSIFICATION_DOCUMENT_FIGURE.model_spec.model_copy(

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -72,11 +72,6 @@ class BaseOptions(BaseModel):
 
     kind: ClassVar[str]
 
-    # TODO: default should become False in a future release, and this field
-    # may be removed entirely once docling-core drops the deprecated
-    # `annotations` attribute from DoclingDocument items.
-    keep_deprecated_annotations: bool = True
-
 
 class TableFormerMode(str, Enum):
     """Operating modes for TableFormer table structure extraction model.
@@ -468,6 +463,11 @@ class OcrMacOptions(OcrOptions):
 
 class PictureDescriptionBaseOptions(BaseOptions):
     """Base configuration for picture description models."""
+
+    # TODO: default should become False in a future release, and this field
+    # may be removed entirely once docling-core drops the deprecated
+    # `annotations` attribute from DoclingDocument items.
+    _keep_deprecated_annotations: bool = True
 
     batch_size: Annotated[
         int,

--- a/docling/models/picture_description_base_model.py
+++ b/docling/models/picture_description_base_model.py
@@ -89,7 +89,7 @@ class PictureDescriptionBaseModel(
 
         for item, output in zip(elements, outputs):
             # FIXME: annotations is deprecated, remove once all consumers use meta.classification
-            if self.options.keep_deprecated_annotations:
+            if self.options._keep_deprecated_annotations:
                 item.annotations.append(
                     PictureDescriptionData(text=output, provenance=self.provenance)
                 )

--- a/docling/models/stages/picture_classifier/document_picture_classifier.py
+++ b/docling/models/stages/picture_classifier/document_picture_classifier.py
@@ -181,7 +181,7 @@ class DocumentPictureClassifier(
             ]
 
             # FIXME: annotations is deprecated, remove once all consumers use meta.classification
-            if self.options.keep_deprecated_annotations:
+            if self.options._keep_deprecated_annotations:
                 item.annotations.append(
                     PictureClassificationData(
                         provenance="DocumentPictureClassifier",

--- a/docling/pipeline/base_pipeline.py
+++ b/docling/pipeline/base_pipeline.py
@@ -167,11 +167,7 @@ class ConvertPipeline(BasePipeline):
             DocumentPictureClassifier(
                 enabled=pipeline_options.do_picture_classification,
                 artifacts_path=self.artifacts_path,
-                options=pipeline_options.picture_classification_options.model_copy(
-                    update={
-                        "keep_deprecated_annotations": pipeline_options.keep_deprecated_annotations
-                    }
-                ),
+                options=pipeline_options.picture_classification_options,
                 accelerator_options=pipeline_options.accelerator_options,
                 enable_remote_services=pipeline_options.enable_remote_services,
             ),


### PR DESCRIPTION
Add deprecation flag to BaseOptions to not populate `annotations`