### PR TITLE
fix(vlm): convert images to RGB before passing to transformers

### DIFF
--- a/docling/models/stages/picture_description/picture_description_vlm_model.py
+++ b/docling/models/stages/picture_description/picture_description_vlm_model.py
@@ -103,6 +103,10 @@ class PictureDescriptionVlmModel(
         # TODO: do batch generation
 
         for image in images:
+            # Ensure RGB mode for compatibility with transformers models
+            if image.mode != "RGB":
+                image = image.convert("RGB")
+
             # Prepare inputs
             prompt = self.processor.apply_chat_template(
                 messages, add_generation_prompt=True


### PR DESCRIPTION
## Summary

Converts PIL images to RGB mode before passing them to the transformers processor in `_annotate_images()`.

## Problem

When processing PDFs containing images with alpha channels (RGBA), grayscale with alpha (LA), palette (P), or grayscale (L) modes, the VLM picture description pipeline can fail or produce inconsistent results because transformers models expect RGB input.

## Solution

Add an explicit `image.convert("RGB")` check before passing images to the processor, matching the pattern already used in the API model variant (`api_image_request.py` line 29 converts to RGBA).

The conversion:
- Only runs when `image.mode != "RGB"` (no overhead for already-RGB images)
- Creates a new image object (no mutation of the input iterable)
- Is a standard PIL operation used widely in transformers pipelines

## Changes

- `docling/models/stages/picture_description/picture_description_vlm_model.py`: Added RGB conversion in `_annotate_images()` loop

Fixes #3000