### PR TITLE
docs: Fix Erroneous vLLM VLM pipeline engine option params causing empty/bad responses

### DIFF
--- a/docs/examples/vlm_pipeline_api_model.py
+++ b/docs/examples/vlm_pipeline_api_model.py
@@ -318,8 +318,9 @@ def run_vllm_example(input_doc_path: Path) -> bool:
             url="http://localhost:8000/v1/chat/completions",
             params={
                 "model": "ibm-granite/granite-docling-258M",
-                "max_tokens": 4096,
-                "skip_special_tokens": True,
+                "temperature": 0.0,
+                "max_tokens": 8192,
+                "skip_special_tokens": False,
             },
             timeout=90,
         ),


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Overview**
The documentation page [VLM pipeline with remote model](https://docling-project.github.io/docling/examples/vlm_pipeline_api_model/) contains information that isn't correct for running vLLM. The `engine_options.params` for vLLM must have `skip_special_tokens` set to `False`, otherwise you get bad output - often blank or mix of incomprehensible doctags which cannot be converted. This leads users to be confused and get bad results when hosting VLM model pipelines using vLLM.

**Description of Changes**
I have updated the documentation page with the parameters used on the [ibm/granite-docling-258M](https://huggingface.co/ibm-granite/granite-docling-258M) hugging face, I think this would resolve all the issues the users are having in the issues below as I had a similar issue and almost all of these issues follow the same pattern with `skip_special_tokens` being set to `True` instead of `False`, which it should be.

**Issue resolved by this Pull Request:**
Resolves #2353, #2356, #2398, #2868, #3033

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
