### PR TITLE
fix(pipeline): prevent cache miss due to pipeline options mutation during chart extraction

### DIFF
--- a/docling/pipeline/base_pipeline.py
+++ b/docling/pipeline/base_pipeline.py
@@ -151,8 +151,11 @@ class ConvertPipeline(BasePipeline):
         self.pipeline_options: ConvertPipelineOptions
 
         # We need picture classification to do chart_extraction
-        if pipeline_options.do_chart_extraction:
-            pipeline_options.do_picture_classification = True
+        # Use local variable to avoid mutating shared pipeline_options
+        do_picture_classification = (
+            pipeline_options.do_picture_classification
+            or pipeline_options.do_chart_extraction
+        )
 
         # ------ Common enrichment models working on all backends
 
@@ -169,7 +172,7 @@ class ConvertPipeline(BasePipeline):
         self.enrichment_pipe = [
             # Document Picture Classifier
             DocumentPictureClassifier(
-                enabled=pipeline_options.do_picture_classification,
+                enabled=do_picture_classification,
                 artifacts_path=self.artifacts_path,
                 options=pipeline_options.picture_classification_options,
                 accelerator_options=pipeline_options.accelerator_options,

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -225,3 +226,41 @@ def test_confidence(test_doc_path):
 
     assert doc_result.confidence.mean_grade == QualityGrade.EXCELLENT
     assert doc_result.confidence.low_grade == QualityGrade.EXCELLENT
+
+
+def test_pipeline_cache_with_chart_extraction():
+    """Test that chart extraction doesn't cause pipeline cache invalidation.
+
+    Verifies the fix for a bug where enabling chart extraction mutated shared
+    pipeline_options, changing its hash and causing unnecessary re-initialization.
+    """
+
+    pipeline_options = PdfPipelineOptions()
+    pipeline_options.do_chart_extraction = True
+
+    with (
+        patch(
+            "docling.pipeline.base_pipeline.ChartExtractionModelGraniteVisionV4"
+        ) as mock_chart,
+        patch(
+            "docling.pipeline.base_pipeline.DocumentPictureClassifier"
+        ) as mock_classifier,
+    ):
+        mock_chart.return_value = Mock(enabled=True)
+        mock_classifier.return_value = Mock(enabled=True)
+
+        converter = DocumentConverter(
+            format_options={
+                InputFormat.PDF: PdfFormatOption(
+                    pipeline_options=pipeline_options,
+                )
+            }
+        )
+
+        converter.initialize_pipeline(InputFormat.PDF)
+        assert len(converter._get_initialized_pipelines()) == 1
+
+        converter._get_pipeline(InputFormat.PDF)
+        assert len(converter._get_initialized_pipelines()) == 1, (
+            "Pipeline should be reused from cache, not re-initialized"
+        )


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

## Description
This PR fixes a bug first discovered in this [comment](https://github.com/docling-project/docling-serve/issues/366#issuecomment-4148599786) on [docling-serve issue #366](https://github.com/docling-project/docling-serve/issues/366), where Docling instantiates the entire pipeline _twice_ when the user sets `do_chart_extraction = True`, **without** also setting `do_picture_classification = True`, resulting in a CUDA OOM error.

### Example
```py
pipeline_options = PdfPipelineOptions()
pipeline_options.do_chart_extraction = True # At this point: do_picture_classification = False (default)

converter = DocumentConverter(
            format_options={
                InputFormat.PDF: PdfFormatOption(
                    pipeline_options=pipeline_options,
                )
            }
        )

# Step 1: Lazy init.
converter.initialize_pipeline(InputFormat.PDF)
# Step 2: Actual conversion
converter.convert("document.pdf")
```



### Bug
https://github.com/docling-project/docling/blob/f5fa294e172684d727a1bafddc9c985f592e8541/docling/pipeline/base_pipeline.py#L153-L155

This is a state mutation bug. Line 155 of [base_pipeline.py](https://github.com/docling-project/docling/blob/main/docling/pipeline/base_pipeline.py) mutates the shared pipeline_options object in-place by setting `do_picture_classification = True` when `do_chart_extraction = True`.  Since the hash was already computed from the original state, the mutation changes the state AFTER the cache key was determined, leading to a cache miss and duplicate instantiation.

This is what is happening internally:
```
# Step 1
initialize_pipeline(InputFormat.PDF)
 --|  _get_pipeline(PDF)
 --------|  pipeline_options: {do_chart_extraction: True, do_picture_classification: False, ...}
 --------|  compute hash -> H1 = MD5(pipeline_options)
 --------|  cache key = (StandardPdfPipeline, H1)
 --------|  cache miss -> create StandardPdfPipeline(pipeline_options)
 ----------------| ConvertPipeline.__init__():
 --------------------------------| pipeline_options.do_picture_classification = True -> MUTATION
 --------|  store pipeline with key H1 -> (StandardPdfPipeline, H1)

# Step 2
convert("document.pdf")
 --|  _execute_pipeline() -> _get_pipeline(PDF)
 --------|  pipeline_options: {do_chart_extraction: True, do_picture_classification: True, ...} -> CHANGED
 --------|  compute hash -> H2 = MD5(pipeline_options) -> H2 != H1, DIFFERENT HASH
 --------|  cache key = (StandardPdfPipeline, H2)
 --------|  cache miss -> create ANOTHER StandardPdfPipeline(pipeline_options)
 --------|  store second pipeline with key H2 -> (StandardPdfPipeline, H2)

Result: Two full pipeline instances exist in GPU memory -> CUDA OOM
```

### Notes
The bug only triggers when `_get_pipeline()` is called **more than once** for the same format, which happens when `initialize_pipeline()` is called before `convert()`. If you only call `convert()` once without prior initialization, the pipeline is created once and cached. The mutation still happens but doesn't create a second lookup since the first pipeline is returned directly.

### Fix
- Instead of mutating `pipeline_options.do_picture_classification`, derive the correct value into a local variable, and use it when constructing `DocumentPictureClassifier` instead of reading from the mutated object.
```python
# Fix
do_picture_classification = (
	pipeline_options.do_picture_classification 
	or pipeline_options.do_chart_extraction
)

...

self.enrichment_pipe = [
	# Document Picture Classifier
	DocumentPictureClassifier(
		enabled=do_picture_classification,
		...
	),
```

## Changes
- **`docling/pipeline/base_pipeline.py`**: Use a local variable instead of mutating shared options object
- **`tests/test_options.py`**: Added `test_pipeline_cache_with_chart_extraction()` regression test using model mocks

## Checklist
- [X] Documentation has been added (inline comments)
- [X] Tests have been added