### PR TITLE
fix(docx): guard against None hyperlink address in _get_paragraph_elements (#2367)

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -595,7 +595,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         for c in paragraph.iter_inner_content():
             if isinstance(c, Hyperlink):
                 text = c.text
-                hyperlink = Path(c.address)
+                hyperlink = Path(c.address) if c.address else None
                 format = (
                     self._get_format_from_run(c.runs[0])
                     if c.runs and len(c.runs) > 0


### PR DESCRIPTION
## Description

Fixes #2367

### Background

Issue #2367 reports an `IndexError: list index out of range` when processing DOCX files with empty paragraph runs in [_get_paragraph_elements](cci:1://file:///c:/Python%20Project/docling/docling/backend/msword_backend.py:578:4-633:33). The original crash at `c.runs[0]` (line 395 in v2.36.1) has since been addressed with a bounds check (`if c.runs and len(c.runs) > 0`).

However, a **closely related crash path in the same `Hyperlink` handling block remains**: `Path(c.address)` on the line immediately above raises a `TypeError` when `c.address` is `None`. This occurs with internal bookmark hyperlinks (e.g., Table of Contents entries, cross-references), where the DOCX XML uses [w:anchor](cci:1://file:///c:/Python%20Project/docling/tests/test_backend_msword.py:150:0-175:5) instead of a relationship ID ([r:id](cci:1://file:///c:/Python%20Project/docling/docling/backend/abstract_backend.py:32:4-34:12)), causing `python-docx`'s `Hyperlink.address` to return `None`.

Both bugs share the same root cause — incomplete defensive handling of `Hyperlink` objects from `python-docx` — and affect the same class of documents (DOCX files with certain structural patterns that cause complete parsing failure).

### Changes

**[docling/backend/msword_backend.py](cci:7://file:///c:/Python%20Project/docling/docling/backend/msword_backend.py:0:0-0:0)** (1 line)
- Added a conditional guard: `hyperlink = Path(c.address) if c.address else None`
- When `c.address` is `None`, [hyperlink](cci:1://file:///c:/Python%20Project/docling/tests/test_backend_msword.py:301:0-354:5) is set to `None`, which downstream logic already handles correctly — the hyperlink text is extracted and grouped with surrounding text instead of being wrapped in a `Path` object

**[tests/test_backend_msword.py](cci:7://file:///c:/Python%20Project/docling/tests/test_backend_msword.py:0:0-0:0)** (56 lines)
- Added regression test [test_hyperlink_with_none_address](cci:1://file:///c:/Python%20Project/docling/tests/test_backend_msword.py:301:0-354:5)
- Programmatically creates a DOCX containing an internal bookmark hyperlink ([w:hyperlink](cci:1://file:///c:/Python%20Project/docling/tests/test_backend_msword.py:301:0-354:5) with [w:anchor](cci:1://file:///c:/Python%20Project/docling/tests/test_backend_msword.py:150:0-175:5), no [r:id](cci:1://file:///c:/Python%20Project/docling/docling/backend/abstract_backend.py:32:4-34:12)) via raw XML manipulation
- Converts the document via `DocumentConverter` and asserts:
  - No exception raised during conversion
  - Surrounding paragraph text is correctly extracted in the markdown export

### Why this is safe
- The fix is a single conditional expression — no new branches, no changed return types
- Downstream code in the same method (lines 611-626) already handles `hyperlink is None` by grouping text normally rather than emitting a link
- All 12 existing DOCX backend tests continue to pass unchanged
- The fix follows the same defensive pattern already used for `c.runs` on the adjacent line

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
