### PR TITLE
fix(csv): set default delimiter by default

### DIFF
--- a/tests/data/csv/csv-single-column.csv
+++ b/tests/data/csv/csv-single-column.csv
@@ -1,0 +1,7 @@
+Industry
+Accounting/Finance
+Automotive
+Healthcare
+Hospitality/Travel
+Sales
+Other

--- a/tests/data/groundtruth/docling_v2/csv-comma-in-cell.csv.json
+++ b/tests/data/groundtruth/docling_v2/csv-comma-in-cell.csv.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.7.0",
+  "version": "1.9.0",
   "name": "csv-comma-in-cell",
   "origin": {
     "mimetype": "text/csv",

--- a/tests/data/groundtruth/docling_v2/csv-comma.csv.json
+++ b/tests/data/groundtruth/docling_v2/csv-comma.csv.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.7.0",
+  "version": "1.9.0",
   "name": "csv-comma",
   "origin": {
     "mimetype": "text/csv",

--- a/tests/data/groundtruth/docling_v2/csv-inconsistent-header.csv.json
+++ b/tests/data/groundtruth/docling_v2/csv-inconsistent-header.csv.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.7.0",
+  "version": "1.9.0",
   "name": "csv-inconsistent-header",
   "origin": {
     "mimetype": "text/csv",

--- a/tests/data/groundtruth/docling_v2/csv-pipe.csv.json
+++ b/tests/data/groundtruth/docling_v2/csv-pipe.csv.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.7.0",
+  "version": "1.9.0",
   "name": "csv-pipe",
   "origin": {
     "mimetype": "text/csv",

--- a/tests/data/groundtruth/docling_v2/csv-semicolon.csv.json
+++ b/tests/data/groundtruth/docling_v2/csv-semicolon.csv.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.7.0",
+  "version": "1.9.0",
   "name": "csv-semicolon",
   "origin": {
     "mimetype": "text/csv",

--- a/tests/data/groundtruth/docling_v2/csv-single-column.csv.itxt
+++ b/tests/data/groundtruth/docling_v2/csv-single-column.csv.itxt
@@ -1,0 +1,2 @@
+item-0 at level 0: unspecified: group _root_
+  item-1 at level 1: table with [7x1]

--- a/tests/data/groundtruth/docling_v2/csv-single-column.csv.json
+++ b/tests/data/groundtruth/docling_v2/csv-single-column.csv.json
@@ -1,0 +1,254 @@
+{
+  "schema_name": "DoclingDocument",
+  "version": "1.9.0",
+  "name": "csv-single-column",
+  "origin": {
+    "mimetype": "text/csv",
+    "binary_hash": 128044256216142336,
+    "filename": "csv-single-column.csv"
+  },
+  "furniture": {
+    "self_ref": "#/furniture",
+    "children": [],
+    "content_layer": "furniture",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "body": {
+    "self_ref": "#/body",
+    "children": [
+      {
+        "$ref": "#/tables/0"
+      }
+    ],
+    "content_layer": "body",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "groups": [],
+  "texts": [],
+  "pictures": [],
+  "tables": [
+    {
+      "self_ref": "#/tables/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "table",
+      "prov": [],
+      "captions": [],
+      "references": [],
+      "footnotes": [],
+      "data": {
+        "table_cells": [
+          {
+            "row_span": 1,
+            "col_span": 1,
+            "start_row_offset_idx": 0,
+            "end_row_offset_idx": 1,
+            "start_col_offset_idx": 0,
+            "end_col_offset_idx": 1,
+            "text": "Industry",
+            "column_header": true,
+            "row_header": false,
+            "row_section": false,
+            "fillable": false
+          },
+          {
+            "row_span": 1,
+            "col_span": 1,
+            "start_row_offset_idx": 1,
+            "end_row_offset_idx": 2,
+            "start_col_offset_idx": 0,
+            "end_col_offset_idx": 1,
+            "text": "Accounting/Finance",
+            "column_header": false,
+            "row_header": false,
+            "row_section": false,
+            "fillable": false
+          },
+          {
+            "row_span": 1,
+            "col_span": 1,
+            "start_row_offset_idx": 2,
+            "end_row_offset_idx": 3,
+            "start_col_offset_idx": 0,
+            "end_col_offset_idx": 1,
+            "text": "Automotive",
+            "column_header": false,
+            "row_header": false,
+            "row_section": false,
+            "fillable": false
+          },
+          {
+            "row_span": 1,
+            "col_span": 1,
+            "start_row_offset_idx": 3,
+            "end_row_offset_idx": 4,
+            "start_col_offset_idx": 0,
+            "end_col_offset_idx": 1,
+            "text": "Healthcare",
+            "column_header": false,
+            "row_header": false,
+            "row_section": false,
+            "fillable": false
+          },
+          {
+            "row_span": 1,
+            "col_span": 1,
+            "start_row_offset_idx": 4,
+            "end_row_offset_idx": 5,
+            "start_col_offset_idx": 0,
+            "end_col_offset_idx": 1,
+            "text": "Hospitality/Travel",
+            "column_header": false,
+            "row_header": false,
+            "row_section": false,
+            "fillable": false
+          },
+          {
+            "row_span": 1,
+            "col_span": 1,
+            "start_row_offset_idx": 5,
+            "end_row_offset_idx": 6,
+            "start_col_offset_idx": 0,
+            "end_col_offset_idx": 1,
+            "text": "Sales",
+            "column_header": false,
+            "row_header": false,
+            "row_section": false,
+            "fillable": false
+          },
+          {
+            "row_span": 1,
+            "col_span": 1,
+            "start_row_offset_idx": 6,
+            "end_row_offset_idx": 7,
+            "start_col_offset_idx": 0,
+            "end_col_offset_idx": 1,
+            "text": "Other",
+            "column_header": false,
+            "row_header": false,
+            "row_section": false,
+            "fillable": false
+          }
+        ],
+        "num_rows": 7,
+        "num_cols": 1,
+        "grid": [
+          [
+            {
+              "row_span": 1,
+              "col_span": 1,
+              "start_row_offset_idx": 0,
+              "end_row_offset_idx": 1,
+              "start_col_offset_idx": 0,
+              "end_col_offset_idx": 1,
+              "text": "Industry",
+              "column_header": true,
+              "row_header": false,
+              "row_section": false,
+              "fillable": false
+            }
+          ],
+          [
+            {
+              "row_span": 1,
+              "col_span": 1,
+              "start_row_offset_idx": 1,
+              "end_row_offset_idx": 2,
+              "start_col_offset_idx": 0,
+              "end_col_offset_idx": 1,
+              "text": "Accounting/Finance",
+              "column_header": false,
+              "row_header": false,
+              "row_section": false,
+              "fillable": false
+            }
+          ],
+          [
+            {
+              "row_span": 1,
+              "col_span": 1,
+              "start_row_offset_idx": 2,
+              "end_row_offset_idx": 3,
+              "start_col_offset_idx": 0,
+              "end_col_offset_idx": 1,
+              "text": "Automotive",
+              "column_header": false,
+              "row_header": false,
+              "row_section": false,
+              "fillable": false
+            }
+          ],
+          [
+            {
+              "row_span": 1,
+              "col_span": 1,
+              "start_row_offset_idx": 3,
+              "end_row_offset_idx": 4,
+              "start_col_offset_idx": 0,
+              "end_col_offset_idx": 1,
+              "text": "Healthcare",
+              "column_header": false,
+              "row_header": false,
+              "row_section": false,
+              "fillable": false
+            }
+          ],
+          [
+            {
+              "row_span": 1,
+              "col_span": 1,
+              "start_row_offset_idx": 4,
+              "end_row_offset_idx": 5,
+              "start_col_offset_idx": 0,
+              "end_col_offset_idx": 1,
+              "text": "Hospitality/Travel",
+              "column_header": false,
+              "row_header": false,
+              "row_section": false,
+              "fillable": false
+            }
+          ],
+          [
+            {
+              "row_span": 1,
+              "col_span": 1,
+              "start_row_offset_idx": 5,
+              "end_row_offset_idx": 6,
+              "start_col_offset_idx": 0,
+              "end_col_offset_idx": 1,
+              "text": "Sales",
+              "column_header": false,
+              "row_header": false,
+              "row_section": false,
+              "fillable": false
+            }
+          ],
+          [
+            {
+              "row_span": 1,
+              "col_span": 1,
+              "start_row_offset_idx": 6,
+              "end_row_offset_idx": 7,
+              "start_col_offset_idx": 0,
+              "end_col_offset_idx": 1,
+              "text": "Other",
+              "column_header": false,
+              "row_header": false,
+              "row_section": false,
+              "fillable": false
+            }
+          ]
+        ]
+      },
+      "annotations": []
+    }
+  ],
+  "key_value_items": [],
+  "form_items": [],
+  "pages": {}
+}

--- a/tests/data/groundtruth/docling_v2/csv-single-column.csv.md
+++ b/tests/data/groundtruth/docling_v2/csv-single-column.csv.md
@@ -1,0 +1,8 @@
+| Industry           |
+|--------------------|
+| Accounting/Finance |
+| Automotive         |
+| Healthcare         |
+| Hospitality/Travel |
+| Sales              |
+| Other              |

--- a/tests/data/groundtruth/docling_v2/csv-tab.csv.json
+++ b/tests/data/groundtruth/docling_v2/csv-tab.csv.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.7.0",
+  "version": "1.9.0",
   "name": "csv-tab",
   "origin": {
     "mimetype": "text/csv",

--- a/tests/data/groundtruth/docling_v2/csv-too-few-columns.csv.json
+++ b/tests/data/groundtruth/docling_v2/csv-too-few-columns.csv.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.7.0",
+  "version": "1.9.0",
   "name": "csv-too-few-columns",
   "origin": {
     "mimetype": "text/csv",

--- a/tests/data/groundtruth/docling_v2/csv-too-many-columns.csv.json
+++ b/tests/data/groundtruth/docling_v2/csv-too-many-columns.csv.json
@@ -1,6 +1,6 @@
 {
   "schema_name": "DoclingDocument",
-  "version": "1.7.0",
+  "version": "1.9.0",
   "name": "csv-too-many-columns",
   "origin": {
     "mimetype": "text/csv",


### PR DESCRIPTION
Handle single-column CSV files and edge cases in CSV backend

## Problem

When attempting to convert a CSV file containing only one column, the conversion fails with:
```
RuntimeError: Pipeline SimplePipeline failed
```

This occurs because `csv.Sniffer().sniff()` cannot determine a delimiter when no delimiters are present in the data.

### Example failing CSV:
```csv
Industry
Accounting/Finance
Advertising/Public Relations
Aerospace/Aviation
```

or the [industry.csv](https://github.com/user-attachments/files/25135697/industry.csv) file attached in https://github.com/docling-project/docling/issues/2960#issue-3908129778

## Root Cause

The `csv.Sniffer().sniff()` method raises `csv.Error: "Could not determine delimiter"` in several scenarios:
1. **Single-column CSV** - No delimiters present in the data
2. **Very short content** - Insufficient data to reliably detect delimiter patterns
3. **Ambiguous formatting** - Unusual or inconsistent delimiter usage
4. **Single-line files** - Not enough rows to establish a pattern

## Solution

Modified `docling/backend/csv_backend.py` to gracefully handle delimiter detection failures by:
1. Wrapping the `csv.Sniffer().sniff()` call in a try-except block
2. Catching `csv.Error` exceptions when delimiter detection fails
3. Falling back to the default `csv.excel` dialect (comma delimiter) as per RFC 4180
4. Adding informative logging to indicate when fallback occurs

## Related Issues

Resolves #2960 

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
