### PR TITLE
fix(vlm): support tool-calling API responses

### DIFF
--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Optional, Type, Union
 
 import numpy as np
 from docling_core.types.doc import (
@@ -373,7 +373,8 @@ class Page(BaseModel):
 
 class OpenAiChatMessage(BaseModel):
     role: str
-    content: str
+    content: str | None = None
+    tool_calls: list[dict[str, Any]] | None = None
 
 
 class OpenAiResponseChoice(BaseModel):

--- a/docling/utils/api_image_request.py
+++ b/docling/utils/api_image_request.py
@@ -2,16 +2,72 @@ import base64
 import json
 import logging
 from io import BytesIO
-from typing import Dict, List, Optional, Tuple
+from typing import Any
 
 import requests
 from PIL import Image
 from pydantic import AnyUrl
 
-from docling.datamodel.base_models import OpenAiApiResponse, VlmStopReason
+from docling.datamodel.base_models import (
+    OpenAiApiResponse,
+    OpenAiChatMessage,
+    VlmStopReason,
+)
 from docling.models.utils.generation_utils import GenerationStopper
 
 _log = logging.getLogger(__name__)
+
+
+def _extract_text_from_tool_arguments(arguments: str | None) -> str:
+    if arguments is None:
+        return ""
+
+    try:
+        payload = json.loads(arguments)
+    except json.JSONDecodeError:
+        return arguments.strip()
+
+    fragments: list[str] = []
+
+    def _collect_text(obj: Any) -> None:
+        if isinstance(obj, list):
+            for item in obj:
+                _collect_text(item)
+        elif isinstance(obj, dict):
+            text = obj.get("text")
+            if isinstance(text, str) and text.strip():
+                fragments.append(text.strip())
+            for value in obj.values():
+                _collect_text(value)
+
+    _collect_text(payload)
+    return "\n".join(fragments)
+
+
+def _extract_generated_text(message: OpenAiChatMessage) -> str:
+    if message.content is not None:
+        return message.content.strip()
+
+    for tool_call in message.tool_calls or []:
+        function = tool_call.get("function")
+        if not isinstance(function, dict):
+            continue
+
+        generated_text = _extract_text_from_tool_arguments(function.get("arguments"))
+        if generated_text:
+            return generated_text
+
+    return ""
+
+
+def _map_stop_reason(finish_reason: str | None) -> VlmStopReason:
+    if finish_reason == "content_filter":
+        _log.warning("API response was filtered due to content safety policy.")
+        return VlmStopReason.CONTENT_FILTERED
+    elif finish_reason == "length":
+        return VlmStopReason.LENGTH
+    else:
+        return VlmStopReason.END_OF_SEQUENCE
 
 
 def api_image_request(
@@ -21,7 +77,7 @@ def api_image_request(
     timeout: float = 20,
     headers: dict[str, str] | None = None,
     **params,
-) -> Tuple[str, int | None, VlmStopReason]:
+) -> tuple[str, int | None, VlmStopReason]:
     img_io = BytesIO()
     image = (
         image.copy()
@@ -75,16 +131,9 @@ def api_image_request(
             # r.raise_for_status()
 
             api_resp = OpenAiApiResponse.model_validate_json(r.text)
-            generated_text = api_resp.choices[0].message.content.strip()
+            generated_text = _extract_generated_text(api_resp.choices[0].message)
             num_tokens = api_resp.usage.total_tokens
-            finish_reason = api_resp.choices[0].finish_reason
-            if finish_reason == "content_filter":
-                _log.warning("API response was filtered due to content safety policy.")
-                stop_reason = VlmStopReason.CONTENT_FILTERED
-            elif finish_reason == "length":
-                stop_reason = VlmStopReason.LENGTH
-            else:
-                stop_reason = VlmStopReason.END_OF_SEQUENCE
+            stop_reason = _map_stop_reason(api_resp.choices[0].finish_reason)
 
             return generated_text, num_tokens, stop_reason
         except Exception as e:
@@ -103,7 +152,7 @@ def api_image_request_streaming(
     headers: dict[str, str] | None = None,
     generation_stoppers: list[GenerationStopper] = [],
     **params,
-) -> Tuple[str, int | None]:
+) -> tuple[str, int | None]:
     """
     Stream a chat completion from an OpenAI-compatible server (e.g., vLLM).
     Parses SSE lines: 'data: {json}\\n\\n', terminated by 'data: [DONE]'.

--- a/tests/test_api_image_request.py
+++ b/tests/test_api_image_request.py
@@ -1,5 +1,6 @@
 """Tests for api_image_request module."""
 
+import json
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -26,19 +27,29 @@ class TestApiImageRequest:
             finish_reason="stop",
             total_tokens=100,
             status_ok=True,
+            message=None,
         ):
             mock_resp = MagicMock()
             mock_resp.ok = status_ok
-            mock_resp.text = f"""{{
-                "id": "test-id",
-                "created": 1234567890,
-                "choices": [{{
-                    "index": 0,
-                    "message": {{"role": "assistant", "content": "{content}"}},
-                    "finish_reason": "{finish_reason}"
-                }}],
-                "usage": {{"prompt_tokens": 50, "completion_tokens": 50, "total_tokens": {total_tokens}}}
-            }}"""
+            mock_resp.text = json.dumps(
+                {
+                    "id": "test-id",
+                    "created": 1234567890,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "message": message
+                            or {"role": "assistant", "content": content},
+                            "finish_reason": finish_reason,
+                        }
+                    ],
+                    "usage": {
+                        "prompt_tokens": 50,
+                        "completion_tokens": 50,
+                        "total_tokens": total_tokens,
+                    },
+                }
+            )
             return mock_resp
 
         return _create_mock_response
@@ -91,4 +102,36 @@ class TestApiImageRequest:
         )
 
         assert result_text == "Normal completion"
+        assert stop_reason == VlmStopReason.END_OF_SEQUENCE
+
+    @patch("docling.utils.api_image_request.requests.post")
+    def test_tool_calls_response(self, mock_post, sample_image, mock_response_factory):
+        """Test that tool calling responses are converted into generated text."""
+        mock_post.return_value = mock_response_factory(
+            message={
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "function": {
+                            "name": "markdown_no_bbox",
+                            "arguments": json.dumps(
+                                [
+                                    {"text": "Extracted text"},
+                                    {"text": "Second block"},
+                                ]
+                            ),
+                        }
+                    }
+                ],
+            }
+        )
+
+        result_text, tokens, stop_reason = api_image_request(
+            image=sample_image,
+            prompt="Test prompt",
+            url="http://test.api/v1/chat/completions",
+        )
+
+        assert result_text == "Extracted text\nSecond block"
+        assert tokens == 100
         assert stop_reason == VlmStopReason.END_OF_SEQUENCE


### PR DESCRIPTION
This updates `api_image_request()` to handle OpenAI-compatible chat responses that return extracted output through `message.tool_calls[*].function.arguments` instead of `message.content`.

Changes:
- allow `OpenAiChatMessage.content` to be absent and accept `tool_calls`
- extract text from tool-call arguments in `api_image_request()`
- add a regression test for the tool-calling response path

Resolves #2440

Related to #2687, but this PR does not add generic Ollama `/api/generate` support.