### PR TITLE
fix(format): add MD fallback for .txt files in _guess_from_content

### DIFF
--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -488,12 +488,13 @@ class _DocumentConversionInput(BaseModel):
     def _guess_format(self, obj: Union[Path, DocumentStream]) -> Optional[InputFormat]:
         content = b""  # empty binary blob
         formats: list[InputFormat] = []
+        obj_ext: Optional[str] = None
 
         if isinstance(obj, Path):
             mime = filetype.guess_mime(str(obj))
+            obj_ext = obj.suffix[1:] if obj.suffix else ""
             if mime is None:
-                ext = obj.suffix[1:]
-                mime = _DocumentConversionInput._mime_from_extension(ext)
+                mime = _DocumentConversionInput._mime_from_extension(obj_ext)
             if mime is None:  # must guess from content
                 with obj.open("rb") as f:
                     content = f.read(1024)  # Read first 1KB
@@ -517,13 +518,13 @@ class _DocumentConversionInput(BaseModel):
             content = obj.stream.read(8192)
             obj.stream.seek(0)
             mime = filetype.guess_mime(content)
+            obj_ext = (
+                obj.name.rsplit(".", 1)[-1]
+                if ("." in obj.name and not obj.name.startswith("."))
+                else ""
+            )
             if mime is None:
-                ext = (
-                    obj.name.rsplit(".", 1)[-1]
-                    if ("." in obj.name and not obj.name.startswith("."))
-                    else ""
-                )
-                mime = _DocumentConversionInput._mime_from_extension(ext.lower())
+                mime = _DocumentConversionInput._mime_from_extension(obj_ext.lower())
             if mime is not None and mime.lower() == "application/zip":
                 objname = obj.name.lower()
                 mime_root = "application/vnd.openxmlformats-officedocument"
@@ -555,7 +556,7 @@ class _DocumentConversionInput(BaseModel):
                 return formats[0]
             else:  # ambiguity in formats
                 return _DocumentConversionInput._guess_from_content(
-                    content, mime, formats
+                    content, mime, formats, ext=obj_ext
                 )
         else:
             return None
@@ -588,7 +589,10 @@ class _DocumentConversionInput(BaseModel):
 
     @staticmethod
     def _guess_from_content(
-        content: bytes, mime: str, formats: list[InputFormat]
+        content: bytes,
+        mime: str,
+        formats: list[InputFormat],
+        ext: Optional[str] = None,
     ) -> Optional[InputFormat]:
         """Guess the input format of a document by checking part of its content."""
         input_format: Optional[InputFormat] = None
@@ -627,8 +631,15 @@ class _DocumentConversionInput(BaseModel):
             content_str = content.decode("utf-8", errors="replace")
             if InputFormat.XML_USPTO in formats and content_str.startswith("PATN\r\n"):
                 input_format = InputFormat.XML_USPTO
-            # No MD fallback: unrecognised text/plain content returns None.
-            # MD is detected via text/markdown mime (from .md/.text/.qmd/… extensions).
+            elif (
+                InputFormat.MD in formats
+                and ext is not None
+                and ext.lower() in FormatToExtensions[InputFormat.MD]
+            ):
+                # Only fall back to MD when the extension is a known plain-text
+                # extension (md/txt/text/qmd/rmd). Unknown extensions (e.g. .xyz)
+                # must not be silently treated as Markdown.
+                input_format = InputFormat.MD
 
         return input_format
 

--- a/tests/test_input_doc.py
+++ b/tests/test_input_doc.py
@@ -245,12 +245,18 @@ def test_guess_format(tmp_path):
     stream = DocumentStream(name="docling_test.xml", stream=buf)
     assert dci._guess_format(stream) is None
 
-    # Invalid USPTO patent (as plain text)
+    # Plain .txt file (not USPTO) should be detected as Markdown
     stream = DocumentStream(name="pftaps057006474.txt", stream=BytesIO(b"xyz"))
-    assert dci._guess_format(stream) is None
+    assert dci._guess_format(stream) == InputFormat.MD
     doc_path = temp_dir / "pftaps_wrong.txt"
     doc_path.write_text("xyz", encoding="utf-8")
-    assert dci._guess_format(doc_path) is None
+    assert dci._guess_format(doc_path) == InputFormat.MD
+
+    # Plain .txt with typical text content
+    stream = DocumentStream(
+        name="readme.txt", stream=BytesIO(b"Hello, this is a plain text file.")
+    )
+    assert dci._guess_format(stream) == InputFormat.MD
 
     # Valid WebVTT
     buf = BytesIO(Path("./tests/data/webvtt/webvtt_example_01.vtt").open("rb").read())


### PR DESCRIPTION
## Summary

Fixes #3259

Plain `.txt` files fail with `ConversionError: File format not allowed` despite v2.81.0 adding `.txt` to the MD format's extension list. The `_guess_from_content` method's `text/plain` branch only checks for USPTO patent format and returns `None` for everything else.

## Root Cause

In `docling/datamodel/document.py`, `_mime_from_extension` intentionally returns `None` for `.txt` because the extension appears in both `XML_USPTO` and `MD` format lists. This defers to the content-probing chain, which falls through to `text/plain`. In `_guess_from_content`, the `text/plain` branch only checks for the `PATN\r\n` USPTO marker — when that doesn't match, `input_format` stays `None`, and the file is rejected.

## Changes

- `docling/datamodel/document.py`: Added `elif InputFormat.MD in formats` fallback in the `text/plain` branch of `_guess_from_content`, so non-USPTO plain text files are detected as Markdown
- `tests/test_input_doc.py`: Updated existing test expectations (`.txt` with non-USPTO content now returns `InputFormat.MD` instead of `None`) and added a regression test for typical `.txt` file content

## Testing

- [x] Full test suite passes (8/8 in test_input_doc.py, no regressions)
- [x] Bug reproduction confirmed: `.txt` conversion now succeeds
- [x] USPTO `.txt` detection still works correctly

```bash
python -m pytest tests/test_input_doc.py -v
```

## Notes

Minimal fix — only changes the content-based format fallback path. No unrelated changes. USPTO detection priority is preserved (checked first in the `elif` chain).