### PR TITLE
feat(cli): add page break placeholder option

### DIFF
--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -216,6 +216,7 @@ def export_documents(
     print_timings: bool,
     export_timings: bool,
     image_export_mode: ImageRefMode,
+    page_break_placeholder: str | None,
 ):
     success_count = 0
     failure_count = 0
@@ -283,6 +284,7 @@ def export_documents(
                     filename=fname,
                     strict_text=True,
                     image_mode=ImageRefMode.PLACEHOLDER,
+                    page_break_placeholder=page_break_placeholder,
                 )
 
             # Export Markdown format:
@@ -290,7 +292,9 @@ def export_documents(
                 fname = output_dir / f"{doc_filename}.md"
                 _log.info(f"writing Markdown output to {fname}")
                 conv_res.document.save_as_markdown(
-                    filename=fname, image_mode=image_export_mode
+                    filename=fname,
+                    image_mode=image_export_mode,
+                    page_break_placeholder=page_break_placeholder,
                 )
 
             # Export Document Tags format:
@@ -426,6 +430,13 @@ def convert(  # noqa: C901
             help="Image export mode for image-capable document outputs (JSON, YAML, HTML, HTML split-page, and Markdown). Text, DocTags, and WebVTT outputs do not export images. With `placeholder`, only the position of the image is marked in the output. In `embedded` mode, the image is embedded as base64 encoded string. In `referenced` mode, the image is exported in PNG format and referenced from the main exported document.",
         ),
     ] = ImageRefMode.EMBEDDED,
+    page_break_placeholder: Annotated[
+        str | None,
+        typer.Option(
+            ...,
+            help="String inserted between pages when exporting Markdown or text output.",
+        ),
+    ] = None,
     pipeline: Annotated[
         ProcessingPipeline,
         typer.Option(..., help="Choose the pipeline to process PDF or image files."),
@@ -968,6 +979,7 @@ def convert(  # noqa: C901
             print_timings=profiling,
             export_timings=save_profiling,
             image_export_mode=image_export_mode,
+            page_break_placeholder=page_break_placeholder,
         )
 
         end_time = time.time() - start_time

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,8 +11,9 @@ runner = CliRunner()
 
 
 def test_cli_help():
-    result = runner.invoke(app, ["--help"])
+    result = runner.invoke(app, ["--help"], env={"COLUMNS": "200"})
     assert result.exit_code == 0
+    assert "--page-break-placeholder" in result.stdout
 
 
 def test_cli_version():
@@ -28,6 +29,40 @@ def test_cli_convert(tmp_path):
     assert result.exit_code == 0
     converted = output / f"{Path(source).stem}.md"
     assert converted.exists()
+
+
+@pytest.mark.parametrize(
+    ("output_format", "extension"),
+    [
+        ("md", ".md"),
+        ("text", ".txt"),
+    ],
+)
+def test_cli_page_break_placeholder(tmp_path, output_format, extension):
+    source = "./tests/data/pdf/normal_4pages.pdf"
+    output = tmp_path / "out"
+    output.mkdir()
+
+    result = runner.invoke(
+        app,
+        [
+            source,
+            "--output",
+            str(output),
+            "--to",
+            output_format,
+            "--page-break-placeholder",
+            "<PAGE_BREAK>",
+            "--no-ocr",
+            "--no-tables",
+        ],
+    )
+
+    assert result.exit_code == 0
+
+    converted = output / f"{Path(source).stem}{extension}"
+    assert converted.exists()
+    assert converted.read_text().count("<PAGE_BREAK>") == 3
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Adds a CLI option for setting the page break placeholder used in markdown and text exports.

Also adds CLI coverage for help output and multi-page markdown/text export.

Closes #3175.