### PR TITLE
fix: section after table incorrectly added as child of table header

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -1461,8 +1461,13 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                 provs_in_cell: list[RefItem] = []
                 rich_table_cell: bool = self._is_rich_table_cell(cell)
 
+                # Save parent state before processing rich cell content
+                # to prevent table cell content from affecting the document hierarchy
+                original_parents = self.parents.copy()
                 if rich_table_cell:
                     _, provs_in_cell = self._walk_linear(cell._element, doc)
+                # Restore parent state after processing rich cell content
+                self.parents = original_parents
                 _log.debug(f"Table cell {row_idx},{col_idx} rich? {rich_table_cell}")
 
                 if len(provs_in_cell) > 0:


### PR DESCRIPTION
## Summary

Fix for Issue #2668: Section after table being incorrectly added as child of table header

## Root Cause

When processing rich table cells (cells with multiple elements), the `_walk_linear` function was called to process cell content. This modified the `self.parents` dictionary, and these changes persisted after the table was processed. Subsequent elements (like section headers after the table) would then incorrectly become children of elements inside the table cell.

## Fix

Save the parent state before processing rich table cell content and restore it afterward, similar to how textbox content is handled in the same file (lines 829-832 and 878-879).

## Changes

- `docling/backend/msword_backend.py`: Added parent state save/restore around the `_walk_linear` call for rich table cells

## Testing

The fix has been verified to have correct syntax. The issue can be reproduced using the sample file from the issue.

---

Fixes #2668