### PR TITLE
feat(cli): add --page-break option for markdown export

### DIFF
--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -216,6 +216,7 @@ def export_documents(
     print_timings: bool,
     export_timings: bool,
     image_export_mode: ImageRefMode,
+    page_break_placeholder: str | None = None,
 ):
     success_count = 0
     failure_count = 0
@@ -290,7 +291,9 @@ def export_documents(
                 fname = output_dir / f"{doc_filename}.md"
                 _log.info(f"writing Markdown output to {fname}")
                 conv_res.document.save_as_markdown(
-                    filename=fname, image_mode=image_export_mode
+                    filename=fname,
+                    image_mode=image_export_mode,
+                    page_break_placeholder=page_break_placeholder,
                 )
 
             # Export Document Tags format:
@@ -632,6 +635,13 @@ def convert(  # noqa: C901
             help="If enabled, it saves the profiling summaries to json.",
         ),
     ] = False,
+    page_break: Annotated[
+        str | None,
+        typer.Option(
+            "--page-break",
+            help="String to insert at page boundaries in Markdown output. If not set, no page break marker is added.",
+        ),
+    ] = None,
 ):
     log_format = "%(asctime)s\t%(levelname)s\t%(name)s: %(message)s"
 
@@ -968,6 +978,7 @@ def convert(  # noqa: C901
             print_timings=profiling,
             export_timings=save_profiling,
             image_export_mode=image_export_mode,
+            page_break_placeholder=page_break,
         )
 
         end_time = time.time() - start_time

--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -639,7 +639,7 @@ def convert(  # noqa: C901
         str | None,
         typer.Option(
             "--page-break",
-            help="String to insert at page boundaries in Markdown output. If not set, no page break marker is added.",
+            help="String to insert at page boundaries in Markdown output (e.g. '---'). Only applies when Markdown output is enabled. If not set, page break positions are not marked.",
         ),
     ] = None,
 ):
@@ -731,6 +731,19 @@ def convert(  # noqa: C901
         export_txt = OutputFormat.TEXT in to_formats
         export_doctags = OutputFormat.DOCTAGS in to_formats
         export_vtt = OutputFormat.VTT in to_formats
+
+        if page_break is not None:
+            if page_break == "":
+                err_console.print(
+                    "[yellow]Warning: --page-break is set to an empty string. "
+                    "This will strip page-break tokens rather than insert them. "
+                    "Did you mean to omit the flag?[/yellow]"
+                )
+            elif not export_md:
+                err_console.print(
+                    "[yellow]Warning: --page-break has no effect unless Markdown "
+                    "output is enabled (add --to markdown).[/yellow]"
+                )
 
         ocr_factory = get_ocr_factory(allow_external_plugins=allow_external_plugins)
         ocr_options: OcrOptions = ocr_factory.create_options(  # type: ignore

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -126,7 +126,7 @@ def test_cli_audio_extensions_coverage():
 
 def test_cli_page_break_inserted(tmp_path):
     """--page-break marker appears in Markdown output."""
-    source = "./tests/data/pdf/2305.03393v1-pg9.pdf"
+    source = "./tests/data/pdf/2305.03393v1.pdf"
     result = runner.invoke(
         app,
         [source, "--output", str(tmp_path), "--page-break", "<!-- page-break -->"],

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -122,3 +122,41 @@ def test_cli_audio_extensions_coverage():
         assert ext in audio_extensions, (
             f"Audio extension {ext} not found in FormatToExtensions[InputFormat.AUDIO]"
         )
+
+
+def test_cli_page_break_inserted(tmp_path):
+    """--page-break marker appears in Markdown output."""
+    source = "./tests/data/pdf/2305.03393v1-pg9.pdf"
+    result = runner.invoke(
+        app,
+        [source, "--output", str(tmp_path), "--page-break", "<!-- page-break -->"],
+    )
+    assert result.exit_code == 0
+    md_files = list(tmp_path.glob("*.md"))
+    assert len(md_files) == 1
+    content = md_files[0].read_text(encoding="utf-8")
+    assert "<!-- page-break -->" in content
+
+
+def test_cli_page_break_empty_string_warns(tmp_path):
+    """--page-break '' emits a warning about empty string behavior."""
+    source = "./tests/data/pdf/2305.03393v1-pg9.pdf"
+    result = runner.invoke(
+        app,
+        [source, "--output", str(tmp_path), "--page-break", ""],
+    )
+    assert result.exit_code == 0
+    combined = result.output
+    assert "Warning" in combined and "empty string" in combined.lower()
+
+
+def test_cli_page_break_non_markdown_warns(tmp_path):
+    """--page-break with --to json emits a warning that it has no effect."""
+    source = "./tests/data/pdf/2305.03393v1-pg9.pdf"
+    result = runner.invoke(
+        app,
+        [source, "--output", str(tmp_path), "--to", "json", "--page-break", "---"],
+    )
+    assert result.exit_code == 0
+    combined = result.output
+    assert "Warning" in combined and "no effect" in combined.lower()


### PR DESCRIPTION
## Summary

Closes #3175

Exposes the existing `page_break_placeholder` parameter of `export_to_markdown()` as a `--page-break` CLI flag, letting users customise the string inserted at page boundaries.

### Usage

```bash
docling document.pdf --to md --page-break "---"
docling document.pdf --to md --page-break "<!-- page-break -->"
```

When the flag is omitted, behaviour is unchanged (no page break marker inserted).

### Changes

- `cli.py`: adds `--page-break` option, passes it through to `export_to_markdown(page_break_placeholder=...)`