### PR TITLE
fix(rapidocr): ORT thread configuration for RapidOCR backend

### DIFF
--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -182,24 +182,23 @@ class RapidOcrModel(BaseOcrModel):
                 # Global settings (these are still correct)
                 "Global.text_score": self.options.text_score,
                 "Global.font_path": font_path,
+                # Engine-level ONNXRuntime settings
+                "EngineConfig.onnxruntime.intra_op_num_threads": intra_op_num_threads,
                 # "Global.verbose": self.options.print_verbose,
                 # Detection model settings
                 "Det.model_path": det_model_path,
                 "Det.use_cuda": use_cuda,
                 "Det.use_dml": use_dml,
-                "Det.intra_op_num_threads": intra_op_num_threads,
                 # Classification model settings
                 "Cls.model_path": cls_model_path,
                 "Cls.use_cuda": use_cuda,
                 "Cls.use_dml": use_dml,
-                "Cls.intra_op_num_threads": intra_op_num_threads,
                 # Recognition model settings
                 "Rec.model_path": rec_model_path,
                 "Rec.font_path": font_path,
                 "Rec.rec_keys_path": rec_keys_path,
                 "Rec.use_cuda": use_cuda,
                 "Rec.use_dml": use_dml,
-                "Rec.intra_op_num_threads": intra_op_num_threads,
                 "Det.engine_type": backend_enum,
                 "Cls.engine_type": backend_enum,
                 "Rec.engine_type": backend_enum,


### PR DESCRIPTION
Description:
Move intra_op_num_threads from Det/Cls/Rec params to EngineConfig.onnxruntime to ensure ONNXRuntime SessionOptions receives the correct thread configuration.

Previously, model-level thread parameters were not consumed by the ORT backend.
This change ensures --num-threads is correctly propagated to ONNXRuntime and applied during OCR inference.