### PR TITLE
fix: handle empty CSV file without crashing

### DIFF
--- a/docling/backend/csv_backend.py
+++ b/docling/backend/csv_backend.py
@@ -77,16 +77,6 @@ class CsvDocumentBackend(DeclarativeDocumentBackend):
         self.csv_data = list(result)
         _log.info(f"Detected {len(self.csv_data)} lines")
 
-        # Ensure uniform column length
-        expected_length = len(self.csv_data[0])
-        is_uniform = all(len(row) == expected_length for row in self.csv_data)
-        if not is_uniform:
-            warnings.warn(
-                f"Inconsistent column lengths detected in CSV data. "
-                f"Expected {expected_length} columns, but found rows with varying lengths. "
-                f"Ensure all rows have the same number of columns."
-            )
-
         # Parse the CSV into a structured document model
         origin = DocumentOrigin(
             filename=self.file.name or "file.csv",
@@ -98,7 +88,18 @@ class CsvDocumentBackend(DeclarativeDocumentBackend):
 
         if self.is_valid():
             # Convert CSV data to table
-            if self.csv_data:
+            if not self.csv_data:
+                _log.warning("CSV file is empty, returning empty document.")
+            else:
+                expected_length = len(self.csv_data[0])
+                is_uniform = all(len(row) == expected_length for row in self.csv_data)
+                if not is_uniform:
+                    warnings.warn(
+                        f"Inconsistent column lengths detected in CSV data. "
+                        f"Expected {expected_length} columns, but found rows with varying lengths. "
+                        f"Ensure all rows have the same number of columns."
+                    )
+
                 num_rows = len(self.csv_data)
                 num_cols = max(len(row) for row in self.csv_data)
 

--- a/tests/test_backend_csv.py
+++ b/tests/test_backend_csv.py
@@ -1,8 +1,9 @@
+from io import BytesIO
 from pathlib import Path
 
 from pytest import warns
 
-from docling.datamodel.base_models import InputFormat
+from docling.datamodel.base_models import DocumentStream, InputFormat
 from docling.datamodel.document import ConversionResult, DoclingDocument
 from docling.document_converter import DocumentConverter
 
@@ -85,3 +86,12 @@ def test_e2e_invalid_csv_conversions():
     print(f"converting {csv_inconsistent_header}")
     with warns(UserWarning, match="Inconsistent column lengths"):
         converter.convert(csv_inconsistent_header)
+
+
+def test_empty_csv():
+    """Regression test: converting an empty CSV file should not raise an IndexError."""
+    conv_result = get_converter().convert(
+        DocumentStream(name="empty.csv", stream=BytesIO(b"")),
+        raises_on_error=True,
+    )
+    assert conv_result.document is not None

--- a/tests/test_backend_csv.py
+++ b/tests/test_backend_csv.py
@@ -94,4 +94,8 @@ def test_empty_csv():
         DocumentStream(name="empty.csv", stream=BytesIO(b"")),
         raises_on_error=True,
     )
-    assert conv_result.document is not None
+    doc = conv_result.document
+    assert doc is not None
+    # The empty CSV should result in an empty document (no tables and no texts).
+    assert len(getattr(doc, "tables", [])) == 0
+    assert len(getattr(doc, "texts", [])) == 0


### PR DESCRIPTION
Fixes #3195

Converting an empty CSV file crashed with an `IndexError` at `self.csv_data[0]` because the column uniformity check ran unconditionally right after parsing, before any guard on the data.

Moved that check inside the `if/else` on `csv_data` (alongside the rest of the conversion logic), so empty files now log a warning and return an empty document instead of crashing.

Also added a regression test.

Signed-off-by: Eugenio-BAYE <baye.eugenio.egnb@gmail.com>