### PR TITLE
fix(pptx): respect page_range during conversion

### DIFF
--- a/docling/backend/mspowerpoint_backend.py
+++ b/docling/backend/mspowerpoint_backend.py
@@ -46,6 +46,7 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
         }
         # Powerpoint file:
         self.path_or_stream: Union[BytesIO, Path] = path_or_stream
+        self.page_range = in_doc.limits.page_range
 
         self.pptx_obj: Optional[presentation.Presentation] = None
         self.valid: bool = False
@@ -106,7 +107,10 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
 
         doc = DoclingDocument(name=self.file.stem or "file", origin=origin)
         if self.pptx_obj:
-            doc = self._walk_linear(self.pptx_obj, doc)
+            start_page, end_page = self.page_range
+            doc = self._walk_linear(
+                self.pptx_obj, doc, start_page=start_page, end_page=end_page
+            )
 
         return doc
 
@@ -659,7 +663,11 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
         return
 
     def _walk_linear(
-        self, pptx_obj: presentation.Presentation, doc: DoclingDocument
+        self,
+        pptx_obj: presentation.Presentation,
+        doc: DoclingDocument,
+        start_page: int = 1,
+        end_page: Optional[int] = None,
     ) -> DoclingDocument:
         # Units of size in PPTX by default are EMU units (English Metric Units)
         slide_width = pptx_obj.slide_width
@@ -671,8 +679,8 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
             parents[i] = None
 
         # Loop through each slide
-        for _, slide in enumerate(pptx_obj.slides):
-            slide_ind = pptx_obj.slides.index(slide)
+        selected_slides = list(enumerate(pptx_obj.slides))[start_page - 1 : end_page]
+        for slide_ind, slide in selected_slides:
             parent_slide = doc.add_group(
                 name=f"slide-{slide_ind}", label=GroupLabel.CHAPTER, parent=parents[0]
             )

--- a/tests/test_backend_pptx.py
+++ b/tests/test_backend_pptx.py
@@ -53,3 +53,19 @@ def test_e2e_pptx_conversions():
         assert verify_document(doc, str(gt_path) + ".json", GENERATE), (
             "document document"
         )
+
+
+def test_pptx_page_range():
+    converter = get_converter()
+    pptx_path = Path("./tests/data/pptx/powerpoint_sample.pptx")
+
+    conv_result: ConversionResult = converter.convert(pptx_path, page_range=(2, 2))
+
+    assert conv_result.input.page_count == 3
+    assert conv_result.document.num_pages() == 1
+    assert list(conv_result.document.pages.keys()) == [2]
+
+    pred_md = conv_result.document.export_to_markdown()
+    assert "Second slide title" in pred_md
+    assert "Test Table Slide" not in pred_md
+    assert "List item4" not in pred_md


### PR DESCRIPTION
This makes the PPTX backend respect `page_range` during conversion.

Changes:
- filter PPTX slides using the validated `page_range`
- preserve original slide numbering in the converted document
- add a regression test covering single-slide PPTX conversion via `page_range`

Resolves #1946
