### PR TITLE
fix: normalize Unicode ligatures in PDF text extraction

### DIFF
--- a/docling/models/stages/page_assemble/page_assemble_model.py
+++ b/docling/models/stages/page_assemble/page_assemble_model.py
@@ -1,7 +1,7 @@
 import logging
 import re
 from collections.abc import Iterable
-from typing import List
+from typing import Dict, List
 
 import numpy as np
 from pydantic import BaseModel
@@ -22,6 +22,21 @@ from docling.utils.profiling import TimeRecorder
 
 _log = logging.getLogger(__name__)
 
+# Ligature normalization map (Unicode Alphabetic Presentation Forms block U+FB00-U+FB06)
+_LIGATURE_MAP: Dict[str, str] = {
+    "\ufb00": "ff",  # ﬀ Latin small ligature ff
+    "\ufb01": "fi",  # ﬁ Latin small ligature fi
+    "\ufb02": "fl",  # ﬂ Latin small ligature fl
+    "\ufb03": "ffi",  # ﬃ Latin small ligature ffi
+    "\ufb04": "ffl",  # ﬄ Latin small ligature ffl
+    "\ufb05": "st",  # ﬅ Latin small ligature long s t
+    "\ufb06": "st",  # ﬆ Latin small ligature st
+}
+# Matches a ligature character optionally followed by a space before a word character
+# (to absorb spurious spaces inserted by PDF parsers between a ligature glyph and the
+# rest of the word, e.g. "ﬁ eld" → "field")
+_LIGATURE_RE = re.compile(r"([\ufb00-\ufb06])( (?=\w))?")
+
 
 class PageAssembleOptions(BaseModel):
     pass
@@ -32,8 +47,8 @@ class PageAssembleModel(BasePageModel):
         self.options = options
 
     def sanitize_text(self, lines):
-        if len(lines) <= 1:
-            return " ".join(lines)
+        if len(lines) == 0:
+            return ""
 
         for ix, line in enumerate(lines[1:]):
             prev_line = lines[ix]
@@ -61,6 +76,12 @@ class PageAssembleModel(BasePageModel):
         sanitized_text = sanitized_text.replace("“", '"')
         sanitized_text = sanitized_text.replace("”", '"')
         sanitized_text = sanitized_text.replace("•", "·")
+        # Ligature expansion: replace ligature characters with their ASCII equivalents,
+        # absorbing any spurious space inserted by the PDF parser between the ligature
+        # glyph and the following word characters (e.g. "ﬁ eld" → "field").
+        sanitized_text = _LIGATURE_RE.sub(
+            lambda m: _LIGATURE_MAP[m.group(1)], sanitized_text
+        )
 
         return sanitized_text.strip()  # Strip any leading or trailing whitespace
 

--- a/tests/test_page_assemble_model.py
+++ b/tests/test_page_assemble_model.py
@@ -1,0 +1,74 @@
+"""Unit tests for PageAssembleModel.sanitize_text(), focusing on ligature normalization."""
+
+import pytest
+
+from docling.models.stages.page_assemble.page_assemble_model import (
+    PageAssembleModel,
+    PageAssembleOptions,
+)
+
+
+@pytest.fixture
+def model() -> PageAssembleModel:
+    return PageAssembleModel(options=PageAssembleOptions())
+
+
+class TestSanitizeTextLigatures:
+    """Tests for Unicode ligature expansion in sanitize_text()."""
+
+    def test_fi_ligature_no_space(self, model):
+        """U+FB01 ﬁ → fi (no spurious space)."""
+        assert model.sanitize_text(["\ufb01eld"]) == "field"
+
+    def test_fl_ligature_no_space(self, model):
+        """U+FB02 ﬂ → fl (no spurious space)."""
+        assert model.sanitize_text(["\ufb02ow"]) == "flow"
+
+    def test_fi_ligature_with_spurious_space(self, model):
+        """U+FB01 ﬁ followed by spurious space before word char → fi (space absorbed)."""
+        assert model.sanitize_text(["\ufb01 eld"]) == "field"
+
+    def test_fl_ligature_with_spurious_space(self, model):
+        """U+FB02 ﬂ followed by spurious space before word char → fl (space absorbed)."""
+        assert model.sanitize_text(["\ufb02 ow"]) == "flow"
+
+    def test_ff_ligature(self, model):
+        """U+FB00 ﬀ → ff."""
+        assert model.sanitize_text(["\ufb00"]) == "ff"
+
+    def test_fi_ligature(self, model):
+        """U+FB01 ﬁ → fi."""
+        assert model.sanitize_text(["\ufb01"]) == "fi"
+
+    def test_fl_ligature(self, model):
+        """U+FB02 ﬂ → fl."""
+        assert model.sanitize_text(["\ufb02"]) == "fl"
+
+    def test_ffi_ligature(self, model):
+        """U+FB03 ﬃ → ffi."""
+        assert model.sanitize_text(["\ufb03"]) == "ffi"
+
+    def test_ffl_ligature(self, model):
+        """U+FB04 ﬄ → ffl."""
+        assert model.sanitize_text(["\ufb04"]) == "ffl"
+
+    def test_long_st_ligature(self, model):
+        """U+FB05 ﬅ → st."""
+        assert model.sanitize_text(["\ufb05"]) == "st"
+
+    def test_st_ligature(self, model):
+        """U+FB06 ﬆ → st."""
+        assert model.sanitize_text(["\ufb06"]) == "st"
+
+    def test_ligature_space_at_word_boundary_preserved(self, model):
+        """Space after ligature at word boundary (not before word char) is preserved."""
+        assert model.sanitize_text(["\ufb01eld of view"]) == "field of view"
+
+    def test_multiple_ligatures_in_text(self, model):
+        """Multiple ligatures in a single text block are all expanded."""
+        # "ﬁeld" + space + "ﬂow" → "field flow"
+        assert model.sanitize_text(["\ufb01eld \ufb02ow"]) == "field flow"
+
+    def test_ligature_with_spurious_space_in_multiline(self, model):
+        """Ligature with spurious space works correctly across multi-line input."""
+        assert model.sanitize_text(["\ufb01 eld", "of view"]) == "field of view"


### PR DESCRIPTION
## fix: normalize Unicode ligatures and absorb spurious spaces in PDF text extraction

Resolves #3056

### Description

This PR improves text quality for PDF-extracted content by adding Unicode ligature normalization to `PageAssembleModel.sanitize_text()`.

PDF parsers often represent typographic ligatures (e.g., **ﬁ**, **ﬂ**, **ﬀ**) as their Unicode Alphabetic Presentation Forms codepoints (`U+FB00`–`U+FB06`) instead of their ASCII equivalents. Additionally, some PDF parsers insert a spurious space between the ligature glyph and the remaining characters of the word (e.g., `"ﬁ eld"` instead of `"field"`).

**Changes made:**

- Added a `_LIGATURE_MAP` dictionary covering all 7 ligatures in the Unicode Presentation Forms block (`U+FB00`–`U+FB06`): `ff`, `fi`, `fl`, `ffi`, `ffl`, `ſt` (long s t), and `st`.
- Added a compiled regex `_LIGATURE_RE` that matches a ligature character optionally followed by a spurious space before a word character, allowing both the ligature and the erroneous space to be replaced in a single pass.
- Applied ligature expansion in `sanitize_text()` after existing character substitutions.
- Fixed a minor edge case in `sanitize_text()`: changed `len(lines) <= 1` early-return to `len(lines) == 0` so that single-line inputs are also processed through the full sanitization pipeline (including ligature expansion).
- Added a comprehensive test suite in `tests/test_page_assemble_model.py` covering all ligature types, spurious space absorption, multi-ligature text, and multi-line inputs.

**Example:**
| Input | Before | After |
|---|---|---|
| `"\ufb01 eld"` | `"ﬁ eld"` | `"field"` |
| `"\ufb00ect"` | `"ﬀect"` | `"ffect"` |
| `"\ufb03cient"` | `"ﬃcient"` | `"fficient"` |

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.