### PR TITLE
fix: detect Office Open XML formats from ZIP contents when filename has no extension

### DIFF
--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -499,11 +499,12 @@ class _DocumentConversionInput(BaseModel):
                     content = f.read(1024)  # Read first 1KB
             if mime is not None and mime.lower() == "application/zip":
                 mime_root = "application/vnd.openxmlformats-officedocument"
-                if obj.suffixes[-1].lower() == ".xlsx":
+                suffix = obj.suffix.lower()
+                if suffix == ".xlsx":
                     mime = mime_root + ".spreadsheetml.sheet"
-                elif obj.suffixes[-1].lower() == ".docx":
+                elif suffix == ".docx":
                     mime = mime_root + ".wordprocessingml.document"
-                elif obj.suffixes[-1].lower() == ".pptx":
+                elif suffix == ".pptx":
                     mime = mime_root + ".presentationml.presentation"
                 else:
                     office_mime = _DocumentConversionInput._detect_office_mime_from_zip(

--- a/tests/test_input_doc.py
+++ b/tests/test_input_doc.py
@@ -134,6 +134,37 @@ def test_guess_format(tmp_path):
     doc_path = Path("./tests/data/docx/lorem_ipsum.docx")
     assert dci._guess_format(doc_path) == InputFormat.DOCX
 
+    # MS Office without file extension (ZIP introspection fallback)
+    buf = BytesIO(Path("./tests/data/docx/lorem_ipsum.docx").open("rb").read())
+    stream = DocumentStream(name="abc123-def456", stream=buf)
+    assert dci._guess_format(stream) == InputFormat.DOCX
+
+    buf = BytesIO(Path("./tests/data/pptx/powerpoint_sample.pptx").open("rb").read())
+    stream = DocumentStream(name="upload_no_ext", stream=buf)
+    assert dci._guess_format(stream) == InputFormat.PPTX
+
+    docx_no_ext = temp_dir / "docx_no_ext"
+    docx_no_ext.write_bytes(Path("./tests/data/docx/lorem_ipsum.docx").read_bytes())
+    assert dci._guess_format(docx_no_ext) == InputFormat.DOCX
+
+    pptx_no_ext = temp_dir / "pptx_no_ext"
+    pptx_no_ext.write_bytes(
+        Path("./tests/data/pptx/powerpoint_sample.pptx").read_bytes()
+    )
+    assert dci._guess_format(pptx_no_ext) == InputFormat.PPTX
+
+    # Plain ZIP (not Office) should not be detected as an Office format
+    import zipfile as _zipfile
+
+    plain_zip_path = temp_dir / "archive_no_ext"
+    with _zipfile.ZipFile(plain_zip_path, "w") as zf:
+        zf.writestr("data.txt", "hello world")
+    assert dci._guess_format(plain_zip_path) is None
+
+    buf = BytesIO(plain_zip_path.read_bytes())
+    stream = DocumentStream(name="archive_no_ext", stream=buf)
+    assert dci._guess_format(stream) is None
+
     # Valid HTML
     buf = BytesIO(Path("./tests/data/html/wiki_duck.html").open("rb").read())
     stream = DocumentStream(name="wiki_duck.html", stream=buf)


### PR DESCRIPTION
## Summary

- **Bug**: Format detection fails for DOCX/XLSX/PPTX files fetched via pre-signed URLs (S3/GCS/Azure Blob) when the storage backend does not return a `Content-Disposition` header with the original filename.
- **Root cause**: `_guess_format()` identifies these files as `application/zip` (correct, since Office Open XML formats are ZIP-based), then attempts to disambiguate using only the filename extension. For pre-signed URLs, the resolved filename often has no extension (e.g. `abc123-def456`), so disambiguation fails, `_guess_format()` returns `None`, and the document is rejected as "File format not allowed".
- **Fix**: Add `_detect_office_mime_from_zip()` that inspects the ZIP archive's internal structure as a fallback when extension-based detection cannot disambiguate. It checks for canonical marker files:
  - `word/document.xml` → DOCX
  - `xl/workbook.xml` → XLSX
  - `ppt/presentation.xml` → PPTX

This fallback is applied in both the `Path` and `DocumentStream` branches of `_guess_format()`.

## Test plan

- [ ] Verify DOCX files with `.docx` extension still resolve correctly (no regression)
- [ ] Verify DOCX/XLSX/PPTX files with no extension are correctly detected via ZIP introspection
- [ ] Verify non-Office ZIP files (e.g. plain `.zip` archives) still return `None` as before
- [ ] Verify corrupted/invalid ZIP files are handled gracefully (`BadZipFile` is caught)
- [ ] Pre-commit checks pass (ruff formatter, ruff linter, mypy)
