### PR TITLE
fix: handle PermissionError on Windows for directory input

### DIFF
--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -654,7 +654,7 @@ def convert(  # noqa: C901
                     f"[red]Error: The input file {src} does not exist.[/red]"
                 )
                 raise typer.Abort()
-            except IsADirectoryError:
+            except (IsADirectoryError, PermissionError):
                 # if the input matches to a file or a folder
                 try:
                     local_path = TypeAdapter(Path).validate_python(src)


### PR DESCRIPTION
## Summary

On Windows, `pathlib.Path.read_bytes()` raises `PermissionError` instead of `IsADirectoryError` when called on a directory. The CLI only catches `IsADirectoryError`, causing a crash on Windows.

## Fix

Catch both `IsADirectoryError` and `PermissionError` to support both Windows and Linux/macOS.

## Test

- [x] Code compiles
- [ ] Tested on Windows (need reviewer)

Closes #3138