### PR TITLE
test: fix missing assert in page_count tests

### DIFF
--- a/tests/test_backend_docling_parse.py
+++ b/tests/test_backend_docling_parse.py
@@ -87,7 +87,7 @@ def test_crop_page_image(test_doc_path):
 
 def test_num_pages(test_doc_path):
     doc_backend = _get_backend(test_doc_path)
-    doc_backend.page_count() == 9
+    assert doc_backend.page_count() == 9
 
     # Explicitly clean up resources to prevent race conditions in CI
     doc_backend.unload()

--- a/tests/test_backend_pdfium.py
+++ b/tests/test_backend_pdfium.py
@@ -93,7 +93,7 @@ def test_crop_page_image(test_doc_path):
 
 def test_num_pages(test_doc_path):
     doc_backend = _get_backend(test_doc_path)
-    doc_backend.page_count() == 9
+    assert doc_backend.page_count() == 9
 
 
 def test_merge_row():


### PR DESCRIPTION
## Summary
- `test_num_pages` in both `test_backend_docling_parse.py` and `test_backend_pdfium.py` used bare comparison expressions (`doc_backend.page_count() == 9`) without `assert`, making them no-ops that always pass
- Added the missing `assert` keyword so these tests actually verify the page count

## Test plan
- [x] `pre-commit run --all-files` passes
- [x] Both `test_num_pages` tests pass with the `assert` added