### PR TITLE
fix(markdown): normalize repeated leading dash markers

### DIFF
--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -109,6 +109,19 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
 
         return shortened_text
 
+    def _shorten_leading_dash_sequences(
+        self, markdown_text: str, max_length: int = 10
+    ) -> str:
+        pattern = re.compile(
+            rf"^([ \t]*)(?:-\s+){{{max_length + 1},}}-?(?=\S)", re.MULTILINE
+        )
+        shortened_text, count = pattern.subn(r"\1- ", markdown_text)
+
+        if count > 0:
+            warnings.warn("Detected potentially incorrect Markdown, correcting...")
+
+        return shortened_text
+
     @override
     def __init__(
         self,
@@ -137,6 +150,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                 # In any proper Markdown files, underscores have to be escaped,
                 # otherwise they represent emphasis (bold or italic)
                 self.markdown = self._shorten_underscore_sequences(text_stream)
+                self.markdown = self._shorten_leading_dash_sequences(self.markdown)
             if isinstance(self.path_or_stream, Path):
                 with open(self.path_or_stream, encoding="utf-8") as f:
                     md_content = f.read()
@@ -145,6 +159,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                     # In any proper Markdown files, underscores have to be escaped,
                     # otherwise they represent emphasis (bold or italic)
                     self.markdown = self._shorten_underscore_sequences(md_content)
+                    self.markdown = self._shorten_leading_dash_sequences(self.markdown)
             self.valid = True
 
             _log.debug(self.markdown)
@@ -497,7 +512,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         else:
             if not isinstance(element, str):
                 self._close_table(doc)
-                _log.debug(f"Some other element: {element}")
+                _log.debug("Some other element: %s", type(element).__name__)
 
         if (
             isinstance(element, marko.block.Paragraph | marko.block.Heading)

--- a/tests/test_backend_markdown.py
+++ b/tests/test_backend_markdown.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 from docling.backend.md_backend import MarkdownDocumentBackend
-from docling.datamodel.base_models import InputFormat
+from docling.datamodel.base_models import ConversionStatus, InputFormat
 from docling.datamodel.document import (
     ConversionResult,
     DoclingDocument,
@@ -109,3 +109,27 @@ def test_e2e_md_conversions():
 
         pred_md_: str = doc_.export_to_markdown()
         assert true_md == pred_md_
+
+
+def test_convert_leading_dash_sequences():
+    converter = get_converter()
+    markdown = """## Research Article
+
+Here is some content...
+
+- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -This is an open access article under the terms of the Creative Commons Attribution License, which permits use, distribution and reproduction in any medium, provided the original work is properly cited.
+
+<!-- image -->
+"""
+
+    conv_result: ConversionResult = converter.convert_string(
+        markdown, format=InputFormat.MD
+    )
+
+    pred_md = conv_result.document.export_to_markdown()
+
+    assert conv_result.status == ConversionStatus.SUCCESS
+    assert (
+        "- This is an open access article under the terms of the Creative Commons Attribution License"
+        in pred_md
+    )


### PR DESCRIPTION
This normalizes pathological leading `- ` marker sequences in Markdown before parsing.

Docling already shortens excessively long underscore runs to avoid unnecessary parser work on malformed Markdown. This applies the same defensive approach to repeated leading dash markers, which can otherwise produce a deeply nested list AST and fail with a recursion error on conversion.

Changes:
- normalize excessively repeated leading `- ` markers before Markdown parsing
- avoid debug logging that stringifies recursive Marko nodes
- add a regression test covering the reported repeated-dash input

Resolves #1796
