### PR TITLE
feat: implement GraniteVisionTableStructureModel for VLM-based table extraction

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,7 +20,7 @@ env:
     tests/test_asr_pipeline.py
     tests/test_threaded_pipeline.py
   PYTEST_TO_SKIP: |-
-  EXAMPLES_TO_SKIP: '^(batch_convert|compare_vlm_models|minimal|minimal_vlm_pipeline|minimal_asr_pipeline|export_multimodal|custom_convert|develop_picture_enrichment|rapidocr_with_custom_models|suryaocr_with_custom_models|offline_convert|pictures_description|pictures_description_api|vlm_pipeline_api_model|granitedocling_repetition_stopping|mlx_whisper_example|gpu_standard_pipeline|gpu_vlm_pipeline|demo_layout_vlm|post_process_ocr_with_vlm|run_with_formats_html_rendered|run_with_formats_html_rendered_mp|chart_extraction)\.py$|xbrl_conversion\.ipynb$'
+  EXAMPLES_TO_SKIP: '^(batch_convert|compare_vlm_models|minimal|minimal_vlm_pipeline|minimal_asr_pipeline|export_multimodal|custom_convert|develop_picture_enrichment|rapidocr_with_custom_models|suryaocr_with_custom_models|offline_convert|pictures_description|pictures_description_api|vlm_pipeline_api_model|granitedocling_repetition_stopping|mlx_whisper_example|gpu_standard_pipeline|gpu_vlm_pipeline|demo_layout_vlm|post_process_ocr_with_vlm|run_with_formats_html_rendered|run_with_formats_html_rendered_mp|chart_extraction|granite_vision_table_structure)\.py$|xbrl_conversion\.ipynb$'
 
 jobs:
   lint:

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -153,6 +153,12 @@ class TableStructureV2Options(BaseTableStructureOptions):
     )
 
 
+class GraniteVisionTableStructureOptions(BaseTableStructureOptions):
+    """Options for the table structure model using Granite Vision (VLM-based)."""
+
+    kind: ClassVar[str] = "granite_vision_table"
+
+
 class OcrOptions(BaseOptions):
     """Base configuration for Optical Character Recognition engines.
 

--- a/docling/models/plugins/defaults.py
+++ b/docling/models/plugins/defaults.py
@@ -62,6 +62,9 @@ def table_structure_engines():
     from docling.models.stages.table_structure.table_structure_model import (
         TableStructureModel,
     )
+    from docling.models.stages.table_structure.table_structure_model_granite_vision import (
+        GraniteVisionTableStructureModel,
+    )
     from docling.models.stages.table_structure.table_structure_model_v2 import (
         TableStructureModelV2,
     )
@@ -70,5 +73,6 @@ def table_structure_engines():
         "table_structure_engines": [
             TableStructureModel,
             TableStructureModelV2,
+            GraniteVisionTableStructureModel,
         ]
     }

--- a/docling/models/stages/table_structure/table_structure_model_granite_vision.py
+++ b/docling/models/stages/table_structure/table_structure_model_granite_vision.py
@@ -1,0 +1,346 @@
+import logging
+import re
+import warnings
+from collections.abc import Sequence
+from itertools import groupby
+from pathlib import Path
+from typing import Any, ClassVar, Literal, cast
+
+import torch
+from docling_core.types.doc import DocItemLabel, TableCell
+from transformers import AutoModelForImageTextToText, AutoProcessor
+
+from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
+from docling.datamodel.base_models import Page, Table, TableStructurePrediction
+from docling.datamodel.document import ConversionResult
+from docling.datamodel.pipeline_options import GraniteVisionTableStructureOptions
+from docling.models.base_table_model import BaseTableStructureModel
+from docling.models.utils.hf_model_download import download_hf_model
+from docling.utils.accelerator_utils import decide_device
+from docling.utils.profiling import TimeRecorder
+
+_log = logging.getLogger(__name__)
+
+# OTSL tokens that represent content-bearing cells (produce a TableCell)
+_CONTENT_TOKENS = {"fcel", "ecel", "ched", "rhed", "srow"}
+# OTSL tokens that are span-extensions (no separate TableCell, affect span of predecessor)
+_SPAN_TOKENS = {"lcel", "ucel", "xcel"}
+
+# Regex to extract (tag_name, inner_text) from VLM OTSL output.
+# Handles two OTSL serialisation styles:
+#   Closed:  <tag>text</tag>  — used in unit tests and some model outputs
+#   Open:    <tag>text<next>  — used by ibm-granite model (no closing tag)
+# Also handles self-closing tags: <tag/>
+_TAG_RE = re.compile(
+    r"<(?P<tag>[a-z]+)>(?P<text>.*?)</(?P=tag)>"  # <tag>text</tag> (closed form)
+    r"|<(?P<stag>[a-z]+)\s*/>"  # <tag/>  (self-closing)
+    r"|<(?P<otag>[a-z]+)>(?P<otext>[^<]*)",  # <tag>text  (open form; otext may be "")
+    re.DOTALL,
+)
+
+
+def _parse_otsl_output(
+    text: str,
+) -> tuple[list[str], list[TableCell], int, int]:
+    """Parse VLM OTSL text output into structured table data.
+
+    Parameters
+    ----------
+    text:
+        Raw VLM output string, e.g.
+        ``"<ched>Name</ched><ched>Val</ched><nl><fcel>Foo</fcel><fcel>42</fcel><nl>"``
+
+    Returns
+    -------
+    tuple of (otsl_seq, table_cells, num_rows, num_cols)
+        otsl_seq: list of bare tag names, e.g. ["ched", "ched", "nl", "fcel", "fcel", "nl"]
+        table_cells: list of TableCell (bbox always None)
+        num_rows: int
+        num_cols: int
+    """
+    if not text or not text.strip():
+        return [], [], 0, 0
+
+    # Unwrap optional [<otsl>...</otsl>] container produced by the model
+    otsl_match = re.search(r"<otsl>(.*)</otsl>", text, re.DOTALL)
+    if otsl_match:
+        text = otsl_match.group(1)
+
+    # Extract (tag, inner_text) pairs
+    token_pairs: list[tuple[str, str]] = []
+    for m in _TAG_RE.finditer(text):
+        if m.group("tag"):
+            token_pairs.append((m.group("tag"), m.group("text") or ""))
+        elif m.group("stag"):
+            token_pairs.append((m.group("stag"), ""))
+        elif m.group("otag"):
+            token_pairs.append((m.group("otag"), m.group("otext") or ""))
+
+    if not token_pairs:
+        return [], [], 0, 0
+
+    otsl_seq = [tag for tag, _ in token_pairs]
+
+    # Split into rows on "nl" tokens
+    rows: list[list[tuple[str, str]]] = [
+        list(group)
+        for k, group in groupby(token_pairs, lambda x: x[0] == "nl")
+        if not k
+    ]
+
+    if not rows:
+        return otsl_seq, [], 0, 0
+
+    num_rows = len(rows)
+    num_cols = max(len(row) for row in rows)
+
+    # Pad rows to equal width
+    grid: list[list[tuple[str, str]]] = [
+        row + [("", "")] * (num_cols - len(row)) for row in rows
+    ]
+
+    table_cells: list[TableCell] = []
+    for row_idx, row in enumerate(grid):
+        for col_idx, (tag, inner_text) in enumerate(row):
+            if tag not in _CONTENT_TOKENS:
+                continue
+
+            # Detect colspan: count consecutive span-extension tokens to the right
+            colspan = 1
+            for c in range(col_idx + 1, num_cols):
+                if grid[row_idx][c][0] in _SPAN_TOKENS:
+                    colspan += 1
+                else:
+                    break
+
+            # Detect rowspan: count consecutive span-extension tokens below
+            rowspan = 1
+            for r in range(row_idx + 1, num_rows):
+                if grid[r][col_idx][0] in _SPAN_TOKENS:
+                    rowspan += 1
+                else:
+                    break
+
+            cell = TableCell(
+                text=inner_text,
+                bbox=None,
+                row_span=rowspan,
+                col_span=colspan,
+                start_row_offset_idx=row_idx,
+                end_row_offset_idx=row_idx + rowspan,
+                start_col_offset_idx=col_idx,
+                end_col_offset_idx=col_idx + colspan,
+                column_header=(tag == "ched"),
+                row_header=(tag == "rhed"),
+                row_section=(tag == "srow"),
+            )
+            table_cells.append(cell)
+
+    return otsl_seq, table_cells, num_rows, num_cols
+
+
+class GraniteVisionTableStructureModel(BaseTableStructureModel):
+    """Table structure model using ibm-granite/granite-4.0-3b-vision with <tables_otsl>."""
+
+    _model_repo_id: ClassVar[str] = "ibm-granite/granite-4.0-3b-vision"
+    _model_repo_folder: ClassVar[str] = "ibm-granite--granite-4.0-3b-vision"
+    _model_repo_revision: ClassVar[str] = "f0d034897bae1cd438c961c8c170a3a3089ebf01"
+
+    def __init__(
+        self,
+        enabled: bool,
+        artifacts_path: Path | None,
+        options: GraniteVisionTableStructureOptions,
+        accelerator_options: AcceleratorOptions,
+        enable_remote_services: Literal[False] = False,
+    ):
+        self.enabled = enabled
+        self.options = options
+        self.accelerator_options = accelerator_options
+
+        if self.enabled:
+            self.device = decide_device(
+                accelerator_options.device,
+                supported_devices=[AcceleratorDevice.CPU, AcceleratorDevice.CUDA],
+            )
+
+            if artifacts_path is None:
+                artifacts_path = self.download_models()
+            elif (artifacts_path / self._model_repo_folder).exists():
+                artifacts_path = artifacts_path / self._model_repo_folder
+            else:
+                _log.warning(
+                    f"Model artifacts not found at {artifacts_path / self._model_repo_folder},"
+                    " they will be downloaded."
+                )
+
+            self._load_model(artifacts_path)
+
+    @classmethod
+    def get_options_type(cls) -> type[GraniteVisionTableStructureOptions]:
+        return GraniteVisionTableStructureOptions
+
+    @classmethod
+    def download_models(
+        cls,
+        local_dir: Path | None = None,
+        force: bool = False,
+        progress: bool = False,
+    ) -> Path:
+        return download_hf_model(
+            repo_id=cls._model_repo_id,
+            revision=cls._model_repo_revision,
+            local_dir=local_dir,
+            force=force,
+            progress=progress,
+        )
+
+    def _load_model(self, artifacts_path: Path) -> None:
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore",
+                message=".*torch_dtype.*deprecated.*",
+                category=UserWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message=".*incorrect regex pattern.*",
+                category=UserWarning,
+            )
+            self._processor = AutoProcessor.from_pretrained(
+                artifacts_path,
+                trust_remote_code=True,
+            )
+            self._model_max_length = self._processor.tokenizer.model_max_length
+            self._model = AutoModelForImageTextToText.from_pretrained(
+                artifacts_path,
+                device_map=self.device,
+                dtype=torch.bfloat16,
+                _attn_implementation=(
+                    "flash_attention_2"
+                    if self.device.startswith("cuda")
+                    and self.accelerator_options.cuda_use_flash_attention2
+                    else "sdpa"
+                ),
+                trust_remote_code=True,
+            )
+        cast(Any, self._model).merge_lora_adapters()
+        self._model.eval()
+
+    def predict_tables(
+        self,
+        conv_res: ConversionResult,
+        pages: Sequence[Page],
+    ) -> Sequence[TableStructurePrediction]:
+        predictions: list[TableStructurePrediction] = []
+
+        for page in pages:
+            assert page._backend is not None
+            if not page._backend.is_valid():
+                existing = page.predictions.tablestructure or TableStructurePrediction()
+                page.predictions.tablestructure = existing
+                predictions.append(existing)
+                continue
+
+            with TimeRecorder(conv_res, "table_structure"):
+                assert page.predictions.layout is not None
+                assert page.size is not None
+
+                table_prediction = TableStructurePrediction()
+                page.predictions.tablestructure = table_prediction
+
+                clusters = [
+                    c
+                    for c in page.predictions.layout.clusters
+                    if c.label in (DocItemLabel.TABLE, DocItemLabel.DOCUMENT_INDEX)
+                ]
+
+                if not clusters or not self.enabled:
+                    predictions.append(table_prediction)
+                    continue
+
+                # Crop one image per table cluster from the page image
+                valid_pairs = []
+                for cluster in clusters:
+                    crop = page.get_image(scale=1.0, cropbox=cluster.bbox)
+                    if crop is not None:
+                        valid_pairs.append((cluster, crop))
+
+                if not valid_pairs:
+                    predictions.append(table_prediction)
+                    continue
+
+                valid_clusters, valid_images = zip(*valid_pairs)
+
+                conversations = [
+                    [
+                        {
+                            "role": "user",
+                            "content": [
+                                {"type": "image"},
+                                {"type": "text", "text": "<tables_otsl>"},
+                            ],
+                        }
+                    ]
+                    for _ in valid_images
+                ]
+
+                texts = [
+                    self._processor.apply_chat_template(
+                        conv, tokenize=False, add_generation_prompt=True
+                    )
+                    for conv in conversations
+                ]
+
+                inputs = self._processor(
+                    text=texts,
+                    images=list(valid_images),
+                    return_tensors="pt",
+                    padding=True,
+                    do_pad=True,
+                ).to(self.device)
+
+                output_ids = cast(Any, self._model).generate(
+                    **inputs,
+                    max_new_tokens=self._model_max_length,
+                    use_cache=True,
+                )
+
+                # Decode only generated tokens (strip input prompt tokens)
+                output_texts = [
+                    self._processor.decode(
+                        output_ids[i, inputs["input_ids"].shape[1] :],
+                        skip_special_tokens=True,
+                    )
+                    for i in range(len(valid_images))
+                ]
+
+                for cluster, raw_text in zip(valid_clusters, output_texts):
+                    _log.debug(
+                        f"GraniteVision table [{cluster.id}] raw output: {raw_text!r}"
+                    )
+                    try:
+                        otsl_seq, table_cells, num_rows, num_cols = _parse_otsl_output(
+                            raw_text
+                        )
+                    except Exception as exc:
+                        _log.warning(
+                            f"Failed to parse OTSL output for table cluster {cluster.id}: {exc}"
+                        )
+                        otsl_seq, table_cells, num_rows, num_cols = [], [], 0, 0
+
+                    tbl = Table(
+                        otsl_seq=otsl_seq,
+                        table_cells=table_cells,
+                        num_rows=num_rows,
+                        num_cols=num_cols,
+                        id=cluster.id,
+                        page_no=page.page_no,
+                        cluster=cluster,
+                        label=cluster.label,
+                    )
+                    table_prediction.table_map[cluster.id] = tbl
+
+                predictions.append(table_prediction)
+
+        return predictions

--- a/docs/examples/granite_vision_table_structure.py
+++ b/docs/examples/granite_vision_table_structure.py
@@ -1,0 +1,79 @@
+# %% [markdown]
+# Extract tables from a PDF using Granite Vision for table structure recognition.
+#
+# What this example does
+# - Converts a PDF using the Granite Vision VLM for table structure extraction
+#   instead of the default TableFormer model.
+# - Prints each detected table as Markdown to stdout.
+#
+# Prerequisites
+# - Install Docling with VLM support: `pip install docling[vlm]`
+# - A CUDA GPU is recommended; CPU works but is significantly slower.
+#
+# How to run
+# - From the repo root: `python docs/examples/granite_vision_table_structure.py`
+#
+# Input document
+# - Defaults to `tests/data/pdf/2206.01062.pdf`. Change `input_doc_path` as needed.
+#
+# Notes
+# - The Granite Vision model (`ibm-granite/granite-4.0-3b-vision`) is downloaded
+#   automatically from HuggingFace on first run.
+# - The model outputs table structure in OTSL (Open Table Structure Language) format,
+#   which Docling parses into structured table cells.
+
+# %%
+
+import logging
+import time
+from pathlib import Path
+
+from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.pipeline_options import (
+    GraniteVisionTableStructureOptions,
+    PdfPipelineOptions,
+)
+from docling.document_converter import DocumentConverter, PdfFormatOption
+
+_log = logging.getLogger(__name__)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+
+    data_folder = Path(__file__).parent / "../../tests/data"
+    input_doc_path = data_folder / "pdf/2206.01062.pdf"
+
+    # Configure pipeline to use Granite Vision for table structure
+    pipeline_options = PdfPipelineOptions()
+    pipeline_options.do_table_structure = True
+    pipeline_options.table_structure_options = GraniteVisionTableStructureOptions()
+    pipeline_options.accelerator_options = AcceleratorOptions(
+        device=AcceleratorDevice.AUTO,
+    )
+
+    doc_converter = DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
+        }
+    )
+
+    start_time = time.time()
+    conv_res = doc_converter.convert(input_doc_path)
+    elapsed = time.time() - start_time
+
+    for table_ix, table in enumerate(conv_res.document.tables):
+        table_df = table.export_to_dataframe(doc=conv_res.document)
+        print(f"## Table {table_ix}")
+        print(table_df.to_markdown())
+        print()
+
+    _log.info(
+        f"Document converted in {elapsed:.2f} seconds "
+        f"({len(conv_res.document.tables)} tables found)."
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/usage/model_catalog.md
+++ b/docs/usage/model_catalog.md
@@ -85,6 +85,21 @@ The following table shows all processing stages in Docling, their model families
     </tr>
     <tr>
       <td rowspan="3"><strong>Table Structure</strong><br/><em>Table cell recognition</em></td>
+      <td rowspan="3">Vision-Language Model<br/>(Granite Vision)</td>
+      <td>
+        <ul>
+          <li><code>granite-4.0-3b-vision</code></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td colspan="2"><strong>Inference Engine:</strong> Transformers</td>
+    </tr>
+    <tr>
+      <td colspan="2"><strong>Purpose:</strong> VLM-based table structure recognition using OTSL (Open Table Structure Language) output</td>
+    </tr>
+    <tr>
+      <td rowspan="3"><strong>Table Structure</strong><br/><em>Table cell recognition</em></td>
       <td rowspan="3">Object Detection</td>
       <td>
         <ul>

--- a/tests/test_table_structure_granite_vision.py
+++ b/tests/test_table_structure_granite_vision.py
@@ -1,0 +1,208 @@
+from docling.datamodel.accelerator_options import AcceleratorOptions
+from docling.datamodel.pipeline_options import GraniteVisionTableStructureOptions
+from docling.models.stages.table_structure.table_structure_model_granite_vision import (
+    GraniteVisionTableStructureModel,
+    _parse_otsl_output,
+)
+
+
+def test_options_kind():
+    opts = GraniteVisionTableStructureOptions()
+    assert opts.kind == "granite_vision_table"
+
+
+def test_parse_simple_table():
+    """2x2 table with column headers."""
+    text = "<ched>Name</ched><ched>Value</ched><nl><fcel>Foo</fcel><fcel>42</fcel><nl>"
+    otsl_seq, cells, num_rows, num_cols = _parse_otsl_output(text)
+
+    assert otsl_seq == ["ched", "ched", "nl", "fcel", "fcel", "nl"]
+    assert num_rows == 2
+    assert num_cols == 2
+    assert len(cells) == 4
+
+    header_cells = [c for c in cells if c.column_header]
+    assert len(header_cells) == 2
+    assert header_cells[0].text == "Name"
+    assert header_cells[1].text == "Value"
+
+    data_cells = [c for c in cells if not c.column_header]
+    assert data_cells[0].text == "Foo"
+    assert data_cells[0].start_row_offset_idx == 1
+    assert data_cells[0].start_col_offset_idx == 0
+    assert data_cells[1].text == "42"
+    assert data_cells[1].start_col_offset_idx == 1
+
+
+def test_parse_empty_cell():
+    """Empty cell produces empty text, still in grid."""
+    text = "<ched>A</ched><ched>B</ched><nl><fcel>x</fcel><ecel></ecel><nl>"
+    _otsl_seq, cells, num_rows, num_cols = _parse_otsl_output(text)
+
+    assert num_rows == 2
+    assert num_cols == 2
+    assert len(cells) == 4
+    empty = [
+        c for c in cells if c.start_row_offset_idx == 1 and c.start_col_offset_idx == 1
+    ]
+    assert len(empty) == 1
+    assert empty[0].text == ""
+
+
+def test_parse_colspan():
+    """lcel produces colspan=2 on the preceding fcel."""
+    text = "<fcel>Merged</fcel><lcel><nl><fcel>A</fcel><fcel>B</fcel><nl>"
+    _otsl_seq, cells, _num_rows, num_cols = _parse_otsl_output(text)
+
+    assert num_cols == 2
+    merged = [
+        c for c in cells if c.start_row_offset_idx == 0 and c.start_col_offset_idx == 0
+    ]
+    assert len(merged) == 1
+    assert merged[0].col_span == 2
+    assert merged[0].end_col_offset_idx == 2
+
+
+def test_parse_rowspan():
+    """ucel produces rowspan=2 on the preceding fcel above it."""
+    text = "<fcel>Tall</fcel><fcel>A</fcel><nl><ucel><fcel>B</fcel><nl>"
+    _otsl_seq, cells, _num_rows, _num_cols = _parse_otsl_output(text)
+
+    tall = [
+        c for c in cells if c.start_row_offset_idx == 0 and c.start_col_offset_idx == 0
+    ]
+    assert len(tall) == 1
+    assert tall[0].row_span == 2
+    assert tall[0].end_row_offset_idx == 2
+
+
+def test_parse_row_header():
+    """rhed token produces row_header=True."""
+    text = "<rhed>Section</rhed><fcel>Data</fcel><nl>"
+    _, cells, _, _ = _parse_otsl_output(text)
+
+    rhed_cells = [c for c in cells if c.row_header]
+    assert len(rhed_cells) == 1
+    assert rhed_cells[0].text == "Section"
+
+
+def test_parse_no_bbox():
+    """All cells must have bbox=None."""
+    text = "<ched>X</ched><nl><fcel>Y</fcel><nl>"
+    _, cells, _, _ = _parse_otsl_output(text)
+    assert all(c.bbox is None for c in cells)
+
+
+def test_parse_empty_string():
+    """Empty or whitespace-only string returns empty table."""
+    otsl_seq, cells, num_rows, num_cols = _parse_otsl_output("")
+    assert otsl_seq == []
+    assert cells == []
+    assert num_rows == 0
+    assert num_cols == 0
+
+
+def test_get_options_type():
+    assert (
+        GraniteVisionTableStructureModel.get_options_type()
+        is GraniteVisionTableStructureOptions
+    )
+
+
+def test_model_disabled_skips_pages():
+    """When enabled=False, predict_tables returns empty prediction without running inference."""
+    from unittest.mock import MagicMock
+
+    from docling_core.types.doc import DocItemLabel
+
+    model = GraniteVisionTableStructureModel(
+        enabled=False,
+        artifacts_path=None,
+        options=GraniteVisionTableStructureOptions(),
+        accelerator_options=AcceleratorOptions(),
+    )
+
+    # Give the page a cluster labelled TABLE so the cluster filter passes —
+    # the skip must be triggered by enabled=False, not by an empty cluster list.
+    cluster = MagicMock()
+    cluster.label = DocItemLabel.TABLE
+
+    page = MagicMock()
+    page._backend.is_valid.return_value = True
+    page.predictions.layout.clusters = [cluster]
+    page.predictions.tablestructure = None
+    page.size = MagicMock()
+
+    results = model.predict_tables(MagicMock(), [page])
+    assert len(results) == 1
+    assert results[0].table_map == {}
+
+
+def test_model_invalid_backend_returns_empty_prediction():
+    """Pages with invalid backends return an empty TableStructurePrediction."""
+    from unittest.mock import MagicMock
+
+    model = GraniteVisionTableStructureModel(
+        enabled=False,
+        artifacts_path=None,
+        options=GraniteVisionTableStructureOptions(),
+        accelerator_options=AcceleratorOptions(),
+    )
+
+    page = MagicMock()
+    page._backend.is_valid.return_value = False
+    page.predictions.tablestructure = None
+
+    results = model.predict_tables(MagicMock(), [page])
+    assert len(results) == 1
+    assert results[0].table_map == {}
+
+
+def test_parse_xcel_2d_merge():
+    """xcel produces both rowspan=2 and colspan=2 on the origin cell."""
+    text = "<fcel>Big</fcel><lcel><nl><ucel><xcel><nl>"
+    _, cells, num_rows, num_cols = _parse_otsl_output(text)
+
+    assert num_rows == 2
+    assert num_cols == 2
+    origin = [
+        c for c in cells if c.start_row_offset_idx == 0 and c.start_col_offset_idx == 0
+    ]
+    assert len(origin) == 1
+    assert origin[0].col_span == 2
+    assert origin[0].row_span == 2
+    assert origin[0].end_col_offset_idx == 2
+    assert origin[0].end_row_offset_idx == 2
+
+
+def test_parse_srow():
+    """srow token produces row_section=True."""
+    text = "<srow>Category</srow><fcel>Data</fcel><nl>"
+    _, cells, _, _ = _parse_otsl_output(text)
+
+    srow_cells = [c for c in cells if c.row_section]
+    assert len(srow_cells) == 1
+    assert srow_cells[0].text == "Category"
+
+
+def test_parse_ecel_self_closing():
+    """<ecel/> self-closing form produces an empty cell."""
+    text = "<fcel>A</fcel><ecel/><nl>"
+    _, cells, _, _ = _parse_otsl_output(text)
+
+    empty = [c for c in cells if c.start_col_offset_idx == 1]
+    assert len(empty) == 1
+    assert empty[0].text == ""
+
+
+def test_factory_registration():
+    """GraniteVisionTableStructureModel must be discoverable via the table structure factory."""
+    from docling.models.factories.table_factory import TableStructureFactory
+    from docling.models.stages.table_structure.table_structure_model_granite_vision import (
+        GraniteVisionTableStructureModel,
+    )
+
+    factory = TableStructureFactory()
+    factory.load_from_plugins()
+    registered = list(factory.classes.values())
+    assert GraniteVisionTableStructureModel in registered


### PR DESCRIPTION

Add a new table structure model using IBM Granite Vision to extract table structure from document images via OTSL token generation.

Changes:
- Add `GraniteVisionTableStructureOptions` with configurable model repo, device, batch size, and crop padding options
- Implement `GraniteVisionTableStructureModel` that uses a VLM pipeline to generate OTSL tokens from cropped table images, then parses them into `TableData` with cells, rows, and columns
- Register the model in `table_structure_engines` alongside existing engines
- Add example script `docs/examples/granite_vision_table_structure.py`
- Add tests covering options, model enable/disable, OTSL parsing (including self-closing tags xcel/srow/ecel), and invalid-backend error handling
- Update model catalog docs and CI workflow accordingly

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ v] Documentation has been updated, if necessary.
- [ v] Examples have been added, if necessary.
- [v ] Tests have been added, if necessary.
