### PR TITLE
fix(ocr): update RapidOCR torch GPU config key

### DIFF
--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -206,7 +206,7 @@ class RapidOcrModel(BaseOcrModel):
                 "EngineConfig.paddle.use_cuda": use_cuda,
                 "EngineConfig.paddle.gpu_id": gpu_id,
                 "EngineConfig.torch.use_cuda": use_cuda,
-                "EngineConfig.torch.gpu_id": gpu_id,
+                "EngineConfig.torch.cuda_ep_cfg.device_id": gpu_id,
             }
 
             if self.options.rec_font_path is not None:


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #2997

Replace obsolete `EngineConfig.torch.gpu_id` with `EngineConfig.torch.cuda_ep_cfg.device_id` to fix GPU device selection with recent RapidOCR releases. The `gpu_id` parameter was deprecated in newer versions of RapidOCR in favor of `cuda_ep_cfg.device_id`.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.