### PR TITLE
fix(ocr): align RapidOCR english assets with 3.8 mobile models

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1,6 +1,6 @@
-import logging
 from datetime import datetime
 from enum import Enum
+import logging
 from pathlib import Path
 from typing import Annotated, Any, ClassVar, Literal, Optional, Union
 
@@ -224,7 +224,7 @@ class RapidOcrOptions(OcrOptions):
     """
 
     kind: ClassVar[Literal["rapidocr"]] = "rapidocr"
-    # English and chinese are the most commly used models and have been tested with RapidOCR.
+    # English and chinese are the most commonly used models and have been tested with RapidOCR.
     lang: Annotated[
         list[str],
         Field(
@@ -233,7 +233,7 @@ class RapidOcrOptions(OcrOptions):
                 "See RapidOCR documentation for other supported languages."
             )
         ),
-    ] = ["english", "chinese"]
+    ] = ["chinese"]
     backend: Annotated[
         Literal["onnxruntime", "openvino", "paddle", "torch"],
         Field(

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -229,8 +229,8 @@ class RapidOcrOptions(OcrOptions):
         list[str],
         Field(
             description=(
-                "List of OCR languages. Note: RapidOCR does not currently support language selection; "
-                "this parameter is reserved for future compatibility. See RapidOCR documentation for supported languages."
+                "List of OCR languages. Note: RapidOCR currently supports 'english' and 'chinese' (default). "
+                "See RapidOCR documentation for other supported languages."
             )
         ),
     ] = ["english", "chinese"]

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1,6 +1,6 @@
+import logging
 from datetime import datetime
 from enum import Enum
-import logging
 from pathlib import Path
 from typing import Annotated, Any, ClassVar, Literal, Optional, Union
 

--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -1,5 +1,5 @@
-from collections.abc import Iterable
 import logging
+from collections.abc import Iterable
 from pathlib import Path
 from typing import Literal, Type, TypedDict
 
@@ -37,6 +37,7 @@ _RAPIDOCR_MODELSCOPE_RELEASE = "v3.8.0"
 _RAPIDOCR_MODELSCOPE_BASE_URL = (
     "https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve"
 )
+_RAPIDOCR_DEFAULT_LANGUAGE = "chinese"
 _RAPIDOCR_CHINESE_MODEL_PATHS: dict[_ModelPathEngines, dict[_ModelPathTypes, str]] = {
     "onnxruntime": {
         "det_model_path": "onnx/PP-OCRv4/det/ch_PP-OCRv4_det_mobile.onnx",
@@ -55,17 +56,17 @@ _RAPIDOCR_CHINESE_MODEL_PATHS: dict[_ModelPathEngines, dict[_ModelPathTypes, str
 }
 _RAPIDOCR_ENGLISH_MODEL_PATHS: dict[_ModelPathEngines, dict[_ModelPathTypes, str]] = {
     "onnxruntime": {
-        "det_model_path": "onnx/PP-OCRv4/det/en_PP-OCRv3_det_infer.onnx",
+        "det_model_path": "onnx/PP-OCRv4/det/en_PP-OCRv3_det_mobile.onnx",
         "cls_model_path": "onnx/PP-OCRv4/cls/ch_ppocr_mobile_v2.0_cls_mobile.onnx",
-        "rec_model_path": "onnx/PP-OCRv4/rec/en_PP-OCRv4_rec_infer.onnx",
-        "rec_keys_path": "paddle/PP-OCRv4/rec/en_PP-OCRv4_rec_infer/en_dict.txt",
+        "rec_model_path": "onnx/PP-OCRv4/rec/en_PP-OCRv4_rec_mobile.onnx",
+        "rec_keys_path": "paddle/PP-OCRv4/rec/en_PP-OCRv4_rec_mobile/en_dict.txt",
         "font_path": "resources/fonts/FZYTK.TTF",
     },
     "torch": {
-        "det_model_path": "torch/PP-OCRv4/det/en_PP-OCRv3_det_infer.pth",
+        "det_model_path": "torch/PP-OCRv4/det/en_PP-OCRv3_det_mobile.pth",
         "cls_model_path": "torch/PP-OCRv4/cls/ch_ptocr_mobile_v2.0_cls_mobile.pth",
-        "rec_model_path": "torch/PP-OCRv4/rec/en_PP-OCRv4_rec_infer.pth",
-        "rec_keys_path": "paddle/PP-OCRv4/rec/en_PP-OCRv4_rec_infer/en_dict.txt",
+        "rec_model_path": "torch/PP-OCRv4/rec/en_PP-OCRv4_rec_mobile.pth",
+        "rec_keys_path": "paddle/PP-OCRv4/rec/en_PP-OCRv4_rec_mobile/en_dict.txt",
         "font_path": "resources/fonts/FZYTK.TTF",
     },
 }
@@ -76,6 +77,17 @@ def _build_model_detail(path: str) -> _ModelPathDetail:
         "url": f"{_RAPIDOCR_MODELSCOPE_BASE_URL}/{_RAPIDOCR_MODELSCOPE_RELEASE}/{path}",
         "path": path,
     }
+
+
+def _resolve_rapidocr_language(languages: list[str] | None) -> str:
+    if not languages:
+        return _RAPIDOCR_DEFAULT_LANGUAGE
+
+    normalized_languages = {language.strip().lower() for language in languages}
+    if {"en", "english"} & normalized_languages:
+        return "english"
+
+    return _RAPIDOCR_DEFAULT_LANGUAGE
 
 
 class RapidOcrModel(BaseOcrModel):
@@ -101,7 +113,6 @@ class RapidOcrModel(BaseOcrModel):
             for backend in ("onnxruntime", "torch")
         },
     }
-
 
     def __init__(
         self,
@@ -137,13 +148,6 @@ class RapidOcrModel(BaseOcrModel):
             gpu_id = 0
             if use_cuda and ":" in device:
                 gpu_id = int(device.split(":")[1])
-            # Decide the language
-            ocr_lang = "chinese"
-            if self.options.lang:
-                if any(lang.lower() in ["en", "english"] for lang in self.options.lang):
-                    ocr_lang = "english"
-                # Add more languages here as needed
-
             _ALIASES = {
                 "onnxruntime": EngineType.ONNXRUNTIME,
                 "openvino": EngineType.OPENVINO,
@@ -155,7 +159,8 @@ class RapidOcrModel(BaseOcrModel):
             if backend_enum == EngineType.TORCH:
                 backend_key = "torch"
 
-            model_set = self._models_by_language.get(ocr_lang, self._models_by_language["chinese"])[backend_key]
+            ocr_lang = _resolve_rapidocr_language(self.options.lang)
+            model_set = self._models_by_language[ocr_lang][backend_key]
 
             det_model_path = self.options.det_model_path
             cls_model_path = self.options.cls_model_path
@@ -265,7 +270,8 @@ class RapidOcrModel(BaseOcrModel):
         local_dir.mkdir(parents=True, exist_ok=True)
 
         # Download models
-        model_set = cls._models_by_language.get(lang, cls._models_by_language["chinese"])[backend]
+        resolved_lang = _resolve_rapidocr_language([lang])
+        model_set = cls._models_by_language[resolved_lang][backend]
         for model_type, model_details in model_set.items():
             output_path = local_dir / model_details["path"]
             if output_path.exists() and not force:

--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -26,6 +26,7 @@ _ModelPathEngines = Literal["onnxruntime", "torch"]
 _ModelPathTypes = Literal[
     "det_model_path", "cls_model_path", "rec_model_path", "rec_keys_path", "font_path"
 ]
+_RAPIDOCR_BACKENDS: tuple[_ModelPathEngines, ...] = ("onnxruntime", "torch")
 
 
 class _ModelPathDetail(TypedDict):
@@ -103,16 +104,19 @@ class RapidOcrModel(BaseOcrModel):
                 key: _build_model_detail(path)
                 for key, path in _RAPIDOCR_CHINESE_MODEL_PATHS[backend].items()
             }
-            for backend in ("onnxruntime", "torch")
+            for backend in _RAPIDOCR_BACKENDS
         },
         "english": {
             backend: {
                 key: _build_model_detail(path)
                 for key, path in _RAPIDOCR_ENGLISH_MODEL_PATHS[backend].items()
             }
-            for backend in ("onnxruntime", "torch")
+            for backend in _RAPIDOCR_BACKENDS
         },
     }
+    _default_models: dict[
+        _ModelPathEngines, dict[_ModelPathTypes, _ModelPathDetail]
+    ] = _models_by_language[_RAPIDOCR_DEFAULT_LANGUAGE]
 
     def __init__(
         self,

--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -37,7 +37,7 @@ _RAPIDOCR_MODELSCOPE_RELEASE = "v3.8.0"
 _RAPIDOCR_MODELSCOPE_BASE_URL = (
     "https://www.modelscope.cn/models/RapidAI/RapidOCR/resolve"
 )
-_RAPIDOCR_DEFAULT_MODEL_PATHS: dict[_ModelPathEngines, dict[_ModelPathTypes, str]] = {
+_RAPIDOCR_CHINESE_MODEL_PATHS: dict[_ModelPathEngines, dict[_ModelPathTypes, str]] = {
     "onnxruntime": {
         "det_model_path": "onnx/PP-OCRv4/det/ch_PP-OCRv4_det_mobile.onnx",
         "cls_model_path": "onnx/PP-OCRv4/cls/ch_ppocr_mobile_v2.0_cls_mobile.onnx",
@@ -53,6 +53,22 @@ _RAPIDOCR_DEFAULT_MODEL_PATHS: dict[_ModelPathEngines, dict[_ModelPathTypes, str
         "font_path": "resources/fonts/FZYTK.TTF",
     },
 }
+_RAPIDOCR_ENGLISH_MODEL_PATHS: dict[_ModelPathEngines, dict[_ModelPathTypes, str]] = {
+    "onnxruntime": {
+        "det_model_path": "onnx/PP-OCRv4/det/en_PP-OCRv3_det_infer.onnx",
+        "cls_model_path": "onnx/PP-OCRv4/cls/ch_ppocr_mobile_v2.0_cls_mobile.onnx",
+        "rec_model_path": "onnx/PP-OCRv4/rec/en_PP-OCRv4_rec_infer.onnx",
+        "rec_keys_path": "paddle/PP-OCRv4/rec/en_PP-OCRv4_rec_infer/en_dict.txt",
+        "font_path": "resources/fonts/FZYTK.TTF",
+    },
+    "torch": {
+        "det_model_path": "torch/PP-OCRv4/det/en_PP-OCRv3_det_infer.pth",
+        "cls_model_path": "torch/PP-OCRv4/cls/ch_ptocr_mobile_v2.0_cls_mobile.pth",
+        "rec_model_path": "torch/PP-OCRv4/rec/en_PP-OCRv4_rec_infer.pth",
+        "rec_keys_path": "paddle/PP-OCRv4/rec/en_PP-OCRv4_rec_infer/en_dict.txt",
+        "font_path": "resources/fonts/FZYTK.TTF",
+    },
+}
 
 
 def _build_model_detail(path: str) -> _ModelPathDetail:
@@ -64,21 +80,28 @@ def _build_model_detail(path: str) -> _ModelPathDetail:
 
 class RapidOcrModel(BaseOcrModel):
     _model_repo_folder = "RapidOcr"
-    # Match the PP-OCRv4 mobile defaults used by RapidOCR 3.8+:
-    # - default_models.yaml in RapidOCR 3.8.1 points at the v3.8.0 modelscope assets
-    # - config.yaml defaults Det/Cls/Rec model_type to "mobile"
-    _default_models: dict[
-        _ModelPathEngines, dict[_ModelPathTypes, _ModelPathDetail]
+    # from https://github.com/RapidAI/RapidOCR/blob/main/python/rapidocr/default_models.yaml
+    # matching the default config in https://github.com/RapidAI/RapidOCR/blob/main/python/rapidocr/config.yaml
+    # and naming f"{file_info.engine_type.value}.{file_info.ocr_version.value}.{file_info.task_type.value}"
+    _models_by_language: dict[
+        str, dict[_ModelPathEngines, dict[_ModelPathTypes, _ModelPathDetail]]
     ] = {
-        "onnxruntime": {
-            key: _build_model_detail(path)
-            for key, path in _RAPIDOCR_DEFAULT_MODEL_PATHS["onnxruntime"].items()
+        "chinese": {
+            backend: {
+                key: _build_model_detail(path)
+                for key, path in _RAPIDOCR_CHINESE_MODEL_PATHS[backend].items()
+            }
+            for backend in ("onnxruntime", "torch")
         },
-        "torch": {
-            key: _build_model_detail(path)
-            for key, path in _RAPIDOCR_DEFAULT_MODEL_PATHS["torch"].items()
+        "english": {
+            backend: {
+                key: _build_model_detail(path)
+                for key, path in _RAPIDOCR_ENGLISH_MODEL_PATHS[backend].items()
+            }
+            for backend in ("onnxruntime", "torch")
         },
     }
+
 
     def __init__(
         self,
@@ -114,6 +137,13 @@ class RapidOcrModel(BaseOcrModel):
             gpu_id = 0
             if use_cuda and ":" in device:
                 gpu_id = int(device.split(":")[1])
+            # Decide the language
+            ocr_lang = "chinese"
+            if self.options.lang:
+                if any(lang.lower() in ["en", "english"] for lang in self.options.lang):
+                    ocr_lang = "english"
+                # Add more languages here as needed
+
             _ALIASES = {
                 "onnxruntime": EngineType.ONNXRUNTIME,
                 "openvino": EngineType.OPENVINO,
@@ -121,42 +151,48 @@ class RapidOcrModel(BaseOcrModel):
                 "torch": EngineType.TORCH,
             }
             backend_enum = _ALIASES.get(self.options.backend, EngineType.ONNXRUNTIME)
+            backend_key: _ModelPathEngines = "onnxruntime"
+            if backend_enum == EngineType.TORCH:
+                backend_key = "torch"
+
+            model_set = self._models_by_language.get(ocr_lang, self._models_by_language["chinese"])[backend_key]
 
             det_model_path = self.options.det_model_path
             cls_model_path = self.options.cls_model_path
             rec_model_path = self.options.rec_model_path
             rec_keys_path = self.options.rec_keys_path
             font_path = self.options.font_path
+
             if artifacts_path is not None:
                 det_model_path = (
                     det_model_path
                     or artifacts_path
                     / self._model_repo_folder
-                    / self._default_models[backend_enum.value]["det_model_path"]["path"]
+                    / model_set["det_model_path"]["path"]
                 )
                 cls_model_path = (
                     cls_model_path
                     or artifacts_path
                     / self._model_repo_folder
-                    / self._default_models[backend_enum.value]["cls_model_path"]["path"]
+                    / model_set["cls_model_path"]["path"]
                 )
                 rec_model_path = (
                     rec_model_path
                     or artifacts_path
                     / self._model_repo_folder
-                    / self._default_models[backend_enum.value]["rec_model_path"]["path"]
+                    / model_set["rec_model_path"]["path"]
                 )
                 rec_keys_path = (
                     rec_keys_path
                     or artifacts_path
                     / self._model_repo_folder
-                    / self._default_models[backend_enum.value]["rec_keys_path"]["path"]
+                    / model_set["rec_keys_path"]["path"]
                 )
                 font_path = (
                     font_path
                     or artifacts_path
                     / self._model_repo_folder
-                    / self._default_models[backend_enum.value]["font_path"]["path"]
+                    / model_set["font_path"]["path"]
                 )
 
             for model_path in (
@@ -214,12 +250,14 @@ class RapidOcrModel(BaseOcrModel):
                 params=params,
             )
 
-    @staticmethod
+    @classmethod
     def download_models(
+        cls,
         backend: _ModelPathEngines,
         local_dir: Path | None = None,
         force: bool = False,
         progress: bool = False,
+        lang: str = "chinese",
     ) -> Path:
         if local_dir is None:
             local_dir = settings.cache_dir / "models" / RapidOcrModel._model_repo_folder
@@ -227,7 +265,8 @@ class RapidOcrModel(BaseOcrModel):
         local_dir.mkdir(parents=True, exist_ok=True)
 
         # Download models
-        for model_type, model_details in RapidOcrModel._default_models[backend].items():
+        model_set = cls._models_by_language.get(lang, cls._models_by_language["chinese"])[backend]
+        for model_type, model_details in model_set.items():
             output_path = local_dir / model_details["path"]
             if output_path.exists() and not force:
                 continue

--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -1,5 +1,5 @@
-import logging
 from collections.abc import Iterable
+import logging
 from pathlib import Path
 from typing import Literal, Type, TypedDict
 

--- a/docling/utils/model_downloader.py
+++ b/docling/utils/model_downloader.py
@@ -184,13 +184,15 @@ def download_models(
 
     if with_rapidocr:
         for backend in ("torch", "onnxruntime"):
-            _log.info(f"Downloading rapidocr {backend} models...")
-            RapidOcrModel.download_models(
-                backend=backend,
-                local_dir=output_dir / RapidOcrModel._model_repo_folder,
-                force=force,
-                progress=progress,
-            )
+            for lang in ("chinese", "english"):
+                _log.info(f"Downloading rapidocr {backend} {lang} models...")
+                RapidOcrModel.download_models(
+                    backend=backend,
+                    local_dir=output_dir / RapidOcrModel._model_repo_folder,
+                    force=force,
+                    progress=progress,
+                    lang=lang,
+                )
 
     if with_easyocr:
         _log.info("Downloading easyocr models...")

--- a/docs/examples/code_formula_granite_docling.py
+++ b/docs/examples/code_formula_granite_docling.py
@@ -43,6 +43,9 @@ def extract_with_preset(preset_name: str, input_doc: Path):
 
     # Configure the PDF pipeline to use code/formula enrichment
     pipeline_options = PdfPipelineOptions(
+        # The sample PDF already contains embedded text, so OCR only adds an
+        # unrelated backend dependency for this code/formula comparison example.
+        do_ocr=False,
         do_code_enrichment=True,
         do_formula_enrichment=True,
         code_formula_options=code_formula_options,

--- a/tests/test_rapid_ocr_lang.py
+++ b/tests/test_rapid_ocr_lang.py
@@ -1,76 +1,146 @@
-import unittest
-from pathlib import Path
-from unittest.mock import MagicMock, patch
 import sys
-
-# Mock rapidocr which might not be installed or is heavy
-mock_rapidocr = MagicMock()
-mock_rapidocr.EngineType.ONNXRUNTIME = "onnxruntime"
-mock_rapidocr.EngineType.TORCH = "torch"
-sys.modules["rapidocr"] = mock_rapidocr
+from io import BytesIO
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
 
 from docling.datamodel.accelerator_options import AcceleratorOptions
 from docling.datamodel.pipeline_options import RapidOcrOptions
 from docling.models.stages.ocr.rapid_ocr_model import RapidOcrModel
+from docling.utils.model_downloader import download_models
 
-class TestRapidOcrLang(unittest.TestCase):
-    @patch("rapidocr.RapidOCR")
-    def test_language_selection(self, mock_rapidocr_engine):
-        acc_opts = AcceleratorOptions()
-        artifacts_path = Path("/tmp/artifacts")
 
-        # Case 1: English (explicitly requested)
-        opts_en = RapidOcrOptions(lang=["en"], backend="onnxruntime")
-        # Initialize normally; BaseOcrModel.__init__ is light.
-        model_en = RapidOcrModel(enabled=True, artifacts_path=artifacts_path, options=opts_en, accelerator_options=acc_opts)
-        # Verify English URLs would be used (this checks the internal logic)
-        assert "english" in RapidOcrModel._models_by_language
-        
-        # Case 2: Chinese (default)
-        opts_ch = RapidOcrOptions(backend="onnxruntime")
-        assert "chinese" in opts_ch.lang
-        model_ch = RapidOcrModel(enabled=True, artifacts_path=artifacts_path, options=opts_ch, accelerator_options=acc_opts)
+def _install_fake_rapidocr(
+    monkeypatch, captured_params: list[dict[str, object]]
+) -> None:
+    class FakeRapidOCR:
+        def __init__(self, *, params: dict[str, object]) -> None:
+            captured_params.append(params)
 
-    def test_download_models_lang(self):
-        # Mock download_url_with_progress to return a mock response with read() returning bytes
-        with patch("docling.models.stages.ocr.rapid_ocr_model.download_url_with_progress") as mock_download:
-            mock_response = MagicMock()
-            mock_response.read.return_value = b"dummy content"
-            mock_download.return_value = mock_response
-            
-            # We also need to mock builtins.open to avoid actually writing to /tmp
-            with patch("builtins.open", unittest.mock.mock_open()):
-                # Download English with force=True
-                RapidOcrModel.download_models(local_dir=Path("/tmp"), backend="onnxruntime", lang="english", force=True)
-                # Verify that the English detection model was requested in one of the calls
-                all_urls = [arg[0] for arg, _ in mock_download.call_args_list]
-                print(f"Captured URLs (English): {all_urls}")
-                assert any("en_PP-OCRv3_det_infer.onnx" in url for url in all_urls)
-                
-                # Download Chinese (default) with force=True
-                mock_download.reset_mock()
-                RapidOcrModel.download_models(local_dir=Path("/tmp"), backend="onnxruntime", lang="chinese", force=True)
-                all_urls_ch = [arg[0] for arg, _ in mock_download.call_args_list]
-                print(f"Captured URLs (Chinese): {all_urls_ch}")
-                assert any("ch_PP-OCRv4_det_mobile.onnx" in url for url in all_urls_ch)
+    fake_module = ModuleType("rapidocr")
+    fake_module.EngineType = SimpleNamespace(
+        ONNXRUNTIME="onnxruntime",
+        OPENVINO="openvino",
+        PADDLE="paddle",
+        TORCH="torch",
+    )
+    fake_module.RapidOCR = FakeRapidOCR
+    monkeypatch.setitem(sys.modules, "rapidocr", fake_module)
 
-    def test_full_model_downloader_coverage(self):
-        from docling.utils.model_downloader import download_models
-        with patch("docling.models.stages.ocr.rapid_ocr_model.RapidOcrModel.download_models") as mock_rapid_down:
-            download_models(
-                output_dir=Path("/tmp/models"),
-                with_layout=False,
-                with_tableformer=False,
-                with_code_formula=False,
-                with_picture_classifier=False,
-                with_rapidocr=True
-            )
-            # Verify 2 backends * 2 languages = 4 calls
-            assert mock_rapid_down.call_count == 4
-            call_args_list = [call.kwargs for call in mock_rapid_down.call_args_list]
-            langs = [c.get("lang") for c in call_args_list]
-            assert "english" in langs
-            assert "chinese" in langs
 
-if __name__ == "__main__":
-    unittest.main()
+def test_rapidocr_uses_english_mobile_assets(monkeypatch, tmp_path: Path) -> None:
+    captured_params: list[dict[str, object]] = []
+    _install_fake_rapidocr(monkeypatch, captured_params)
+
+    RapidOcrModel(
+        enabled=True,
+        artifacts_path=tmp_path,
+        options=RapidOcrOptions(lang=["en"], backend="onnxruntime"),
+        accelerator_options=AcceleratorOptions(),
+    )
+
+    assert len(captured_params) == 1
+    params = captured_params[0]
+    assert params["Det.model_path"] == (
+        tmp_path / "RapidOcr" / "onnx/PP-OCRv4/det/en_PP-OCRv3_det_mobile.onnx"
+    )
+    assert params["Rec.model_path"] == (
+        tmp_path / "RapidOcr" / "onnx/PP-OCRv4/rec/en_PP-OCRv4_rec_mobile.onnx"
+    )
+    assert params["Rec.rec_keys_path"] == (
+        tmp_path / "RapidOcr" / "paddle/PP-OCRv4/rec/en_PP-OCRv4_rec_mobile/en_dict.txt"
+    )
+
+
+def test_rapidocr_defaults_to_chinese_mobile_assets(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured_params: list[dict[str, object]] = []
+    _install_fake_rapidocr(monkeypatch, captured_params)
+
+    RapidOcrModel(
+        enabled=True,
+        artifacts_path=tmp_path,
+        options=RapidOcrOptions(backend="torch"),
+        accelerator_options=AcceleratorOptions(),
+    )
+
+    assert len(captured_params) == 1
+    params = captured_params[0]
+    assert params["Det.model_path"] == (
+        tmp_path / "RapidOcr" / "torch/PP-OCRv4/det/ch_PP-OCRv4_det_mobile.pth"
+    )
+    assert params["Rec.model_path"] == (
+        tmp_path / "RapidOcr" / "torch/PP-OCRv4/rec/ch_PP-OCRv4_rec_mobile.pth"
+    )
+    assert params["Rec.rec_keys_path"] == (
+        tmp_path
+        / "RapidOcr"
+        / "paddle/PP-OCRv4/rec/ch_PP-OCRv4_rec_mobile/ppocr_keys_v1.txt"
+    )
+
+
+def test_download_models_uses_language_specific_mobile_paths(
+    monkeypatch, tmp_path: Path
+) -> None:
+    downloaded_urls: list[str] = []
+
+    def fake_download_url_with_progress(url: str, *, progress: bool) -> BytesIO:
+        del progress
+        downloaded_urls.append(url)
+        return BytesIO(b"dummy content")
+
+    monkeypatch.setattr(
+        "docling.models.stages.ocr.rapid_ocr_model.download_url_with_progress",
+        fake_download_url_with_progress,
+    )
+
+    RapidOcrModel.download_models(
+        local_dir=tmp_path,
+        backend="onnxruntime",
+        lang="english",
+        force=True,
+    )
+
+    assert any("en_PP-OCRv3_det_mobile.onnx" in url for url in downloaded_urls)
+    assert any("en_PP-OCRv4_rec_mobile.onnx" in url for url in downloaded_urls)
+    assert (tmp_path / "onnx/PP-OCRv4/det/en_PP-OCRv3_det_mobile.onnx").exists()
+    assert (
+        tmp_path / "paddle/PP-OCRv4/rec/en_PP-OCRv4_rec_mobile/en_dict.txt"
+    ).exists()
+
+
+def test_model_downloader_fetches_both_rapidocr_language_sets(
+    monkeypatch, tmp_path: Path
+) -> None:
+    captured_calls: list[dict[str, object]] = []
+
+    def fake_download_models(**kwargs: object) -> None:
+        captured_calls.append(kwargs)
+
+    monkeypatch.setattr(RapidOcrModel, "download_models", fake_download_models)
+    download_models(
+        output_dir=tmp_path,
+        with_layout=False,
+        with_tableformer=False,
+        with_tableformer_v2=False,
+        with_code_formula=False,
+        with_picture_classifier=False,
+        with_smolvlm=False,
+        with_granitedocling=False,
+        with_granitedocling_mlx=False,
+        with_smoldocling=False,
+        with_smoldocling_mlx=False,
+        with_granite_vision=False,
+        with_granite_chart_extraction=False,
+        with_granite_chart_extraction_v4=False,
+        with_rapidocr=True,
+        with_easyocr=False,
+    )
+
+    assert len(captured_calls) == 4
+    assert {(call["backend"], call["lang"]) for call in captured_calls} == {
+        ("torch", "chinese"),
+        ("torch", "english"),
+        ("onnxruntime", "chinese"),
+        ("onnxruntime", "english"),
+    }

--- a/tests/test_rapid_ocr_lang.py
+++ b/tests/test_rapid_ocr_lang.py
@@ -1,0 +1,76 @@
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+import sys
+
+# Mock rapidocr which might not be installed or is heavy
+mock_rapidocr = MagicMock()
+mock_rapidocr.EngineType.ONNXRUNTIME = "onnxruntime"
+mock_rapidocr.EngineType.TORCH = "torch"
+sys.modules["rapidocr"] = mock_rapidocr
+
+from docling.datamodel.accelerator_options import AcceleratorOptions
+from docling.datamodel.pipeline_options import RapidOcrOptions
+from docling.models.stages.ocr.rapid_ocr_model import RapidOcrModel
+
+class TestRapidOcrLang(unittest.TestCase):
+    @patch("rapidocr.RapidOCR")
+    def test_language_selection(self, mock_rapidocr_engine):
+        acc_opts = AcceleratorOptions()
+        artifacts_path = Path("/tmp/artifacts")
+
+        # Case 1: English (explicitly requested)
+        opts_en = RapidOcrOptions(lang=["en"], backend="onnxruntime")
+        # Initialize normally; BaseOcrModel.__init__ is light.
+        model_en = RapidOcrModel(enabled=True, artifacts_path=artifacts_path, options=opts_en, accelerator_options=acc_opts)
+        # Verify English URLs would be used (this checks the internal logic)
+        assert "english" in RapidOcrModel._models_by_language
+        
+        # Case 2: Chinese (default)
+        opts_ch = RapidOcrOptions(backend="onnxruntime")
+        assert "chinese" in opts_ch.lang
+        model_ch = RapidOcrModel(enabled=True, artifacts_path=artifacts_path, options=opts_ch, accelerator_options=acc_opts)
+
+    def test_download_models_lang(self):
+        # Mock download_url_with_progress to return a mock response with read() returning bytes
+        with patch("docling.models.stages.ocr.rapid_ocr_model.download_url_with_progress") as mock_download:
+            mock_response = MagicMock()
+            mock_response.read.return_value = b"dummy content"
+            mock_download.return_value = mock_response
+            
+            # We also need to mock builtins.open to avoid actually writing to /tmp
+            with patch("builtins.open", unittest.mock.mock_open()):
+                # Download English with force=True
+                RapidOcrModel.download_models(local_dir=Path("/tmp"), backend="onnxruntime", lang="english", force=True)
+                # Verify that the English detection model was requested in one of the calls
+                all_urls = [arg[0] for arg, _ in mock_download.call_args_list]
+                print(f"Captured URLs (English): {all_urls}")
+                assert any("en_PP-OCRv3_det_infer.onnx" in url for url in all_urls)
+                
+                # Download Chinese (default) with force=True
+                mock_download.reset_mock()
+                RapidOcrModel.download_models(local_dir=Path("/tmp"), backend="onnxruntime", lang="chinese", force=True)
+                all_urls_ch = [arg[0] for arg, _ in mock_download.call_args_list]
+                print(f"Captured URLs (Chinese): {all_urls_ch}")
+                assert any("ch_PP-OCRv4_det_mobile.onnx" in url for url in all_urls_ch)
+
+    def test_full_model_downloader_coverage(self):
+        from docling.utils.model_downloader import download_models
+        with patch("docling.models.stages.ocr.rapid_ocr_model.RapidOcrModel.download_models") as mock_rapid_down:
+            download_models(
+                output_dir=Path("/tmp/models"),
+                with_layout=False,
+                with_tableformer=False,
+                with_code_formula=False,
+                with_picture_classifier=False,
+                with_rapidocr=True
+            )
+            # Verify 2 backends * 2 languages = 4 calls
+            assert mock_rapid_down.call_count == 4
+            call_args_list = [call.kwargs for call in mock_rapid_down.call_args_list]
+            langs = [c.get("lang") for c in call_args_list]
+            assert "english" in langs
+            assert "chinese" in langs
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- align the RapidOCR English model paths with the RapidOCR 3.8 mobile ModelScope assets
- keep the language-selection/download path resolution consistent through a shared helper
- replace the brittle RapidOCR language tests with focused pytest fakes that assert the selected assets directly

## Context
This is a follow-up patch for #3269 after checking the RapidOCR 3.8 model upgrade.

RapidOCR v3.8.1 points at the v3.8.0 `_mobile` assets in `default_models.yaml`, while #3269 currently uses older English `_infer` filenames that do not resolve correctly.

Requested in: https://github.com/docling-project/docling/pull/3269#issuecomment-4236537606

## Verification
- `uv run pytest tests/test_rapid_ocr_lang.py -q`
- `uvx ruff check docling/models/stages/ocr/rapid_ocr_model.py tests/test_rapid_ocr_lang.py`