### PR TITLE
fix: skip picture description model init when disabled

### DIFF
--- a/docling/pipeline/base_pipeline.py
+++ b/docling/pipeline/base_pipeline.py
@@ -152,15 +152,17 @@ class ConvertPipeline(BasePipeline):
 
         # ------ Common enrichment models working on all backends
 
-        # Picture description model
-        if (
-            picture_description_model := self._get_picture_description_model(
+        # Picture description model (only instantiate when enabled to avoid
+        # requiring optional VLM dependencies for simple conversions)
+        picture_description_model = None
+        if pipeline_options.do_picture_description:
+            picture_description_model = self._get_picture_description_model(
                 artifacts_path=self.artifacts_path
             )
-        ) is None:
-            raise RuntimeError(
-                f"The specified picture description kind is not supported: {pipeline_options.picture_description_options.kind}."
-            )
+            if picture_description_model is None:
+                raise RuntimeError(
+                    f"The specified picture description kind is not supported: {pipeline_options.picture_description_options.kind}."
+                )
 
         self.enrichment_pipe = [
             # Document Picture Classifier
@@ -171,8 +173,10 @@ class ConvertPipeline(BasePipeline):
                 accelerator_options=pipeline_options.accelerator_options,
                 enable_remote_services=pipeline_options.enable_remote_services,
             ),
-            # Document Picture description
-            picture_description_model,
+        ]
+        if picture_description_model is not None:
+            self.enrichment_pipe.append(picture_description_model)
+        self.enrichment_pipe.append(
             # Document Chart Extraction
             ChartExtractionModelGraniteVision(
                 enabled=pipeline_options.do_chart_extraction,
@@ -180,7 +184,7 @@ class ConvertPipeline(BasePipeline):
                 options=ChartExtractionModelOptions(),
                 accelerator_options=pipeline_options.accelerator_options,
             ),
-        ]
+        )
 
     def _get_picture_description_model(
         self, artifacts_path: Optional[Path] = None


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #2515

When `do_picture_description` is `False`, `ConvertPipeline.__init__` no longer calls the picture description model factory. This prevents `RuntimeError` when optional VLM dependencies are not installed, which is common for `SimplePipeline` use cases (DOCX, HTML, PPTX conversions).

Previously, the factory was always invoked regardless of the flag, and would fail with `No class found with the name 'vlm'` if the VLM plugin was not registered.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.