### PR TITLE
fix: forward VLM convert runtime generation settings

### DIFF
--- a/docling/datamodel/stage_model_specs.py
+++ b/docling/datamodel/stage_model_specs.py
@@ -9,6 +9,7 @@ This module defines:
 from __future__ import annotations
 
 import logging
+from copy import deepcopy
 from typing import TYPE_CHECKING, Any, ClassVar, Dict, List, Set
 
 from pydantic import BaseModel, Field
@@ -163,14 +164,23 @@ class VlmModelSpec(BaseModel):
         default_factory=list, description="Stop strings for generation"
     )
 
+    temperature: float = Field(
+        default=0.0, description="Sampling temperature for generation"
+    )
+
     max_new_tokens: int = Field(
         default=4096, description="Maximum number of new tokens to generate"
     )
 
-    temperature: float = Field(
-        default=0.0,
-        description="Sampling temperature for generation. 0.0 uses greedy decoding.",
+    extra_generation_config: Dict[str, Any] = Field(
+        default_factory=dict, description="Additional generation configuration"
     )
+
+    _RUNTIME_INPUT_OVERRIDE_KEYS: ClassVar[Set[str]] = {
+        "transformers_prompt_style",
+        "extra_processor_kwargs",
+        "custom_stopping_criteria",
+    }
 
     def get_repo_id(self, engine_type: VlmEngineType) -> str:
         """Get the repository ID for a specific engine.
@@ -259,6 +269,34 @@ class VlmModelSpec(BaseModel):
             torch_dtype=torch_dtype,
             extra_config=extra_config,
         )
+
+    def get_runtime_input_extra_config(
+        self, engine_type: VlmEngineType
+    ) -> Dict[str, Any]:
+        """Build runtime input config for a specific engine.
+
+        This returns only the subset of model/engine configuration that should
+        flow into ``VlmEngineInput.extra_generation_config``. Load-time engine
+        options such as ``torch_dtype`` or ``transformers_model_type`` remain in
+        ``EngineModelConfig.extra_config`` and are intentionally excluded.
+        """
+
+        runtime_config: Dict[str, Any] = deepcopy(self.extra_generation_config)
+
+        if engine_type not in self.engine_overrides:
+            return runtime_config
+
+        override_config = self.engine_overrides[engine_type].extra_config
+        nested_generation_config = override_config.get("extra_generation_config")
+
+        if isinstance(nested_generation_config, dict):
+            runtime_config.update(deepcopy(nested_generation_config))
+
+        for key in self._RUNTIME_INPUT_OVERRIDE_KEYS:
+            if key in override_config:
+                runtime_config[key] = deepcopy(override_config[key])
+
+        return runtime_config
 
     def has_explicit_engine_export(self, engine_type: VlmEngineType) -> bool:
         """Check if this model has an explicit export for the given engine.

--- a/docling/models/inference_engines/vlm/api_openai_compatible_engine.py
+++ b/docling/models/inference_engines/vlm/api_openai_compatible_engine.py
@@ -56,6 +56,8 @@ class ApiVlmEngine(BaseVlmEngine):
         super().__init__(options, model_config=model_config)
         self.enable_remote_services = enable_remote_services
         self.options: ApiVlmEngineOptions = options
+        self.model_api_params: dict[str, object] = {}
+        self.user_params: dict[str, object] = self.options.params.copy()
 
         if not self.enable_remote_services:
             raise OperationNotAllowed(
@@ -63,21 +65,12 @@ class ApiVlmEngine(BaseVlmEngine):
                 "pipeline_options.enable_remote_services=True."
             )
 
-        # Merge model_config extra_config (which contains API params from model spec)
-        # with runtime options params. Runtime options take precedence.
+        # Keep model spec API params as defaults only when the user has not
+        # provided explicit API params; explicit runtime params are treated as
+        # complete overrides to avoid vendor-specific conflicts.
         if model_config and "api_params" in model_config.extra_config:
-            # Model spec provides API params (e.g., model name)
-            model_api_params = model_config.extra_config["api_params"]
-
-            # Only use model spec params if user hasn't provided any params
-            # This prevents conflicts when users provide custom params (e.g., model_id for watsonx)
             if not self.options.params:
-                self.merged_params = model_api_params.copy()
-            else:
-                # User provided params - use them as-is (don't merge with model spec)
-                self.merged_params = self.options.params.copy()
-        else:
-            self.merged_params = self.options.params.copy()
+                self.model_api_params = model_config.extra_config["api_params"].copy()
 
     def initialize(self) -> None:
         """Initialize the API engine.
@@ -122,19 +115,21 @@ class ApiVlmEngine(BaseVlmEngine):
             images = preprocess_image_batch([input_data.image])
             image = images[0]
 
-            # Prepare API parameters: engine defaults first, then user/model
-            # params override. This allows users to set Azure-specific params
-            # like max_completion_tokens or override temperature (#3112).
-            api_params: dict[str, object] = {
-                "temperature": input_data.temperature,
-            }
+            # Apply precedence in this order:
+            # 1. model spec API defaults
+            # 2. per-request generation settings from VlmEngineInput
+            # 3. explicit user API params from engine_options.params
+            api_params: dict[str, object] = self.model_api_params.copy()
+            api_params["temperature"] = input_data.temperature
 
             # Add max_tokens if specified
             if input_data.max_new_tokens:
                 api_params["max_tokens"] = input_data.max_new_tokens
 
-            # User/model spec params take precedence over engine defaults
-            api_params.update(self.merged_params)
+            # Explicit user params take precedence over per-request defaults.
+            # This allows users to set Azure-specific params like
+            # max_completion_tokens or override temperature (#3112).
+            api_params.update(self.user_params)
 
             # If user specified max_completion_tokens, remove conflicting
             # max_tokens (required for Azure OpenAI compatibility)

--- a/docling/models/inference_engines/vlm/api_openai_compatible_engine.py
+++ b/docling/models/inference_engines/vlm/api_openai_compatible_engine.py
@@ -122,23 +122,21 @@ class ApiVlmEngine(BaseVlmEngine):
             api_params: dict[str, object] = self.model_api_params.copy()
             api_params["temperature"] = input_data.temperature
 
-            # Add max_tokens if specified
             if input_data.max_new_tokens:
                 api_params["max_tokens"] = input_data.max_new_tokens
 
-            # Explicit user params take precedence over per-request defaults.
-            # This allows users to set Azure-specific params like
-            # max_completion_tokens or override temperature (#3112).
+            if input_data.stop_strings:
+                api_params["stop"] = input_data.stop_strings
+
+            # Explicit user params win over both model defaults and per-request
+            # settings. This allows users to set Azure-specific params like
+            # max_completion_tokens or override temperature/stop (#3112).
             api_params.update(self.user_params)
 
             # If user specified max_completion_tokens, remove conflicting
             # max_tokens (required for Azure OpenAI compatibility)
             if "max_completion_tokens" in api_params:
                 api_params.pop("max_tokens", None)
-
-            # Add stop strings if specified
-            if input_data.stop_strings:
-                api_params["stop"] = input_data.stop_strings
 
             # Extract custom stopping criteria using shared utility
             custom_stoppers = extract_generation_stoppers(

--- a/docling/models/inference_engines/vlm/api_openai_compatible_engine.py
+++ b/docling/models/inference_engines/vlm/api_openai_compatible_engine.py
@@ -54,6 +54,7 @@ class ApiVlmEngine(BaseVlmEngine):
             model_config: Model configuration (repo_id, revision, extra_config)
         """
         super().__init__(options, model_config=model_config)
+        self._initialized: bool = False
         self.enable_remote_services = enable_remote_services
         self.options: ApiVlmEngineOptions = options
         self.model_api_params: dict[str, object] = {}

--- a/docling/models/stages/vlm_convert/vlm_convert_model.py
+++ b/docling/models/stages/vlm_convert/vlm_convert_model.py
@@ -19,12 +19,22 @@ from docling.models.base_model import BasePageModel
 from docling.models.inference_engines.vlm import (
     BaseVlmEngine,
     VlmEngineInput,
+    VlmEngineOutput,
     VlmEngineType,
     create_vlm_engine,
 )
 from docling.utils.profiling import TimeRecorder
 
 _log = logging.getLogger(__name__)
+_VLM_STOP_REASON_VALUES = {reason.value for reason in VlmStopReason}
+
+
+def _prediction_from_engine_output(output: VlmEngineOutput) -> VlmPrediction:
+    stop_reason = VlmStopReason.UNSPECIFIED
+    if output.stop_reason in _VLM_STOP_REASON_VALUES:
+        stop_reason = VlmStopReason(output.stop_reason)
+
+    return VlmPrediction(text=output.text, stop_reason=stop_reason)
 
 
 class VlmConvertModel(BasePageModel):
@@ -192,17 +202,8 @@ class VlmConvertModel(BasePageModel):
 
                 # Attach predictions to pages
                 for page, output in zip(valid_pages, outputs):
-                    # Convert string stop_reason to VlmStopReason enum
-                    stop_reason = VlmStopReason.UNSPECIFIED
-                    if output.stop_reason:
-                        try:
-                            stop_reason = VlmStopReason(output.stop_reason)
-                        except ValueError:
-                            stop_reason = VlmStopReason.UNSPECIFIED
-
-                    page.predictions.vlm_response = VlmPrediction(
-                        text=output.text,
-                        stop_reason=stop_reason,
+                    page.predictions.vlm_response = _prediction_from_engine_output(
+                        output
                     )
                     _log.debug(
                         f"Page {page.page_no}: Generated {len(output.text)} chars, "
@@ -262,19 +263,7 @@ class VlmConvertModel(BasePageModel):
 
         # Convert outputs to VlmPredictions
         for output in outputs:
-            # Convert string stop_reason to VlmStopReason enum
-            stop_reason = VlmStopReason.UNSPECIFIED
-            if output.stop_reason:
-                try:
-                    stop_reason = VlmStopReason(output.stop_reason)
-                except ValueError:
-                    stop_reason = VlmStopReason.UNSPECIFIED
-
-            # Convert to VlmPrediction
-            yield VlmPrediction(
-                text=output.text,
-                stop_reason=stop_reason,
-            )
+            yield _prediction_from_engine_output(output)
 
     def __del__(self):
         """Cleanup engine resources."""

--- a/docling/models/stages/vlm_convert/vlm_convert_model.py
+++ b/docling/models/stages/vlm_convert/vlm_convert_model.py
@@ -82,25 +82,40 @@ class VlmConvertModel(BasePageModel):
 
         _log.info("VlmConvertModel initialized successfully")
 
-    def _get_runtime_engine_type(self) -> VlmEngineType:
+    def _resolve_runtime_engine_type(self) -> VlmEngineType:
         selected_engine_type = getattr(self.engine, "selected_engine_type", None)
         if selected_engine_type is not None:
             return selected_engine_type
         return self.options.engine_options.engine_type
 
-    def _build_engine_input(self, image: PILImage.Image, prompt: str) -> VlmEngineInput:
+    def _build_engine_inputs(
+        self,
+        images: list[PILImage.Image],
+        prompts: list[str],
+    ) -> list[VlmEngineInput]:
+        """Build a batch of ``VlmEngineInput`` sharing one generation-config template.
+
+        Stop strings and the runtime generation config are identical for every
+        page in a batch, so building them once here avoids reallocating them
+        per item.
+        """
         model_spec = self.options.model_spec
-        runtime_engine_type = self._get_runtime_engine_type()
-        return VlmEngineInput(
-            image=image,
-            prompt=prompt,
-            temperature=model_spec.temperature,
-            max_new_tokens=model_spec.max_new_tokens,
-            stop_strings=list(model_spec.stop_strings),
-            extra_generation_config=model_spec.get_runtime_input_extra_config(
-                runtime_engine_type
-            ),
+        runtime_engine_type = self._resolve_runtime_engine_type()
+        stop_strings = list(model_spec.stop_strings)
+        extra_generation_config = model_spec.get_runtime_input_extra_config(
+            runtime_engine_type
         )
+        return [
+            VlmEngineInput(
+                image=image,
+                prompt=prompt,
+                temperature=model_spec.temperature,
+                max_new_tokens=model_spec.max_new_tokens,
+                stop_strings=stop_strings,
+                extra_generation_config=extra_generation_config,
+            )
+            for image, prompt in zip(images, prompts)
+        ]
 
     def __call__(
         self, conv_res: ConversionResult, page_batch: Iterable[Page]
@@ -163,11 +178,8 @@ class VlmConvertModel(BasePageModel):
             )
 
             try:
-                # Create batch of runtime inputs
-                engine_inputs = [
-                    self._build_engine_input(image=img, prompt=prompt)
-                    for img, prompt in zip(images, prompts)
-                ]
+                # Create batch of runtime inputs (shared generation template)
+                engine_inputs = self._build_engine_inputs(images, prompts)
 
                 # Run batch inference
                 batch_start = time.perf_counter()
@@ -242,11 +254,8 @@ class VlmConvertModel(BasePageModel):
                 )
             prompts = prompt
 
-        # Process batch of images
-        engine_inputs = [
-            self._build_engine_input(image=img, prompt=p)
-            for img, p in zip(images, prompts)
-        ]
+        # Process batch of images (shared generation template)
+        engine_inputs = self._build_engine_inputs(images, prompts)
 
         # Run batch inference
         outputs = self.engine.predict_batch(engine_inputs)

--- a/docling/models/stages/vlm_convert/vlm_convert_model.py
+++ b/docling/models/stages/vlm_convert/vlm_convert_model.py
@@ -5,9 +5,9 @@ using vision-language models through a pluggable runtime system.
 """
 
 import logging
+import time
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Optional, Union
 
 from PIL import Image as PILImage
 
@@ -19,6 +19,7 @@ from docling.models.base_model import BasePageModel
 from docling.models.inference_engines.vlm import (
     BaseVlmEngine,
     VlmEngineInput,
+    VlmEngineType,
     create_vlm_engine,
 )
 from docling.utils.profiling import TimeRecorder
@@ -42,7 +43,7 @@ class VlmConvertModel(BasePageModel):
         self,
         enabled: bool,
         enable_remote_services: bool,
-        artifacts_path: Union[Path, str] | None,
+        artifacts_path: Path | str | None,
         options: VlmConvertOptions,
         accelerator_options: AcceleratorOptions,
     ):
@@ -81,6 +82,26 @@ class VlmConvertModel(BasePageModel):
 
         _log.info("VlmConvertModel initialized successfully")
 
+    def _get_runtime_engine_type(self) -> VlmEngineType:
+        selected_engine_type = getattr(self.engine, "selected_engine_type", None)
+        if selected_engine_type is not None:
+            return selected_engine_type
+        return self.options.engine_options.engine_type
+
+    def _build_engine_input(self, image: PILImage.Image, prompt: str) -> VlmEngineInput:
+        model_spec = self.options.model_spec
+        runtime_engine_type = self._get_runtime_engine_type()
+        return VlmEngineInput(
+            image=image,
+            prompt=prompt,
+            temperature=model_spec.temperature,
+            max_new_tokens=model_spec.max_new_tokens,
+            stop_strings=list(model_spec.stop_strings),
+            extra_generation_config=model_spec.get_runtime_input_extra_config(
+                runtime_engine_type
+            ),
+        )
+
     def __call__(
         self, conv_res: ConversionResult, page_batch: Iterable[Page]
     ) -> Iterable[Page]:
@@ -106,12 +127,18 @@ class VlmConvertModel(BasePageModel):
             images = []
             prompts = []
             valid_pages = []
+            rasterize_time = 0.0
+            scale_resize_time = 0.0
+            max_size_resize_time = 0.0
 
             for page in page_list:
+                rasterize_start = time.perf_counter()
                 image = page.get_image(
                     scale=self.options.scale,
                     max_size=self.options.max_size,
                 )
+                rasterize_time += time.perf_counter() - rasterize_start
+
                 if image is None:
                     _log.warning(
                         f"Page {page.page_no} has no image, skipping VLM conversion"
@@ -127,23 +154,29 @@ class VlmConvertModel(BasePageModel):
                 return
 
             # Process through runtime using batch prediction
-            _log.debug(f"Processing {len(images)} pages through VLM engine (batched)")
+            _log.debug(
+                "Prepared %s pages for VLM engine: rasterize=%.3fs, scale_resize=%.3fs, max_size_resize=%.3fs",
+                len(images),
+                rasterize_time,
+                scale_resize_time,
+                max_size_resize_time,
+            )
 
             try:
                 # Create batch of runtime inputs
                 engine_inputs = [
-                    VlmEngineInput(
-                        image=img,
-                        prompt=prompt,
-                        temperature=self.options.model_spec.temperature,
-                        max_new_tokens=self.options.model_spec.max_new_tokens,
-                        stop_strings=self.options.model_spec.stop_strings,
-                    )
+                    self._build_engine_input(image=img, prompt=prompt)
                     for img, prompt in zip(images, prompts)
                 ]
 
                 # Run batch inference
+                batch_start = time.perf_counter()
                 outputs = self.engine.predict_batch(engine_inputs)
+                _log.debug(
+                    "Processed %s pages through VLM engine in %.3fs",
+                    len(engine_inputs),
+                    time.perf_counter() - batch_start,
+                )
 
                 # Attach predictions to pages
                 for page, output in zip(valid_pages, outputs):
@@ -211,13 +244,7 @@ class VlmConvertModel(BasePageModel):
 
         # Process batch of images
         engine_inputs = [
-            VlmEngineInput(
-                image=img,
-                prompt=p,
-                temperature=self.options.model_spec.temperature,
-                max_new_tokens=self.options.model_spec.max_new_tokens,
-                stop_strings=self.options.model_spec.stop_strings,
-            )
+            self._build_engine_input(image=img, prompt=p)
             for img, p in zip(images, prompts)
         ]
 

--- a/docling/models/stages/vlm_convert/vlm_convert_model.py
+++ b/docling/models/stages/vlm_convert/vlm_convert_model.py
@@ -152,18 +152,15 @@ class VlmConvertModel(BasePageModel):
             images = []
             prompts = []
             valid_pages = []
-            rasterize_time = 0.0
-            scale_resize_time = 0.0
-            max_size_resize_time = 0.0
+            image_prep_time = 0.0
 
             for page in page_list:
-                rasterize_start = time.perf_counter()
+                image_prep_start = time.perf_counter()
                 image = page.get_image(
                     scale=self.options.scale,
                     max_size=self.options.max_size,
                 )
-                rasterize_time += time.perf_counter() - rasterize_start
-
+                image_prep_time += time.perf_counter() - image_prep_start
                 if image is None:
                     _log.warning(
                         f"Page {page.page_no} has no image, skipping VLM conversion"
@@ -180,11 +177,9 @@ class VlmConvertModel(BasePageModel):
 
             # Process through runtime using batch prediction
             _log.debug(
-                "Prepared %s pages for VLM engine: rasterize=%.3fs, scale_resize=%.3fs, max_size_resize=%.3fs",
+                "Prepared %s pages for VLM engine in %.3fs",
                 len(images),
-                rasterize_time,
-                scale_resize_time,
-                max_size_resize_time,
+                image_prep_time,
             )
 
             try:

--- a/tests/test_api_vlm_engine.py
+++ b/tests/test_api_vlm_engine.py
@@ -93,9 +93,7 @@ def test_api_vlm_engine_allows_explicit_user_params_to_override_request_settings
         ),
     )
 
-    outputs = engine.predict_batch(
-        [_make_input(temperature=0.4, max_new_tokens=128)]
-    )
+    outputs = engine.predict_batch([_make_input(temperature=0.4, max_new_tokens=128)])
 
     assert [output.text for output in outputs] == ["ok"]
     assert captured_api_call["model"] == "override-model"

--- a/tests/test_api_vlm_engine.py
+++ b/tests/test_api_vlm_engine.py
@@ -1,3 +1,6 @@
+from typing import Any
+
+import pytest
 from PIL import Image
 
 from docling.datamodel.stage_model_specs import EngineModelConfig
@@ -7,11 +10,12 @@ from docling.models.inference_engines.vlm.api_openai_compatible_engine import (
 )
 from docling.models.inference_engines.vlm.base import VlmEngineInput, VlmEngineType
 
+_API_URL = "http://localhost:11434/v1/chat/completions"
 
-def test_api_vlm_engine_uses_request_generation_settings_over_model_defaults(
-    monkeypatch,
-) -> None:
-    captured = {}
+
+@pytest.fixture
+def captured_api_call(monkeypatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {}
 
     def _fake_api_image_request(**kwargs):
         captured.update(kwargs)
@@ -21,12 +25,26 @@ def test_api_vlm_engine_uses_request_generation_settings_over_model_defaults(
         "docling.models.inference_engines.vlm.api_openai_compatible_engine.api_image_request",
         _fake_api_image_request,
     )
+    return captured
 
+
+def _make_input(**overrides) -> VlmEngineInput:
+    params: dict[str, Any] = {
+        "image": Image.new("RGB", (8, 8), "white"),
+        "prompt": "Prompt",
+    }
+    params.update(overrides)
+    return VlmEngineInput(**params)
+
+
+def test_api_vlm_engine_uses_request_generation_settings_over_model_defaults(
+    captured_api_call,
+) -> None:
     engine = ApiVlmEngine(
         enable_remote_services=True,
         options=ApiVlmEngineOptions(
             engine_type=VlmEngineType.API_OPENAI,
-            url="http://localhost:11434/v1/chat/completions",
+            url=_API_URL,
         ),
         model_config=EngineModelConfig(
             extra_config={
@@ -41,9 +59,7 @@ def test_api_vlm_engine_uses_request_generation_settings_over_model_defaults(
 
     outputs = engine.predict_batch(
         [
-            VlmEngineInput(
-                image=Image.new("RGB", (8, 8), "white"),
-                prompt="Prompt",
+            _make_input(
                 temperature=0.4,
                 max_new_tokens=128,
                 stop_strings=["</doctag>"],
@@ -52,31 +68,20 @@ def test_api_vlm_engine_uses_request_generation_settings_over_model_defaults(
     )
 
     assert [output.text for output in outputs] == ["ok"]
-    assert captured["model"] == "test-model"
-    assert captured["temperature"] == 0.4
-    assert captured["max_tokens"] == 128
-    assert captured["stop"] == ["</doctag>"]
+    assert captured_api_call["model"] == "test-model"
+    assert captured_api_call["temperature"] == 0.4
+    assert captured_api_call["max_tokens"] == 128
+    assert captured_api_call["stop"] == ["</doctag>"]
 
 
 def test_api_vlm_engine_allows_explicit_user_params_to_override_request_settings(
-    monkeypatch,
+    captured_api_call,
 ) -> None:
-    captured = {}
-
-    def _fake_api_image_request(**kwargs):
-        captured.update(kwargs)
-        return "ok", 1, "stop"
-
-    monkeypatch.setattr(
-        "docling.models.inference_engines.vlm.api_openai_compatible_engine.api_image_request",
-        _fake_api_image_request,
-    )
-
     engine = ApiVlmEngine(
         enable_remote_services=True,
         options=ApiVlmEngineOptions(
             engine_type=VlmEngineType.API_OPENAI,
-            url="http://localhost:11434/v1/chat/completions",
+            url=_API_URL,
             params={
                 "model": "override-model",
                 "temperature": 0.8,
@@ -89,18 +94,53 @@ def test_api_vlm_engine_allows_explicit_user_params_to_override_request_settings
     )
 
     outputs = engine.predict_batch(
-        [
-            VlmEngineInput(
-                image=Image.new("RGB", (8, 8), "white"),
-                prompt="Prompt",
-                temperature=0.4,
-                max_new_tokens=128,
-            )
-        ]
+        [_make_input(temperature=0.4, max_new_tokens=128)]
     )
 
     assert [output.text for output in outputs] == ["ok"]
-    assert captured["model"] == "override-model"
-    assert captured["temperature"] == 0.8
-    assert captured["max_completion_tokens"] == 256
-    assert "max_tokens" not in captured
+    assert captured_api_call["model"] == "override-model"
+    assert captured_api_call["temperature"] == 0.8
+    assert captured_api_call["max_completion_tokens"] == 256
+    assert "max_tokens" not in captured_api_call
+
+
+def test_api_vlm_engine_user_stop_overrides_request_stop_strings(
+    captured_api_call,
+) -> None:
+    """User-provided ``stop`` wins over per-request ``stop_strings`` (#3321)."""
+    engine = ApiVlmEngine(
+        enable_remote_services=True,
+        options=ApiVlmEngineOptions(
+            engine_type=VlmEngineType.API_OPENAI,
+            url=_API_URL,
+            params={"model": "m", "stop": ["USER_STOP"]},
+        ),
+    )
+
+    engine.predict_batch([_make_input(stop_strings=["MODEL_STOP"])])
+
+    assert captured_api_call["stop"] == ["USER_STOP"]
+
+
+def test_api_vlm_engine_preserves_user_params_exclusivity(
+    captured_api_call,
+) -> None:
+    """Vendor-specific user params (e.g. watsonx ``model_id``) are not mixed
+    with model-spec defaults, so no conflicting ``model`` key leaks through."""
+    engine = ApiVlmEngine(
+        enable_remote_services=True,
+        options=ApiVlmEngineOptions(
+            engine_type=VlmEngineType.API,
+            url=_API_URL,
+            params={"model_id": "vendor-model", "project_id": "proj"},
+        ),
+        model_config=EngineModelConfig(
+            extra_config={"api_params": {"model": "default-model"}}
+        ),
+    )
+
+    engine.predict_batch([_make_input()])
+
+    assert captured_api_call["model_id"] == "vendor-model"
+    assert captured_api_call["project_id"] == "proj"
+    assert "model" not in captured_api_call

--- a/tests/test_api_vlm_engine.py
+++ b/tests/test_api_vlm_engine.py
@@ -1,0 +1,106 @@
+from PIL import Image
+
+from docling.datamodel.stage_model_specs import EngineModelConfig
+from docling.datamodel.vlm_engine_options import ApiVlmEngineOptions
+from docling.models.inference_engines.vlm.api_openai_compatible_engine import (
+    ApiVlmEngine,
+)
+from docling.models.inference_engines.vlm.base import VlmEngineInput, VlmEngineType
+
+
+def test_api_vlm_engine_uses_request_generation_settings_over_model_defaults(
+    monkeypatch,
+) -> None:
+    captured = {}
+
+    def _fake_api_image_request(**kwargs):
+        captured.update(kwargs)
+        return "ok", 1, "stop"
+
+    monkeypatch.setattr(
+        "docling.models.inference_engines.vlm.api_openai_compatible_engine.api_image_request",
+        _fake_api_image_request,
+    )
+
+    engine = ApiVlmEngine(
+        enable_remote_services=True,
+        options=ApiVlmEngineOptions(
+            engine_type=VlmEngineType.API_OPENAI,
+            url="http://localhost:11434/v1/chat/completions",
+        ),
+        model_config=EngineModelConfig(
+            extra_config={
+                "api_params": {
+                    "model": "test-model",
+                    "max_tokens": 4096,
+                    "temperature": 0.0,
+                }
+            }
+        ),
+    )
+
+    outputs = engine.predict_batch(
+        [
+            VlmEngineInput(
+                image=Image.new("RGB", (8, 8), "white"),
+                prompt="Prompt",
+                temperature=0.4,
+                max_new_tokens=128,
+                stop_strings=["</doctag>"],
+            )
+        ]
+    )
+
+    assert [output.text for output in outputs] == ["ok"]
+    assert captured["model"] == "test-model"
+    assert captured["temperature"] == 0.4
+    assert captured["max_tokens"] == 128
+    assert captured["stop"] == ["</doctag>"]
+
+
+def test_api_vlm_engine_allows_explicit_user_params_to_override_request_settings(
+    monkeypatch,
+) -> None:
+    captured = {}
+
+    def _fake_api_image_request(**kwargs):
+        captured.update(kwargs)
+        return "ok", 1, "stop"
+
+    monkeypatch.setattr(
+        "docling.models.inference_engines.vlm.api_openai_compatible_engine.api_image_request",
+        _fake_api_image_request,
+    )
+
+    engine = ApiVlmEngine(
+        enable_remote_services=True,
+        options=ApiVlmEngineOptions(
+            engine_type=VlmEngineType.API_OPENAI,
+            url="http://localhost:11434/v1/chat/completions",
+            params={
+                "model": "override-model",
+                "temperature": 0.8,
+                "max_completion_tokens": 256,
+            },
+        ),
+        model_config=EngineModelConfig(
+            extra_config={"api_params": {"model": "default-model", "max_tokens": 4096}}
+        ),
+    )
+
+    outputs = engine.predict_batch(
+        [
+            VlmEngineInput(
+                image=Image.new("RGB", (8, 8), "white"),
+                prompt="Prompt",
+                temperature=0.4,
+                max_new_tokens=128,
+            )
+        ]
+    )
+
+    assert [output.text for output in outputs] == ["ok"]
+    assert captured["model"] == "override-model"
+    assert captured["temperature"] == 0.8
+    assert captured["max_completion_tokens"] == 256
+    assert "max_tokens" not in captured

--- a/tests/test_cli_remote.py
+++ b/tests/test_cli_remote.py
@@ -3,6 +3,7 @@
 The service client is faked so these run without a live docling-serve instance.
 """
 
+import re
 from pathlib import Path, PurePath
 
 import pytest
@@ -14,6 +15,11 @@ from docling.datamodel.base_models import ConversionStatus, InputFormat, OutputF
 
 runner = CliRunner()
 pytestmark = pytest.mark.external_service
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _strip_ansi(text: str) -> str:
+    return _ANSI_RE.sub("", text)
 
 
 class _FakeDoc:
@@ -86,6 +92,7 @@ def _patch_client(monkeypatch):
 def test_remote_help_is_self_sufficient():
     result = runner.invoke(app, ["convert-remote", "--help"])
     assert result.exit_code == 0
+    help_text = _strip_ansi(result.output)
     for marker in (
         "Authentication",
         "Exit codes",
@@ -94,7 +101,7 @@ def test_remote_help_is_self_sufficient():
         "DOCLING_SERVICE_API_KEY",
         "--service-url",
     ):
-        assert marker in result.output
+        assert marker in help_text
 
 
 def test_remote_missing_url_exits_2(monkeypatch):

--- a/tests/test_vlm_convert_model.py
+++ b/tests/test_vlm_convert_model.py
@@ -150,6 +150,35 @@ def test_process_images_flattens_nested_override_generation_config() -> None:
     assert "extra_generation_config" not in engine_input.extra_generation_config
 
 
+def test_process_images_shares_generation_template_across_batch() -> None:
+    """Batch items get consistent generation settings without per-item reallocation."""
+    model, model_spec = _build_model()
+
+    list(
+        model.process_images(
+            [
+                Image.new("RGB", (8, 8), "white"),
+                Image.new("RGB", (8, 8), "black"),
+                Image.new("RGB", (8, 8), "red"),
+            ],
+            prompt="Prompt.",
+        )
+    )
+
+    batch = model.engine.batches[-1]
+    assert len(batch) == 3
+
+    first = batch[0]
+    for engine_input in batch[1:]:
+        assert engine_input.temperature == first.temperature
+        assert engine_input.max_new_tokens == first.max_new_tokens
+        assert engine_input.stop_strings == first.stop_strings
+        assert engine_input.extra_generation_config == first.extra_generation_config
+
+    assert first.stop_strings == model_spec.stop_strings
+    assert first.extra_generation_config == model_spec.extra_generation_config
+
+
 def test_process_images_uses_selected_auto_inline_engine_for_runtime_input_config() -> None:
     model = VlmConvertModel.__new__(VlmConvertModel)
     model.enabled = True

--- a/tests/test_vlm_convert_model.py
+++ b/tests/test_vlm_convert_model.py
@@ -179,7 +179,9 @@ def test_process_images_shares_generation_template_across_batch() -> None:
     assert first.extra_generation_config == model_spec.extra_generation_config
 
 
-def test_process_images_uses_selected_auto_inline_engine_for_runtime_input_config() -> None:
+def test_process_images_uses_selected_auto_inline_engine_for_runtime_input_config() -> (
+    None
+):
     model = VlmConvertModel.__new__(VlmConvertModel)
     model.enabled = True
     model.engine = _CapturingEngine()

--- a/tests/test_vlm_convert_model.py
+++ b/tests/test_vlm_convert_model.py
@@ -1,0 +1,174 @@
+from types import SimpleNamespace
+
+from PIL import Image
+
+from docling.datamodel.base_models import Page
+from docling.datamodel.pipeline_options import VlmConvertOptions
+from docling.datamodel.pipeline_options_vlm_model import (
+    ResponseFormat,
+    TransformersPromptStyle,
+)
+from docling.datamodel.stage_model_specs import VlmModelSpec
+from docling.datamodel.vlm_engine_options import (
+    AutoInlineVlmEngineOptions,
+    TransformersVlmEngineOptions,
+)
+from docling.models.inference_engines.vlm.base import VlmEngineOutput, VlmEngineType
+from docling.models.stages.vlm_convert.vlm_convert_model import VlmConvertModel
+
+
+class _CapturingEngine:
+    def __init__(self) -> None:
+        self.batches = []
+
+    def predict_batch(self, batch):
+        self.batches.append(batch)
+        return [
+            VlmEngineOutput(text=f"output-{index}", stop_reason="unspecified")
+            for index, _input in enumerate(batch)
+        ]
+
+    def cleanup(self) -> None:
+        return None
+
+
+def _build_model() -> tuple[VlmConvertModel, VlmModelSpec]:
+    model_spec = VlmModelSpec(
+        name="Test Model",
+        default_repo_id="org/model",
+        prompt="Convert this page to docling.",
+        response_format=ResponseFormat.DOCTAGS,
+        temperature=0.4,
+        max_new_tokens=128,
+        stop_strings=["</doctag>"],
+        extra_generation_config={"top_p": 0.9},
+    )
+
+    model = VlmConvertModel.__new__(VlmConvertModel)
+    model.enabled = True
+    model.engine = _CapturingEngine()
+    model.options = VlmConvertOptions(
+        model_spec=model_spec,
+        engine_options=AutoInlineVlmEngineOptions(),
+    )
+    return model, model_spec
+
+
+def test_process_images_uses_configured_generation_settings() -> None:
+    model, model_spec = _build_model()
+
+    outputs = list(
+        model.process_images(
+            [Image.new("RGB", (8, 8), "white")],
+            prompt="Use this prompt instead.",
+        )
+    )
+
+    assert [prediction.text for prediction in outputs] == ["output-0"]
+
+    batch = model.engine.batches[-1]
+    assert len(batch) == 1
+
+    engine_input = batch[0]
+    assert engine_input.prompt == "Use this prompt instead."
+    assert engine_input.temperature == model_spec.temperature
+    assert engine_input.max_new_tokens == model_spec.max_new_tokens
+    assert engine_input.stop_strings == model_spec.stop_strings
+    assert engine_input.extra_generation_config == model_spec.extra_generation_config
+
+
+def test_call_uses_model_spec_generation_settings() -> None:
+    model, model_spec = _build_model()
+
+    image = Image.new("RGB", (8, 8), "black")
+    page = Page(page_no=1)
+    page._image_cache = {model.options.scale: image}
+    page._default_image_scale = model.options.scale
+
+    outputs = list(model(SimpleNamespace(timings={}), [page]))
+
+    assert outputs == [page]
+    assert page.predictions.vlm_response is not None
+    assert page.predictions.vlm_response.text == "output-0"
+
+    batch = model.engine.batches[-1]
+    assert len(batch) == 1
+
+    engine_input = batch[0]
+    assert engine_input.prompt == model_spec.prompt
+    assert engine_input.temperature == model_spec.temperature
+    assert engine_input.max_new_tokens == model_spec.max_new_tokens
+    assert engine_input.stop_strings == model_spec.stop_strings
+    assert engine_input.extra_generation_config == model_spec.extra_generation_config
+
+
+def test_process_images_merges_transformers_override_runtime_input_config() -> None:
+    model = VlmConvertModel.__new__(VlmConvertModel)
+    model.enabled = True
+    model.engine = _CapturingEngine()
+    model.options = VlmConvertOptions.from_preset(
+        "got_ocr",
+        engine_options=TransformersVlmEngineOptions(),
+    )
+
+    list(
+        model.process_images(
+            [Image.new("RGB", (8, 8), "white")],
+            prompt="ignored",
+        )
+    )
+
+    engine_input = model.engine.batches[-1][0]
+    assert (
+        engine_input.extra_generation_config["transformers_prompt_style"]
+        == TransformersPromptStyle.NONE
+    )
+    assert engine_input.extra_generation_config["extra_processor_kwargs"] == {
+        "format": True
+    }
+    assert "transformers_model_type" not in engine_input.extra_generation_config
+
+
+def test_process_images_flattens_nested_override_generation_config() -> None:
+    model = VlmConvertModel.__new__(VlmConvertModel)
+    model.enabled = True
+    model.engine = _CapturingEngine()
+    model.options = VlmConvertOptions.from_preset(
+        "phi4",
+        engine_options=TransformersVlmEngineOptions(),
+    )
+
+    list(
+        model.process_images(
+            [Image.new("RGB", (8, 8), "white")],
+            prompt="ignored",
+        )
+    )
+
+    engine_input = model.engine.batches[-1][0]
+    assert engine_input.extra_generation_config["num_logits_to_keep"] == 0
+    assert "extra_generation_config" not in engine_input.extra_generation_config
+
+
+def test_process_images_uses_selected_auto_inline_engine_for_runtime_input_config() -> None:
+    model = VlmConvertModel.__new__(VlmConvertModel)
+    model.enabled = True
+    model.engine = _CapturingEngine()
+    model.engine.selected_engine_type = VlmEngineType.TRANSFORMERS
+    model.options = VlmConvertOptions.from_preset(
+        "dolphin",
+        engine_options=AutoInlineVlmEngineOptions(),
+    )
+
+    list(
+        model.process_images(
+            [Image.new("RGB", (8, 8), "white")],
+            prompt="ignored",
+        )
+    )
+
+    engine_input = model.engine.batches[-1][0]
+    assert (
+        engine_input.extra_generation_config["transformers_prompt_style"]
+        == TransformersPromptStyle.RAW
+    )


### PR DESCRIPTION
Forward the VLM convert stage generation settings from `model_spec` when constructing `VlmEngineInput`, and add debug timing around preprocessing and batch inference.

This change:

- adds `temperature` and `extra_generation_config` to `VlmModelSpec`
- threads `temperature`, `max_new_tokens`, `stop_strings`, and `extra_generation_config` through both `VlmConvertModel.__call__()` and `process_images()`
- logs rasterization/resize timing and batch inference timing in the VLM convert stage
- adds regression tests covering both VLM convert entry points

**Issue resolved by this Pull Request:**
Resolves #3321

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
