### PR TITLE
feat: normalize enum-backed RapidOCR param overrides

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -318,7 +318,9 @@ class RapidOcrOptions(OcrOptions):
         Field(
             description=(
                 "Additional parameters to pass through to RapidOCR engine. Use this to override or extend "
-                "default RapidOCR configuration with engine-specific options."
+                "default RapidOCR configuration with engine-specific options. Enum-backed string values "
+                "for keys such as `Det.lang_type`, `Det.model_type`, and `Det.ocr_version` are accepted "
+                "and normalized internally before Docling constructs `RapidOCR`."
             )
         ),
     ] = {}

--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -1,7 +1,8 @@
 import logging
 from collections.abc import Iterable
+from enum import Enum
 from pathlib import Path
-from typing import Literal, Type, TypedDict
+from typing import Any, Literal, Type, TypedDict
 
 import numpy
 from docling_core.types.doc import BoundingBox, CoordOrigin
@@ -117,6 +118,64 @@ class RapidOcrModel(BaseOcrModel):
     _default_models: dict[
         _ModelPathEngines, dict[_ModelPathTypes, _ModelPathDetail]
     ] = _models_by_language[_RAPIDOCR_DEFAULT_LANGUAGE]
+
+    @staticmethod
+    def _normalize_rapidocr_param_value(value: Any, enum_type: type[Enum]) -> Any:
+        if isinstance(value, enum_type):
+            return value
+
+        candidate = value.value if isinstance(value, Enum) else value
+        if not isinstance(candidate, str):
+            return value
+
+        for member in enum_type:
+            if member.value == candidate:
+                return member
+
+        return value
+
+    @classmethod
+    def _normalize_rapidocr_params(cls, params: dict[str, Any]) -> dict[str, Any]:
+        from rapidocr import EngineType  # type: ignore
+        from rapidocr.utils.typings import (  # type: ignore
+            LangCls,
+            LangDet,
+            LangRec,
+            ModelType,
+            OCRVersion,
+            TaskType,
+        )
+
+        common_enum_types: dict[str, type[Enum]] = {
+            "engine_type": EngineType,
+            "model_type": ModelType,
+            "ocr_version": OCRVersion,
+            "task_type": TaskType,
+        }
+        language_enum_types: dict[str, type[Enum]] = {
+            "Det": LangDet,
+            "Cls": LangCls,
+            "Rec": LangRec,
+        }
+
+        normalized_params: dict[str, Any] = {}
+        for key, value in params.items():
+            section, separator, option = key.partition(".")
+            if not separator:
+                normalized_params[key] = value
+                continue
+
+            enum_type = common_enum_types.get(option)
+            if option == "lang_type":
+                enum_type = language_enum_types.get(section)
+
+            normalized_params[key] = (
+                cls._normalize_rapidocr_param_value(value, enum_type)
+                if enum_type is not None
+                else value
+            )
+
+        return normalized_params
 
     def __init__(
         self,
@@ -253,7 +312,7 @@ class RapidOcrModel(BaseOcrModel):
             user_params = self.options.rapidocr_params
             if user_params:
                 _log.debug("Overwriting RapidOCR params with user-provided values.")
-                params.update(user_params)
+                params.update(self._normalize_rapidocr_params(user_params))
 
             self.reader = RapidOCR(
                 params=params,

--- a/docs/examples/rapidocr_with_custom_models.py
+++ b/docs/examples/rapidocr_with_custom_models.py
@@ -4,6 +4,7 @@
 # What this example does
 # - Downloads RapidOCR models from Hugging Face via ModelScope.
 # - Configures `RapidOcrOptions` with explicit det/rec/cls model paths.
+# - Shows `rapidocr_params` overrides using plain strings; Docling normalizes enum-backed keys.
 # - Runs the PDF pipeline with RapidOCR and prints Markdown output.
 #
 # Prerequisites
@@ -54,6 +55,18 @@ def main():
         det_model_path=det_model_path,
         rec_model_path=rec_model_path,
         cls_model_path=cls_model_path,
+        rapidocr_params={
+            # String values are accepted here; Docling converts enum-backed keys for RapidOCR.
+            "Det.lang_type": "ch",
+            "Det.model_type": "server",
+            "Det.ocr_version": "PP-OCRv5",
+            "Cls.lang_type": "ch",
+            "Cls.model_type": "mobile",
+            "Cls.ocr_version": "PP-OCRv4",
+            "Rec.lang_type": "ch",
+            "Rec.model_type": "server",
+            "Rec.ocr_version": "PP-OCRv5",
+        },
     )
 
     pipeline_options = PdfPipelineOptions(

--- a/tests/test_rapid_ocr_model.py
+++ b/tests/test_rapid_ocr_model.py
@@ -1,9 +1,18 @@
 import sys
 from enum import Enum
 from pathlib import Path
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
+from rapidocr import EngineType as RapidEngineType
+from rapidocr.utils.typings import (
+    LangCls,
+    LangDet,
+    LangRec,
+    ModelType,
+    OCRVersion,
+    TaskType,
+)
 
 from docling.datamodel.accelerator_options import AcceleratorOptions
 from docling.datamodel.pipeline_options import RapidOcrOptions
@@ -111,3 +120,132 @@ def test_rapidocr_model_initialization_uses_mobile_default_paths(
     assert Path(params["Rec.model_path"]).name == rec_name
     assert Path(params["Rec.rec_keys_path"]).name == "ppocr_keys_v1.txt"
     assert Path(params["Global.font_path"]).name == "FZYTK.TTF"
+
+
+def _install_fake_rapidocr_package(
+    monkeypatch: pytest.MonkeyPatch, captured: dict[str, object]
+) -> None:
+    class FakeRapidOCR:
+        def __init__(self, params: dict[str, object]) -> None:
+            for key, value in params.items():
+                _, _, option = key.partition(".")
+                if option in {
+                    "engine_type",
+                    "lang_type",
+                    "model_type",
+                    "ocr_version",
+                    "task_type",
+                } and not isinstance(value, Enum):
+                    raise TypeError(f"The value of {key} must be Enum Type.")
+
+            captured["params"] = params
+
+    fake_module = ModuleType("rapidocr")
+    fake_module.__path__ = []
+    fake_module.EngineType = RapidEngineType
+    fake_module.RapidOCR = FakeRapidOCR
+
+    fake_utils_module = ModuleType("rapidocr.utils")
+    fake_typings_module = ModuleType("rapidocr.utils.typings")
+    fake_typings_module.LangCls = LangCls
+    fake_typings_module.LangDet = LangDet
+    fake_typings_module.LangRec = LangRec
+    fake_typings_module.ModelType = ModelType
+    fake_typings_module.OCRVersion = OCRVersion
+    fake_typings_module.TaskType = TaskType
+    fake_utils_module.typings = fake_typings_module
+    fake_module.utils = fake_utils_module
+
+    monkeypatch.setitem(sys.modules, "rapidocr", fake_module)
+    monkeypatch.setitem(sys.modules, "rapidocr.utils", fake_utils_module)
+    monkeypatch.setitem(sys.modules, "rapidocr.utils.typings", fake_typings_module)
+
+
+@pytest.mark.parametrize(
+    ("param_key", "param_value", "expected_value"),
+    [
+        ("Det.lang_type", "ch", LangDet.CH),
+        ("Cls.lang_type", "ch", LangCls.CH),
+        ("Rec.lang_type", "en", LangRec.EN),
+        ("Det.model_type", "server", ModelType.SERVER),
+        ("Cls.model_type", "mobile", ModelType.MOBILE),
+        ("Rec.model_type", "server", ModelType.SERVER),
+        ("Det.ocr_version", "PP-OCRv5", OCRVersion.PPOCRV5),
+        ("Cls.ocr_version", "PP-OCRv4", OCRVersion.PPOCRV4),
+        ("Rec.ocr_version", "PP-OCRv5", OCRVersion.PPOCRV5),
+        ("Det.engine_type", "onnxruntime", RapidEngineType.ONNXRUNTIME),
+        ("Cls.engine_type", "torch", RapidEngineType.TORCH),
+        ("Rec.task_type", "rec", TaskType.REC),
+    ],
+)
+def test_rapidocr_param_normalization_converts_known_enum_strings(
+    param_key: str,
+    param_value: str,
+    expected_value: Enum,
+) -> None:
+    normalized = RapidOcrModel._normalize_rapidocr_params(
+        {
+            param_key: param_value,
+            "Global.text_score": 0.75,
+        }
+    )
+
+    assert normalized[param_key] is expected_value
+    assert normalized["Global.text_score"] == 0.75
+
+
+def test_rapidocr_param_normalization_preserves_enum_instances_and_other_keys() -> None:
+    normalized = RapidOcrModel._normalize_rapidocr_params(
+        {
+            "Det.lang_type": LangDet.EN,
+            "Cls.model_type": "mobile",
+            "Rec.ocr_version": OCRVersion.PPOCRV5,
+            "Rec.task_type": TaskType.REC,
+            "Global.text_score": 0.9,
+            "Rec.rec_batch_num": 8,
+        }
+    )
+
+    assert normalized["Det.lang_type"] is LangDet.EN
+    assert normalized["Cls.model_type"] is ModelType.MOBILE
+    assert normalized["Rec.ocr_version"] is OCRVersion.PPOCRV5
+    assert normalized["Rec.task_type"] is TaskType.REC
+    assert normalized["Global.text_score"] == 0.9
+    assert normalized["Rec.rec_batch_num"] == 8
+
+
+def test_rapidocr_model_initialization_normalizes_string_enum_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    captured: dict[str, object] = {}
+    _install_fake_rapidocr_package(monkeypatch, captured)
+
+    model_root = tmp_path / RapidOcrModel._model_repo_folder
+    for detail in RapidOcrModel._default_models["onnxruntime"].values():
+        file_path = model_root / detail["path"]
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_bytes(b"")
+
+    RapidOcrModel(
+        enabled=True,
+        artifacts_path=tmp_path,
+        options=RapidOcrOptions(
+            backend="onnxruntime",
+            rapidocr_params={
+                "Det.lang_type": "ch",
+                "Cls.model_type": "mobile",
+                "Rec.ocr_version": "PP-OCRv5",
+                "Rec.task_type": "rec",
+                "Rec.engine_type": "onnxruntime",
+            },
+        ),
+        accelerator_options=AcceleratorOptions(device="cpu", num_threads=1),
+    )
+
+    params = captured["params"]
+    assert params["Det.lang_type"] is LangDet.CH
+    assert params["Cls.model_type"] is ModelType.MOBILE
+    assert params["Rec.ocr_version"] is OCRVersion.PPOCRV5
+    assert params["Rec.task_type"] is TaskType.REC
+    assert params["Rec.engine_type"] is RapidEngineType.ONNXRUNTIME


### PR DESCRIPTION
## Summary
- normalize enum-backed `rapidocr_params` string overrides before constructing `RapidOCR`
- add regression coverage for string, enum, and mixed RapidOCR override inputs
- document that Docling accepts string values for enum-backed RapidOCR config keys

## Testing
- `uv run pytest tests/test_rapid_ocr_model.py`
- `uv run pytest tests/test_rapid_ocr_lang.py`

Closes #3305