### PR TITLE
fix(docx): preserve parent state when processing table cells

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -1411,7 +1411,11 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             cell_element = table.rows[0].cells[0]
             # In case we have a table of only 1 cell, we consider it furniture
             # And proceed processing the content of the cell as though it's in the document body
+            # Save parent state before processing cell content
+            original_parents = self.parents.copy()
             self._walk_linear(cell_element._element, doc)
+            # Restore parent state after processing cell content
+            self.parents = original_parents
             return elem_ref
 
         data = TableData(num_rows=num_rows, num_cols=num_cols)
@@ -1464,7 +1468,11 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                 rich_table_cell: bool = self._is_rich_table_cell(cell)
 
                 if rich_table_cell:
+                    # Save parent state before processing cell content
+                    original_parents = self.parents.copy()
                     _, provs_in_cell = self._walk_linear(cell._element, doc)
+                    # Restore parent state after processing cell content
+                    self.parents = original_parents
                 _log.debug(f"Table cell {row_idx},{col_idx} rich? {rich_table_cell}")
 
                 if len(provs_in_cell) > 0:


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #2668
---

## Summary

Fixed a bug where section headers appearing after tables in DOCX documents were incorrectly being added as children of table header cells. This caused the document hierarchy to be corrupted, resulting in malformed markdown and other exports.

## Root Cause

The `_handle_tables` method in `msword_backend.py` calls `_walk_linear` to process rich table cell content. However, `_walk_linear` modifies `self.parents` (especially when cells contain headings). This parent state was never restored after processing each cell, polluting the parent hierarchy for subsequent document elements.

## Changes

- Save `self.parents.copy()` before calling `_walk_linear` in two places within `_handle_tables`:
  1. For rich table cells (multi-cell tables)
  2. For 1x1 tables treated as furniture
- Restore `self.parents` after processing each cell

This follows the same pattern already used in `_handle_textbox_content`.

## Testing

- All existing msword backend tests pass
- Verified fix with a test case that creates a table followed by a section header - the header now correctly appears at the document level, not nested within the table

**Checklist:**

- [x] Documentation has been updated, if necessary. (Not necessary - internal fix)
- [ ] Examples have been added, if necessary. (Not necessary)
- [ ] Tests have been added, if necessary. (Existing tests cover this area)