### PR TITLE
feat: add do_reading_order option to PdfPipelineOptions

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1459,6 +1459,17 @@ class PdfPipelineOptions(PaginatedPipelineOptions):
         - `examples/pipeline_options_advanced.py`: Comprehensive configuration examples.
     """
 
+    do_reading_order: Annotated[
+        bool,
+        Field(
+            description=(
+                "Enable reading-order prediction to reorder document elements into logical reading sequence. "
+                "When disabled, elements retain the order produced by the layout postprocessor. "
+                "Disabling can improve results for PDFs where the reading-order predictor produces incorrect "
+                "output, such as scanned pages with a native text layer and many small orphan clusters."
+            )
+        ),
+    ] = True
     do_table_structure: Annotated[
         bool,
         Field(

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -37,6 +37,7 @@ class ReadingOrderOptions(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
     model_names: str = ""  # e.g. "language;term;reference"
+    skip_prediction: bool = False  # if True, keep layout postprocessor order as-is
 
 
 class ReadingOrderModel:
@@ -433,9 +434,12 @@ class ReadingOrderModel:
             page_elements = self._assembled_to_readingorder_elements(conv_res)
 
             # Apply reading order
-            sorted_elements = self.ro_model.predict_reading_order(
-                page_elements=page_elements
-            )
+            if self.options.skip_prediction:
+                sorted_elements = page_elements
+            else:
+                sorted_elements = self.ro_model.predict_reading_order(
+                    page_elements=page_elements
+                )
             el_to_captions_mapping = self.ro_model.predict_to_captions(
                 sorted_elements=sorted_elements
             )

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -40,7 +40,9 @@ class ReadingOrderOptions(BaseModel):
 
 
 class ReadingOrderModel:
-    def __init__(self, enabled: bool = True, options: ReadingOrderOptions = ReadingOrderOptions()):
+    def __init__(
+        self, enabled: bool = True, options: ReadingOrderOptions = ReadingOrderOptions()
+    ):
         self.enabled = enabled
         self.options = options
         self.ro_model = ReadingOrderPredictor()

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -37,11 +37,11 @@ class ReadingOrderOptions(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
     model_names: str = ""  # e.g. "language;term;reference"
-    skip_prediction: bool = False  # if True, keep layout postprocessor order as-is
 
 
 class ReadingOrderModel:
-    def __init__(self, options: ReadingOrderOptions):
+    def __init__(self, enabled: bool = True, options: ReadingOrderOptions = ReadingOrderOptions()):
+        self.enabled = enabled
         self.options = options
         self.ro_model = ReadingOrderPredictor()
         self.list_item_processor = ListItemMarkerProcessor()
@@ -434,7 +434,7 @@ class ReadingOrderModel:
             page_elements = self._assembled_to_readingorder_elements(conv_res)
 
             # Apply reading order
-            if self.options.skip_prediction:
+            if not self.enabled:
                 sorted_elements = page_elements
             else:
                 sorted_elements = self.ro_model.predict_reading_order(

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -37,13 +37,11 @@ class ReadingOrderOptions(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
     model_names: str = ""  # e.g. "language;term;reference"
+    reorder_elements: bool = True  # if False, keep layout postprocessor order as-is
 
 
 class ReadingOrderModel:
-    def __init__(
-        self, enabled: bool = True, options: ReadingOrderOptions = ReadingOrderOptions()
-    ):
-        self.enabled = enabled
+    def __init__(self, options: ReadingOrderOptions = ReadingOrderOptions()):
         self.options = options
         self.ro_model = ReadingOrderPredictor()
         self.list_item_processor = ListItemMarkerProcessor()
@@ -436,7 +434,7 @@ class ReadingOrderModel:
             page_elements = self._assembled_to_readingorder_elements(conv_res)
 
             # Apply reading order
-            if not self.enabled:
+            if not self.options.reorder_elements:
                 sorted_elements = page_elements
             else:
                 sorted_elements = self.ro_model.predict_reading_order(

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -504,8 +504,9 @@ class StandardPdfPipeline(ConvertPipeline):
         )
         self.assemble_model = PageAssembleModel(options=PageAssembleOptions())
         self.reading_order_model = ReadingOrderModel(
-            enabled=self.pipeline_options.do_reading_order,
-            options=ReadingOrderOptions(),
+            options=ReadingOrderOptions(
+                reorder_elements=self.pipeline_options.do_reading_order,
+            ),
         )
 
         # --- optional enrichment ------------------------------------------------

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -503,7 +503,9 @@ class StandardPdfPipeline(ConvertPipeline):
             enable_remote_services=self.pipeline_options.enable_remote_services,
         )
         self.assemble_model = PageAssembleModel(options=PageAssembleOptions())
-        self.reading_order_model = ReadingOrderModel(options=ReadingOrderOptions())
+        self.reading_order_model = ReadingOrderModel(options=ReadingOrderOptions(
+            skip_prediction=not self.pipeline_options.do_reading_order
+        ))
 
         # --- optional enrichment ------------------------------------------------
         # Create a copy to avoid mutating pipeline_options in-place,

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -503,9 +503,10 @@ class StandardPdfPipeline(ConvertPipeline):
             enable_remote_services=self.pipeline_options.enable_remote_services,
         )
         self.assemble_model = PageAssembleModel(options=PageAssembleOptions())
-        self.reading_order_model = ReadingOrderModel(options=ReadingOrderOptions(
-            skip_prediction=not self.pipeline_options.do_reading_order
-        ))
+        self.reading_order_model = ReadingOrderModel(
+            enabled=self.pipeline_options.do_reading_order,
+            options=ReadingOrderOptions(),
+        )
 
         # --- optional enrichment ------------------------------------------------
         # Create a copy to avoid mutating pipeline_options in-place,


### PR DESCRIPTION
## Summary

This draft PR adds a `do_reading_order` flag to `PdfPipelineOptions`, analogous to the existing `do_table_structure` and `do_ocr` options.

## Motivation

The `ReadingOrderPredictor` works well for most PDFs, but produces incorrect results for certain document types — in particular, scanned PDFs that also carry a native text layer. On such pages, each line of text typically becomes its own small orphan cluster, and the graph-based predictor struggles with 50–100 small clusters and reorders them incorrectly.

With `do_reading_order=False`, elements retain the order produced by the layout postprocessor. Combined with spatial cell sorting (`sort_cells_spatial` in `BaseLayoutOptions`), this gives correct reading order for the affected pages.

## Changes

- `PdfPipelineOptions.do_reading_order: bool = True` — new flag, defaults to True (no change in existing behaviour)
- `ReadingOrderOptions.skip_prediction: bool = False` — internal flag on the model
- `StandardPdfPipeline` wires `do_reading_order` → `skip_prediction`

## Open question

Is this the right approach, or would you prefer a different mechanism to handle cases where the reading-order predictor produces poor results? Happy to adjust based on feedback.