### PR TITLE
fix: fall back to pypdfium2 page count when docling-parse returns -1

### DIFF
--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -234,6 +234,14 @@ class DoclingParseDocumentBackend(PdfDocumentBackend):
         if len_1 != len_2:
             _log.error(f"Inconsistent number of pages: {len_1}!={len_2}")
 
+        # Fall back to pypdfium2 count when docling-parse fails (returns -1)
+        if len_2 < 0:
+            _log.warning(
+                f"docling-parse returned invalid page count ({len_2}), "
+                f"falling back to pypdfium2 count ({len_1})."
+            )
+            return len_1
+
         return len_2
 
     def load_page(

--- a/tests/test_backend_docling_parse.py
+++ b/tests/test_backend_docling_parse.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -90,4 +91,17 @@ def test_num_pages(test_doc_path):
     assert doc_backend.page_count() == 9
 
     # Explicitly clean up resources to prevent race conditions in CI
+    doc_backend.unload()
+
+
+def test_page_count_fallback_on_parse_failure(test_doc_path):
+    """page_count() should fall back to pypdfium2 when docling-parse returns -1."""
+    doc_backend = _get_backend(test_doc_path)
+
+    # Simulate docling-parse failure: number_of_pages() returns -1
+    with patch.object(type(doc_backend.dp_doc), "number_of_pages", return_value=-1):
+        count = doc_backend.page_count()
+        assert count == 9, f"Expected pypdfium2 fallback count (9), got {count}"
+        assert doc_backend.is_valid()
+
     doc_backend.unload()


### PR DESCRIPTION
## Summary

Fixes #3031

When docling-parse's C++ backend fails to parse a PDF's page tree (QPDF exception), `number_of_pages()` returns `-1`. The current `page_count()` method returns this value directly, causing `is_valid()` to reject documents that pypdfium2 can read fine.

## Changes

- Added fallback in `page_count()`: when docling-parse returns a negative count, fall back to pypdfium2's page count (`len(self._pdoc)`) with a warning log
- Added `test_page_count_fallback_on_parse_failure` test that mocks docling-parse failure and verifies pypdfium2 fallback

## Test plan

- [x] `pre-commit run --all-files` passes (Ruff + MyPy)
- [x] All 5 existing + new backend tests pass
- [x] New test verifies `page_count()` returns pypdfium2 count when docling-parse returns -1
- [x] New test verifies `is_valid()` returns True in fallback scenario