### PR TITLE
docs: add indexed picture placeholder example to serialization notebook

### DIFF
--- a/docs/examples/serialization.ipynb
+++ b/docs/examples/serialization.ipynb
@@ -640,6 +640,88 @@
     "\n",
     "print_in_console(ser_text[ser_text.find(start_cue) : ser_text.find(stop_cue)])"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Indexed picture placeholders\n",
+    "\n",
+    "Another common use case is to uniquely identify each picture in the serialized output,\n",
+    "e.g. for downstream matching or cross-referencing with the original `DoclingDocument`.\n",
+    "\n",
+    "The example below derives a per-picture index from `self_ref` and resolves an\n",
+    "`{index}` token inside the placeholder string:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from docling_core.transforms.serializer.base import SerializationResult\n",
+    "from docling_core.transforms.serializer.common import create_ser_result\n",
+    "from docling_core.transforms.serializer.markdown import (\n",
+    "    MarkdownPictureSerializer,\n",
+    ")\n",
+    "from docling_core.types.doc.base import ImageRefMode\n",
+    "from docling_core.types.doc.document import DoclingDocument, PictureItem\n",
+    "\n",
+    "\n",
+    "class IndexedMarkdownPictureSerializer(MarkdownPictureSerializer):\n",
+    "    \"\"\"Custom picture serializer that supports {index} in the placeholder.\"\"\"\n",
+    "\n",
+    "    def _serialize_image_part(\n",
+    "        self,\n",
+    "        item: PictureItem,\n",
+    "        doc: DoclingDocument,\n",
+    "        image_mode: ImageRefMode,\n",
+    "        image_placeholder: str,\n",
+    "        **kwargs,\n",
+    "    ) -> SerializationResult:\n",
+    "        pic_idx = item.self_ref.rsplit(\"/\", 1)[-1]\n",
+    "        resolved_placeholder = image_placeholder.replace(\"{index}\", pic_idx)\n",
+    "\n",
+    "        if image_mode != ImageRefMode.PLACEHOLDER:\n",
+    "            return super()._serialize_image_part(\n",
+    "                item=item,\n",
+    "                doc=doc,\n",
+    "                image_mode=image_mode,\n",
+    "                image_placeholder=resolved_placeholder,\n",
+    "                **kwargs,\n",
+    "            )\n",
+    "\n",
+    "        return create_ser_result(text=resolved_placeholder, span_source=item)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can now use this serializer with a placeholder containing `{index}`.\n",
+    "Each picture will receive its own unique identifier in the output:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "serializer = MarkdownDocSerializer(\n",
+    "    doc=doc,\n",
+    "    picture_serializer=IndexedMarkdownPictureSerializer(),\n",
+    "    params=MarkdownParams(\n",
+    "        image_mode=ImageRefMode.PLACEHOLDER,\n",
+    "        image_placeholder=\"<!-- image_{index} -->\",\n",
+    "    ),\n",
+    ")\n",
+    "ser_result = serializer.serialize()\n",
+    "ser_text = ser_result.text\n",
+    "\n",
+    "print_in_console(ser_text[ser_text.find(start_cue) : ser_text.find(stop_cue)])"
+   ]
   }
  ],
  "metadata": {


### PR DESCRIPTION
## Summary
- Add an example of `IndexedMarkdownPictureSerializer` to `docs/examples/serialization.ipynb`
- Shows how to resolve `{index}` tokens in image placeholders using `self_ref`
- Follows up on docling-project/docling-core#555, where this was suggested as a documentation example rather than a library default

Closes #3078

## Test plan
- [x] Verify the notebook cells execute without errors