### PR TITLE
fix(vlm): add explicit MLX support for OCR presets

### DIFF
--- a/docling/datamodel/stage_model_specs.py
+++ b/docling/datamodel/stage_model_specs.py
@@ -6,8 +6,10 @@ This module defines:
 3. StagePresetMixin - Mixin for stage options to manage presets
 """
 
+from __future__ import annotations
+
 import logging
-from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Optional, Set
+from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Set
 
 from pydantic import BaseModel, Field
 
@@ -48,15 +50,15 @@ class EngineModelConfig(BaseModel):
     For example, MLX might use a different repo_id than Transformers.
     """
 
-    repo_id: Optional[str] = Field(
+    repo_id: str | None = Field(
         default=None, description="Override model repository ID for this engine"
     )
 
-    revision: Optional[str] = Field(
+    revision: str | None = Field(
         default=None, description="Override model revision for this engine"
     )
 
-    torch_dtype: Optional[str] = Field(
+    torch_dtype: str | None = Field(
         default=None,
         description="Override torch dtype for this engine (e.g., 'bfloat16')",
     )
@@ -67,7 +69,7 @@ class EngineModelConfig(BaseModel):
 
     def merge_with(
         self, base_repo_id: str, base_revision: str = "main"
-    ) -> "EngineModelConfig":
+    ) -> EngineModelConfig:
         """Merge with base configuration.
 
         Args:
@@ -96,7 +98,7 @@ class ApiModelConfig(BaseModel):
         description="API parameters (model name, max_tokens, etc.)",
     )
 
-    def merge_with(self, base_params: Dict[str, Any]) -> "ApiModelConfig":
+    def merge_with(self, base_params: Dict[str, Any]) -> ApiModelConfig:
         """Merge with base parameters.
 
         Args:
@@ -137,7 +139,7 @@ class VlmModelSpec(BaseModel):
         description="Expected response format from the model"
     )
 
-    supported_engines: Optional[Set[VlmEngineType]] = Field(
+    supported_engines: Set[VlmEngineType] | None = Field(
         default=None, description="Set of supported engines (None = all supported)"
     )
 
@@ -250,13 +252,13 @@ class VlmModelSpec(BaseModel):
         """Check if this model has an explicit export for the given engine.
 
         An explicit export means either:
-        1. The engine has a different repo_id in engine_overrides, OR
+        1. The engine has an entry in engine_overrides, OR
         2. The engine is explicitly listed in supported_engines (not None)
 
         This is used by auto_inline to determine if it should attempt to use
-        a specific engine. For example, MLX should only be used if there's
-        an actual MLX export available (different repo_id) or if the model
-        explicitly declares MLX support.
+        a specific engine. For example, MLX should only be used if the model
+        explicitly declares MLX support, either via engine_overrides or
+        supported_engines.
 
         Args:
             engine_type: The engine type to check
@@ -276,7 +278,16 @@ class VlmModelSpec(BaseModel):
             >>> spec.has_explicit_engine_export(VlmEngineType.MLX)
             True
 
-            >>> # Model without MLX export (same repo_id or no override)
+            >>> # Model with same-repo MLX support (native handler, no separate weights)
+            >>> spec = VlmModelSpec(
+            ...     name="Test",
+            ...     default_repo_id="org/model",
+            ...     engine_overrides={VlmEngineType.MLX: EngineModelConfig()}
+            ... )
+            >>> spec.has_explicit_engine_export(VlmEngineType.MLX)
+            True
+
+            >>> # Model without MLX export
             >>> spec = VlmModelSpec(name="Test", default_repo_id="org/model")
             >>> spec.has_explicit_engine_export(VlmEngineType.MLX)
             False
@@ -294,16 +305,7 @@ class VlmModelSpec(BaseModel):
         if self.supported_engines is not None:
             return engine_type in self.supported_engines
 
-        # Check if there's a different repo_id for this engine
-        if engine_type in self.engine_overrides:
-            override = self.engine_overrides[engine_type]
-            if (
-                override.repo_id is not None
-                and override.repo_id != self.default_repo_id
-            ):
-                return True
-
-        return False
+        return engine_type in self.engine_overrides
 
 
 # =============================================================================
@@ -325,13 +327,13 @@ class ObjectDetectionModelSpec(BaseModel):
 
     revision: str = Field(default="main", description="Default model revision")
 
-    engine_overrides: Dict["ObjectDetectionEngineType", EngineModelConfig] = Field(
+    engine_overrides: Dict[ObjectDetectionEngineType, EngineModelConfig] = Field(
         default_factory=dict,
         description="Engine-specific configuration overrides",
     )
 
     def get_engine_config(
-        self, engine_type: "ObjectDetectionEngineType"
+        self, engine_type: ObjectDetectionEngineType
     ) -> EngineModelConfig:
         """Get EngineModelConfig for a specific object-detection engine.
 
@@ -346,7 +348,7 @@ class ObjectDetectionModelSpec(BaseModel):
             return override.merge_with(self.repo_id, self.revision)
         return EngineModelConfig(repo_id=self.repo_id, revision=self.revision)
 
-    def get_repo_id(self, engine_type: "ObjectDetectionEngineType") -> str:
+    def get_repo_id(self, engine_type: ObjectDetectionEngineType) -> str:
         """Get repository ID for specific engine.
 
         Args:
@@ -360,7 +362,7 @@ class ObjectDetectionModelSpec(BaseModel):
             return override.repo_id
         return self.repo_id
 
-    def get_revision(self, engine_type: "ObjectDetectionEngineType") -> str:
+    def get_revision(self, engine_type: ObjectDetectionEngineType) -> str:
         """Get revision for specific engine.
 
         Args:
@@ -389,13 +391,13 @@ class ImageClassificationModelSpec(BaseModel):
 
     revision: str = Field(default="main", description="Default model revision")
 
-    engine_overrides: Dict["ImageClassificationEngineType", EngineModelConfig] = Field(
+    engine_overrides: Dict[ImageClassificationEngineType, EngineModelConfig] = Field(
         default_factory=dict,
         description="Engine-specific configuration overrides",
     )
 
     def get_engine_config(
-        self, engine_type: "ImageClassificationEngineType"
+        self, engine_type: ImageClassificationEngineType
     ) -> EngineModelConfig:
         """Get EngineModelConfig for a specific image-classification engine."""
         override = self.engine_overrides.get(engine_type)
@@ -403,14 +405,14 @@ class ImageClassificationModelSpec(BaseModel):
             return override.merge_with(self.repo_id, self.revision)
         return EngineModelConfig(repo_id=self.repo_id, revision=self.revision)
 
-    def get_repo_id(self, engine_type: "ImageClassificationEngineType") -> str:
+    def get_repo_id(self, engine_type: ImageClassificationEngineType) -> str:
         """Get repository ID for specific engine."""
         override = self.engine_overrides.get(engine_type)
         if override and override.repo_id:
             return override.repo_id
         return self.repo_id
 
-    def get_revision(self, engine_type: "ImageClassificationEngineType") -> str:
+    def get_revision(self, engine_type: ImageClassificationEngineType) -> str:
         """Get revision for specific engine."""
         override = self.engine_overrides.get(engine_type)
         if override and override.revision:
@@ -442,7 +444,7 @@ class StageModelPreset(BaseModel):
 
     scale: float = Field(default=2.0, description="Image scaling factor")
 
-    max_size: Optional[int] = Field(default=None, description="Maximum image dimension")
+    max_size: int | None = Field(default=None, description="Maximum image dimension")
 
     default_engine_type: VlmEngineType = Field(
         default=VlmEngineType.AUTO_INLINE,
@@ -571,7 +573,7 @@ class StagePresetMixin:
     def from_preset(
         cls,
         preset_id: str,
-        engine_options: Optional[BaseVlmEngineOptions] = None,
+        engine_options: BaseVlmEngineOptions | None = None,
         **overrides,
     ):
         """Create options from a registered preset.
@@ -705,7 +707,7 @@ class ObjectDetectionStagePresetMixin:
     def from_preset(
         cls,
         preset_id: str,
-        engine_options: Optional["BaseObjectDetectionEngineOptions"] = None,
+        engine_options: BaseObjectDetectionEngineOptions | None = None,
         **overrides: Any,
     ):
         from docling.datamodel.object_detection_engine_options import (
@@ -815,7 +817,7 @@ class ImageClassificationStagePresetMixin:
     def from_preset(
         cls,
         preset_id: str,
-        engine_options: Optional["BaseImageClassificationEngineOptions"] = None,
+        engine_options: BaseImageClassificationEngineOptions | None = None,
         **overrides: Any,
     ):
         from docling.datamodel.image_classification_engine_options import (
@@ -1211,6 +1213,8 @@ VLM_CONVERT_GLMOCR = StageModelPreset(
         prompt="Text Recognition:",
         response_format=ResponseFormat.MARKDOWN,
         engine_overrides={
+            # Native GLM-OCR support was added to mlx-vlm in v0.3.11.
+            VlmEngineType.MLX: EngineModelConfig(repo_id="mlx-community/GLM-OCR-bf16"),
             VlmEngineType.TRANSFORMERS: EngineModelConfig(
                 torch_dtype="bfloat16",
                 extra_config={
@@ -1219,8 +1223,6 @@ VLM_CONVERT_GLMOCR = StageModelPreset(
                     "torch_dtype": "bfloat16",
                 },
             ),
-            # No MLX export available yet; when one appears on mlx-community,
-            # add: VlmEngineType.MLX: EngineModelConfig(repo_id="mlx-community/GLM-OCR-...")
         },
         api_overrides={
             VlmEngineType.API: ApiModelConfig(
@@ -1246,6 +1248,10 @@ VLM_CONVERT_FALCON_OCR = StageModelPreset(
         response_format=ResponseFormat.MARKDOWN,
         trust_remote_code=True,
         engine_overrides={
+            # Native Falcon-OCR support was added to mlx-vlm in v0.4.3.
+            # MLX can load the original HF repo directly, so no separate
+            # mlx-community checkpoint is required here.
+            VlmEngineType.MLX: EngineModelConfig(repo_id="tiiuae/Falcon-OCR"),
             VlmEngineType.TRANSFORMERS: EngineModelConfig(
                 torch_dtype="bfloat16",
                 extra_config={
@@ -1254,8 +1260,6 @@ VLM_CONVERT_FALCON_OCR = StageModelPreset(
                     "torch_dtype": "bfloat16",
                 },
             ),
-            # No MLX export available yet; when one appears on mlx-community,
-            # add: VlmEngineType.MLX: EngineModelConfig(repo_id="mlx-community/Falcon-OCR-...")
         },
         api_overrides={
             VlmEngineType.API_LMSTUDIO: ApiModelConfig(
@@ -1281,6 +1285,10 @@ VLM_CONVERT_LIGHTONOCR = StageModelPreset(
         response_format=ResponseFormat.MARKDOWN,
         max_new_tokens=4096,
         engine_overrides={
+            # LightOnOCR currently runs on mlx-vlm via the generic mistral3 handler.
+            VlmEngineType.MLX: EngineModelConfig(
+                repo_id="mlx-community/LightOnOCR-2-1B-bf16"
+            ),
             VlmEngineType.TRANSFORMERS: EngineModelConfig(
                 torch_dtype="bfloat16",
                 extra_config={

--- a/docling/datamodel/stage_model_specs.py
+++ b/docling/datamodel/stage_model_specs.py
@@ -1249,9 +1249,10 @@ VLM_CONVERT_FALCON_OCR = StageModelPreset(
         trust_remote_code=True,
         engine_overrides={
             # Native Falcon-OCR support was added to mlx-vlm in v0.4.3.
-            # MLX can load the original HF repo directly, so no separate
-            # mlx-community checkpoint is required here.
-            VlmEngineType.MLX: EngineModelConfig(repo_id="tiiuae/Falcon-OCR"),
+            # A dedicated mlx-community checkpoint is now available for MLX.
+            VlmEngineType.MLX: EngineModelConfig(
+                repo_id="mlx-community/Falcon-OCR-bf16"
+            ),
             VlmEngineType.TRANSFORMERS: EngineModelConfig(
                 torch_dtype="bfloat16",
                 extra_config={

--- a/docling/datamodel/vlm_model_specs.py
+++ b/docling/datamodel/vlm_model_specs.py
@@ -336,6 +336,17 @@ GLMOCR_TRANSFORMERS = InlineVlmOptions(
     temperature=0.0,
 )
 
+# Requires mlx-vlm >=0.3.11.
+GLMOCR_MLX = InlineVlmOptions(
+    repo_id="mlx-community/GLM-OCR-bf16",
+    prompt="Text Recognition:",
+    response_format=ResponseFormat.MARKDOWN,
+    inference_framework=InferenceFramework.MLX,
+    supported_devices=[AcceleratorDevice.MPS],
+    scale=2.0,
+    temperature=0.0,
+)
+
 GLMOCR_VLLM = GLMOCR_TRANSFORMERS.model_copy(deep=True)
 GLMOCR_VLLM.inference_framework = InferenceFramework.VLLM
 
@@ -368,6 +379,19 @@ LIGHTONOCR_TRANSFORMERS = InlineVlmOptions(
         AcceleratorDevice.XPU,
     ],
     torch_dtype="bfloat16",
+    scale=2.0,
+    temperature=0.0,
+    max_new_tokens=4096,
+)
+
+# Routed via mlx-vlm's generic mistral3 handler; there is no LightOn-specific
+# handler in mlx-vlm today.
+LIGHTONOCR_MLX = InlineVlmOptions(
+    repo_id="mlx-community/LightOnOCR-2-1B-bf16",
+    prompt="",
+    response_format=ResponseFormat.MARKDOWN,
+    inference_framework=InferenceFramework.MLX,
+    supported_devices=[AcceleratorDevice.MPS],
     scale=2.0,
     temperature=0.0,
     max_new_tokens=4096,

--- a/docling/models/inference_engines/vlm/auto_inline_engine.py
+++ b/docling/models/inference_engines/vlm/auto_inline_engine.py
@@ -1,9 +1,11 @@
 """Auto-inline VLM inference engine that selects the best local engine."""
 
+from __future__ import annotations
+
 import logging
 import platform
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, List, Union
 
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
 from docling.datamodel.vlm_engine_options import (
@@ -41,8 +43,8 @@ class AutoInlineVlmEngine(BaseVlmEngine):
         self,
         options: AutoInlineVlmEngineOptions,
         accelerator_options: AcceleratorOptions,
-        artifacts_path: Optional[Union[Path, str]],
-        model_spec: Optional["VlmModelSpec"] = None,
+        artifacts_path: Union[Path, str] | None,
+        model_spec: VlmModelSpec | None = None,
     ):
         """Initialize the auto-inline engine.
 
@@ -59,8 +61,8 @@ class AutoInlineVlmEngine(BaseVlmEngine):
         self.model_spec = model_spec
 
         # The actual engine will be set during initialization
-        self.actual_engine: Optional[BaseVlmEngine] = None
-        self.selected_engine_type: Optional[VlmEngineType] = None
+        self.actual_engine: BaseVlmEngine | None = None
+        self.selected_engine_type: VlmEngineType | None = None
 
         # Initialize immediately if model_spec is provided
         if self.model_spec is not None:
@@ -112,8 +114,8 @@ class AutoInlineVlmEngine(BaseVlmEngine):
                     )
             else:
                 _log.info(
-                    "MLX not selected: no explicit MLX export found for this model "
-                    "(no different repo_id in engine_overrides or not in supported_engines). "
+                    "MLX not selected: no explicit MLX support found for this model "
+                    "(no MLX engine override or supported_engines declaration). "
                     "Falling back to Transformers."
                 )
 

--- a/docling/models/inference_engines/vlm/mlx_engine.py
+++ b/docling/models/inference_engines/vlm/mlx_engine.py
@@ -1,11 +1,15 @@
 """MLX-based VLM inference engine for Apple Silicon."""
 
+from __future__ import annotations
+
+import importlib.metadata
 import logging
 import threading
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Union
 
+from packaging import version
 from PIL.Image import Image
 
 from docling.datamodel.vlm_engine_options import MlxVlmEngineOptions
@@ -26,6 +30,29 @@ if TYPE_CHECKING:
 
 _log = logging.getLogger(__name__)
 
+_MLX_VLM_MIN_VERSION_BY_REPO = {
+    "mlx-community/GLM-OCR-bf16": "0.3.11",
+    "tiiuae/Falcon-OCR": "0.4.3",
+}
+
+
+def _validate_mlx_vlm_version(repo_id: str) -> None:
+    """Raise a clear error when a model needs a newer mlx-vlm release."""
+    min_version = _MLX_VLM_MIN_VERSION_BY_REPO.get(repo_id)
+    if min_version is None:
+        return
+
+    installed_version = importlib.metadata.version("mlx-vlm")
+    if version.parse(installed_version) >= version.parse(min_version):
+        return
+
+    raise ImportError(
+        f"{repo_id} requires mlx-vlm>={min_version} for MLX inference, but "
+        f"{installed_version} is installed. Upgrade mlx-vlm or choose a "
+        "different VLM engine."
+    )
+
+
 # Global lock for MLX model calls - MLX models are not thread-safe
 # All MLX models share this lock to prevent concurrent MLX operations
 _MLX_GLOBAL_LOCK = threading.Lock()
@@ -43,8 +70,8 @@ class MlxVlmEngine(BaseVlmEngine, HuggingFaceModelDownloadMixin):
     def __init__(
         self,
         options: MlxVlmEngineOptions,
-        artifacts_path: Optional[Union[Path, str]],
-        model_config: Optional["EngineModelConfig"] = None,
+        artifacts_path: Union[Path, str] | None,
+        model_config: EngineModelConfig | None = None,
     ):
         """Initialize the MLX engine.
 
@@ -111,6 +138,8 @@ class MlxVlmEngine(BaseVlmEngine, HuggingFaceModelDownloadMixin):
         """
         from mlx_vlm import load
         from mlx_vlm.utils import load_config
+
+        _validate_mlx_vlm_version(repo_id)
 
         # Download or locate model artifacts
         repo_cache_folder = repo_id.replace("/", "--")

--- a/docling/models/inference_engines/vlm/mlx_engine.py
+++ b/docling/models/inference_engines/vlm/mlx_engine.py
@@ -2,14 +2,12 @@
 
 from __future__ import annotations
 
-import importlib.metadata
 import logging
 import threading
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, List, Union
 
-from packaging import version
 from PIL.Image import Image
 
 from docling.datamodel.vlm_engine_options import MlxVlmEngineOptions
@@ -29,28 +27,6 @@ if TYPE_CHECKING:
     from docling.datamodel.stage_model_specs import EngineModelConfig
 
 _log = logging.getLogger(__name__)
-
-_MLX_VLM_MIN_VERSION_BY_REPO = {
-    "mlx-community/GLM-OCR-bf16": "0.3.11",
-    "tiiuae/Falcon-OCR": "0.4.3",
-}
-
-
-def _validate_mlx_vlm_version(repo_id: str) -> None:
-    """Raise a clear error when a model needs a newer mlx-vlm release."""
-    min_version = _MLX_VLM_MIN_VERSION_BY_REPO.get(repo_id)
-    if min_version is None:
-        return
-
-    installed_version = importlib.metadata.version("mlx-vlm")
-    if version.parse(installed_version) >= version.parse(min_version):
-        return
-
-    raise ImportError(
-        f"{repo_id} requires mlx-vlm>={min_version} for MLX inference, but "
-        f"{installed_version} is installed. Upgrade mlx-vlm or choose a "
-        "different VLM engine."
-    )
 
 
 # Global lock for MLX model calls - MLX models are not thread-safe
@@ -138,8 +114,6 @@ class MlxVlmEngine(BaseVlmEngine, HuggingFaceModelDownloadMixin):
         """
         from mlx_vlm import load
         from mlx_vlm.utils import load_config
-
-        _validate_mlx_vlm_version(repo_id)
 
         # Download or locate model artifacts
         repo_cache_folder = repo_id.replace("/", "--")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,8 @@ vlm = [
   'transformers (>=4.42.0,<6.0.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*)',
   'accelerate (>=1.2.1,<2.0.0)',
   'mlx-vlm (>=0.3.0,<1.0.0) ; python_version >= "3.10" and sys_platform == "darwin" and platform_machine == "arm64"',
+  # Some MLX OCR presets need newer mlx-vlm releases at runtime:
+  # GLM-OCR requires >=0.3.11 and Falcon-OCR requires >=0.4.3.
   # 'vllm (>=0.10.0,<1.0.0) ; python_version >= "3.10" and python_version < "3.14" and sys_platform == "linux" and platform_machine == "x86_64"',
   "qwen-vl-utils>=0.0.11",
   "peft>=0.18.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,9 +97,7 @@ htmlrender = ["playwright>=1.58.0"]
 vlm = [
   'transformers (>=4.42.0,<6.0.0,!=5.0.*,!=5.1.*,!=5.2.*,!=5.3.*)',
   'accelerate (>=1.2.1,<2.0.0)',
-  'mlx-vlm (>=0.3.0,<1.0.0) ; python_version >= "3.10" and sys_platform == "darwin" and platform_machine == "arm64"',
-  # Some MLX OCR presets need newer mlx-vlm releases at runtime:
-  # GLM-OCR requires >=0.3.11 and Falcon-OCR requires >=0.4.3.
+  'mlx-vlm (>=0.4.3,<1.0.0) ; python_version >= "3.10" and sys_platform == "darwin" and platform_machine == "arm64"',
   # 'vllm (>=0.10.0,<1.0.0) ; python_version >= "3.10" and python_version < "3.14" and sys_platform == "linux" and platform_machine == "x86_64"',
   "qwen-vl-utils>=0.0.11",
   "peft>=0.18.1",

--- a/tests/test_falcon_ocr_vlm.py
+++ b/tests/test_falcon_ocr_vlm.py
@@ -62,9 +62,9 @@ def test_falcon_ocr_preset_engine_config():
     assert VlmEngineType.API_OPENAI in api_overrides
     assert api_overrides[VlmEngineType.API_OPENAI].params["model"] == "falcon-ocr"
 
-    # Falcon-OCR now declares explicit same-repo MLX support.
+    # Falcon-OCR now uses the dedicated mlx-community export.
     mlx_config = spec.get_engine_config(VlmEngineType.MLX)
-    assert mlx_config.repo_id == "tiiuae/Falcon-OCR"
+    assert mlx_config.repo_id == "mlx-community/Falcon-OCR-bf16"
     assert mlx_config.extra_config == {}
     assert spec.has_explicit_engine_export(VlmEngineType.MLX) is True
 

--- a/tests/test_falcon_ocr_vlm.py
+++ b/tests/test_falcon_ocr_vlm.py
@@ -62,10 +62,11 @@ def test_falcon_ocr_preset_engine_config():
     assert VlmEngineType.API_OPENAI in api_overrides
     assert api_overrides[VlmEngineType.API_OPENAI].params["model"] == "falcon-ocr"
 
-    # No MLX override -- engine config should fall back to default repo_id
+    # Falcon-OCR now declares explicit same-repo MLX support.
     mlx_config = spec.get_engine_config(VlmEngineType.MLX)
     assert mlx_config.repo_id == "tiiuae/Falcon-OCR"
     assert mlx_config.extra_config == {}
+    assert spec.has_explicit_engine_export(VlmEngineType.MLX) is True
 
 
 def test_falcon_ocr_preset_instantiation():

--- a/tests/test_glmocr_vlm.py
+++ b/tests/test_glmocr_vlm.py
@@ -63,10 +63,11 @@ def test_glmocr_preset_engine_config():
     assert VlmEngineType.API_OPENAI in api_overrides
     assert api_overrides[VlmEngineType.API_OPENAI].params["model"] == "glm-ocr"
 
-    # No MLX override yet — engine config should fall back to default repo_id
+    # GLM-OCR now has an explicit MLX export for Apple Silicon.
     mlx_config = spec.get_engine_config(VlmEngineType.MLX)
-    assert mlx_config.repo_id == "zai-org/GLM-OCR"
+    assert mlx_config.repo_id == "mlx-community/GLM-OCR-bf16"
     assert mlx_config.extra_config == {}
+    assert spec.has_explicit_engine_export(VlmEngineType.MLX) is True
 
 
 def test_glmocr_preset_instantiation():
@@ -95,6 +96,12 @@ def test_glmocr_legacy_specs():
     assert v.repo_id == t.repo_id
     assert v.inference_framework == InferenceFramework.VLLM
     assert v.response_format == t.response_format
+
+    # MLX spec uses the converted mlx-community weights.
+    m = vlm_model_specs.GLMOCR_MLX
+    assert m.repo_id == "mlx-community/GLM-OCR-bf16"
+    assert m.inference_framework == InferenceFramework.MLX
+    assert m.response_format == t.response_format
 
     # API spec
     a = vlm_model_specs.GLMOCR_VLLM_API

--- a/tests/test_lightonocr_vlm.py
+++ b/tests/test_lightonocr_vlm.py
@@ -67,10 +67,11 @@ def test_lightonocr_preset_engine_config():
     assert VlmEngineType.API_OPENAI in api_overrides
     assert api_overrides[VlmEngineType.API_OPENAI].params["model"] == "lightonocr-2-1b"
 
-    # No MLX override -- engine config should fall back to default repo_id
+    # LightOnOCR now has an explicit MLX export for Apple Silicon.
     mlx_config = spec.get_engine_config(VlmEngineType.MLX)
-    assert mlx_config.repo_id == "lightonai/LightOnOCR-2-1B"
+    assert mlx_config.repo_id == "mlx-community/LightOnOCR-2-1B-bf16"
     assert mlx_config.extra_config == {}
+    assert spec.has_explicit_engine_export(VlmEngineType.MLX) is True
 
 
 def test_lightonocr_preset_instantiation():
@@ -102,6 +103,12 @@ def test_lightonocr_legacy_specs():
     assert v.repo_id == t.repo_id
     assert v.inference_framework == InferenceFramework.VLLM
     assert v.response_format == t.response_format
+
+    # MLX spec uses the converted mlx-community weights.
+    m = vlm_model_specs.LIGHTONOCR_MLX
+    assert m.repo_id == "mlx-community/LightOnOCR-2-1B-bf16"
+    assert m.inference_framework == InferenceFramework.MLX
+    assert m.response_format == t.response_format
 
     # API spec
     a = vlm_model_specs.LIGHTONOCR_VLLM_API

--- a/tests/test_vlm_presets_and_runtime_options.py
+++ b/tests/test_vlm_presets_and_runtime_options.py
@@ -11,6 +11,7 @@ This test suite validates:
 import pytest
 from pydantic import ValidationError
 
+import docling.models.inference_engines.vlm.mlx_engine as mlx_engine_module
 from docling.datamodel.pipeline_options import (
     CodeFormulaVlmOptions,
     PictureDescriptionVlmEngineOptions,
@@ -189,6 +190,18 @@ class TestVlmModelSpec:
         config_other = spec.get_engine_config(VlmEngineType.MLX)
         assert "torch_dtype" not in config_other.extra_config
 
+    def test_same_repo_engine_override_counts_as_explicit_support(self):
+        """Native handlers can use the default repo_id and still be explicit."""
+        spec = VlmModelSpec(
+            name="Falcon-Style Model",
+            default_repo_id="org/model",
+            prompt="Test prompt",
+            response_format=ResponseFormat.MARKDOWN,
+            engine_overrides={VlmEngineType.MLX: EngineModelConfig()},
+        )
+
+        assert spec.has_explicit_engine_export(VlmEngineType.MLX) is True
+
     def test_model_spec_with_api_overrides(self):
         """Test model spec with API-specific overrides."""
         spec = VlmModelSpec(
@@ -330,6 +343,29 @@ class TestPresetSystem:
             assert "description" in preset_info
             assert "model" in preset_info
             assert "default_engine" in preset_info
+
+
+class TestMlxRuntimeCompatibility:
+    """Test MLX runtime compatibility checks for model-specific handlers."""
+
+    def test_validate_mlx_vlm_version_accepts_supported_release(self, monkeypatch):
+        monkeypatch.setattr(
+            mlx_engine_module.importlib.metadata,
+            "version",
+            lambda package: "0.4.3",
+        )
+
+        mlx_engine_module._validate_mlx_vlm_version("tiiuae/Falcon-OCR")
+
+    def test_validate_mlx_vlm_version_rejects_too_old_release(self, monkeypatch):
+        monkeypatch.setattr(
+            mlx_engine_module.importlib.metadata,
+            "version",
+            lambda package: "0.3.10",
+        )
+
+        with pytest.raises(ImportError, match=r"mlx-vlm>=0\.3\.11"):
+            mlx_engine_module._validate_mlx_vlm_version("mlx-community/GLM-OCR-bf16")
 
 
 # =============================================================================

--- a/tests/test_vlm_presets_and_runtime_options.py
+++ b/tests/test_vlm_presets_and_runtime_options.py
@@ -11,7 +11,6 @@ This test suite validates:
 import pytest
 from pydantic import ValidationError
 
-import docling.models.inference_engines.vlm.mlx_engine as mlx_engine_module
 from docling.datamodel.pipeline_options import (
     CodeFormulaVlmOptions,
     PictureDescriptionVlmEngineOptions,
@@ -343,29 +342,6 @@ class TestPresetSystem:
             assert "description" in preset_info
             assert "model" in preset_info
             assert "default_engine" in preset_info
-
-
-class TestMlxRuntimeCompatibility:
-    """Test MLX runtime compatibility checks for model-specific handlers."""
-
-    def test_validate_mlx_vlm_version_accepts_supported_release(self, monkeypatch):
-        monkeypatch.setattr(
-            mlx_engine_module.importlib.metadata,
-            "version",
-            lambda package: "0.4.3",
-        )
-
-        mlx_engine_module._validate_mlx_vlm_version("tiiuae/Falcon-OCR")
-
-    def test_validate_mlx_vlm_version_rejects_too_old_release(self, monkeypatch):
-        monkeypatch.setattr(
-            mlx_engine_module.importlib.metadata,
-            "version",
-            lambda package: "0.3.10",
-        )
-
-        with pytest.raises(ImportError, match=r"mlx-vlm>=0\.3\.11"):
-            mlx_engine_module._validate_mlx_vlm_version("mlx-community/GLM-OCR-bf16")
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- add explicit MLX support for `glm_ocr`, `lightonocr`, and `falcon_ocr` VLM presets
- allow same-repo MLX handlers to count as explicit engine support for `AUTO_INLINE`
- document model-specific `mlx-vlm` version requirements and raise a clear runtime error when GLM-OCR or Falcon-OCR are used with an older `mlx-vlm`
- update regression tests for GLM-OCR, LightOnOCR, Falcon-OCR, and explicit-engine-export semantics

## Testing
- `pytest -q tests/test_glmocr_vlm.py tests/test_lightonocr_vlm.py tests/test_falcon_ocr_vlm.py tests/test_vlm_presets_and_runtime_options.py`
- `uv tool run ruff format --check docling/datamodel/stage_model_specs.py docling/datamodel/vlm_model_specs.py docling/models/inference_engines/vlm/auto_inline_engine.py docling/models/inference_engines/vlm/mlx_engine.py pyproject.toml tests/test_glmocr_vlm.py tests/test_lightonocr_vlm.py tests/test_falcon_ocr_vlm.py tests/test_vlm_presets_and_runtime_options.py`
- `uv tool run ruff check docling/datamodel/stage_model_specs.py docling/datamodel/vlm_model_specs.py docling/models/inference_engines/vlm/auto_inline_engine.py docling/models/inference_engines/vlm/mlx_engine.py tests/test_glmocr_vlm.py tests/test_lightonocr_vlm.py tests/test_falcon_ocr_vlm.py tests/test_vlm_presets_and_runtime_options.py`

Closes #3270.
