### PR TITLE
feat: add configurable graph_optimization_level for ONNX Runtime engines

### DIFF
--- a/docling/datamodel/image_classification_engine_options.py
+++ b/docling/datamodel/image_classification_engine_options.py
@@ -30,6 +30,17 @@ class OnnxRuntimeImageClassificationEngineOptions(BaseImageClassificationEngineO
         description="Ordered list of ONNX Runtime execution providers to try",
     )
 
+    graph_optimization_level: int = Field(
+        default=99,
+        description=(
+            "ONNX Runtime graph optimization level. "
+            "Accepts onnxruntime.GraphOptimizationLevel int values: "
+            "0 (ORT_DISABLE_ALL), 1 (ORT_ENABLE_BASIC), "
+            "2 (ORT_ENABLE_EXTENDED), 99 (ORT_ENABLE_ALL). "
+            "Default enables all optimizations including layout optimizations."
+        ),
+    )
+
 
 class TransformersImageClassificationEngineOptions(
     BaseImageClassificationEngineOptions

--- a/docling/datamodel/object_detection_engine_options.py
+++ b/docling/datamodel/object_detection_engine_options.py
@@ -34,6 +34,17 @@ class OnnxRuntimeObjectDetectionEngineOptions(BaseObjectDetectionEngineOptions):
         description="Ordered list of ONNX Runtime execution providers to try",
     )
 
+    graph_optimization_level: int = Field(
+        default=99,
+        description=(
+            "ONNX Runtime graph optimization level. "
+            "Accepts onnxruntime.GraphOptimizationLevel int values: "
+            "0 (ORT_DISABLE_ALL), 1 (ORT_ENABLE_BASIC), "
+            "2 (ORT_ENABLE_EXTENDED), 99 (ORT_ENABLE_ALL). "
+            "Default enables all optimizations including layout optimizations."
+        ),
+    )
+
 
 class TransformersObjectDetectionEngineOptions(BaseObjectDetectionEngineOptions):
     """Runtime configuration for Transformers-based object-detection models."""

--- a/docling/models/inference_engines/image_classification/onnxruntime_engine.py
+++ b/docling/models/inference_engines/image_classification/onnxruntime_engine.py
@@ -109,6 +109,9 @@ class OnnxRuntimeImageClassificationEngine(HfImageClassificationEngineBase):
 
         sess_options = ort.SessionOptions()
         sess_options.intra_op_num_threads = self._accelerator_options.num_threads
+        sess_options.graph_optimization_level = ort.GraphOptimizationLevel(
+            self.options.graph_optimization_level
+        )
         providers = self._resolve_providers()
 
         self._session = ort.InferenceSession(

--- a/docling/models/inference_engines/object_detection/onnxruntime_engine.py
+++ b/docling/models/inference_engines/object_detection/onnxruntime_engine.py
@@ -117,6 +117,9 @@ class OnnxRuntimeObjectDetectionEngine(HfObjectDetectionEngineBase):
         # Create ONNX session
         sess_options = ort.SessionOptions()
         sess_options.intra_op_num_threads = self._accelerator_options.num_threads
+        sess_options.graph_optimization_level = ort.GraphOptimizationLevel(
+            self.options.graph_optimization_level
+        )
         providers = self._resolve_providers()
 
         self._session = ort.InferenceSession(


### PR DESCRIPTION
Adds a `graph_optimization_level` field to `OnnxRuntimeObjectDetectionEngineOptions` and `OnnxRuntimeImageClassificationEngineOptions`, defaulting to `ORT_ENABLE_ALL (99)`. This enables ONNX Runtime graph optimizations such as operator fusion, constant folding, and layout optimizations, improving inference performance.

The field accepts `onnxruntime.GraphOptimizationLevel` integer values:

* `0` — `ORT_DISABLE_ALL`
* `1` — `ORT_ENABLE_BASIC`
* `2` — `ORT_ENABLE_EXTENDED`
* `99` — `ORT_ENABLE_ALL` (default)

This is comparable to the `compile_model` option available in the Transformers engines, as suggested by @cau-git.

Resolves #3068 