### PR TITLE
fix(readingorder): assign FURNITURE content_layer to footer/header in container groups

### DIFF
--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -101,7 +101,19 @@ class ReadingOrderModel:
             elif c_label == DocItemLabel.SECTION_HEADER:
                 doc.add_heading(parent=doc_item, text=c_text, prov=c_prov)
             else:
-                doc.add_text(parent=doc_item, label=c_label, text=c_text, prov=c_prov)
+                content_layer = ContentLayer.BODY
+                if c_label in (
+                    DocItemLabel.PAGE_HEADER,
+                    DocItemLabel.PAGE_FOOTER,
+                ):
+                    content_layer = ContentLayer.FURNITURE
+                doc.add_text(
+                    parent=doc_item,
+                    label=c_label,
+                    text=c_text,
+                    prov=c_prov,
+                    content_layer=content_layer,
+                )
 
     def _create_rich_cell_group(
         self, element: BasePageElement, doc: DoclingDocument, table_item: NodeItem


### PR DESCRIPTION
## Summary

Fixes `content_layer` assignment for `page_footer`/`page_header` elements that are children of container groups (e.g. `key_value_region`, `form`).

## Problem

Elements correctly labeled as `page_footer` or `page_header` by the layout model retain `content_layer=BODY` when they are processed as children inside container groups. This causes them to appear in markdown/HTML exports despite being recognized as page furniture.

The root cause is in `_add_child_elements()`: the `else` branch calls `add_text()` without specifying `content_layer`, so it defaults to `BODY`. The same check exists in `_handle_text_element()` for standalone elements but was missing for container children.

## Example

A 5-page PDF with a letterhead footer/sidebar:
- 52 text elements labeled as `page_footer`
- Only 16 correctly got `content_layer=FURNITURE` (standalone `TextElement`s)
- **36 incorrectly got `content_layer=BODY`** (elements inside container groups)

## Solution

Apply the same `content_layer` check in `_add_child_elements()` that `_handle_text_element()` already uses:

```python
content_layer = ContentLayer.BODY
if c_label in (DocItemLabel.PAGE_HEADER, DocItemLabel.PAGE_FOOTER):
    content_layer = ContentLayer.FURNITURE
```

## Changes

- `docling/models/stages/reading_order/readingorder_model.py`: Added `content_layer` assignment in `_add_child_elements()`

Fixes #3015