### PR TITLE
fix: assign FURNITURE content_layer to page_header/footer in container children

### DIFF
--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -45,6 +45,18 @@ class ReadingOrderModel:
         self.ro_model = ReadingOrderPredictor()
         self.list_item_processor = ListItemMarkerProcessor()
 
+    @staticmethod
+    def _resolve_content_layer(label: DocItemLabel) -> ContentLayer:
+        """Resolve the content layer based on the element's label.
+
+        Elements labeled as PAGE_HEADER or PAGE_FOOTER are page furniture
+        and should be placed in the FURNITURE layer so they are excluded
+        from body exports (markdown, HTML, iterate_items).
+        """
+        if label in (DocItemLabel.PAGE_HEADER, DocItemLabel.PAGE_FOOTER):
+            return ContentLayer.FURNITURE
+        return ContentLayer.BODY
+
     def _assembled_to_readingorder_elements(
         self, conv_res: ConversionResult
     ) -> list[ReadingOrderPageElement]:
@@ -94,14 +106,31 @@ class ReadingOrderModel:
             c_prov = ProvenanceItem(
                 page_no=element.page_no, charspan=(0, len(c_text)), bbox=c_bbox
             )
+            content_layer = self._resolve_content_layer(c_label)
             if c_label == DocItemLabel.LIST_ITEM:
                 # TODO: Infer if this is a numbered or a bullet list item
-                l_item = doc.add_list_item(parent=doc_item, text=c_text, prov=c_prov)
+                l_item = doc.add_list_item(
+                    parent=doc_item,
+                    text=c_text,
+                    prov=c_prov,
+                    content_layer=content_layer,
+                )
                 self.list_item_processor.process_list_item(l_item)
             elif c_label == DocItemLabel.SECTION_HEADER:
-                doc.add_heading(parent=doc_item, text=c_text, prov=c_prov)
+                doc.add_heading(
+                    parent=doc_item,
+                    text=c_text,
+                    prov=c_prov,
+                    content_layer=content_layer,
+                )
             else:
-                doc.add_text(parent=doc_item, label=c_label, text=c_text, prov=c_prov)
+                doc.add_text(
+                    parent=doc_item,
+                    label=c_label,
+                    text=c_text,
+                    prov=c_prov,
+                    content_layer=content_layer,
+                )
 
     def _create_rich_cell_group(
         self, element: BasePageElement, doc: DoclingDocument, table_item: NodeItem
@@ -371,15 +400,11 @@ class ReadingOrderModel:
         else:
             current_list = None
 
-            content_layer = ContentLayer.BODY
-            if element.label in [DocItemLabel.PAGE_HEADER, DocItemLabel.PAGE_FOOTER]:
-                content_layer = ContentLayer.FURNITURE
-
             new_item = out_doc.add_text(
                 label=element.label,
                 text=cap_text,
                 prov=prov,
-                content_layer=content_layer,
+                content_layer=self._resolve_content_layer(element.label),
             )
         return new_item, current_list
 

--- a/tests/test_readingorder_content_layer.py
+++ b/tests/test_readingorder_content_layer.py
@@ -1,0 +1,59 @@
+"""Unit tests for content_layer resolution in ReadingOrderModel.
+
+Verifies that page_header/page_footer elements are assigned
+ContentLayer.FURNITURE regardless of whether they are standalone
+TextElements or children of container groups (issue #3015).
+"""
+
+import pytest
+from docling_core.types.doc import DocItemLabel
+from docling_core.types.doc.document import ContentLayer
+
+from docling.models.stages.reading_order.readingorder_model import (
+    ReadingOrderModel,
+    ReadingOrderOptions,
+)
+
+
+@pytest.fixture
+def model() -> ReadingOrderModel:
+    return ReadingOrderModel(options=ReadingOrderOptions())
+
+
+class TestResolveContentLayer:
+    """Tests for _resolve_content_layer static method."""
+
+    def test_page_footer_returns_furniture(self, model):
+        assert (
+            model._resolve_content_layer(DocItemLabel.PAGE_FOOTER)
+            == ContentLayer.FURNITURE
+        )
+
+    def test_page_header_returns_furniture(self, model):
+        assert (
+            model._resolve_content_layer(DocItemLabel.PAGE_HEADER)
+            == ContentLayer.FURNITURE
+        )
+
+    def test_text_returns_body(self, model):
+        assert (
+            model._resolve_content_layer(DocItemLabel.TEXT) == ContentLayer.BODY
+        )
+
+    def test_list_item_returns_body(self, model):
+        assert (
+            model._resolve_content_layer(DocItemLabel.LIST_ITEM)
+            == ContentLayer.BODY
+        )
+
+    def test_section_header_returns_body(self, model):
+        assert (
+            model._resolve_content_layer(DocItemLabel.SECTION_HEADER)
+            == ContentLayer.BODY
+        )
+
+    def test_caption_returns_body(self, model):
+        assert (
+            model._resolve_content_layer(DocItemLabel.CAPTION)
+            == ContentLayer.BODY
+        )


### PR DESCRIPTION
## Summary

Fixes page_footer/page_header elements retaining `content_layer=BODY` when processed as children of container groups (e.g. `key_value_region`, `form`), causing them to leak into markdown/HTML exports despite being correctly labeled as page furniture.

**Root cause**: `_add_child_elements()` called `add_text()`, `add_list_item()`, and `add_heading()` without passing `content_layer`, so all child elements defaulted to `BODY` regardless of their label. The content_layer check only existed in the `else` branch of `_handle_text_element()`, which only processes standalone `TextElement` objects.

**Changes**:
- Add `_resolve_content_layer()` static helper that maps `PAGE_HEADER`/`PAGE_FOOTER` labels to `ContentLayer.FURNITURE`
- Pass `content_layer` in all branches of `_add_child_elements()` (the actual fix)
- Refactor `_handle_text_element()` to use the same helper (consistency, no behavior change)
- Add unit tests for `_resolve_content_layer()`

## Test plan

- [x] Unit tests for `_resolve_content_layer()` covering all relevant label types
- [ ] CI passes (linting, type checking, existing test suite)

Closes #3015