### PR TITLE
fix(msword): skip GroupItem targets without comments attribute

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -8,6 +8,7 @@ from urllib.parse import urlparse
 
 from docling_core.types.doc import (
     ContentLayer,
+    DocItem,
     DocItemLabel,
     DoclingDocument,
     DocumentOrigin,
@@ -1812,8 +1813,8 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                 group_ref = FineRef(cref=comment_group.self_ref)
                 for target in targets:
                     # Only DocItem has a 'comments' field; GroupItem does not,
-                    # so skip targets that lack it (fixes #2955).
-                    if hasattr(target, "comments"):
+                    # so skip non-DocItem targets (fixes #2955).
+                    if isinstance(target, DocItem):
                         target.comments.append(group_ref)
 
             _log.debug(


### PR DESCRIPTION
## Summary

Fix `AttributeError: 'GroupItem' object has no attribute 'comments'` when converting Word documents that contain comments attached to items resolved as `GroupItem` instances.

## Problem

The `_add_comments` method in `msword_backend.py` resolves items from `self.paragraph_to_items` and unconditionally calls `target.comments.append(group_ref)`. However, only `DocItem` has a `comments` field — `GroupItem` inherits from `NodeItem` which does not define `comments`. This causes an `AttributeError` crash during Word document conversion.

Traceback from #2955:
```
File "docling/backend/msword_backend.py", line 1772, in _add_comments
    target.comments.append(group_ref)
AttributeError: 'GroupItem' object has no attribute 'comments'
```

## Fix

Add a `hasattr(target, "comments")` check before appending the comment reference. Targets that lack the `comments` field (like `GroupItem`) are silently skipped, which is the correct behavior since comments should only be linked to content-bearing items (`DocItem`).

## Test plan

- Converts Word documents with comments (existing behavior preserved)
- Converts Word documents where comments target paragraphs resolved as GroupItem (no longer crashes)
- Converts Word documents without comments (no change, early return at line 1751)

Closes #2955