### PR TITLE
chore: re-export DocumentStream explicitly for type checkers

### DIFF
--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -13,7 +13,9 @@ from docling_core.types.doc import (
 )
 from docling_core.types.doc.base import PydanticSerCtxKey, round_pydantic_float
 from docling_core.types.doc.page import SegmentedPdfPage, TextCell
-from docling_core.types.io import DocumentStream
+from docling_core.types.io import (
+    DocumentStream as DocumentStream,
+)
 
 # DO NOT REMOVE; explicitly exposed from this location
 from PIL.Image import Image


### PR DESCRIPTION
Fixes #3165

`DocumentStream` was imported with a plain `import`, which Pyright treats as a private symbol in `py.typed` packages and raises `reportPrivateImportUsage` for users importing it from `docling.datamodel.base_models`.

Using `import X as X` (PEP 484) marks it as an intentional re-export.