### PR TITLE
fix(html):preserve fragment-only anchor links during path resolution

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -1309,7 +1309,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
             if loc.startswith("//"):
                 # Protocol-relative URL - default to https
                 abs_loc = "https:" + loc
-            elif not loc.startswith(("http://", "https://", "data:", "file://")):
+            elif not loc.startswith(("http://", "https://", "data:", "file://", "#")):
                 if HTMLDocumentBackend._is_remote_url(self.base_path):  # remote fetch
                     abs_loc = urljoin(self.base_path, loc)
                 elif self.base_path:  # local fetch

--- a/tests/data/groundtruth/docling_v2/hyperlink_06.html.itxt
+++ b/tests/data/groundtruth/docling_v2/hyperlink_06.html.itxt
@@ -1,0 +1,13 @@
+item-0 at level 0: unspecified: group _root_
+  item-1 at level 1: title: Anchor Links Test
+    item-2 at level 2: inline: group group
+      item-3 at level 3: text: Jump to
+      item-4 at level 3: text: Section 2
+      item-5 at level 3: text: or visit
+      item-6 at level 3: text: Example
+      item-7 at level 3: text: .
+    item-8 at level 2: section_header: Section 2
+      item-9 at level 3: inline: group group
+        item-10 at level 4: text: Content for section 2 with a
+        item-11 at level 4: text: top link
+        item-12 at level 4: text: .

--- a/tests/data/groundtruth/docling_v2/hyperlink_06.html.json
+++ b/tests/data/groundtruth/docling_v2/hyperlink_06.html.json
@@ -1,0 +1,233 @@
+{
+  "schema_name": "DoclingDocument",
+  "version": "1.10.0",
+  "name": "hyperlink_06",
+  "origin": {
+    "mimetype": "text/html",
+    "binary_hash": 8681866349936264156,
+    "filename": "hyperlink_06.html"
+  },
+  "furniture": {
+    "self_ref": "#/furniture",
+    "children": [],
+    "content_layer": "furniture",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "body": {
+    "self_ref": "#/body",
+    "children": [
+      {
+        "$ref": "#/texts/0"
+      },
+      {
+        "$ref": "#/texts/1"
+      }
+    ],
+    "content_layer": "body",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "groups": [
+    {
+      "self_ref": "#/groups/0",
+      "parent": {
+        "$ref": "#/texts/1"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/2"
+        },
+        {
+          "$ref": "#/texts/3"
+        },
+        {
+          "$ref": "#/texts/4"
+        },
+        {
+          "$ref": "#/texts/5"
+        },
+        {
+          "$ref": "#/texts/6"
+        }
+      ],
+      "content_layer": "body",
+      "name": "group",
+      "label": "inline"
+    },
+    {
+      "self_ref": "#/groups/1",
+      "parent": {
+        "$ref": "#/texts/7"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/8"
+        },
+        {
+          "$ref": "#/texts/9"
+        },
+        {
+          "$ref": "#/texts/10"
+        }
+      ],
+      "content_layer": "body",
+      "name": "group",
+      "label": "inline"
+    }
+  ],
+  "texts": [
+    {
+      "self_ref": "#/texts/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "furniture",
+      "label": "title",
+      "prov": [],
+      "orig": "Anchor Links Test",
+      "text": "Anchor Links Test"
+    },
+    {
+      "self_ref": "#/texts/1",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/groups/0"
+        },
+        {
+          "$ref": "#/texts/7"
+        }
+      ],
+      "content_layer": "body",
+      "label": "title",
+      "prov": [],
+      "orig": "Anchor Links Test",
+      "text": "Anchor Links Test"
+    },
+    {
+      "self_ref": "#/texts/2",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Jump to",
+      "text": "Jump to"
+    },
+    {
+      "self_ref": "#/texts/3",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Section 2",
+      "text": "Section 2",
+      "hyperlink": "#section-2"
+    },
+    {
+      "self_ref": "#/texts/4",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "or visit",
+      "text": "or visit"
+    },
+    {
+      "self_ref": "#/texts/5",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Example",
+      "text": "Example",
+      "hyperlink": "https://example.com/"
+    },
+    {
+      "self_ref": "#/texts/6",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": ".",
+      "text": "."
+    },
+    {
+      "self_ref": "#/texts/7",
+      "parent": {
+        "$ref": "#/texts/1"
+      },
+      "children": [
+        {
+          "$ref": "#/groups/1"
+        }
+      ],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [],
+      "orig": "Section 2",
+      "text": "Section 2",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/8",
+      "parent": {
+        "$ref": "#/groups/1"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Content for section 2 with a",
+      "text": "Content for section 2 with a"
+    },
+    {
+      "self_ref": "#/texts/9",
+      "parent": {
+        "$ref": "#/groups/1"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "top link",
+      "text": "top link",
+      "hyperlink": "#"
+    },
+    {
+      "self_ref": "#/texts/10",
+      "parent": {
+        "$ref": "#/groups/1"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": ".",
+      "text": "."
+    }
+  ],
+  "pictures": [],
+  "tables": [],
+  "key_value_items": [],
+  "form_items": [],
+  "pages": {}
+}

--- a/tests/data/groundtruth/docling_v2/hyperlink_06.html.md
+++ b/tests/data/groundtruth/docling_v2/hyperlink_06.html.md
@@ -1,0 +1,7 @@
+# Anchor Links Test
+
+Jump to [Section 2](#section-2) or visit [Example](https://example.com/) .
+
+## Section 2
+
+Content for section 2 with a [top link](#) .

--- a/tests/data/html/hyperlink_06.html
+++ b/tests/data/html/hyperlink_06.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="en">
+<head><title>Anchor Links Test</title></head>
+<body>
+    <h1>Anchor Links Test</h1>
+    <p>Jump to <a href="#section-2">Section 2</a> or visit
+       <a href="https://example.com">Example</a>.</p>
+    <h2 id="section-2">Section 2</h2>
+    <p>Content for section 2 with a <a href="#">top link</a>.</p>
+</body>
+</html>

--- a/tests/test_backend_html.py
+++ b/tests/test_backend_html.py
@@ -90,6 +90,17 @@ def test_resolve_relative_path():
     relative_path = "subdir/file.html"
     assert html_doc._resolve_relative_path(relative_path) == relative_path
 
+    # Fragment-only hrefs must pass through unchanged
+    html_doc.base_path = "/local/path/to/file.html"
+    assert html_doc._resolve_relative_path("#section1") == "#section1"
+    assert html_doc._resolve_relative_path("#") == "#"
+
+    html_doc.base_path = "http://example.com/page.html"
+    assert html_doc._resolve_relative_path("#section1") == "#section1"
+
+    html_doc.base_path = None
+    assert html_doc._resolve_relative_path("#section1") == "#section1"
+
 
 def test_heading_levels():
     in_path = Path("tests/data/html/wiki_duck.html")
@@ -797,3 +808,30 @@ def test_load_image_data_enforces_data_uri_size_limit():
 
     with pytest.raises(ValueError, match="exceeds size limit"):
         backend._load_image_data(data_uri)
+
+
+def test_anchor_fragment_links_with_source_uri():
+    """Fragment-only hrefs must not be mangled when source_uri is set."""
+    html_path = Path("tests/data/html/hyperlink_06.html")
+    in_doc = InputDocument(
+        path_or_stream=html_path,
+        format=InputFormat.HTML,
+        backend=HTMLDocumentBackend,
+        filename="test",
+    )
+    backend = HTMLDocumentBackend(
+        in_doc=in_doc,
+        path_or_stream=html_path,
+        options=HTMLBackendOptions(source_uri=PurePath(str(html_path.resolve()))),
+    )
+    doc = backend.convert()
+    md = doc.export_to_markdown()
+
+    # Fragment links preserved
+    assert "[Section 2](#section-2)" in md
+    assert "[top link](#)" in md
+    # External links still work (regression check)
+    assert (
+        "[Example](https://example.com)" in md
+        or "[Example](https://example.com/)" in md
+    )


### PR DESCRIPTION
Fragment-only hrefs (e.g. `<a href="#section1">`) were resolved as filesystem paths when `source_uri` was set, breaking  internal document navigation links.

Adds `"#"` to the skip-resolution prefixes in 
`_resolve_relative_path()` so
fragment links pass through unchanged.

### Note
This is the first of two PRs for #2929:
1. **This PR** — fix fragment href resolution (anchor links)
2. **Follow-up PR** — extract heading `id` attributes and store in
item meta

The markdown serializer emitting `{#id}` syntax requires a
docling-core change and will be addressed separately.

## Issue resolved
Partially addresses #2929

## Checklist
- [ ] Documentation has been updated, if necessary
- [ ] Examples have been added, if necessary
- [x] Tests have been added, if necessary