### PR TITLE
feat(vlm): add PARTIAL_SUCCESS status for VLM pipeline pages

### DIFF
--- a/docling/pipeline/vlm_pipeline.py
+++ b/docling/pipeline/vlm_pipeline.py
@@ -5,6 +5,8 @@ from io import BytesIO
 from pathlib import Path
 from typing import List, Union, cast
 
+from typing_extensions import override
+
 from docling_core.types.doc import (
     BoundingBox,
     ContentLayer,
@@ -29,7 +31,14 @@ from docling.backend.abstract_backend import (
 from docling.backend.html_backend import HTMLDocumentBackend
 from docling.backend.md_backend import MarkdownDocumentBackend
 from docling.backend.pdf_backend import PdfDocumentBackend
-from docling.datamodel.base_models import InputFormat, Page
+from docling.datamodel.base_models import (
+    ConversionStatus,
+    DoclingComponentType,
+    ErrorItem,
+    InputFormat,
+    Page,
+    VlmStopReason,
+)
 from docling.datamodel.document import ConversionResult, InputDocument
 from docling.datamodel.pipeline_options import (
     VlmConvertOptions,
@@ -206,6 +215,43 @@ class VlmPipeline(PaginatedPipeline):
                 if page._backend:
                     text = page._backend.get_text_in_rect(bbox)
         return text
+
+    @override
+    def _determine_status(self, conv_res: ConversionResult) -> ConversionStatus:
+        """Determine conversion status accounting for VLM stop reasons.
+
+        Extends the base implementation to detect partial failures from VLM
+        inference, such as truncated output (LENGTH) or filtered content
+        (CONTENT_FILTERED).
+        """
+        status = super()._determine_status(conv_res)
+
+        for page in conv_res.pages:
+            vlm_response = page.predictions.vlm_response
+            if vlm_response is None:
+                conv_res.errors.append(
+                    ErrorItem(
+                        component_type=DoclingComponentType.PIPELINE,
+                        module_name=self.__class__.__name__,
+                        error_message=f"Page {page.page_no} has no VLM prediction.",
+                    )
+                )
+                status = ConversionStatus.PARTIAL_SUCCESS
+            elif vlm_response.stop_reason in (
+                VlmStopReason.LENGTH,
+                VlmStopReason.CONTENT_FILTERED,
+            ):
+                conv_res.errors.append(
+                    ErrorItem(
+                        component_type=DoclingComponentType.PIPELINE,
+                        module_name=self.__class__.__name__,
+                        error_message=f"Page {page.page_no} VLM output incomplete "
+                        f"(stop_reason={vlm_response.stop_reason.value}).",
+                    )
+                )
+                status = ConversionStatus.PARTIAL_SUCCESS
+
+        return status
 
     def _assemble_document(self, conv_res: ConversionResult) -> ConversionResult:
         with TimeRecorder(conv_res, "doc_assemble", scope=ProfilingScope.DOCUMENT):

--- a/tests/test_vlm_pipeline_status.py
+++ b/tests/test_vlm_pipeline_status.py
@@ -1,0 +1,154 @@
+"""Tests for VlmPipeline._determine_status with VLM stop reasons.
+
+Verifies that VlmPipeline correctly reports PARTIAL_SUCCESS when
+individual pages have problematic VLM stop reasons (LENGTH,
+CONTENT_FILTERED) or missing predictions.
+
+Related: https://github.com/docling-project/docling/issues/2583
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from docling.datamodel.base_models import (
+    ConversionStatus,
+    Page,
+    PagePredictions,
+    VlmPrediction,
+    VlmStopReason,
+)
+from docling.datamodel.document import ConversionResult
+from docling.datamodel.pipeline_options import VlmPipelineOptions
+from docling.pipeline.vlm_pipeline import VlmPipeline
+
+
+def _make_page(page_no: int, stop_reason: VlmStopReason) -> Page:
+    """Create a Page with a VLM prediction using the given stop reason."""
+    page = Page(page_no=page_no)
+    page.predictions = PagePredictions(
+        vlm_response=VlmPrediction(
+            text="some output",
+            stop_reason=stop_reason,
+        )
+    )
+    # Provide a valid mock backend so the parent check doesn't flag it
+    backend = MagicMock()
+    backend.is_valid.return_value = True
+    page._backend = backend
+    return page
+
+
+def _make_page_no_vlm(page_no: int) -> Page:
+    """Create a Page with no VLM prediction."""
+    page = Page(page_no=page_no)
+    page.predictions = PagePredictions(vlm_response=None)
+    backend = MagicMock()
+    backend.is_valid.return_value = True
+    page._backend = backend
+    return page
+
+
+def _make_conv_res(pages: list) -> ConversionResult:
+    """Create a minimal ConversionResult with the given pages."""
+    conv_res = MagicMock(spec=ConversionResult)
+    conv_res.pages = pages
+    conv_res.errors = []
+    conv_res.status = ConversionStatus.STARTED
+    # Provide input with a mock backend for parent _determine_status
+    conv_res.input = MagicMock()
+    conv_res.input._backend = None
+    return conv_res
+
+
+@pytest.fixture
+def pipeline() -> VlmPipeline:
+    """Create a VlmPipeline instance with minimal options."""
+    return VlmPipeline.__new__(VlmPipeline)
+
+
+def test_all_pages_success(pipeline: VlmPipeline) -> None:
+    """All pages with END_OF_SEQUENCE should yield SUCCESS."""
+    pages = [
+        _make_page(1, VlmStopReason.END_OF_SEQUENCE),
+        _make_page(2, VlmStopReason.END_OF_SEQUENCE),
+    ]
+    conv_res = _make_conv_res(pages)
+    status = pipeline._determine_status(conv_res)
+    assert status == ConversionStatus.SUCCESS
+    assert len(conv_res.errors) == 0
+
+
+def test_page_truncated_length(pipeline: VlmPipeline) -> None:
+    """A page with LENGTH stop reason should yield PARTIAL_SUCCESS."""
+    pages = [
+        _make_page(1, VlmStopReason.END_OF_SEQUENCE),
+        _make_page(2, VlmStopReason.LENGTH),
+    ]
+    conv_res = _make_conv_res(pages)
+    status = pipeline._determine_status(conv_res)
+    assert status == ConversionStatus.PARTIAL_SUCCESS
+    assert len(conv_res.errors) == 1
+    assert "Page 2" in conv_res.errors[0].error_message
+
+
+def test_page_content_filtered(pipeline: VlmPipeline) -> None:
+    """A page with CONTENT_FILTERED stop reason should yield PARTIAL_SUCCESS."""
+    pages = [
+        _make_page(1, VlmStopReason.CONTENT_FILTERED),
+    ]
+    conv_res = _make_conv_res(pages)
+    status = pipeline._determine_status(conv_res)
+    assert status == ConversionStatus.PARTIAL_SUCCESS
+    assert len(conv_res.errors) == 1
+    assert "content_filter" in conv_res.errors[0].error_message
+
+
+def test_page_no_vlm_response(pipeline: VlmPipeline) -> None:
+    """A page with no VLM prediction should yield PARTIAL_SUCCESS."""
+    pages = [
+        _make_page(1, VlmStopReason.END_OF_SEQUENCE),
+        _make_page_no_vlm(2),
+    ]
+    conv_res = _make_conv_res(pages)
+    status = pipeline._determine_status(conv_res)
+    assert status == ConversionStatus.PARTIAL_SUCCESS
+    assert len(conv_res.errors) == 1
+    assert "no VLM prediction" in conv_res.errors[0].error_message
+
+
+def test_stop_sequence_is_success(pipeline: VlmPipeline) -> None:
+    """STOP_SEQUENCE is a normal completion and should yield SUCCESS."""
+    pages = [
+        _make_page(1, VlmStopReason.STOP_SEQUENCE),
+    ]
+    conv_res = _make_conv_res(pages)
+    status = pipeline._determine_status(conv_res)
+    assert status == ConversionStatus.SUCCESS
+    assert len(conv_res.errors) == 0
+
+
+def test_unspecified_is_success(pipeline: VlmPipeline) -> None:
+    """UNSPECIFIED (the default stop reason) should yield SUCCESS."""
+    pages = [
+        _make_page(1, VlmStopReason.UNSPECIFIED),
+    ]
+    conv_res = _make_conv_res(pages)
+    status = pipeline._determine_status(conv_res)
+    assert status == ConversionStatus.SUCCESS
+    assert len(conv_res.errors) == 0
+
+
+def test_multiple_failures_accumulate_errors(pipeline: VlmPipeline) -> None:
+    """Multiple problematic pages should each record an error."""
+    pages = [
+        _make_page(1, VlmStopReason.LENGTH),
+        _make_page(2, VlmStopReason.CONTENT_FILTERED),
+        _make_page(3, VlmStopReason.END_OF_SEQUENCE),
+    ]
+    conv_res = _make_conv_res(pages)
+    status = pipeline._determine_status(conv_res)
+    assert status == ConversionStatus.PARTIAL_SUCCESS
+    assert len(conv_res.errors) == 2
+    assert "Page 1" in conv_res.errors[0].error_message
+    assert "Page 2" in conv_res.errors[1].error_message


### PR DESCRIPTION
## Description

`VlmPipeline` inherits `_determine_status()` from `PaginatedPipeline`, which only checks PDF backend validity — it never inspects VLM stop reasons. When a vision-language model truncates output (hits max tokens) or an API provider filters content, the pipeline silently reports `SUCCESS` even though page data is incomplete.

This PR overrides `_determine_status()` in `VlmPipeline` to check each page's `VlmPrediction.stop_reason` and set `PARTIAL_SUCCESS` when:

- **`LENGTH`** — model hit max token limit, output is truncated
- **`CONTENT_FILTERED`** — API provider blocked the output
- **`vlm_response is None`** — page was never processed by the VLM

Descriptive `ErrorItem` objects are appended for each affected page, including the page number and stop reason, so downstream consumers can log, retry, or warn accordingly.

### Design note: `STOP_SEQUENCE` treated as success

The issue description and DosuBot both suggested flagging `STOP_SEQUENCE` as a partial failure. This implementation intentionally does not. In `ExtractionVlmPipeline`, hitting a stop sequence may indicate incomplete JSON extraction — flagging it makes sense there. But in `VlmPipeline`, stop sequences are part of normal operation: doctags format uses them to delimit page boundaries. Flagging `STOP_SEQUENCE` here would cause false positives on every successful conversion.

### Changes

- **`docling/pipeline/vlm_pipeline.py`** — Added `_determine_status()` override with `@override` decorator, new imports (`ConversionStatus`, `DoclingComponentType`, `ErrorItem`, `VlmStopReason`)
- **`tests/test_vlm_pipeline_status.py`** — 7 unit tests covering all `VlmStopReason` variants: `END_OF_SEQUENCE`, `STOP_SEQUENCE`, `LENGTH`, `CONTENT_FILTERED`, `UNSPECIFIED`, missing VLM response, and multi-error accumulation

**Issue resolved by this Pull Request:**
Closes #2583

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
