### PR TITLE
test: fix picture checks in shared verifier

### DIFF
--- a/tests/test_verify_utils.py
+++ b/tests/test_verify_utils.py
@@ -1,7 +1,8 @@
 import pytest
-from docling_core.types.doc import DoclingDocument, ProvenanceItem
+from docling_core.types.doc import DoclingDocument, ImageRef, ProvenanceItem
 from docling_core.types.doc.base import BoundingBox, Size
 from docling_core.types.doc.labels import DocItemLabel
+from PIL import Image
 
 from tests.verify_utils import verify_docitems
 
@@ -20,6 +21,14 @@ def _make_doc_with_bbox(
             bbox=BoundingBox(l=left, t=20.0, r=30.0, b=40.0),
             charspan=(0, 10),
         ),
+    )
+    return doc
+
+
+def _make_doc_with_picture(*, image_size: tuple[int, int]) -> DoclingDocument:
+    doc = DoclingDocument(name="test")
+    doc.add_picture(
+        image=ImageRef.from_pil(Image.new("RGB", image_size, "red"), dpi=72)
     )
     return doc
 
@@ -72,6 +81,32 @@ def test_verify_docitems_rejects_bbox_presence_mismatch():
     doc_pred.texts[0].prov[0].bbox = None
 
     with pytest.raises(AssertionError, match="BBox presence mismatch"):
+        verify_docitems(
+            doc_pred=doc_pred,
+            doc_true=doc_true,
+            fuzzy=False,
+            pdf_filename="fixture.json",
+        )
+
+
+def test_verify_docitems_rejects_picture_count_mismatch():
+    doc_true = _make_doc_with_picture(image_size=(2, 2))
+    doc_pred = DoclingDocument(name="test")
+
+    with pytest.raises(AssertionError, match="Picture lengths do not match"):
+        verify_docitems(
+            doc_pred=doc_pred,
+            doc_true=doc_true,
+            fuzzy=False,
+            pdf_filename="fixture.json",
+        )
+
+
+def test_verify_docitems_uses_predicted_picture_image():
+    doc_true = _make_doc_with_picture(image_size=(2, 2))
+    doc_pred = _make_doc_with_picture(image_size=(3, 2))
+
+    with pytest.raises(AssertionError):
         verify_docitems(
             doc_pred=doc_pred,
             doc_true=doc_true,

--- a/tests/verify_utils.py
+++ b/tests/verify_utils.py
@@ -276,6 +276,9 @@ def verify_docitems(
     assert len(doc_true.tables) == len(doc_pred.tables), (
         f"[{pdf_filename}] document has different count of tables than expected."
     )
+    assert len(doc_true.pictures) == len(doc_pred.pictures), (
+        f"[{pdf_filename}] Picture lengths do not match: {len(doc_true.pictures)} != {len(doc_pred.pictures)}"
+    )
 
     for (true_item, _true_level), (pred_item, _pred_level) in zip(
         doc_true.iterate_items(), doc_pred.iterate_items()
@@ -359,7 +362,7 @@ def verify_docitems(
             )
 
             true_image = true_item.get_image(doc=doc_true)
-            pred_image = true_item.get_image(doc=doc_pred)
+            pred_image = pred_item.get_image(doc=doc_pred)
             if true_image is not None:
                 assert verify_picture_image_v2(true_image, pred_image), (
                     f"[{pdf_filename}] Picture image mismatch"


### PR DESCRIPTION
Small followup to #3108.

There were still two picture-specific holes in `verify_docitems`:
- the predicted image was being read from `true_item`, so embedded image mismatches could pass
- missing or extra pictures could slip through the `zip(...)` walk

This adds the count check and two focused tests for the picture path. Kept it smll on purpose.

Ran `tests/test_verify_utils.py`, `tests/test_interfaces.py`, `tests/test_e2e_conversion.py`, `tests/test_backend_msword.py`, plus a quick EasyOCR webp check locally.