### PR TITLE
feat(vlm): add support for Nanonets-OCR2-3B

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -957,6 +957,7 @@ VlmConvertOptions.register_preset(stage_model_specs.VLM_CONVERT_GEMMA_27B)
 VlmConvertOptions.register_preset(stage_model_specs.VLM_CONVERT_DOLPHIN)
 VlmConvertOptions.register_preset(stage_model_specs.VLM_CONVERT_GLMOCR)
 VlmConvertOptions.register_preset(stage_model_specs.VLM_CONVERT_LIGHTONOCR)
+VlmConvertOptions.register_preset(stage_model_specs.VLM_CONVERT_NANONETS_OCR)
 VlmConvertOptions.register_preset(stage_model_specs.VLM_CONVERT_FALCON_OCR)
 
 # Register PictureDescription presets (for new runtime-based implementation)

--- a/docling/datamodel/stage_model_specs.py
+++ b/docling/datamodel/stage_model_specs.py
@@ -1304,6 +1304,53 @@ VLM_CONVERT_LIGHTONOCR = StageModelPreset(
     default_engine_type=VlmEngineType.AUTO_INLINE,
 )
 
+_NANONETS_OCR_PROMPT = (
+    "Extract the text from the above document as if you were reading it naturally. "
+    "Return the tables in html format. Return the equations in LaTeX representation. "
+    "If there is an image in the document and image caption is not present, add a "
+    "small description of the image inside the <img></img> tag; otherwise, add the "
+    "image caption inside <img></img>. Watermarks should be wrapped in brackets. "
+    "Ex: <watermark>OFFICIAL COPY</watermark>. Page numbers should be wrapped in "
+    "brackets. Ex: <page_number>14</page_number> or <page_number>9/22</page_number>. "
+    "Prefer using \u2610 and \u2611 for check boxes."
+)
+
+VLM_CONVERT_NANONETS_OCR = StageModelPreset(
+    preset_id="nanonets_ocr",
+    name="Nanonets-OCR2-3B",
+    description="Nanonets-OCR2 model for OCR and markdown conversion with tables, equations, and check boxes (3B parameters)",
+    model_spec=VlmModelSpec(
+        name="Nanonets-OCR2-3B",
+        default_repo_id="nanonets/Nanonets-OCR2-3B",
+        prompt=_NANONETS_OCR_PROMPT,
+        response_format=ResponseFormat.MARKDOWN,
+        max_new_tokens=8192,
+        engine_overrides={
+            VlmEngineType.TRANSFORMERS: EngineModelConfig(
+                torch_dtype="bfloat16",
+                extra_config={
+                    "transformers_model_type": TransformersModelType.AUTOMODEL_IMAGETEXTTOTEXT,
+                    "transformers_prompt_style": TransformersPromptStyle.CHAT,
+                    "torch_dtype": "bfloat16",
+                },
+            ),
+        },
+        api_overrides={
+            VlmEngineType.API: ApiModelConfig(
+                params={"model": "nanonets/Nanonets-OCR2-3B", "max_tokens": 8192}
+            ),
+            VlmEngineType.API_LMSTUDIO: ApiModelConfig(
+                params={"model": "nanonets-ocr2-3b", "max_tokens": 8192}
+            ),
+            VlmEngineType.API_OPENAI: ApiModelConfig(
+                params={"model": "nanonets-ocr2-3b", "max_tokens": 8192}
+            ),
+        },
+    ),
+    scale=2.0,
+    default_engine_type=VlmEngineType.AUTO_INLINE,
+)
+
 # -----------------------------------------------------------------------------
 # PICTURE_DESCRIPTION PRESETS (for image captioning/description)
 # -----------------------------------------------------------------------------

--- a/docling/datamodel/vlm_model_specs.py
+++ b/docling/datamodel/vlm_model_specs.py
@@ -390,6 +390,68 @@ LIGHTONOCR_VLLM_API = ApiVlmOptions(
     response_format=ResponseFormat.MARKDOWN,
 )
 
+# Nanonets-OCR2-3B
+NANONETS_OCR_PROMPT = (
+    "Extract the text from the above document as if you were reading it naturally. "
+    "Return the tables in html format. Return the equations in LaTeX representation. "
+    "If there is an image in the document and image caption is not present, add a "
+    "small description of the image inside the <img></img> tag; otherwise, add the "
+    "image caption inside <img></img>. Watermarks should be wrapped in brackets. "
+    "Ex: <watermark>OFFICIAL COPY</watermark>. Page numbers should be wrapped in "
+    "brackets. Ex: <page_number>14</page_number> or <page_number>9/22</page_number>. "
+    "Prefer using \u2610 and \u2611 for check boxes."
+)
+
+NANONETS_OCR_TRANSFORMERS = InlineVlmOptions(
+    repo_id="nanonets/Nanonets-OCR2-3B",
+    prompt=NANONETS_OCR_PROMPT,
+    response_format=ResponseFormat.MARKDOWN,
+    inference_framework=InferenceFramework.TRANSFORMERS,
+    transformers_model_type=TransformersModelType.AUTOMODEL_IMAGETEXTTOTEXT,
+    transformers_prompt_style=TransformersPromptStyle.CHAT,
+    supported_devices=[
+        AcceleratorDevice.CUDA,
+        AcceleratorDevice.CPU,
+        AcceleratorDevice.MPS,
+        AcceleratorDevice.XPU,
+    ],
+    torch_dtype="bfloat16",
+    scale=2.0,
+    temperature=0.0,
+    max_new_tokens=8192,
+)
+
+NANONETS_OCR_VLLM = NANONETS_OCR_TRANSFORMERS.model_copy(deep=True)
+NANONETS_OCR_VLLM.inference_framework = InferenceFramework.VLLM
+
+NANONETS_OCR_VLLM_API = ApiVlmOptions(
+    url="http://localhost:8000/v1/chat/completions",
+    params=dict(
+        model="nanonets/Nanonets-OCR2-3B",
+        max_tokens=8192,
+    ),
+    prompt=NANONETS_OCR_PROMPT,
+    timeout=90,
+    scale=2.0,
+    temperature=0.0,
+    concurrency=4,
+    response_format=ResponseFormat.MARKDOWN,
+)
+
+NANONETS_OCR_LMSTUDIO_API = ApiVlmOptions(
+    url=AnyUrl("http://localhost:1234/v1/chat/completions"),
+    params=dict(
+        model="nanonets-ocr2-3b",
+        max_tokens=8192,
+    ),
+    prompt=NANONETS_OCR_PROMPT,
+    timeout=120,
+    scale=2.0,
+    temperature=0.0,
+    concurrency=2,
+    response_format=ResponseFormat.MARKDOWN,
+)
+
 # DeepSeek-OCR
 DEEPSEEKOCR_OLLAMA = ApiVlmOptions(
     url="http://localhost:11434/v1/chat/completions",
@@ -439,4 +501,7 @@ class VlmModelType(str, Enum):
     GLMOCR_VLLM = "glm_ocr_vllm"
     LIGHTONOCR = "lightonocr"
     LIGHTONOCR_VLLM = "lightonocr_vllm"
+    NANONETS_OCR = "nanonets_ocr"
+    NANONETS_OCR_VLLM = "nanonets_ocr_vllm"
+    NANONETS_OCR_LMSTUDIO = "nanonets_ocr_lmstudio"
     DEEPSEEKOCR_OLLAMA = "deepseekocr_ollama"

--- a/tests/test_nanonets_ocr_vlm.py
+++ b/tests/test_nanonets_ocr_vlm.py
@@ -1,0 +1,161 @@
+"""Test Nanonets-OCR2-3B VLM integration."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from docling.datamodel import vlm_model_specs
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.pipeline_options import VlmConvertOptions, VlmPipelineOptions
+from docling.datamodel.pipeline_options_vlm_model import (
+    InferenceFramework,
+    ResponseFormat,
+    TransformersModelType,
+    TransformersPromptStyle,
+)
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.models.inference_engines.vlm.base import VlmEngineType
+from docling.pipeline.vlm_pipeline import VlmPipeline
+
+
+def test_nanonets_ocr_preset_exists():
+    """Verify preset is registered with correct metadata and model spec."""
+    preset_ids = VlmConvertOptions.list_preset_ids()
+    assert "nanonets_ocr" in preset_ids
+
+    preset = VlmConvertOptions.get_preset("nanonets_ocr")
+    assert preset.preset_id == "nanonets_ocr"
+    assert preset.name == "Nanonets-OCR2-3B"
+    assert preset.scale == 2.0
+    assert preset.default_engine_type == VlmEngineType.AUTO_INLINE
+
+    spec = preset.model_spec
+    assert spec.default_repo_id == "nanonets/Nanonets-OCR2-3B"
+    assert spec.response_format == ResponseFormat.MARKDOWN
+    assert "Extract the text" in spec.prompt
+    assert spec.trust_remote_code is False
+    assert spec.max_new_tokens == 8192
+
+
+def test_nanonets_ocr_preset_engine_config():
+    """Verify engine overrides propagate correctly through get_engine_config."""
+    preset = VlmConvertOptions.get_preset("nanonets_ocr")
+    spec = preset.model_spec
+
+    # Transformers engine config should carry torch_dtype and model type
+    tf_config = spec.get_engine_config(VlmEngineType.TRANSFORMERS)
+    assert tf_config.repo_id == "nanonets/Nanonets-OCR2-3B"
+    assert tf_config.extra_config["torch_dtype"] == "bfloat16"
+    assert (
+        tf_config.extra_config["transformers_model_type"]
+        == TransformersModelType.AUTOMODEL_IMAGETEXTTOTEXT
+    )
+    assert (
+        tf_config.extra_config["transformers_prompt_style"]
+        == TransformersPromptStyle.CHAT
+    )
+
+    # API overrides should have correct model params
+    api_overrides = spec.api_overrides
+    assert VlmEngineType.API in api_overrides
+    assert api_overrides[VlmEngineType.API].params["model"] == "nanonets/Nanonets-OCR2-3B"
+    assert api_overrides[VlmEngineType.API].params["max_tokens"] == 8192
+    assert VlmEngineType.API_LMSTUDIO in api_overrides
+    assert api_overrides[VlmEngineType.API_LMSTUDIO].params["model"] == "nanonets-ocr2-3b"
+    assert VlmEngineType.API_OPENAI in api_overrides
+    assert api_overrides[VlmEngineType.API_OPENAI].params["model"] == "nanonets-ocr2-3b"
+
+    # No MLX override -- engine config should fall back to default repo_id
+    mlx_config = spec.get_engine_config(VlmEngineType.MLX)
+    assert mlx_config.repo_id == "nanonets/Nanonets-OCR2-3B"
+    assert mlx_config.extra_config == {}
+
+
+def test_nanonets_ocr_preset_instantiation():
+    """Verify from_preset produces a usable VlmConvertOptions with engine options."""
+    options = VlmConvertOptions.from_preset("nanonets_ocr")
+    assert options.model_spec.default_repo_id == "nanonets/Nanonets-OCR2-3B"
+    assert options.model_spec.response_format == ResponseFormat.MARKDOWN
+    assert options.engine_options is not None
+
+
+def test_nanonets_ocr_legacy_specs():
+    """Verify legacy InlineVlmOptions/ApiVlmOptions specs are consistent."""
+    # Transformers spec
+    t = vlm_model_specs.NANONETS_OCR_TRANSFORMERS
+    assert t.repo_id == "nanonets/Nanonets-OCR2-3B"
+    assert t.inference_framework == InferenceFramework.TRANSFORMERS
+    assert t.response_format == ResponseFormat.MARKDOWN
+    assert t.torch_dtype == "bfloat16"
+    assert t.transformers_prompt_style == TransformersPromptStyle.CHAT
+    assert t.transformers_model_type == TransformersModelType.AUTOMODEL_IMAGETEXTTOTEXT
+    assert t.scale == 2.0
+    assert t.temperature == 0.0
+    assert "Extract the text" in t.prompt
+    assert t.max_new_tokens == 8192
+
+    # VLLM spec should share repo_id but differ in framework
+    v = vlm_model_specs.NANONETS_OCR_VLLM
+    assert v.repo_id == t.repo_id
+    assert v.inference_framework == InferenceFramework.VLLM
+    assert v.response_format == t.response_format
+
+    # vLLM-compatible API spec
+    a = vlm_model_specs.NANONETS_OCR_VLLM_API
+    assert a.params["model"] == "nanonets/Nanonets-OCR2-3B"
+    assert a.params["max_tokens"] == 8192
+    assert a.response_format == ResponseFormat.MARKDOWN
+    assert a.concurrency == 4
+    assert a.timeout == 90
+
+    # LM Studio API spec
+    lmstudio = vlm_model_specs.NANONETS_OCR_LMSTUDIO_API
+    assert lmstudio.params["model"] == "nanonets-ocr2-3b"
+    assert lmstudio.params["max_tokens"] == 8192
+    assert lmstudio.response_format == ResponseFormat.MARKDOWN
+    assert str(lmstudio.url).startswith("http://localhost:1234")
+
+
+def test_e2e_nanonets_ocr_conversion():
+    """E2E test with vLLM server (skipped in CI and when server is unavailable)."""
+    if os.getenv("CI"):
+        pytest.skip("Skipping in CI environment")
+
+    try:
+        import requests
+
+        response = requests.get("http://localhost:8000/v1/models", timeout=2)
+        if response.status_code != 200:
+            pytest.skip("vLLM server is not available")
+    except Exception:
+        pytest.skip("vLLM server is not available")
+
+    pipeline_options = VlmPipelineOptions(
+        vlm_options=vlm_model_specs.NANONETS_OCR_VLLM_API,
+        enable_remote_services=True,
+    )
+
+    converter = DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(
+                pipeline_cls=VlmPipeline,
+                pipeline_options=pipeline_options,
+            ),
+        }
+    )
+
+    pdf_path = Path("./tests/data/pdf/2206.01062.pdf")
+    conv_result = converter.convert(pdf_path)
+    doc = conv_result.document
+
+    assert len(doc.pages) > 0, "Document should have pages"
+    assert len(doc.texts) > 0, "Document should have text elements"
+
+
+if __name__ == "__main__":
+    test_nanonets_ocr_preset_exists()
+    test_nanonets_ocr_preset_engine_config()
+    test_nanonets_ocr_preset_instantiation()
+    test_nanonets_ocr_legacy_specs()
+    test_e2e_nanonets_ocr_conversion()


### PR DESCRIPTION
## Summary
- Register Nanonets-OCR2-3B as a first-class VLM preset (`nanonets_ocr`) in `stage_model_specs.py` and `pipeline_options.py`.
- Add legacy `InlineVlmOptions` / `ApiVlmOptions` specs (`NANONETS_OCR_TRANSFORMERS`, `NANONETS_OCR_VLLM`, `NANONETS_OCR_VLLM_API`, `NANONETS_OCR_LMSTUDIO_API`) plus `VlmModelType` enum entries.
- Qwen2.5-VL-based model, `AUTOMODEL_IMAGETEXTTOTEXT` + CHAT prompt style, bfloat16, markdown response format.
- Engine overrides for TRANSFORMERS, API, API_LMSTUDIO, and API_OPENAI.

Relates to / builds on #3272 (MLX support for OCR presets). Once that lands, an MLX override can be added here if an `mlx-community` export becomes available for Nanonets-OCR2-3B.

## Test plan
- [x] `pytest -q tests/test_nanonets_ocr_vlm.py` — 4 unit tests pass, E2E skipped without a running vLLM server
- [x] `pytest -q tests/test_glmocr_vlm.py tests/test_lightonocr_vlm.py` — neighbor VLM tests still pass
- [ ] E2E smoke via LM Studio (`nanonets-ocr2-3b`) / vLLM (`nanonets/Nanonets-OCR2-3B`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)