### PR TITLE
fix: catch PermissionError for directory input on Windows (CLI)

### DIFF
--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -654,7 +654,10 @@ def convert(  # noqa: C901
                     f"[red]Error: The input file {src} does not exist.[/red]"
                 )
                 raise typer.Abort()
-            except IsADirectoryError:
+            except (IsADirectoryError, PermissionError):
+                # On Windows, Path.read_bytes() on a directory raises PermissionError
+                # instead of IsADirectoryError (Python issue: https://bugs.python.org/issue43095).
+                # Both exceptions are handled identically here.
                 # if the input matches to a file or a folder
                 try:
                     local_path = TypeAdapter(Path).validate_python(src)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -90,3 +90,44 @@ def test_cli_audio_extensions_coverage():
         assert ext in audio_extensions, (
             f"Audio extension {ext} not found in FormatToExtensions[InputFormat.AUDIO]"
         )
+
+
+def test_cli_directory_input_permission_error(tmp_path, monkeypatch):
+    """Regression test for GitHub issue #3138.
+
+    On Windows, Path.read_bytes() raises PermissionError on a directory path
+    instead of IsADirectoryError (Linux/macOS).  The CLI handler must catch
+    both so that directory inputs work correctly on Windows.
+    """
+    import docling.cli.main as cli_main
+    from docling_core.utils.file import resolve_source_to_path
+
+    # Create a temporary input dir with a dummy PDF placeholder
+    input_dir = tmp_path / "input"
+    input_dir.mkdir()
+    dummy_pdf = input_dir / "test.pdf"
+    dummy_pdf.write_bytes(b"%PDF-1.4 dummy")
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    # Simulate the Windows behaviour: resolve_source_to_path raises PermissionError
+    # when called on a directory (instead of IsADirectoryError on Linux/macOS).
+    original_resolve = resolve_source_to_path
+
+    def raise_permission_error(source, **kwargs):
+        from pathlib import Path as _Path
+        p = _Path(str(source))
+        if p.is_dir():
+            raise PermissionError(f"[Errno 13] Permission denied: '{source}'")
+        return original_resolve(source, **kwargs)
+
+    monkeypatch.setattr(cli_main, "resolve_source_to_path", raise_permission_error)
+
+    # The CLI should handle PermissionError the same as IsADirectoryError:
+    # it should NOT propagate as an unhandled exception (exit_code != 2).
+    result = runner.invoke(app, [str(input_dir), "--output", str(output_dir)])
+    assert result.exit_code != 2, (
+        f"CLI crashed with unhandled PermissionError on directory input. "
+        f"Output: {result.output}"
+    )


### PR DESCRIPTION
## Summary

Fixes #3138

### Problem

On Windows, `Path.read_bytes()` raises `PermissionError` when called on a directory path, instead of the `IsADirectoryError` raised on Linux/macOS (Python issue [#43095](https://bugs.python.org/issue43095)).

The CLI handler in `docling/cli/main.py` only caught `IsADirectoryError`, so passing a directory as the input source on Windows would crash with an unhandled `PermissionError` rather than gracefully iterating over the directory contents.

### Fix

One-line change: extend the `except` clause on line 657 to also catch `PermissionError`:

```python
# Before
except IsADirectoryError:

# After
except (IsADirectoryError, PermissionError):
```

Both exceptions are already handled by identical logic (checking `is_dir()` and globbing for supported files).

### Test

Added `test_cli_directory_input_permission_error` which monkeypatches `resolve_source_to_path` to raise `PermissionError` on directory paths, simulating the Windows behaviour without requiring a Windows host.