### PR TITLE
fix(ocr): support rapidocr 3.8 mobile model naming

### DIFF
--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Literal, Optional, Type, TypedDict
+from typing import Literal, Type, TypedDict
 
 import numpy
 from docling_core.types.doc import BoundingBox, CoordOrigin
@@ -33,64 +33,57 @@ class _ModelPathDetail(TypedDict):
     path: str
 
 
+_RAPIDOCR_MODELSCOPE_RELEASE = "v3.8.0"
+_RAPIDOCR_MODELSCOPE_BASE_URL = (
+    "https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve"
+)
+_RAPIDOCR_DEFAULT_MODEL_PATHS: dict[_ModelPathEngines, dict[_ModelPathTypes, str]] = {
+    "onnxruntime": {
+        "det_model_path": "onnx/PP-OCRv4/det/ch_PP-OCRv4_det_mobile.onnx",
+        "cls_model_path": "onnx/PP-OCRv4/cls/ch_ppocr_mobile_v2.0_cls_mobile.onnx",
+        "rec_model_path": "onnx/PP-OCRv4/rec/ch_PP-OCRv4_rec_mobile.onnx",
+        "rec_keys_path": "paddle/PP-OCRv4/rec/ch_PP-OCRv4_rec_mobile/ppocr_keys_v1.txt",
+        "font_path": "resources/fonts/FZYTK.TTF",
+    },
+    "torch": {
+        "det_model_path": "torch/PP-OCRv4/det/ch_PP-OCRv4_det_mobile.pth",
+        "cls_model_path": "torch/PP-OCRv4/cls/ch_ptocr_mobile_v2.0_cls_mobile.pth",
+        "rec_model_path": "torch/PP-OCRv4/rec/ch_PP-OCRv4_rec_mobile.pth",
+        "rec_keys_path": "paddle/PP-OCRv4/rec/ch_PP-OCRv4_rec_mobile/ppocr_keys_v1.txt",
+        "font_path": "resources/fonts/FZYTK.TTF",
+    },
+}
+
+
+def _build_model_detail(path: str) -> _ModelPathDetail:
+    return {
+        "url": f"{_RAPIDOCR_MODELSCOPE_BASE_URL}/{_RAPIDOCR_MODELSCOPE_RELEASE}/{path}",
+        "path": path,
+    }
+
+
 class RapidOcrModel(BaseOcrModel):
     _model_repo_folder = "RapidOcr"
-    # from https://github.com/RapidAI/RapidOCR/blob/main/python/rapidocr/default_models.yaml
-    # matching the default config in https://github.com/RapidAI/RapidOCR/blob/main/python/rapidocr/config.yaml
-    # and naming f"{file_info.engine_type.value}.{file_info.ocr_version.value}.{file_info.task_type.value}"
+    # Match the PP-OCRv4 mobile defaults used by RapidOCR 3.8+:
+    # - default_models.yaml in RapidOCR 3.8.1 points at the v3.8.0 modelscope assets
+    # - config.yaml defaults Det/Cls/Rec model_type to "mobile"
     _default_models: dict[
         _ModelPathEngines, dict[_ModelPathTypes, _ModelPathDetail]
     ] = {
         "onnxruntime": {
-            "det_model_path": {
-                "url": "https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/v3.5.0/onnx/PP-OCRv4/det/ch_PP-OCRv4_det_infer.onnx",
-                "path": "onnx/PP-OCRv4/det/ch_PP-OCRv4_det_infer.onnx",
-            },
-            "cls_model_path": {
-                "url": "https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/v3.5.0/onnx/PP-OCRv4/cls/ch_ppocr_mobile_v2.0_cls_infer.onnx",
-                "path": "onnx/PP-OCRv4/cls/ch_ppocr_mobile_v2.0_cls_infer.onnx",
-            },
-            "rec_model_path": {
-                "url": "https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/v3.5.0/onnx/PP-OCRv4/rec/ch_PP-OCRv4_rec_infer.onnx",
-                "path": "onnx/PP-OCRv4/rec/ch_PP-OCRv4_rec_infer.onnx",
-            },
-            "rec_keys_path": {
-                "url": "https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/v3.5.0/paddle/PP-OCRv4/rec/ch_PP-OCRv4_rec_infer/ppocr_keys_v1.txt",
-                "path": "paddle/PP-OCRv4/rec/ch_PP-OCRv4_rec_infer/ppocr_keys_v1.txt",
-            },
-            "font_path": {
-                "url": "https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/v3.5.0/resources/fonts/FZYTK.TTF",
-                "path": "fonts/FZYTK.TTF",
-            },
+            key: _build_model_detail(path)
+            for key, path in _RAPIDOCR_DEFAULT_MODEL_PATHS["onnxruntime"].items()
         },
         "torch": {
-            "det_model_path": {
-                "url": "https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/v3.5.0/torch/PP-OCRv4/det/ch_PP-OCRv4_det_infer.pth",
-                "path": "torch/PP-OCRv4/det/ch_PP-OCRv4_det_infer.pth",
-            },
-            "cls_model_path": {
-                "url": "https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/v3.5.0/torch/PP-OCRv4/cls/ch_ptocr_mobile_v2.0_cls_infer.pth",
-                "path": "torch/PP-OCRv4/cls/ch_ptocr_mobile_v2.0_cls_infer.pth",
-            },
-            "rec_model_path": {
-                "url": "https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/v3.5.0/torch/PP-OCRv4/rec/ch_PP-OCRv4_rec_infer.pth",
-                "path": "torch/PP-OCRv4/rec/ch_PP-OCRv4_rec_infer.pth",
-            },
-            "rec_keys_path": {
-                "url": "https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/v3.5.0/paddle/PP-OCRv4/rec/ch_PP-OCRv4_rec_infer/ppocr_keys_v1.txt",
-                "path": "paddle/PP-OCRv4/rec/ch_PP-OCRv4_rec_infer/ppocr_keys_v1.txt",
-            },
-            "font_path": {
-                "url": "https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve/v3.5.0/resources/fonts/FZYTK.TTF",
-                "path": "fonts/FZYTK.TTF",
-            },
+            key: _build_model_detail(path)
+            for key, path in _RAPIDOCR_DEFAULT_MODEL_PATHS["torch"].items()
         },
     }
 
     def __init__(
         self,
         enabled: bool,
-        artifacts_path: Optional[Path],
+        artifacts_path: Path | None,
         options: RapidOcrOptions,
         accelerator_options: AcceleratorOptions,
     ):
@@ -167,10 +160,10 @@ class RapidOcrModel(BaseOcrModel):
                 )
 
             for model_path in (
+                det_model_path,
                 rec_keys_path,
                 cls_model_path,
                 rec_model_path,
-                rec_keys_path,
                 font_path,
             ):
                 if model_path is None:
@@ -224,7 +217,7 @@ class RapidOcrModel(BaseOcrModel):
     @staticmethod
     def download_models(
         backend: _ModelPathEngines,
-        local_dir: Optional[Path] = None,
+        local_dir: Path | None = None,
         force: bool = False,
         progress: bool = False,
     ) -> Path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
   'huggingface_hub (>=0.23,<2)',
   'requests (>=2.32.2,<3.0.0)',
   'ocrmac (>=1.0.0,<2.0.0) ; sys_platform == "darwin"',
-  'rapidocr (>=3.3,<4.0.0)',
+  'rapidocr (>=3.8,<4.0.0)',
   'certifi (>=2024.7.4)',
   'rtree (>=1.3.0,<2.0.0)',
   'typer (>=0.12.5,<0.22.0)',
@@ -103,7 +103,7 @@ vlm = [
   "peft>=0.18.1",
 ]
 rapidocr = [
-  'rapidocr (>=3.3,<4.0.0)',
+  'rapidocr (>=3.8,<4.0.0)',
   'onnxruntime (>=1.7.0,<2.0.0) ; python_version < "3.14"',
 ]
 onnxruntime = [

--- a/tests/test_rapid_ocr_model.py
+++ b/tests/test_rapid_ocr_model.py
@@ -1,0 +1,113 @@
+import sys
+from enum import Enum
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from docling.datamodel.accelerator_options import AcceleratorOptions
+from docling.datamodel.pipeline_options import RapidOcrOptions
+from docling.models.stages.ocr.rapid_ocr_model import RapidOcrModel
+
+
+@pytest.mark.parametrize(
+    ("backend", "det_name", "cls_name", "rec_name"),
+    [
+        (
+            "onnxruntime",
+            "ch_PP-OCRv4_det_mobile.onnx",
+            "ch_ppocr_mobile_v2.0_cls_mobile.onnx",
+            "ch_PP-OCRv4_rec_mobile.onnx",
+        ),
+        (
+            "torch",
+            "ch_PP-OCRv4_det_mobile.pth",
+            "ch_ptocr_mobile_v2.0_cls_mobile.pth",
+            "ch_PP-OCRv4_rec_mobile.pth",
+        ),
+    ],
+)
+def test_rapidocr_default_models_use_3_8_mobile_assets(
+    backend: str,
+    det_name: str,
+    cls_name: str,
+    rec_name: str,
+):
+    model_paths = RapidOcrModel._default_models[backend]
+
+    assert "/v3.8.0/" in model_paths["det_model_path"]["url"]
+    assert model_paths["det_model_path"]["path"].endswith(det_name)
+    assert model_paths["cls_model_path"]["path"].endswith(cls_name)
+    assert model_paths["rec_model_path"]["path"].endswith(rec_name)
+    assert model_paths["rec_keys_path"]["path"].endswith(
+        "paddle/PP-OCRv4/rec/ch_PP-OCRv4_rec_mobile/ppocr_keys_v1.txt"
+    )
+    assert model_paths["font_path"]["path"] == "resources/fonts/FZYTK.TTF"
+
+    for detail in model_paths.values():
+        assert "_infer" not in detail["path"]
+        assert "_infer" not in detail["url"]
+
+
+@pytest.mark.parametrize(
+    ("backend", "det_name", "cls_name", "rec_name"),
+    [
+        (
+            "onnxruntime",
+            "ch_PP-OCRv4_det_mobile.onnx",
+            "ch_ppocr_mobile_v2.0_cls_mobile.onnx",
+            "ch_PP-OCRv4_rec_mobile.onnx",
+        ),
+        (
+            "torch",
+            "ch_PP-OCRv4_det_mobile.pth",
+            "ch_ptocr_mobile_v2.0_cls_mobile.pth",
+            "ch_PP-OCRv4_rec_mobile.pth",
+        ),
+    ],
+)
+def test_rapidocr_model_initialization_uses_mobile_default_paths(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    backend: str,
+    det_name: str,
+    cls_name: str,
+    rec_name: str,
+):
+    captured: dict[str, object] = {}
+
+    class FakeEngineType(str, Enum):
+        ONNXRUNTIME = "onnxruntime"
+        OPENVINO = "openvino"
+        PADDLE = "paddle"
+        TORCH = "torch"
+
+    class FakeRapidOCR:
+        def __init__(self, params):
+            captured["params"] = params
+
+    monkeypatch.setitem(
+        sys.modules,
+        "rapidocr",
+        SimpleNamespace(EngineType=FakeEngineType, RapidOCR=FakeRapidOCR),
+    )
+
+    model_root = tmp_path / RapidOcrModel._model_repo_folder
+    for detail in RapidOcrModel._default_models[backend].values():
+        file_path = model_root / detail["path"]
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_bytes(b"")
+
+    RapidOcrModel(
+        enabled=True,
+        artifacts_path=tmp_path,
+        options=RapidOcrOptions(backend=backend),
+        accelerator_options=AcceleratorOptions(device="cpu", num_threads=1),
+    )
+
+    params = captured["params"]
+    assert Path(params["Det.model_path"]).name == det_name
+    assert Path(params["Cls.model_path"]).name == cls_name
+    assert Path(params["Rec.model_path"]).name == rec_name
+    assert Path(params["Rec.rec_keys_path"]).name == "ppocr_keys_v1.txt"
+    assert Path(params["Global.font_path"]).name == "FZYTK.TTF"

--- a/uv.lock
+++ b/uv.lock
@@ -1277,8 +1277,8 @@ requires-dist = [
     { name = "python-docx", specifier = ">=1.1.2,<2.0.0" },
     { name = "python-pptx", specifier = ">=1.0.2,<2.0.0" },
     { name = "qwen-vl-utils", marker = "extra == 'vlm'", specifier = ">=0.0.11" },
-    { name = "rapidocr", specifier = ">=3.3,<4.0.0" },
-    { name = "rapidocr", marker = "extra == 'rapidocr'", specifier = ">=3.3,<4.0.0" },
+    { name = "rapidocr", specifier = ">=3.8,<4.0.0" },
+    { name = "rapidocr", marker = "extra == 'rapidocr'", specifier = ">=3.8,<4.0.0" },
     { name = "requests", specifier = ">=2.32.2,<3.0.0" },
     { name = "rtree", specifier = ">=1.3.0,<2.0.0" },
     { name = "scipy", specifier = ">=1.6.0,<2.0.0" },
@@ -5830,7 +5830,7 @@ wheels = [
 
 [[package]]
 name = "rapidocr"
-version = "3.7.0"
+version = "3.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorlog" },
@@ -5847,7 +5847,7 @@ dependencies = [
     { name = "tqdm" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/b8/011338eec8aea40cf9b82da7481f3e65e100537cff4c866b3c1b1e719b97/rapidocr-3.7.0-py3-none-any.whl", hash = "sha256:ace47f037956fa3780875f8556a0f27ab20d91962d36a9a2816aa367bb48718f", size = 15080131, upload-time = "2026-03-04T15:38:20.339Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/4a/fa521d947f0fc7bb304bf11bec4cb66266bd81494588b4cb48dc01001719/rapidocr-3.8.1-py3-none-any.whl", hash = "sha256:650044b1fbce9e6bae5cae462dcf8be754cde11e2f23fc51f65dcc08deae2c46", size = 15080319, upload-time = "2026-04-11T07:13:22.56Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This supersedes #3266.

Instead of capping `rapidocr` below 3.8, this updates Docling's RapidOCR defaults to the 3.8+ mobile asset naming and raises the dependency floor to `rapidocr>=3.8,<4.0.0`.

## Root cause

RapidOCR 3.8 switched the default PP-OCRv4 assets away from the old `_infer` stems to `_mobile` / `_server` size tiers. Docling was still hard-coding the pre-3.8 `_infer` filenames and v3.5.0 ModelScope paths in `RapidOcrModel._default_models`, so fresh installs failed during OCR init with:

```text
ValueError: architecture ch_PP-OCRv4_det_infer is not in arch_config.yaml
```

## Scope

- update `RapidOcrModel._default_models` to the RapidOCR 3.8+ mobile defaults for both `onnxruntime` and `torch`
- align the default `ppocr_keys_v1.txt` and font asset paths with the upstream ModelScope layout
- raise the main dependency and `rapidocr` extra to `rapidocr>=3.8,<4.0.0`
- regenerate `uv.lock` so the resolver now lands on `rapidocr==3.8.1`
- add regression coverage for the default asset map and the init-time model path wiring

## Links

- Supersedes #3266
- Fixes #3265

## Test plan

- `pytest -q tests/test_rapid_ocr_model.py`
- `uv tool run ruff format --check docling/models/stages/ocr/rapid_ocr_model.py tests/test_rapid_ocr_model.py`
- `uv tool run ruff check docling/models/stages/ocr/rapid_ocr_model.py tests/test_rapid_ocr_model.py`
