### PR TITLE
fix: detect .txt files as Markdown instead of rejecting them

### DIFF
--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -627,8 +627,8 @@ class _DocumentConversionInput(BaseModel):
             content_str = content.decode("utf-8", errors="replace")
             if InputFormat.XML_USPTO in formats and content_str.startswith("PATN\r\n"):
                 input_format = InputFormat.XML_USPTO
-            # No MD fallback: unrecognised text/plain content returns None.
-            # MD is detected via text/markdown mime (from .md/.text/.qmd/… extensions).
+            elif InputFormat.MD in formats:
+                input_format = InputFormat.MD
 
         return input_format
 

--- a/tests/test_input_doc.py
+++ b/tests/test_input_doc.py
@@ -253,9 +253,7 @@ def test_guess_format(tmp_path):
     assert dci._guess_format(doc_path) == InputFormat.MD
 
     # Plain .txt file detected as MD
-    stream = DocumentStream(
-        name="readme.txt", stream=BytesIO(b"Hello, world!\n")
-    )
+    stream = DocumentStream(name="readme.txt", stream=BytesIO(b"Hello, world!\n"))
     assert dci._guess_format(stream) == InputFormat.MD
 
     # Valid WebVTT

--- a/tests/test_input_doc.py
+++ b/tests/test_input_doc.py
@@ -245,12 +245,18 @@ def test_guess_format(tmp_path):
     stream = DocumentStream(name="docling_test.xml", stream=buf)
     assert dci._guess_format(stream) is None
 
-    # Invalid USPTO patent (as plain text)
+    # Non-USPTO .txt falls back to MD (plain-text support via #3161)
     stream = DocumentStream(name="pftaps057006474.txt", stream=BytesIO(b"xyz"))
-    assert dci._guess_format(stream) is None
+    assert dci._guess_format(stream) == InputFormat.MD
     doc_path = temp_dir / "pftaps_wrong.txt"
     doc_path.write_text("xyz", encoding="utf-8")
-    assert dci._guess_format(doc_path) is None
+    assert dci._guess_format(doc_path) == InputFormat.MD
+
+    # Plain .txt file detected as MD
+    stream = DocumentStream(
+        name="readme.txt", stream=BytesIO(b"Hello, world!\n")
+    )
+    assert dci._guess_format(stream) == InputFormat.MD
 
     # Valid WebVTT
     buf = BytesIO(Path("./tests/data/webvtt/webvtt_example_01.vtt").open("rb").read())


### PR DESCRIPTION
## Summary

Fixes #3259

PR #3161 added `"txt"` to `FormatToExtensions[InputFormat.MD]`, but the content-based disambiguation in `_guess_from_content` was never updated to handle the new case. When a `.txt` file enters `_guess_format`:

1. `_mime_from_extension("txt")` returns `None` (intentionally, because `"txt"` is in both the XML_USPTO and MD extension lists).
2. The content-detection chain produces `mime = "text/plain"`.
3. `_guess_from_content` checks for USPTO format (`PATN\r\n` header), finds nothing, and returns `None`.
4. `_guess_format` returns `None` → converter raises "File format not allowed".

The fix adds an `elif InputFormat.MD in formats` fallback so non-USPTO `text/plain` content resolves to `InputFormat.MD`. USPTO `.txt` files are unaffected because the existing `if` check runs first.

## Changes

- `docling/datamodel/document.py`: add MD fallback in `_guess_from_content` for `text/plain`
- `tests/test_input_doc.py`: update expectations for non-USPTO `.txt` files (`None` → `InputFormat.MD`) and add a plain `.txt` detection case

## Checks

- `pytest tests/test_input_doc.py` — 8/8 passed