### PR TITLE
Fix Egret layout label normalization (Fixes #3053)

### DIFF
--- a/docling/models/stages/layout/layout_object_detection_model.py
+++ b/docling/models/stages/layout/layout_object_detection_model.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 from typing import Dict, List, Optional, Sequence
 
@@ -54,15 +55,22 @@ class LayoutObjectDetectionModel(BaseLayoutModel):
     def _build_label_map(self) -> Dict[int, DocItemLabel]:
         """Build label mapping from engine's label names to DocItemLabel enums.
 
-        Raises:
-            RuntimeError: If labels don't match DocItemLabel enum.
+        Normalizes label names so that hyphens and spaces (e.g. from Egret
+        id2label like "List-item", "Key-Value Region") become underscores
+        before enum lookup, matching DocItemLabel (e.g. LIST_ITEM, KEY_VALUE_REGION).
         """
-        id_to_label_str = self.engine.get_label_mapping()
-        label_map = {}
+        return self._build_label_map_from_mapping(self.engine.get_label_mapping())
 
+    @staticmethod
+    def _build_label_map_from_mapping(
+        id_to_label_str: Dict[int, str],
+    ) -> Dict[int, DocItemLabel]:
+        """Build label map from id->label name dict. Normalizes names (hyphens/spaces -> underscores)."""
+        label_map = {}
         for label_id, label_name in id_to_label_str.items():
-            # Convert label name to uppercase to match DocItemLabel enum convention
-            label_enum_name = label_name.upper()
+            # Uppercase and normalize separators: hyphens and spaces -> underscore
+            # (DocItemLabel uses UPPER_SNAKE; Egret uses "List-item", "Key-Value Region", etc.)
+            label_enum_name = re.sub(r"[-\s]+", "_", label_name).upper()
             try:
                 label_map[label_id] = DocItemLabel[label_enum_name]
             except KeyError:
@@ -70,7 +78,6 @@ class LayoutObjectDetectionModel(BaseLayoutModel):
                     f"Label '{label_name}' (ID {label_id}) from model config "
                     f"does not match any DocItemLabel enum value."
                 )
-
         return label_map
 
     @classmethod

--- a/tests/test_layout_object_detection_model.py
+++ b/tests/test_layout_object_detection_model.py
@@ -1,0 +1,38 @@
+"""Tests for layout object detection model (label mapping, Egret/Heron compatibility)."""
+
+from docling_core.types.doc import DocItemLabel
+
+from docling.models.stages.layout.layout_object_detection_model import (
+    LayoutObjectDetectionModel,
+)
+
+
+def test_build_label_map_egret_style_id2label():
+    """Egret layout models use id2label with hyphens/spaces (e.g. 'List-item', 'Key-Value Region').
+
+    _build_label_map_from_mapping normalizes these to DocItemLabel enum names (LIST_ITEM, etc.).
+    """
+    id2label = {
+        3: "List-item",
+        4: "Page-footer",
+        11: "Document Index",
+        16: "Key-Value Region",
+    }
+    label_map = LayoutObjectDetectionModel._build_label_map_from_mapping(id2label)
+    assert label_map[3] == DocItemLabel.LIST_ITEM
+    assert label_map[4] == DocItemLabel.PAGE_FOOTER
+    assert label_map[11] == DocItemLabel.DOCUMENT_INDEX
+    assert label_map[16] == DocItemLabel.KEY_VALUE_REGION
+
+
+def test_build_label_map_heron_style_unchanged():
+    """Heron models use underscored labels; normalization should not break them."""
+    id2label = {
+        0: "list_item",
+        1: "page_footer",
+        2: "document_index",
+    }
+    label_map = LayoutObjectDetectionModel._build_label_map_from_mapping(id2label)
+    assert label_map[0] == DocItemLabel.LIST_ITEM
+    assert label_map[1] == DocItemLabel.PAGE_FOOTER
+    assert label_map[2] == DocItemLabel.DOCUMENT_INDEX


### PR DESCRIPTION
Fixes #3053

Egret layout model configs use hyphenated and space-separated label names in `id2label`
(e.g., "List-item", "Key-Value Region").

_build_label_map() previously only uppercased labels, producing values like
"LIST-ITEM" which do not match the `DocItemLabel` enum (expects `LIST_ITEM`,
`PAGE_FOOTER`, etc.), causing a RuntimeError during layout pipeline initialization.

This PR normalizes labels before enum lookup using:

re.sub(r"[-\s]+", "_", label_name).upper()

This ensures:
- Egret model labels with hyphens or spaces map correctly
- Heron model labels with underscores continue working unchanged

Tests added:
- Egret-style label normalization
- Heron-style labels remain unchanged

Tested locally with:
pytest tests/test_layout_object_detection_model.py -v