### PR TITLE
docs: update code snippet to use modern pipeline options syntax

### DIFF
--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -76,16 +76,19 @@ the following engines.
 The Docling `DocumentConverter` allows to choose the OCR engine with the `ocr_options` settings. For example
 
 ```python
-from docling.datamodel.base_models import ConversionStatus, PipelineOptions
-from docling.datamodel.pipeline_options import PipelineOptions, EasyOcrOptions, TesseractOcrOptions
-from docling.document_converter import DocumentConverter
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.pipeline_options import (
+    TesseractOcrOptions,
+    PdfPipelineOptions,
+)
+from docling.document_converter import DocumentConverter, PdfFormatOption
 
-pipeline_options = PipelineOptions()
+pipeline_options = PdfPipelineOptions()
 pipeline_options.do_ocr = True
 pipeline_options.ocr_options = TesseractOcrOptions()  # Use Tesseract
 
 doc_converter = DocumentConverter(
-    pipeline_options=pipeline_options,
+    format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)}
 )
 ```
 


### PR DESCRIPTION
In `getting_started/installation.md` there's a code snippet that illustrates how pipeline options are passed to docling. The syntax is wrong/outdated, and this PR updates that.

## Before

```
from docling.datamodel.base_models import ConversionStatus, PipelineOptions
from docling.datamodel.pipeline_options import PipelineOptions, EasyOcrOptions, TesseractOcrOptions
from docling.document_converter import DocumentConverter

pipeline_options = PipelineOptions()
pipeline_options.do_ocr = True
pipeline_options.ocr_options = TesseractOcrOptions()  # Use Tesseract

doc_converter = DocumentConverter(
    pipeline_options=pipeline_options,
)
```

would give me a ValueError

```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[5], line 6
      3 from docling.document_converter import DocumentConverter
      5 pipeline_options = PipelineOptions()
----> 6 pipeline_options.do_ocr = True
      7 pipeline_options.ocr_options = TesseractOcrOptions()  # Use Tesseract
      9 doc_converter = DocumentConverter(
     10     pipeline_options=pipeline_options,
     11 )

File ~/miniforge3/envs/dev/lib/python3.12/site-packages/pydantic/main.py:1032, in BaseModel.__setattr__(self, name, value)
   1030     setattr_handler(self, name, value)
   1031 # if None is returned from _setattr_handler, the attribute was set directly
-> 1032 elif (setattr_handler := self._setattr_handler(name, value)) is not None:
   1033     setattr_handler(self, name, value)  # call here to not memo on possibly unknown fields
   1034     self.__pydantic_setattr_handlers__[name] = setattr_handler

File ~/miniforge3/envs/dev/lib/python3.12/site-packages/pydantic/main.py:1079, in BaseModel._setattr_handler(self, name, value)
   1076 elif name not in cls.__pydantic_fields__:
   1077     if cls.model_config.get('extra') != 'allow':
   1078         # TODO - matching error
-> 1079         raise ValueError(f'"{cls.__name__}" object has no field "{name}"')
   1080     elif attr is None:
   1081         # attribute does not exist, so put it in extra
   1082         self.__pydantic_extra__[name] = value

ValueError: "PipelineOptions" object has no field "do_ocr"
```


## After

```
from docling.datamodel.base_models import InputFormat
from docling.datamodel.pipeline_options import (
    TesseractOcrOptions,
    PdfPipelineOptions,
)
from docling.document_converter import DocumentConverter, PdfFormatOption

pipeline_options = PdfPipelineOptions()
pipeline_options.do_ocr = True
pipeline_options.ocr_options = TesseractOcrOptions()  # Use Tesseract

doc_converter = DocumentConverter(
    format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)}
)
```

no error.

If maintainers would like me to create an issue with more details and link it back to this PR, I'm happy to do so. 

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
