### PR TITLE
fix: strip soft hyphen when joining merged text elements

### DIFF
--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -421,10 +421,12 @@ class ReadingOrderModel:
             ),
             bbox=merged_elem.cluster.bbox.to_bottom_left_origin(page_height),
         )
-        if new_item.text.endswith('\u00AD'):
+        if new_item.text.endswith("\u00ad"):
             # Soft hyphen (U+00AD): strip it and join without space (hyphenated word split across lines)
             new_item.text = new_item.text[:-1] + merged_elem.text
-            new_item.orig = new_item.orig[:-1] + merged_elem.text  # TODO: This is incomplete, we don't have the `orig` field of the merged element.
+            new_item.orig = (
+                new_item.orig[:-1] + merged_elem.text
+            )  # TODO: This is incomplete, we don't have the `orig` field of the merged element.
         else:
             new_item.text += f" {merged_elem.text}"
             new_item.orig += f" {merged_elem.text}"  # TODO: This is incomplete, we don't have the `orig` field of the merged element.


### PR DESCRIPTION
## Problem

`_merge_elements` always joins two text elements with a space:

```python
new_item.text += f" {merged_elem.text}"
```

For lines ending with U+00AD (SOFT HYPHEN) this produces `abge­ rackerten` instead of `abgerackerten`.

A soft hyphen marks an optional line-break point in typeset text (books, journals, typeset PDFs). The two fragments are halves of one hyphenated word and must be joined **without a space**, with the soft hyphen itself removed.

## Fix

Check for trailing U+00AD before joining and use direct concatenation (after stripping the soft hyphen) in that case:

```python
if new_item.text.endswith('\u00AD'):
    new_item.text = new_item.text[:-1] + merged_elem.text
    new_item.orig = new_item.orig[:-1] + merged_elem.text
else:
    new_item.text += f" {merged_elem.text}"
    new_item.orig += f" {merged_elem.text}"
```