### PR TITLE
fix(docx): preserve URL fragments and query params in hyperlinks

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Callable, Final, Optional, Union
+from urllib.parse import urlparse
 
 from docling_core.types.doc import (
     ContentLayer,
@@ -633,7 +634,14 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         for c in paragraph.iter_inner_content():
             if isinstance(c, Hyperlink):
                 text = c.text
-                hyperlink = Path(c.address) if c.address else None
+                if c.address:
+                    hyperlink = (
+                        AnyUrl(c.address)
+                        if urlparse(c.address).scheme
+                        else Path(c.address)
+                    )
+                else:
+                    hyperlink = None
                 format = (
                     self._get_format_from_run(c.runs[0])
                     if c.runs and len(c.runs) > 0

--- a/tests/data/groundtruth/docling_v2/unit_test_formatting.docx.md
+++ b/tests/data/groundtruth/docling_v2/unit_test_formatting.docx.md
@@ -4,11 +4,11 @@
 
 underline
 
-[hyperlink](https:/github.com/DS4SD/docling)
+[hyperlink](https://github.com/DS4SD/docling)
 
-[***italic and bold hyperlink***](https:/github.com/DS4SD/docling)
+[***italic and bold hyperlink***](https://github.com/DS4SD/docling)
 
-Normal *italic* **bold** underline and [hyperlink](https:/github.com/DS4SD/docling) on the same line
+Normal *italic* **bold** underline and [hyperlink](https://github.com/DS4SD/docling) on the same line
 
 - *Italic bullet 1*
 - **Bold bullet 2**

--- a/tests/data/groundtruth/docling_v2/word_comments.docx.itxt
+++ b/tests/data/groundtruth/docling_v2/word_comments.docx.itxt
@@ -1,0 +1,6 @@
+item-0 at level 0: unspecified: group _root_
+  item-1 at level 1: title: Document with Comments
+    item-2 at level 2: text: This is the first paragraph that has a comment attached to it.
+    item-3 at level 2: text: This second paragraph also has a reviewer annotation.
+    item-4 at level 2: text: This third paragraph has no comments attached to it.
+    item-5 at level 2: text: This paragraph has an anonymous comment.

--- a/tests/data/groundtruth/docling_v2/word_comments.docx.json
+++ b/tests/data/groundtruth/docling_v2/word_comments.docx.json
@@ -1,0 +1,240 @@
+{
+  "schema_name": "DoclingDocument",
+  "version": "1.9.0",
+  "name": "word_comments",
+  "origin": {
+    "mimetype": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "binary_hash": 1843681623434877502,
+    "filename": "word_comments.docx"
+  },
+  "furniture": {
+    "self_ref": "#/furniture",
+    "children": [],
+    "content_layer": "furniture",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "body": {
+    "self_ref": "#/body",
+    "children": [
+      {
+        "$ref": "#/texts/0"
+      },
+      {
+        "$ref": "#/groups/0"
+      },
+      {
+        "$ref": "#/groups/1"
+      },
+      {
+        "$ref": "#/groups/2"
+      }
+    ],
+    "content_layer": "body",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "groups": [
+    {
+      "self_ref": "#/groups/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/5"
+        }
+      ],
+      "content_layer": "notes",
+      "name": "comment-0",
+      "label": "comment_section"
+    },
+    {
+      "self_ref": "#/groups/1",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/6"
+        }
+      ],
+      "content_layer": "notes",
+      "name": "comment-1",
+      "label": "comment_section"
+    },
+    {
+      "self_ref": "#/groups/2",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/7"
+        }
+      ],
+      "content_layer": "notes",
+      "name": "comment-2",
+      "label": "comment_section"
+    }
+  ],
+  "texts": [
+    {
+      "self_ref": "#/texts/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/1"
+        },
+        {
+          "$ref": "#/texts/2"
+        },
+        {
+          "$ref": "#/texts/3"
+        },
+        {
+          "$ref": "#/texts/4"
+        }
+      ],
+      "content_layer": "body",
+      "label": "title",
+      "prov": [],
+      "orig": "Document with Comments",
+      "text": "Document with Comments"
+    },
+    {
+      "self_ref": "#/texts/1",
+      "parent": {
+        "$ref": "#/texts/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "comments": [
+        {
+          "$ref": "#/groups/0"
+        }
+      ],
+      "orig": "This is the first paragraph that has a comment attached to it.",
+      "text": "This is the first paragraph that has a comment attached to it.",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "script": "baseline"
+      }
+    },
+    {
+      "self_ref": "#/texts/2",
+      "parent": {
+        "$ref": "#/texts/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "comments": [
+        {
+          "$ref": "#/groups/1"
+        }
+      ],
+      "orig": "This second paragraph also has a reviewer annotation.",
+      "text": "This second paragraph also has a reviewer annotation.",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "script": "baseline"
+      }
+    },
+    {
+      "self_ref": "#/texts/3",
+      "parent": {
+        "$ref": "#/texts/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "This third paragraph has no comments attached to it.",
+      "text": "This third paragraph has no comments attached to it.",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "script": "baseline"
+      }
+    },
+    {
+      "self_ref": "#/texts/4",
+      "parent": {
+        "$ref": "#/texts/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "comments": [
+        {
+          "$ref": "#/groups/2"
+        }
+      ],
+      "orig": "This paragraph has an anonymous comment.",
+      "text": "This paragraph has an anonymous comment.",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "script": "baseline"
+      }
+    },
+    {
+      "self_ref": "#/texts/5",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "notes",
+      "label": "text",
+      "prov": [],
+      "orig": "[author: John Reviewer (JR), time: 2026-01-04T05:48:07+00:00]: This is a sample reviewer comment on the first paragraph.",
+      "text": "[author: John Reviewer (JR), time: 2026-01-04T05:48:07+00:00]: This is a sample reviewer comment on the first paragraph."
+    },
+    {
+      "self_ref": "#/texts/6",
+      "parent": {
+        "$ref": "#/groups/1"
+      },
+      "children": [],
+      "content_layer": "notes",
+      "label": "text",
+      "prov": [],
+      "orig": "[author: Jane Editor (JE), time: 2026-01-04T05:48:07+00:00]: Another comment by a different reviewer.",
+      "text": "[author: Jane Editor (JE), time: 2026-01-04T05:48:07+00:00]: Another comment by a different reviewer."
+    },
+    {
+      "self_ref": "#/texts/7",
+      "parent": {
+        "$ref": "#/groups/2"
+      },
+      "children": [],
+      "content_layer": "notes",
+      "label": "text",
+      "prov": [],
+      "orig": "[time: 2026-01-04T05:48:07+00:00]: Anonymous feedback on this paragraph.",
+      "text": "[time: 2026-01-04T05:48:07+00:00]: Anonymous feedback on this paragraph."
+    }
+  ],
+  "pictures": [],
+  "tables": [],
+  "key_value_items": [],
+  "form_items": [],
+  "pages": {}
+}

--- a/tests/data/groundtruth/docling_v2/word_comments.docx.md
+++ b/tests/data/groundtruth/docling_v2/word_comments.docx.md
@@ -1,0 +1,9 @@
+# Document with Comments
+
+This is the first paragraph that has a comment attached to it.
+
+This second paragraph also has a reviewer annotation.
+
+This third paragraph has no comments attached to it.
+
+This paragraph has an anonymous comment.


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #2943

Remove `Path()` wrapper from hyperlink address extraction in `msword_backend.py`. `Path()` is designed for filesystem paths and strips URL fragments (`#`) and query parameters (`?`), causing truncated hyperlinks in DOCX output (e.g. `https://example.pl/hr#Statements-Core?view=STATEMENT` becomes `https://example.pl/hr`).

The fix uses the address string directly instead of wrapping it in `Path()`.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.