### PR TITLE
docs: fix nanonets_ocr2 runtime support matrix

### DIFF
--- a/docs/usage/model_catalog.md
+++ b/docs/usage/model_catalog.md
@@ -228,10 +228,12 @@ The following table shows all processing stages in Docling, their model families
 | `got_ocr` | GOT-OCR-2.0 | - | ✅ | ❌ | ❌ | ❌ | Markdown |
 | `phi4` | Phi-4-Multimodal | - | ✅ | ❌ | ❌ | ✅ | Markdown |
 | `qwen` | Qwen2.5-VL-3B | 3B | ✅ | ✅ | ❌ | ❌ | Markdown |
-| `nanonets_ocr2` | Nanonets-OCR2-3B | 3B | ✅ | ✅ | ❌ | ❌ | Markdown |
+| `nanonets_ocr2` | Nanonets-OCR2-3B | 3B | ✅ | ✅ | OpenAI-compatible<br/>LM Studio | ✅ | Markdown |
 | `gemma_12b` | Gemma-3-12B | 12B | ❌ | ✅ | ❌ | ❌ | Markdown |
 | `gemma_27b` | Gemma-3-27B | 27B | ❌ | ✅ | ❌ | ❌ | Markdown |
 | `dolphin` | Dolphin | - | ✅ | ❌ | ❌ | ❌ | Markdown |
+
+`nanonets_ocr2` includes preset API overrides for OpenAI-compatible runtimes and LM Studio, and can also be used with vLLM runtimes.
 
 #### Picture Description Stage
 


### PR DESCRIPTION
## Summary
- correct the `nanonets_ocr2` row in the VLM model catalog to match the current preset/runtime behavior
- document that the preset has OpenAI-compatible / LM Studio API paths and a vLLM path
- align the docs with the current code and tests

## Testing
- `uv run pre-commit run --files docs/usage/model_catalog.md`

Closes #3316