### PR TITLE
perf(markdown): avoid eager string formatting in Markdown backend debug logs

### DIFF
--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -297,7 +297,9 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         ) and len(element.children) > 0:
             self._close_table(doc)
             _log.debug(
-                f" - Heading level {element.level}, content: {element.children[0].children}"  # type: ignore
+                " - Heading level %s, content: %s",
+                element.level,
+                element.children[0].children,  # type: ignore
             )
 
             if len(element.children) > 1:  # inline group will be created further down
@@ -320,7 +322,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                     break
 
             self._close_table(doc)
-            _log.debug(f" - List {'ordered' if element.ordered else 'unordered'}")
+            _log.debug(" - List %s", "ordered" if element.ordered else "unordered")
             if has_non_empty_list_items:
                 parent_item = doc.add_list_group(name="list", parent=parent_item)
                 list_ordered_flag_by_ref[parent_item.self_ref] = element.ordered
@@ -363,7 +365,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
 
         elif isinstance(element, marko.inline.Image):
             self._close_table(doc)
-            _log.debug(f" - Image with alt: {element.title}, url: {element.dest}")
+            _log.debug(" - Image with alt: %s, url: %s", element.title, element.dest)
 
             fig_caption: Optional[TextItem] = None
             if element.title is not None and element.title != "":
@@ -378,23 +380,23 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
             doc.add_picture(parent=parent_item, caption=fig_caption)
 
         elif isinstance(element, marko.inline.Emphasis):
-            _log.debug(f" - Emphasis: {element.children}")
+            _log.debug(" - Emphasis: %s", element.children)
             formatting = deepcopy(formatting) if formatting else Formatting()
             formatting.italic = True
 
         elif isinstance(element, marko.inline.StrongEmphasis):
-            _log.debug(f" - StrongEmphasis: {element.children}")
+            _log.debug(" - StrongEmphasis: %s", element.children)
             formatting = deepcopy(formatting) if formatting else Formatting()
             formatting.bold = True
 
         elif isinstance(element, marko.inline.Link):
-            _log.debug(f" - Link: {element.children}")
+            _log.debug(" - Link: %s", element.children)
             hyperlink = TypeAdapter(Optional[Union[AnyUrl, Path]]).validate_python(
                 element.dest
             )
 
         elif isinstance(element, marko.inline.RawText | marko.inline.Literal):
-            _log.debug(f" - RawText/Literal: {element.children}")
+            _log.debug(" - RawText/Literal: %s", element.children)
             original_text = (
                 element.children if isinstance(element.children, str) else ""
             )
@@ -463,7 +465,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
 
         elif isinstance(element, marko.inline.CodeSpan):
             self._close_table(doc)
-            _log.debug(f" - Code Span: {element.children}")
+            _log.debug(" - Code Span: %s", element.children)
             snippet_text = str(element.children).strip()
             doc.add_code(
                 parent=parent_item,
@@ -479,7 +481,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
             and len(snippet_text := (child.children.strip())) > 0
         ):
             self._close_table(doc)
-            _log.debug(f" - Code Block: {element.children}")
+            _log.debug(" - Code Block: %s", element.children)
             doc.add_code(
                 parent=parent_item,
                 text=snippet_text,
@@ -495,7 +497,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         elif isinstance(element, marko.block.HTMLBlock):
             self._html_blocks += 1
             self._close_table(doc)
-            _log.debug(f"HTML Block: {element}")
+            _log.debug("HTML Block: %s", element)
             if (
                 len(element.body) > 0
             ):  # If Marko doesn't return any content for HTML block, skip it
@@ -538,7 +540,8 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                     and list_last_item_by_ref.get(parent_item.self_ref, None)
                 ):
                     _log.debug(
-                        f"walking into new List hanging from item of parent list {parent_item.self_ref}"
+                        "walking into new List hanging from item of parent list %s",
+                        parent_item.self_ref,
                     )
                     parent_item = list_last_item_by_ref[parent_item.self_ref]
 


### PR DESCRIPTION
# Issue

Running code below with this file [train_1098.md](https://github.com/user-attachments/files/26733291/train_1098.md). It wasn't completed even after 90 minutes.

```python
from pathlib import Path, PurePath
from docling.document_converter import DocumentConverter
import time

file='train_1098.md'
p=Path(file)

converter = DocumentConverter()
t0 = time.perf_counter()
result = converter.convert(file)
dt_s = time.perf_counter() - t0
print(f"converter.convert time cost: {dt_s:.3f}s")
```

The stack:

```
Process 56941: /opt/homebrew/Cellar/python@3.11/3.11.12/Frameworks/Python.framework/Versions/3.11/Resources/Python.app/Contents/MacOS/Python debug.py
Python v3.11.12 (/opt/homebrew/Cellar/python@3.11/3.11.12/Frameworks/Python.framework/Versions/3.11/Resources/Python.app/Contents/MacOS/Python)

Thread 0x20BA7A240 (active+gil): "MainThread"
    <listcomp> (<frozen importlib._bootstrap_external>:128)
    _path_join (<frozen importlib._bootstrap_external>:128)
    find_spec (<frozen importlib._bootstrap_external>:1643)
    _get_spec (<frozen importlib._bootstrap_external>:1479)
    find_spec (<frozen importlib._bootstrap_external>:1507)
    _find_spec (<frozen importlib._bootstrap>:1078)
    _find_and_load_unlocked (<frozen importlib._bootstrap>:1138)
    _find_and_load (<frozen importlib._bootstrap>:1176)
    __repr__ (marko/element.py:33)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _safe_repr (pprint.py:622)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    _format_items (pprint.py:453)
    _pprint_list (pprint.py:241)
    _format (pprint.py:184)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    _format_items (pprint.py:453)
    _pprint_list (pprint.py:241)
    _format (pprint.py:184)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _safe_repr (pprint.py:622)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    _format_items (pprint.py:453)
    _pprint_list (pprint.py:241)
    _format (pprint.py:184)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _safe_repr (pprint.py:622)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _safe_repr (pprint.py:622)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _safe_repr (pprint.py:622)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _safe_repr (pprint.py:622)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    _format_items (pprint.py:453)
    _pprint_list (pprint.py:241)
    _format (pprint.py:184)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    _format_items (pprint.py:453)
    _pprint_list (pprint.py:241)
    _format (pprint.py:184)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _safe_repr (pprint.py:622)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    _format_items (pprint.py:453)
    _pprint_list (pprint.py:241)
    _format (pprint.py:184)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    _format_items (pprint.py:453)
    _pprint_list (pprint.py:241)
    _format (pprint.py:184)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    _format_items (pprint.py:453)
    _pprint_list (pprint.py:241)
    _format (pprint.py:184)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    _format_items (pprint.py:453)
    _pprint_list (pprint.py:241)
    _format (pprint.py:184)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    _format_items (pprint.py:453)
    _pprint_list (pprint.py:241)
    _format (pprint.py:184)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _safe_repr (pprint.py:622)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _safe_repr (pprint.py:622)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    _format_items (pprint.py:453)
    _pprint_list (pprint.py:241)
    _format (pprint.py:184)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    _format_items (pprint.py:453)
    _pprint_list (pprint.py:241)
    _format (pprint.py:184)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    _format_items (pprint.py:453)
    _pprint_list (pprint.py:241)
    _format (pprint.py:184)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _safe_repr (pprint.py:622)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _safe_repr (pprint.py:622)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _safe_repr (pprint.py:632)
    format (pprint.py:471)
    _safe_repr (pprint.py:622)
    format (pprint.py:471)
    _repr (pprint.py:458)
    _format (pprint.py:178)
    pformat (pprint.py:161)
    pformat (pprint.py:62)
    __repr__ (marko/element.py:38)
    _iterate_elements (docling/backend/md_backend.py:381)
    _iterate_elements (docling/backend/md_backend.py:545)
    _iterate_elements (docling/backend/md_backend.py:545)
    convert (docling/backend/md_backend.py:590)
    _build_document (docling/pipeline/simple_pipeline.py:40)
    execute (docling/pipeline/base_pipeline.py:78)
    _execute_pipeline (docling/document_converter.py:634)
    _process_document (docling/document_converter.py:611)
    _convert (docling/document_converter.py:564)
    convert_all (docling/document_converter.py:447)
    convert (docling/document_converter.py:388)
    __call__ (pydantic/_internal/_validate_call.py:136)
    wrapper_function (pydantic/_internal/_validate_call.py:39)
    <module> (debug.py:19)
```

# Cause

marko `Element.__repr__` is inefficient if objprint not installed

<https://github.com/frostming/marko/blob/88e65f1f51c1e88e9e06a8f0b855200122578b28/marko/element.py#L31-L44>

```python
class Element:

    def __repr__(self) -> str:
        try:
            from objprint import objstr
        except ImportError:
            from pprint import pformat

            if hasattr(self, "children"):
                children = f" children={pformat(self.children)}"
            else:
                children = ""

            return f"<{self.__class__.__name__}{children}>"
        else:
            return objstr(self, honor_existing=False, include=["children"])
```

# Solution

- Install objprint by `uv add marko[repr]`, the case will cost 2.765s (Apple M3)
- Or make log message lazy format what I commited, then the case will cost 1.577s

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
