### PR TITLE
fix: avoid in-place mutation of pipeline options breaking cache key

### DIFF
--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -506,10 +506,14 @@ class StandardPdfPipeline(ConvertPipeline):
         self.reading_order_model = ReadingOrderModel(options=ReadingOrderOptions())
 
         # --- optional enrichment ------------------------------------------------
-        # Update code_formula_options to match the boolean flags
-        code_formula_opts = self.pipeline_options.code_formula_options
-        code_formula_opts.extract_code = self.pipeline_options.do_code_enrichment
-        code_formula_opts.extract_formulas = self.pipeline_options.do_formula_enrichment
+        # Create a copy to avoid mutating pipeline_options in-place,
+        # which would change its hash and break pipeline caching (#3109).
+        code_formula_opts = self.pipeline_options.code_formula_options.model_copy(
+            update={
+                "extract_code": self.pipeline_options.do_code_enrichment,
+                "extract_formulas": self.pipeline_options.do_formula_enrichment,
+            }
+        )
 
         self.enrichment_pipe = [
             # Code Formula Enrichment Model (using new VLM runtime system)

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -191,6 +191,34 @@ def test_parser_backends(test_doc_path):
         assert doc_result.status == ConversionStatus.SUCCESS
 
 
+def test_pipeline_cache_after_initialize(test_doc_path):
+    """Test that initialize_pipeline caches correctly and convert reuses the cache.
+
+    Regression test for #3109: code_formula_options were mutated in-place during
+    pipeline initialization, changing the options hash and causing a cache miss
+    when convert() was called afterwards.
+    """
+    pipeline_options = PdfPipelineOptions()
+    pipeline_options.do_ocr = False
+    pipeline_options.do_table_structure = False
+
+    converter = DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(
+                pipeline_options=pipeline_options,
+            )
+        }
+    )
+
+    converter.initialize_pipeline(InputFormat.PDF)
+    assert len(converter._get_initialized_pipelines()) == 1
+
+    converter.convert(test_doc_path)
+    assert len(converter._get_initialized_pipelines()) == 1, (
+        "Pipeline should be reused from cache, not re-initialized"
+    )
+
+
 def test_confidence(test_doc_path):
     converter = DocumentConverter()
     doc_result: ConversionResult = converter.convert(test_doc_path, page_range=(6, 9))


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #3109

## Summary

`StandardPdfPipeline._init_models()` was mutating `pipeline_options.code_formula_options` in-place (overwriting `extract_code` and `extract_formulas`), which changed the hash computed by `_get_pipeline_options_hash()`. This caused a cache miss when `convert()` called `_get_pipeline()` after `initialize_pipeline()`, resulting in unnecessary pipeline re-initialization.

### Root cause

1. `CodeFormulaVlmOptions.extract_code` defaults to `True`, `extract_formulas` defaults to `True`
2. `PdfPipelineOptions.do_code_enrichment` defaults to `False`, `do_formula_enrichment` defaults to `False`
3. `_init_models()` mutated the shared options: `code_formula_opts.extract_code = self.pipeline_options.do_code_enrichment` (False)
4. This mutation changed the hash of `pipeline_options`, so the cached pipeline was stored under hash A but looked up under hash B

### Fix

Use `model_copy(update=...)` to create a local copy of the options with the updated values, instead of mutating the original `pipeline_options` object. This keeps the hash stable across calls.

## Changes

- `docling/pipeline/standard_pdf_pipeline.py`: Replace in-place mutation with `model_copy()`
- `tests/test_options.py`: Add regression test verifying pipeline cache reuse after `initialize_pipeline()`

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.