### PR TITLE
feat(xlsx): add sheet_names filter to MsExcelBackendOptions

### DIFF
--- a/docling/backend/msexcel_backend.py
+++ b/docling/backend/msexcel_backend.py
@@ -243,7 +243,9 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
             # Iterate over all sheets, applying optional name filter
             for idx, name in enumerate(self.workbook.sheetnames):
                 if sheet_names_filter is not None and name not in sheet_names_filter:
-                    _log.debug(f"Skipping sheet {idx}: {name} (not in sheet_names filter)")
+                    _log.debug(
+                        f"Skipping sheet {idx}: {name} (not in sheet_names filter)"
+                    )
                     continue
 
                 page_no += 1

--- a/docling/backend/msexcel_backend.py
+++ b/docling/backend/msexcel_backend.py
@@ -177,7 +177,16 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
     @override
     def page_count(self) -> int:
         if self.is_valid() and self.workbook:
-            return len(self.workbook.sheetnames)
+            sheet_names_filter = (
+                cast(MsExcelBackendOptions, self.options).sheet_names
+                if isinstance(self.options, MsExcelBackendOptions)
+                else None
+            )
+            if sheet_names_filter is None:
+                return len(self.workbook.sheetnames)
+            return sum(
+                1 for name in self.workbook.sheetnames if name in sheet_names_filter
+            )
         else:
             return 0
 
@@ -225,12 +234,22 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         """
 
         if self.workbook is not None:
-            # Iterate over all sheets
+            sheet_names_filter = (
+                cast(MsExcelBackendOptions, self.options).sheet_names
+                if isinstance(self.options, MsExcelBackendOptions)
+                else None
+            )
+            page_no = 0
+            # Iterate over all sheets, applying optional name filter
             for idx, name in enumerate(self.workbook.sheetnames):
-                _log.info(f"Processing sheet {idx}: {name}")
+                if sheet_names_filter is not None and name not in sheet_names_filter:
+                    _log.debug(f"Skipping sheet {idx}: {name} (not in sheet_names filter)")
+                    continue
+
+                page_no += 1
+                _log.info(f"Processing sheet {idx}: {name} as page {page_no}")
 
                 sheet = self.workbook[name]
-                page_no = idx + 1
                 # do not rely on sheet.max_column, sheet.max_row if there are images
                 page = doc.add_page(page_no=page_no, size=Size(width=0, height=0))
 
@@ -240,42 +259,52 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
                     name=f"sheet: {name}",
                     content_layer=self._get_sheet_content_layer(sheet),
                 )
-                doc = self._convert_sheet(doc, sheet)
+                doc = self._convert_sheet(doc, sheet, page_no)
                 width, height = self._find_page_size(doc, page_no)
                 page.size = Size(width=width, height=height)
+
+            if sheet_names_filter is not None:
+                unmatched = set(sheet_names_filter) - set(self.workbook.sheetnames)
+                if unmatched:
+                    _log.warning(
+                        "sheet_names filter contains names not found in workbook: %s",
+                        sorted(unmatched),
+                    )
         else:
             _log.error("Workbook is not initialized.")
 
         return doc
 
     def _convert_sheet(
-        self, doc: DoclingDocument, sheet: Union[Worksheet, Chartsheet]
+        self, doc: DoclingDocument, sheet: Union[Worksheet, Chartsheet], page_no: int
     ) -> DoclingDocument:
         """Parse an Excel worksheet and attach its structure to a DoclingDocument
 
         Args:
             doc: The DoclingDocument to be updated.
             sheet: The Excel worksheet to be parsed.
+            page_no: The dense (1-based) page number for this sheet in the output document.
 
         Returns:
             The updated DoclingDocument.
         """
         if isinstance(sheet, Worksheet):
-            doc = self._find_tables_in_sheet(doc, sheet)
-            doc = self._find_images_in_sheet(doc, sheet)
+            doc = self._find_tables_in_sheet(doc, sheet, page_no)
+            doc = self._find_images_in_sheet(doc, sheet, page_no)
 
         # TODO: parse charts in sheet
 
         return doc
 
     def _find_tables_in_sheet(
-        self, doc: DoclingDocument, sheet: Worksheet
+        self, doc: DoclingDocument, sheet: Worksheet, page_no: int
     ) -> DoclingDocument:
         """Find all tables in an Excel sheet and attach them to a DoclingDocument.
 
         Args:
             doc: The DoclingDocument to be updated.
             sheet: The Excel worksheet to be parsed.
+            page_no: The dense (1-based) page number for this sheet in the output document.
 
         Returns:
             The updated DoclingDocument.
@@ -296,7 +325,6 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
                 num_rows = excel_table.num_rows
                 num_cols = excel_table.num_cols
                 if treat_singleton_as_text and len(excel_table.data) == 1:
-                    page_no = self.workbook.index(sheet) + 1
                     doc.add_text(
                         text=excel_table.data[0].text,
                         label=DocItemLabel.TEXT,
@@ -337,7 +365,6 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
                         )
                         table_data.table_cells.append(cell)
 
-                    page_no = self.workbook.index(sheet) + 1
                     doc.add_table(
                         data=table_data,
                         parent=self.parents[0],
@@ -606,13 +633,14 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         )
 
     def _find_images_in_sheet(
-        self, doc: DoclingDocument, sheet: Worksheet
+        self, doc: DoclingDocument, sheet: Worksheet, page_no: int
     ) -> DoclingDocument:
         """Find images in the Excel sheet and attach them to the DoclingDocument.
 
         Args:
             doc: The DoclingDocument to be updated.
             sheet: The Excel worksheet to be parsed.
+            page_no: The dense (1-based) page number for this sheet in the output document.
 
         Returns:
             The updated DoclingDocument.
@@ -624,7 +652,6 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
                 try:
                     image: Image = cast(Image, item)
                     pil_image = PILImage.open(image.ref)  # type: ignore[arg-type]
-                    page_no = self.workbook.index(sheet) + 1
                     anchor = (0, 0, 0, 0)
                     if isinstance(image.anchor, TwoCellAnchor):
                         anchor = (

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -137,6 +137,14 @@ class MsExcelBackendOptions(BaseBackendOptions):
             "data clusters into a single table. Default is 0 (strict)."
         ),
     )
+    sheet_names: Optional[list[str]] = Field(
+        None,
+        description=(
+            "An optional list of sheet names to include in the conversion. "
+            "When set, only the specified sheets are processed; all others are "
+            "skipped. When None (default), all sheets are converted."
+        ),
+    )
 
 
 class LatexBackendOptions(BaseBackendOptions):

--- a/tests/test_backend_msexcel.py
+++ b/tests/test_backend_msexcel.py
@@ -413,6 +413,117 @@ def test_gap_tolerance_comparison() -> None:
     )
 
 
+def test_sheet_names_filter() -> None:
+    """Test that sheet_names filter produces dense (gap-free) page numbering.
+
+    xlsx_01 has four sheets: Sheet1, Sheet2, Sheet3, Sheet4.
+    When sheet_names=["Sheet1", "Sheet3"], only those two sheets should appear
+    in the output document with pages densely numbered 1 and 2 (not 1 and 3).
+    """
+    path = next(item for item in get_excel_paths() if item.stem == "xlsx_01")
+
+    options = MsExcelBackendOptions(sheet_names=["Sheet1", "Sheet3"])
+    format_options = {InputFormat.XLSX: ExcelFormatOption(backend_options=options)}
+    converter = DocumentConverter(
+        allowed_formats=[InputFormat.XLSX], format_options=format_options
+    )
+
+    conv_result: ConversionResult = converter.convert(path)
+    doc: DoclingDocument = conv_result.document
+
+    assert len(doc.pages) == 2, (
+        f"Document should have 2 pages (one per included sheet), got {len(doc.pages)}"
+    )
+    assert set(doc.pages.keys()) == {1, 2}, (
+        f"Pages should be densely numbered {{1, 2}}, got {set(doc.pages.keys())}"
+    )
+
+
+def test_sheet_names_filter_empty_list():
+    """Test that sheet_names=[] produces 0 pages (no sheets included).
+
+    The backend is exercised directly because the DocumentConverter framework
+    marks a document with page_count=0 as invalid before conversion runs.
+    """
+    path = next(item for item in get_excel_paths() if item.stem == "xlsx_01")
+
+    options = MsExcelBackendOptions(sheet_names=[])
+    in_doc = InputDocument(
+        path_or_stream=path,
+        format=InputFormat.XLSX,
+        filename=path.stem,
+        backend=MsExcelDocumentBackend,
+        backend_options=options,
+    )
+    backend = MsExcelDocumentBackend(in_doc=in_doc, path_or_stream=path, options=options)
+    doc: DoclingDocument = backend.convert()
+
+    assert len(doc.pages) == 0, (
+        f"Empty sheet_names filter should produce 0 pages, got {len(doc.pages)}"
+    )
+
+
+def test_sheet_names_filter_case_sensitive():
+    """Test that sheet_names matching is case-sensitive.
+
+    xlsx_01 has "Sheet1" (capital S). Requesting "sheet1" (lowercase s)
+    should match nothing and produce 0 pages.
+
+    The backend is exercised directly because the DocumentConverter framework
+    marks a document with page_count=0 as invalid before conversion runs.
+    """
+    path = next(item for item in get_excel_paths() if item.stem == "xlsx_01")
+
+    options = MsExcelBackendOptions(sheet_names=["sheet1"])  # lowercase -- wrong case
+    in_doc = InputDocument(
+        path_or_stream=path,
+        format=InputFormat.XLSX,
+        filename=path.stem,
+        backend=MsExcelDocumentBackend,
+        backend_options=options,
+    )
+    backend = MsExcelDocumentBackend(in_doc=in_doc, path_or_stream=path, options=options)
+    doc: DoclingDocument = backend.convert()
+
+    assert len(doc.pages) == 0, (
+        f"Case-mismatched sheet name should produce 0 pages, got {len(doc.pages)}"
+    )
+
+
+def test_sheet_names_filter_nonexistent(caplog) -> None:
+    """Test that a WARNING is logged when sheet_names contains unknown names.
+
+    When a sheet_names entry does not match any sheet in the workbook a WARNING
+    should be emitted that includes the unrecognised name.
+    """
+    path = next(item for item in get_excel_paths() if item.stem == "xlsx_01")
+
+    nonexistent_name = "DoesNotExist"
+    options = MsExcelBackendOptions(sheet_names=["Sheet1", nonexistent_name])
+    format_options = {InputFormat.XLSX: ExcelFormatOption(backend_options=options)}
+    converter = DocumentConverter(
+        allowed_formats=[InputFormat.XLSX], format_options=format_options
+    )
+
+    with caplog.at_level(logging.WARNING, logger="docling.backend.msexcel_backend"):
+        conv_result: ConversionResult = converter.convert(path)
+        doc: DoclingDocument = conv_result.document
+
+    # The known sheet should still be processed
+    assert len(doc.pages) == 1, (
+        f"Only Sheet1 should be converted, expected 1 page, got {len(doc.pages)}"
+    )
+
+    # A WARNING must have been logged mentioning the unrecognised name
+    warning_messages = [
+        r.message for r in caplog.records if r.levelno == logging.WARNING
+    ]
+    assert any(nonexistent_name in str(msg) for msg in warning_messages), (
+        f"Expected a WARNING mentioning '{nonexistent_name}'. "
+        f"Logged warnings: {warning_messages}"
+    )
+
+
 def test_one_cell_anchor_image():
     """Test that images with OneCellAnchor are positioned correctly.
 

--- a/tests/test_backend_msexcel.py
+++ b/tests/test_backend_msexcel.py
@@ -455,7 +455,9 @@ def test_sheet_names_filter_empty_list():
         backend=MsExcelDocumentBackend,
         backend_options=options,
     )
-    backend = MsExcelDocumentBackend(in_doc=in_doc, path_or_stream=path, options=options)
+    backend = MsExcelDocumentBackend(
+        in_doc=in_doc, path_or_stream=path, options=options
+    )
     doc: DoclingDocument = backend.convert()
 
     assert len(doc.pages) == 0, (
@@ -482,7 +484,9 @@ def test_sheet_names_filter_case_sensitive():
         backend=MsExcelDocumentBackend,
         backend_options=options,
     )
-    backend = MsExcelDocumentBackend(in_doc=in_doc, path_or_stream=path, options=options)
+    backend = MsExcelDocumentBackend(
+        in_doc=in_doc, path_or_stream=path, options=options
+    )
     doc: DoclingDocument = backend.convert()
 
     assert len(doc.pages) == 0, (


### PR DESCRIPTION
## Summary

Closes #2269

Adds an optional `sheet_names` parameter to `MsExcelBackendOptions` that restricts Excel conversion to specified sheets only.

### Usage

```python
from docling.document_converter import DocumentConverter, ExcelFormatOption
from docling.datamodel.base_models import InputFormat
from docling.datamodel.backend_options import MsExcelBackendOptions

options = MsExcelBackendOptions(sheet_names=["Sheet1", "Sheet3"])
converter = DocumentConverter(
    allowed_formats=[InputFormat.XLSX],
    format_options={InputFormat.XLSX: ExcelFormatOption(backend_options=options)},
)
result = converter.convert("workbook.xlsx")
```

### Changes

- `MsExcelBackendOptions`: new `sheet_names: Optional[list[str]]` field (default `None` = all sheets)
- `MsExcelDocumentBackend._convert_workbook()`: skips sheets not in the filter
- `MsExcelDocumentBackend.page_count()`: returns count of matching sheets only
- Non-existent sheet names are silently skipped

### Tests

- `test_sheet_names_filter`: verifies only specified sheets appear in pages and groups
- `test_sheet_names_filter_nonexistent`: verifies non-existent names are silently skipped