### PR TITLE
Fix: Skip VLM model creation when picture description is disabled (Issue #2515)

### DIFF
--- a/docling/pipeline/base_pipeline.py
+++ b/docling/pipeline/base_pipeline.py
@@ -185,6 +185,10 @@ class ConvertPipeline(BasePipeline):
     def _get_picture_description_model(
         self, artifacts_path: Optional[Path] = None
     ) -> Optional[PictureDescriptionBaseModel]:
+        # Skip model creation if picture description is disabled
+        if not self.pipeline_options.do_picture_description:
+            return None
+
         factory = get_picture_description_factory(
             allow_external_plugins=self.pipeline_options.allow_external_plugins
         )


### PR DESCRIPTION
Fixes Issue #2515 - Docling fails to convert docx document

The issue was that even when do_picture_description=False, the
ConvertPipeline still tried to create a picture description model
using the default 'vlm' kind, which failed if VLM was not installed.

This fix adds an early return in _get_picture_description_model when
do_picture_description is False, avoiding the model creation attempt.