### PR TITLE
fix: explicitly re-export DocumentStream from base_models

### DIFF
--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -13,10 +13,10 @@ from docling_core.types.doc import (
 )
 from docling_core.types.doc.base import PydanticSerCtxKey, round_pydantic_float
 from docling_core.types.doc.page import SegmentedPdfPage, TextCell
-from docling_core.types.io import DocumentStream
+from docling_core.types.io import DocumentStream as DocumentStream
 
 # DO NOT REMOVE; explicitly exposed from this location
-from PIL.Image import Image
+from PIL.Image import Image as Image
 from pydantic import (
     BaseModel,
     ConfigDict,
@@ -32,6 +32,47 @@ if TYPE_CHECKING:
 
 from docling.backend.abstract_backend import AbstractDocumentBackend
 from docling.datamodel.pipeline_options import PipelineOptions
+
+__all__ = [
+    "DocumentStream",
+    "Image",
+    "BaseFormatOption",
+    "ConversionStatus",
+    "InputFormat",
+    "OutputFormat",
+    "FormatToExtensions",
+    "FormatToMimeType",
+    "MimeTypeToFormat",
+    "DocInputType",
+    "DoclingComponentType",
+    "VlmStopReason",
+    "ErrorItem",
+    "Cluster",
+    "BasePageElement",
+    "LayoutPrediction",
+    "VlmPredictionToken",
+    "VlmPrediction",
+    "ContainerElement",
+    "Table",
+    "TableStructurePrediction",
+    "TextElement",
+    "FigureElement",
+    "FigureClassificationPrediction",
+    "EquationPrediction",
+    "PagePredictions",
+    "PageElement",
+    "AssembledUnit",
+    "ItemAndImageEnrichmentElement",
+    "Page",
+    "OpenAiChatMessage",
+    "OpenAiResponseChoice",
+    "OpenAiResponseUsage",
+    "OpenAiApiResponse",
+    "ScoreValue",
+    "QualityGrade",
+    "PageConfidenceScores",
+    "ConfidenceReport",
+]
 
 
 class BaseFormatOption(BaseModel):

--- a/tests/test_input_doc.py
+++ b/tests/test_input_doc.py
@@ -11,10 +11,16 @@ from docling.datamodel.backend_options import (
     DeclarativeBackendOptions,
     HTMLBackendOptions,
 )
+from docling.datamodel import base_models
 from docling.datamodel.base_models import DocumentStream, InputFormat
 from docling.datamodel.document import InputDocument, _DocumentConversionInput
 from docling.datamodel.settings import DocumentLimits
 from docling.document_converter import ImageFormatOption, PdfFormatOption
+
+
+def test_base_models_explicitly_exports_document_stream():
+    assert "DocumentStream" in base_models.__all__
+    assert base_models.DocumentStream is DocumentStream
 
 
 def test_in_doc_from_valid_path():


### PR DESCRIPTION
## Summary
- explicitly re-export `DocumentStream` from `docling.datamodel.base_models`
- add `__all__` to make the module's public exports explicit for static type checkers
- add a regression test that checks `DocumentStream` stays part of the public export surface

## Testing
- `python3 -m py_compile docling/datamodel/base_models.py tests/test_input_doc.py`
- attempted: `python3 -m pytest tests/test_input_doc.py -k 'explicitly_exports_document_stream or valid_buf or invalid_buf'`
  - could not run in this workspace because the local environment is missing repo dependencies such as `pydantic`

Fixes #3165
Related to #614
