### PR TITLE
ci: implement phase 1 path-based workflow skipping

### DIFF
--- a/.github/scripts/run_pr_fast_checks.py
+++ b/.github/scripts/run_pr_fast_checks.py
@@ -432,9 +432,7 @@ def main() -> int:
             delta_cell = f"{delta_seconds:+.2f}s"
             if summary_base_result.targets != summary_head_result.targets:
                 note = "target set changed"
-            elif is_significant_regression(
-                summary_base_result, summary_head_result
-            ):
+            elif is_significant_regression(summary_base_result, summary_head_result):
                 note = "significant increase"
                 regressions.append(
                     f"`{unit.name}` increased from "

--- a/.github/scripts/run_pr_fast_checks.py
+++ b/.github/scripts/run_pr_fast_checks.py
@@ -9,9 +9,16 @@ import time
 from dataclasses import dataclass
 from pathlib import Path
 
-
 RUFF_DIRECTORIES = ("docling", "tests", "docs/examples", ".github/scripts")
 MYPY_DIRECTORIES = ("docling", ".github/scripts")
+TOOLING_SMOKE_TRIGGER_PATHS = (
+    ".github/scripts/run_pr_fast_checks.py",
+    ".github/workflows/pr-fast-checks.yml",
+    ".pre-commit-config.yaml",
+    "pyproject.toml",
+    "uv.lock",
+)
+SMOKE_CHECK_TARGET = ".github/scripts/run_pr_fast_checks.py"
 RELATIVE_INCREASE_THRESHOLD = 0.5
 ABSOLUTE_INCREASE_THRESHOLD_SECONDS = 2.0
 
@@ -117,14 +124,20 @@ def is_python_or_notebook_file(path: str, directories: tuple[str, ...]) -> bool:
     if suffix not in {".py", ".ipynb"}:
         return False
 
-    return any(path == directory or path.startswith(f"{directory}/") for directory in directories)
+    return any(
+        path == directory or path.startswith(f"{directory}/")
+        for directory in directories
+    )
 
 
 def is_mypy_target(path: str) -> bool:
     if Path(path).suffix != ".py":
         return False
 
-    return any(path == directory or path.startswith(f"{directory}/") for directory in MYPY_DIRECTORIES)
+    return any(
+        path == directory or path.startswith(f"{directory}/")
+        for directory in MYPY_DIRECTORIES
+    )
 
 
 def filter_existing(repo_root: Path, paths: list[str]) -> list[str]:
@@ -147,7 +160,9 @@ def resolve_executable(repo_root: Path, executable_name: str) -> Path:
 
     system_executable = shutil.which(executable_name)
     if system_executable is None:
-        raise FileNotFoundError(f"Could not find `{executable_name}` in .venv or on PATH.")
+        raise FileNotFoundError(
+            f"Could not find `{executable_name}` in .venv or on PATH."
+        )
 
     return Path(system_executable)
 
@@ -187,6 +202,9 @@ def build_check_units(repo_root: Path) -> list[CheckUnit]:
                 str(mypy_executable),
                 "--config-file",
                 str(config_path),
+                "--follow-imports",
+                "skip",
+                "--ignore-missing-imports",
             ],
             base_targets=[],
             head_targets=[],
@@ -196,7 +214,7 @@ def build_check_units(repo_root: Path) -> list[CheckUnit]:
 
 def collect_targets(
     repo_root: Path, changed_paths: list[str]
-) -> tuple[list[str], list[str], list[str], list[str]]:
+) -> tuple[list[str], list[str], list[str], list[str], bool]:
     ruff_targets = [
         path
         for path in changed_paths
@@ -204,10 +222,25 @@ def collect_targets(
     ]
     mypy_targets = [path for path in changed_paths if is_mypy_target(path)]
 
+    used_tooling_smoke_targets = (
+        not ruff_targets
+        and not mypy_targets
+        and any(path in TOOLING_SMOKE_TRIGGER_PATHS for path in changed_paths)
+    )
+    if used_tooling_smoke_targets:
+        ruff_targets = [SMOKE_CHECK_TARGET]
+        mypy_targets = [SMOKE_CHECK_TARGET]
+
     existing_ruff_targets = filter_existing(repo_root, ruff_targets)
     existing_mypy_targets = filter_existing(repo_root, mypy_targets)
 
-    return ruff_targets, mypy_targets, existing_ruff_targets, existing_mypy_targets
+    return (
+        ruff_targets,
+        mypy_targets,
+        existing_ruff_targets,
+        existing_mypy_targets,
+        used_tooling_smoke_targets,
+    )
 
 
 def populate_targets(
@@ -234,7 +267,9 @@ def render_target_list(paths: list[str]) -> str:
     return "<br>".join(f"`{path}`" for path in paths)
 
 
-def is_significant_regression(base: CommandResult | None, head: CommandResult | None) -> bool:
+def is_significant_regression(
+    base: CommandResult | None, head: CommandResult | None
+) -> bool:
     if base is None or head is None:
         return False
     if base.returncode != 0 or head.returncode != 0:
@@ -289,23 +324,38 @@ def main() -> int:
     summary_file = Path(summary_path) if summary_path else None
 
     changed_paths = get_changed_paths(repo_root, args.base_ref, args.head_ref)
-    ruff_targets, mypy_targets, existing_ruff_targets, existing_mypy_targets = collect_targets(
-        repo_root, changed_paths
-    )
+    (
+        ruff_targets,
+        mypy_targets,
+        existing_ruff_targets,
+        existing_mypy_targets,
+        used_tooling_smoke_targets,
+    ) = collect_targets(repo_root, changed_paths)
 
-    all_head_targets = sorted(
-        set(ruff_targets).union(mypy_targets)
-    )
+    all_head_targets = sorted(set(ruff_targets).union(mypy_targets))
 
     append_summary(summary_file, "## PR Fast Checks\n")
-    append_summary(summary_file, "### Changed files considered\n")
+    append_summary(summary_file, "### Changed paths\n")
+    append_summary(
+        summary_file,
+        "\n".join(f"- `{path}`" for path in changed_paths) + "\n",
+    )
+    append_summary(summary_file, "\n### Check targets\n")
+    if used_tooling_smoke_targets:
+        append_summary(
+            summary_file,
+            "- Tooling-only change detected; using the smoke target set.\n",
+        )
     if all_head_targets:
         append_summary(
             summary_file,
             "\n".join(f"- `{target}`" for target in all_head_targets) + "\n",
         )
     else:
-        append_summary(summary_file, "- No Python or notebook targets matched the fast-check rules.\n")
+        append_summary(
+            summary_file,
+            "- No Python or notebook targets matched the fast-check rules.\n",
+        )
         print("No Python or notebook targets matched the fast-check rules.")
         return 0
 
@@ -369,21 +419,28 @@ def main() -> int:
 
     regressions: list[str] = []
     for unit in units:
-        base_result = base_results[unit.name]
-        head_result = head_results[unit.name]
+        summary_base_result = base_results[unit.name]
+        summary_head_result = head_results[unit.name]
 
         delta_cell = "_n/a_"
         note = ""
-        if base_result is not None and head_result is not None:
-            delta_seconds = head_result.duration_seconds - base_result.duration_seconds
+        if summary_base_result is not None and summary_head_result is not None:
+            delta_seconds = (
+                summary_head_result.duration_seconds
+                - summary_base_result.duration_seconds
+            )
             delta_cell = f"{delta_seconds:+.2f}s"
-            if base_result.targets != head_result.targets:
+            if summary_base_result.targets != summary_head_result.targets:
                 note = "target set changed"
-            elif is_significant_regression(base_result, head_result):
+            elif is_significant_regression(
+                summary_base_result, summary_head_result
+            ):
                 note = "significant increase"
                 regressions.append(
-                    f"`{unit.name}` increased from {base_result.duration_seconds:.2f}s "
-                    f"to {head_result.duration_seconds:.2f}s on the same target set."
+                    f"`{unit.name}` increased from "
+                    f"{summary_base_result.duration_seconds:.2f}s to "
+                    f"{summary_head_result.duration_seconds:.2f}s on the same "
+                    f"target set."
                 )
             else:
                 note = "within threshold"
@@ -396,8 +453,8 @@ def main() -> int:
                     unit.name,
                     render_target_list(unit.base_targets),
                     render_target_list(unit.head_targets),
-                    format_result_cell(base_result),
-                    format_result_cell(head_result),
+                    format_result_cell(summary_base_result),
+                    format_result_cell(summary_head_result),
                     delta_cell,
                     note or "_n/a_",
                 ]

--- a/.github/scripts/run_pr_fast_checks.py
+++ b/.github/scripts/run_pr_fast_checks.py
@@ -1,0 +1,431 @@
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+
+RUFF_DIRECTORIES = ("docling", "tests", "docs/examples", ".github/scripts")
+MYPY_DIRECTORIES = ("docling", ".github/scripts")
+RELATIVE_INCREASE_THRESHOLD = 0.5
+ABSOLUTE_INCREASE_THRESHOLD_SECONDS = 2.0
+
+
+@dataclass(slots=True)
+class CheckUnit:
+    name: str
+    command: list[str]
+    base_targets: list[str]
+    head_targets: list[str]
+
+
+@dataclass(slots=True)
+class CommandResult:
+    unit_name: str
+    label: str
+    targets: list[str]
+    duration_seconds: float
+    returncode: int
+    stdout: str
+    stderr: str
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Run cheap PR-target lint and typing checks on changed files only, "
+            "then compare timings against the base snapshot."
+        )
+    )
+    parser.add_argument("--repo-root", type=Path, required=True)
+    parser.add_argument("--base-ref", required=True)
+    parser.add_argument("--head-ref", required=True)
+    return parser.parse_args()
+
+
+def run_command(
+    args: list[str],
+    *,
+    cwd: Path,
+    env: dict[str, str],
+    unit_name: str,
+    label: str,
+    targets: list[str],
+) -> CommandResult:
+    start = time.perf_counter()
+    completed = subprocess.run(
+        args,
+        cwd=cwd,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    duration_seconds = time.perf_counter() - start
+
+    return CommandResult(
+        unit_name=unit_name,
+        label=label,
+        targets=targets,
+        duration_seconds=duration_seconds,
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+    )
+
+
+def run_git_text(repo_root: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout
+
+
+def run_git_bytes(repo_root: Path, *args: str) -> bytes:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        capture_output=True,
+        check=True,
+    )
+    return completed.stdout
+
+
+def get_changed_paths(repo_root: Path, base_ref: str, head_ref: str) -> list[str]:
+    output = run_git_text(
+        repo_root,
+        "diff",
+        "--name-only",
+        "--diff-filter=ACMR",
+        base_ref,
+        head_ref,
+    )
+    return [line for line in output.splitlines() if line]
+
+
+def is_python_or_notebook_file(path: str, directories: tuple[str, ...]) -> bool:
+    suffix = Path(path).suffix
+    if suffix not in {".py", ".ipynb"}:
+        return False
+
+    return any(path == directory or path.startswith(f"{directory}/") for directory in directories)
+
+
+def is_mypy_target(path: str) -> bool:
+    if Path(path).suffix != ".py":
+        return False
+
+    return any(path == directory or path.startswith(f"{directory}/") for directory in MYPY_DIRECTORIES)
+
+
+def filter_existing(repo_root: Path, paths: list[str]) -> list[str]:
+    return [path for path in paths if (repo_root / path).exists()]
+
+
+def overlay_head_files(repo_root: Path, head_ref: str, paths: list[str]) -> None:
+    for relative_path in paths:
+        output_path = repo_root / relative_path
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(
+            run_git_bytes(repo_root, "show", f"{head_ref}:{relative_path}")
+        )
+
+
+def resolve_executable(repo_root: Path, executable_name: str) -> Path:
+    venv_executable = repo_root / f".venv/bin/{executable_name}"
+    if venv_executable.exists():
+        return venv_executable
+
+    system_executable = shutil.which(executable_name)
+    if system_executable is None:
+        raise FileNotFoundError(f"Could not find `{executable_name}` in .venv or on PATH.")
+
+    return Path(system_executable)
+
+
+def build_check_units(repo_root: Path) -> list[CheckUnit]:
+    ruff_executable = resolve_executable(repo_root, "ruff")
+    mypy_executable = resolve_executable(repo_root, "mypy")
+    config_path = repo_root / "pyproject.toml"
+
+    return [
+        CheckUnit(
+            name="ruff-format",
+            command=[
+                str(ruff_executable),
+                "format",
+                "--check",
+                "--config",
+                str(config_path),
+            ],
+            base_targets=[],
+            head_targets=[],
+        ),
+        CheckUnit(
+            name="ruff-lint",
+            command=[
+                str(ruff_executable),
+                "check",
+                "--config",
+                str(config_path),
+            ],
+            base_targets=[],
+            head_targets=[],
+        ),
+        CheckUnit(
+            name="mypy",
+            command=[
+                str(mypy_executable),
+                "--config-file",
+                str(config_path),
+            ],
+            base_targets=[],
+            head_targets=[],
+        ),
+    ]
+
+
+def collect_targets(
+    repo_root: Path, changed_paths: list[str]
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    ruff_targets = [
+        path
+        for path in changed_paths
+        if is_python_or_notebook_file(path, RUFF_DIRECTORIES)
+    ]
+    mypy_targets = [path for path in changed_paths if is_mypy_target(path)]
+
+    existing_ruff_targets = filter_existing(repo_root, ruff_targets)
+    existing_mypy_targets = filter_existing(repo_root, mypy_targets)
+
+    return ruff_targets, mypy_targets, existing_ruff_targets, existing_mypy_targets
+
+
+def populate_targets(
+    units: list[CheckUnit],
+    *,
+    ruff_targets: list[str],
+    mypy_targets: list[str],
+    existing_ruff_targets: list[str],
+    existing_mypy_targets: list[str],
+) -> None:
+    for unit in units:
+        if unit.name.startswith("ruff"):
+            unit.base_targets = existing_ruff_targets
+            unit.head_targets = ruff_targets
+        else:
+            unit.base_targets = existing_mypy_targets
+            unit.head_targets = mypy_targets
+
+
+def render_target_list(paths: list[str]) -> str:
+    if not paths:
+        return "_none_"
+
+    return "<br>".join(f"`{path}`" for path in paths)
+
+
+def is_significant_regression(base: CommandResult | None, head: CommandResult | None) -> bool:
+    if base is None or head is None:
+        return False
+    if base.returncode != 0 or head.returncode != 0:
+        return False
+    if base.targets != head.targets:
+        return False
+
+    delta_seconds = head.duration_seconds - base.duration_seconds
+    if delta_seconds < ABSOLUTE_INCREASE_THRESHOLD_SECONDS:
+        return False
+
+    if base.duration_seconds <= 0:
+        return True
+
+    relative_increase = delta_seconds / base.duration_seconds
+    return relative_increase >= RELATIVE_INCREASE_THRESHOLD
+
+
+def format_result_cell(result: CommandResult | None) -> str:
+    if result is None:
+        return "_skipped_"
+
+    status = "passed" if result.returncode == 0 else f"failed ({result.returncode})"
+    return f"{result.duration_seconds:.2f}s<br>{status}"
+
+
+def append_summary(summary_path: Path | None, text: str) -> None:
+    if summary_path is None:
+        return
+
+    with summary_path.open("a", encoding="utf-8") as handle:
+        handle.write(text)
+        if not text.endswith("\n"):
+            handle.write("\n")
+
+
+def log_result(result: CommandResult) -> None:
+    print(
+        f"[{result.label}] {result.unit_name} on {len(result.targets)} target(s) "
+        f"finished in {result.duration_seconds:.2f}s with exit code {result.returncode}."
+    )
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    summary_file = Path(summary_path) if summary_path else None
+
+    changed_paths = get_changed_paths(repo_root, args.base_ref, args.head_ref)
+    ruff_targets, mypy_targets, existing_ruff_targets, existing_mypy_targets = collect_targets(
+        repo_root, changed_paths
+    )
+
+    all_head_targets = sorted(
+        set(ruff_targets).union(mypy_targets)
+    )
+
+    append_summary(summary_file, "## PR Fast Checks\n")
+    append_summary(summary_file, "### Changed files considered\n")
+    if all_head_targets:
+        append_summary(
+            summary_file,
+            "\n".join(f"- `{target}`" for target in all_head_targets) + "\n",
+        )
+    else:
+        append_summary(summary_file, "- No Python or notebook targets matched the fast-check rules.\n")
+        print("No Python or notebook targets matched the fast-check rules.")
+        return 0
+
+    units = build_check_units(repo_root)
+    populate_targets(
+        units,
+        ruff_targets=ruff_targets,
+        mypy_targets=mypy_targets,
+        existing_ruff_targets=existing_ruff_targets,
+        existing_mypy_targets=existing_mypy_targets,
+    )
+
+    env = os.environ.copy()
+    env.setdefault("MYPY_FORCE_COLOR", "0")
+    env.setdefault("PYTHONUTF8", "1")
+
+    base_results: dict[str, CommandResult | None] = {}
+    head_results: dict[str, CommandResult | None] = {}
+
+    for unit in units:
+        if unit.base_targets:
+            base_result = run_command(
+                [*unit.command, *unit.base_targets],
+                cwd=repo_root,
+                env=env,
+                unit_name=unit.name,
+                label="base",
+                targets=unit.base_targets,
+            )
+            log_result(base_result)
+            base_results[unit.name] = base_result
+        else:
+            base_results[unit.name] = None
+
+    overlay_head_files(repo_root, args.head_ref, all_head_targets)
+
+    head_failures: list[CommandResult] = []
+    for unit in units:
+        if unit.head_targets:
+            head_result = run_command(
+                [*unit.command, *unit.head_targets],
+                cwd=repo_root,
+                env=env,
+                unit_name=unit.name,
+                label="head",
+                targets=unit.head_targets,
+            )
+            log_result(head_result)
+            head_results[unit.name] = head_result
+            if head_result.returncode != 0:
+                head_failures.append(head_result)
+        else:
+            head_results[unit.name] = None
+
+    append_summary(summary_file, "\n### Timing comparison\n")
+    append_summary(
+        summary_file,
+        "| Unit | Base targets | Head targets | Base | Head | Delta | Timing note |\n"
+        "| --- | --- | --- | --- | --- | --- | --- |\n",
+    )
+
+    regressions: list[str] = []
+    for unit in units:
+        base_result = base_results[unit.name]
+        head_result = head_results[unit.name]
+
+        delta_cell = "_n/a_"
+        note = ""
+        if base_result is not None and head_result is not None:
+            delta_seconds = head_result.duration_seconds - base_result.duration_seconds
+            delta_cell = f"{delta_seconds:+.2f}s"
+            if base_result.targets != head_result.targets:
+                note = "target set changed"
+            elif is_significant_regression(base_result, head_result):
+                note = "significant increase"
+                regressions.append(
+                    f"`{unit.name}` increased from {base_result.duration_seconds:.2f}s "
+                    f"to {head_result.duration_seconds:.2f}s on the same target set."
+                )
+            else:
+                note = "within threshold"
+
+        append_summary(
+            summary_file,
+            "| "
+            + " | ".join(
+                [
+                    unit.name,
+                    render_target_list(unit.base_targets),
+                    render_target_list(unit.head_targets),
+                    format_result_cell(base_result),
+                    format_result_cell(head_result),
+                    delta_cell,
+                    note or "_n/a_",
+                ]
+            )
+            + " |\n",
+        )
+
+    if regressions:
+        append_summary(summary_file, "\n### Timing regressions\n")
+        append_summary(
+            summary_file,
+            "\n".join(f"- {regression}" for regression in regressions) + "\n",
+        )
+        for regression in regressions:
+            print(f"::warning::{regression}")
+    else:
+        append_summary(
+            summary_file,
+            "\n### Timing regressions\n- None detected on unchanged target sets.\n",
+        )
+
+    if head_failures:
+        failing_units = ", ".join(failure.unit_name for failure in head_failures)
+        print(f"Head checks failed: {failing_units}", file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -8,6 +8,9 @@ env:
     
 jobs:
   code-checks:
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/checks.yml
     with:
       push_coverage: false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -11,6 +11,9 @@ jobs:
     uses: ./.github/workflows/checks.yml
     with:
       push_coverage: false
+      force_all_checks: true
+      run_package_compat: true
+      python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
   pre-release-check:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,6 +5,10 @@ on:
         type: boolean
         description: "If true, the coverage results are pushed to codecov.io."
         default: true
+      run_lint:
+        type: boolean
+        description: "If true, run the full lint job in this workflow."
+        default: true
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -68,6 +72,7 @@ jobs:
               - "docling/**"
 
   lint:
+    if: ${{ inputs.run_lint }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -41,6 +41,7 @@ env:
 jobs:
   changes:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     permissions:
       contents: read
       pull-requests: read
@@ -96,6 +97,7 @@ jobs:
   lint:
     if: ${{ inputs.run_lint }}
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -132,6 +134,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.run_tests == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -201,6 +204,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.run_tests == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
@@ -275,6 +279,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.run_examples == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -368,6 +373,7 @@ jobs:
     needs: changes
     if: ${{ inputs.run_package_compat && needs.changes.outputs.run_package == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       SELECTED_PYTHON_VERSIONS: ${{ join(fromJSON(inputs.python_versions), ' ') }}
     steps:
@@ -405,6 +411,7 @@ jobs:
     needs: changes
     if: ${{ inputs.run_package_compat && needs.changes.outputs.run_package == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       SELECTED_PYTHON_VERSIONS: ${{ join(fromJSON(inputs.python_versions), ' ') }}
     steps:
@@ -483,6 +490,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.run_package == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ["3.12"]
@@ -520,6 +528,7 @@ jobs:
       - build-package
     if: ${{ needs.changes.outputs.run_package == 'true' }}
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         python-version: ["3.12"]

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,6 +9,18 @@ on:
         type: boolean
         description: "If true, run the full lint job in this workflow."
         default: true
+      force_all_checks:
+        type: boolean
+        description: "If true, run all test/example/package lanes regardless of changed-path filters."
+        default: false
+      run_package_compat:
+        type: boolean
+        description: "If true, run the cross-version package compatibility lanes."
+        default: false
+      python_versions:
+        type: string
+        description: 'JSON array of Python versions to use for multi-version jobs, e.g. ["3.10", "3.12"].'
+        default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
     secrets:
       CODECOV_TOKEN:
         required: false
@@ -33,15 +45,25 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      run_tests: ${{ steps.filter.outputs.run_tests }}
-      run_examples: ${{ steps.filter.outputs.run_examples }}
-      run_package: ${{ steps.filter.outputs.run_package }}
+      run_tests: ${{ steps.force.outputs.run_tests || steps.filter.outputs.run_tests }}
+      run_examples: ${{ steps.force.outputs.run_examples || steps.filter.outputs.run_examples }}
+      run_package: ${{ steps.force.outputs.run_package || steps.filter.outputs.run_package }}
     steps:
+      - name: Force all lanes
+        if: ${{ inputs.force_all_checks }}
+        id: force
+        run: |
+          echo "run_tests=true" >> "$GITHUB_OUTPUT"
+          echo "run_examples=true" >> "$GITHUB_OUTPUT"
+          echo "run_package=true" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v6
+        if: ${{ !inputs.force_all_checks }}
         with:
           fetch-depth: 0
 
       - name: Detect changed paths
+        if: ${{ !inputs.force_all_checks }}
         id: filter
         uses: dorny/paths-filter@v3
         with:
@@ -113,7 +135,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ${{ fromJSON(inputs.python_versions) }}
     steps:
       - uses: actions/checkout@v6
 
@@ -182,7 +204,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ${{ fromJSON(inputs.python_versions) }}
     steps:
       - uses: actions/checkout@v6
 
@@ -256,7 +278,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ${{ fromJSON(inputs.python_versions) }}
     steps:
       - uses: actions/checkout@v6
 
@@ -344,17 +366,19 @@ jobs:
 
   test-pip-install-no-lock:
     needs: changes
-    if: ${{ needs.changes.outputs.run_package == 'true' }}
+    if: ${{ inputs.run_package_compat && needs.changes.outputs.run_package == 'true' }}
     runs-on: ubuntu-latest
+    env:
+      SELECTED_PYTHON_VERSIONS: ${{ join(fromJSON(inputs.python_versions), ' ') }}
     steps:
       - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
-      - name: Test pip install across Python versions
+      - name: Test pip install across selected Python versions
         run: |
-          for py_version in 3.10 3.11 3.12 3.13 3.14; do
+          for py_version in $SELECTED_PYTHON_VERSIONS; do
             echo "=========================================="
             echo "Testing Python $py_version"
             echo "=========================================="
@@ -379,17 +403,19 @@ jobs:
 
   test-pip-install-no-dev-headers:
     needs: changes
-    if: ${{ needs.changes.outputs.run_package == 'true' }}
+    if: ${{ inputs.run_package_compat && needs.changes.outputs.run_package == 'true' }}
     runs-on: ubuntu-latest
+    env:
+      SELECTED_PYTHON_VERSIONS: ${{ join(fromJSON(inputs.python_versions), ' ') }}
     steps:
       - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v6
 
-      - name: Test pip install without dev headers across Python versions
+      - name: Test pip install without dev headers across selected Python versions
         run: |
-          for py_version in 3.10 3.11 3.12 3.13 3.14; do
+          for py_version in $SELECTED_PYTHON_VERSIONS; do
             echo "=========================================="
             echo "Testing Python $py_version (no dev headers)"
             echo "=========================================="

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,6 +23,50 @@ env:
   EXAMPLES_TO_SKIP: '^(batch_convert|compare_vlm_models|minimal|minimal_vlm_pipeline|minimal_asr_pipeline|export_multimodal|custom_convert|develop_picture_enrichment|rapidocr_with_custom_models|suryaocr_with_custom_models|offline_convert|pictures_description|pictures_description_api|vlm_pipeline_api_model|granitedocling_repetition_stopping|mlx_whisper_example|gpu_standard_pipeline|gpu_vlm_pipeline|demo_layout_vlm|post_process_ocr_with_vlm|run_with_formats_html_rendered|run_with_formats_html_rendered_mp|chart_extraction|granite_vision_table_structure)\.py$|xbrl_conversion\.ipynb$'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run_tests: ${{ steps.filter.outputs.run_tests }}
+      run_examples: ${{ steps.filter.outputs.run_examples }}
+      run_package: ${{ steps.filter.outputs.run_package }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            run_tests:
+              - ".github/workflows/ci.yml"
+              - ".github/workflows/checks.yml"
+              - "pyproject.toml"
+              - "uv.lock"
+              - "Dockerfile"
+              - "docling/**"
+              - "tests/**"
+            run_examples:
+              - ".github/workflows/ci.yml"
+              - ".github/workflows/checks.yml"
+              - "pyproject.toml"
+              - "uv.lock"
+              - "Dockerfile"
+              - "docling/**"
+              - "docs/examples/**"
+            run_package:
+              - ".github/workflows/ci.yml"
+              - ".github/workflows/checks.yml"
+              - "pyproject.toml"
+              - "uv.lock"
+              - "README.md"
+              - "LICENSE"
+              - "docling/**"
+
   lint:
     runs-on: ubuntu-latest
     strategy:
@@ -58,6 +102,8 @@ jobs:
           uv run pre-commit run --all-files
 
   run-tests-1:
+    needs: changes
+    if: ${{ needs.changes.outputs.run_tests == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -125,6 +171,8 @@ jobs:
         run: sudo chown -R $USER:$USER /var/cache/apt/archives
 
   run-tests-2:
+    needs: changes
+    if: ${{ needs.changes.outputs.run_tests == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -197,6 +245,8 @@ jobs:
         run: sudo chown -R $USER:$USER /var/cache/apt/archives
 
   run-examples:
+    needs: changes
+    if: ${{ needs.changes.outputs.run_examples == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -288,6 +338,8 @@ jobs:
         run: sudo chown -R $USER:$USER /var/cache/apt/archives
 
   test-pip-install-no-lock:
+    needs: changes
+    if: ${{ needs.changes.outputs.run_package == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -321,6 +373,8 @@ jobs:
           done
 
   test-pip-install-no-dev-headers:
+    needs: changes
+    if: ${{ needs.changes.outputs.run_package == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -395,6 +449,8 @@ jobs:
           done
 
   build-package:
+    needs: changes
+    if: ${{ needs.changes.outputs.run_package == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -429,7 +485,9 @@ jobs:
 
   test-package:
     needs:
+      - changes
       - build-package
+    if: ${{ needs.changes.outputs.run_package == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Detect changed paths
         if: ${{ !inputs.force_all_checks }}
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             run_tests:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -23,6 +23,50 @@ env:
   EXAMPLES_TO_SKIP: '^(batch_convert|compare_vlm_models|minimal|minimal_vlm_pipeline|minimal_asr_pipeline|export_multimodal|custom_convert|develop_picture_enrichment|rapidocr_with_custom_models|suryaocr_with_custom_models|offline_convert|pictures_description|pictures_description_api|vlm_pipeline_api_model|granitedocling_repetition_stopping|mlx_whisper_example|gpu_standard_pipeline|gpu_vlm_pipeline|demo_layout_vlm|post_process_ocr_with_vlm|run_with_formats_html_rendered|run_with_formats_html_rendered_mp|chart_extraction|granite_vision_table_structure)\.py$|xbrl_conversion\.ipynb$'
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run_tests: ${{ steps.filter.outputs.run_tests }}
+      run_examples: ${{ steps.filter.outputs.run_examples }}
+      run_package: ${{ steps.filter.outputs.run_package }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            run_tests:
+              - ".github/workflows/ci.yml"
+              - ".github/workflows/checks.yml"
+              - "pyproject.toml"
+              - "uv.lock"
+              - "Dockerfile"
+              - "docling/**"
+              - "tests/**"
+            run_examples:
+              - ".github/workflows/ci.yml"
+              - ".github/workflows/checks.yml"
+              - "pyproject.toml"
+              - "uv.lock"
+              - "Dockerfile"
+              - "docling/**"
+              - "docs/examples/**"
+            run_package:
+              - ".github/workflows/ci.yml"
+              - ".github/workflows/checks.yml"
+              - "pyproject.toml"
+              - "uv.lock"
+              - "README.md"
+              - "LICENSE"
+              - "docling/**"
+
   lint:
     runs-on: ubuntu-latest
     strategy:
@@ -58,6 +102,8 @@ jobs:
           uv run pre-commit run --all-files
 
   run-tests-1:
+    needs: changes
+    if: ${{ needs.changes.outputs.run_tests == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -125,6 +171,8 @@ jobs:
         run: sudo chown -R $USER:$USER /var/cache/apt/archives
 
   run-tests-2:
+    needs: changes
+    if: ${{ needs.changes.outputs.run_tests == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -197,6 +245,8 @@ jobs:
         run: sudo chown -R $USER:$USER /var/cache/apt/archives
 
   run-examples:
+    needs: changes
+    if: ${{ needs.changes.outputs.run_examples == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -288,6 +338,8 @@ jobs:
         run: sudo chown -R $USER:$USER /var/cache/apt/archives
 
   test-pip-install-no-lock:
+    needs: changes
+    if: ${{ needs.changes.outputs.run_package == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -321,6 +373,8 @@ jobs:
           done
 
   test-pip-install-no-dev-headers:
+    needs: changes
+    if: ${{ needs.changes.outputs.run_package == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -396,6 +450,8 @@ jobs:
           done
 
   build-package:
+    needs: changes
+    if: ${{ needs.changes.outputs.run_package == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -426,7 +482,9 @@ jobs:
 
   test-package:
     needs:
+      - changes
       - build-package
+    if: ${{ needs.changes.outputs.run_package == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -3,6 +3,8 @@ name: "Run Docs CI"
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - "**"
@@ -22,15 +24,22 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      run_docs: ${{ steps.filter.outputs.run_docs }}
+      run_docs: ${{ steps.manual.outputs.run_docs || steps.filter.outputs.run_docs }}
     steps:
+      - name: Mark merge queue runs to execute docs CI
+        if: ${{ github.event_name == 'merge_group' }}
+        id: manual
+        run: echo "run_docs=true" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v6
+        if: ${{ github.event_name != 'merge_group' }}
         with:
           fetch-depth: 0
 
       - name: Detect changed paths
+        if: ${{ github.event_name != 'merge_group' }}
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             run_docs:
@@ -44,7 +53,7 @@ jobs:
 
   build-docs:
     needs: changes
-    if: ${{ needs.changes.outputs.run_docs == 'true' && (github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'docling-project/docling' && github.event.pull_request.head.repo.full_name != 'docling-project/docling')) }}
+    if: ${{ needs.changes.outputs.run_docs == 'true' }}
     uses: ./.github/workflows/docs.yml
     with:
       deploy: false

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,8 +1,6 @@
 name: "Run Docs CI"
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize]
   merge_group:
     types: [checks_requested]
   push:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -1,12 +1,8 @@
 name: "Run Docs CI"
 
 on:
-  merge_group:
-    types: [checks_requested]
-  push:
-    branches:
-      - "**"
-      - "!gh-pages"
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
 
 env:
   UV_FROZEN: "1"
@@ -22,20 +18,13 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      run_docs: ${{ steps.manual.outputs.run_docs || steps.filter.outputs.run_docs }}
+      run_docs: ${{ steps.filter.outputs.run_docs }}
     steps:
-      - name: Mark merge queue runs to execute docs CI
-        if: ${{ github.event_name == 'merge_group' }}
-        id: manual
-        run: echo "run_docs=true" >> "$GITHUB_OUTPUT"
-
       - uses: actions/checkout@v6
-        if: ${{ github.event_name != 'merge_group' }}
         with:
           fetch-depth: 0
 
       - name: Detect changed paths
-        if: ${{ github.event_name != 'merge_group' }}
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -11,9 +11,40 @@ on:
 env:
   UV_FROZEN: "1"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run_docs: ${{ steps.filter.outputs.run_docs }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            run_docs:
+              - ".github/workflows/ci-docs.yml"
+              - ".github/workflows/docs.yml"
+              - "mkdocs.yml"
+              - "pyproject.toml"
+              - "uv.lock"
+              - "docling/**"
+              - "docs/**"
+
   build-docs:
-    if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'docling-project/docling' && github.event.pull_request.head.repo.full_name != 'docling-project/docling') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.run_docs == 'true' && (github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'docling-project/docling' && github.event.pull_request.head.repo.full_name != 'docling-project/docling')) }}
     uses: ./.github/workflows/docs.yml
     with:
       deploy: false

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -1,0 +1,23 @@
+name: "Run CI Main"
+
+on:
+  push:
+    branches:
+      - "main"
+  schedule:
+    - cron: "17 3 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  code-checks:
+    uses: ./.github/workflows/checks.yml
+    with:
+      run_lint: true
+      force_all_checks: true
+      run_package_compat: true
+      python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -13,6 +13,9 @@ concurrency:
 
 jobs:
   code-checks:
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/checks.yml
     with:
       run_lint: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,8 @@
 name: "Run CI"
 
 on:
-  merge_group:
-    types: [checks_requested]
-  push:
-    branches:
-      - "**"
-      - "!main"
-      - "!gh-pages"
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
   workflow_dispatch:
     inputs:
       python_versions:
@@ -42,18 +37,18 @@ jobs:
           echo "default_python_versions=${DEFAULT_PYTHON_VERSIONS}" >> "$GITHUB_OUTPUT"
           echo "full_python_versions=${FULL_PYTHON_VERSIONS}" >> "$GITHUB_OUTPUT"
 
-      - name: Mark manual and merge queue runs to execute CI
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' }}
+      - name: Mark manual runs to execute CI
+        if: ${{ github.event_name == 'workflow_dispatch' }}
         id: manual
         run: echo "run_ci=true" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v6
-        if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'merge_group' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           fetch-depth: 0
 
       - name: Detect changed paths
-        if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'merge_group' }}
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
@@ -91,8 +86,7 @@ jobs:
       run_lint: ${{ github.event_name != 'pull_request' }}
       force_all_checks: >-
         ${{
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'merge_group'
+          github.event_name == 'workflow_dispatch'
         }}
       run_package_compat: >-
         ${{

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
       pull-requests: read
     uses: ./.github/workflows/checks.yml
     with:
-      run_lint: ${{ github.event_name != 'pull_request' }}
+      run_lint: true
       force_all_checks: >-
         ${{
           github.event_name == 'workflow_dispatch'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,6 @@
 name: "Run CI"
 
 on:
-  pull_request:
-    types: [opened, reopened, synchronize, labeled, unlabeled]
   merge_group:
     types: [checks_requested]
   push:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,14 +13,18 @@ on:
   workflow_dispatch:
     inputs:
       python_versions:
-        description: 'JSON array of Python versions to run, e.g. ["3.10"] or ["3.10", "3.12", "3.14"].'
-        required: true
-        default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+        description: 'JSON array of Python versions to run. Leave empty for the full default matrix.'
+        required: false
+        default: ""
         type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
+
+env:
+  DEFAULT_PYTHON_VERSIONS: '["3.10"]'
+  FULL_PYTHON_VERSIONS: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
 
 jobs:
   changes:
@@ -31,7 +35,15 @@ jobs:
     outputs:
       run_ci: ${{ steps.manual.outputs.run_ci || steps.filter.outputs.run_ci }}
       full_matrix_override: ${{ steps.filter.outputs.full_matrix_override }}
+      default_python_versions: ${{ steps.python_versions.outputs.default_python_versions }}
+      full_python_versions: ${{ steps.python_versions.outputs.full_python_versions }}
     steps:
+      - name: Set Python version selections
+        id: python_versions
+        run: |
+          echo "default_python_versions=${DEFAULT_PYTHON_VERSIONS}" >> "$GITHUB_OUTPUT"
+          echo "full_python_versions=${FULL_PYTHON_VERSIONS}" >> "$GITHUB_OUTPUT"
+
       - name: Mark manual and merge queue runs to execute CI
         if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' }}
         id: manual
@@ -94,18 +106,18 @@ jobs:
         ${{
           (
             github.event_name == 'workflow_dispatch' &&
-            inputs.python_versions
+            (inputs.python_versions || needs.changes.outputs.full_python_versions)
           ) ||
           (
             needs.changes.outputs.full_matrix_override == 'true' &&
-            '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+            needs.changes.outputs.full_python_versions
           ) ||
           (
             github.event_name == 'pull_request' &&
             contains(github.event.pull_request.labels.*.name, 'tests:full') &&
-            '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+            needs.changes.outputs.full_python_versions
           ) ||
-          '["3.10"]'
+          needs.changes.outputs.default_python_versions
         }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,8 @@ jobs:
             run_ci:
               - ".github/workflows/ci.yml"
               - ".github/workflows/checks.yml"
+              - ".github/workflows/pr-fast-checks.yml"
+              - ".github/scripts/run_pr_fast_checks.py"
               - ".pre-commit-config.yaml"
               - "pyproject.toml"
               - "uv.lock"
@@ -48,5 +50,7 @@ jobs:
     needs: changes
     if: ${{ needs.changes.outputs.run_ci == 'true' && (github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'docling-project/docling' && github.event.pull_request.head.repo.full_name != 'docling-project/docling')) }}
     uses: ./.github/workflows/checks.yml
+    with:
+      run_lint: ${{ github.event_name == 'push' }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,19 @@ name: "Run CI"
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   push:
     branches:
       - "**"
       - "!main"
       - "!gh-pages"
+  workflow_dispatch:
+    inputs:
+      python_versions:
+        description: 'JSON array of Python versions to run, e.g. ["3.10"] or ["3.10", "3.12", "3.14"].'
+        required: true
+        default: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -20,13 +27,21 @@ jobs:
       contents: read
       pull-requests: read
     outputs:
-      run_ci: ${{ steps.filter.outputs.run_ci }}
+      run_ci: ${{ steps.manual.outputs.run_ci || steps.filter.outputs.run_ci }}
+      full_matrix_override: ${{ steps.filter.outputs.full_matrix_override }}
     steps:
+      - name: Mark manual runs to execute CI
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        id: manual
+        run: echo "run_ci=true" >> "$GITHUB_OUTPUT"
+
       - uses: actions/checkout@v6
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         with:
           fetch-depth: 0
 
       - name: Detect changed paths
+        if: ${{ github.event_name != 'workflow_dispatch' }}
         id: filter
         uses: dorny/paths-filter@v3
         with:
@@ -45,12 +60,60 @@ jobs:
               - "docling/**"
               - "tests/**"
               - "docs/examples/**"
+            full_matrix_override:
+              - ".github/workflows/ci.yml"
+              - ".github/workflows/checks.yml"
+              - "pyproject.toml"
+              - "uv.lock"
+              - "README.md"
+              - "LICENSE"
 
   code-checks:
     needs: changes
-    if: ${{ needs.changes.outputs.run_ci == 'true' && (github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'docling-project/docling' && github.event.pull_request.head.repo.full_name != 'docling-project/docling')) }}
+    if: >-
+      ${{
+        needs.changes.outputs.run_ci == 'true' &&
+        (
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'push' ||
+          (
+            github.event_name == 'pull_request' &&
+            (
+              github.event.pull_request.head.repo.full_name != github.repository ||
+              contains(github.event.pull_request.labels.*.name, 'tests:full')
+            )
+          )
+        )
+      }}
     uses: ./.github/workflows/checks.yml
     with:
-      run_lint: ${{ github.event_name == 'push' }}
+      run_lint: ${{ github.event_name != 'pull_request' }}
+      force_all_checks: ${{ github.event_name == 'workflow_dispatch' }}
+      run_package_compat: >-
+        ${{
+          github.event_name == 'workflow_dispatch' ||
+          needs.changes.outputs.full_matrix_override == 'true' ||
+          (
+            github.event_name == 'pull_request' &&
+            contains(github.event.pull_request.labels.*.name, 'tests:full')
+          )
+        }}
+      python_versions: >-
+        ${{
+          (
+            github.event_name == 'workflow_dispatch' &&
+            inputs.python_versions
+          ) ||
+          (
+            needs.changes.outputs.full_matrix_override == 'true' &&
+            '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+          ) ||
+          (
+            github.event_name == 'pull_request' &&
+            contains(github.event.pull_request.labels.*.name, 'tests:full') &&
+            '["3.10", "3.11", "3.12", "3.13", "3.14"]'
+          ) ||
+          '["3.10"]'
+        }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: "Run CI"
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
+  merge_group:
+    types: [checks_requested]
   push:
     branches:
       - "**"
@@ -30,20 +32,20 @@ jobs:
       run_ci: ${{ steps.manual.outputs.run_ci || steps.filter.outputs.run_ci }}
       full_matrix_override: ${{ steps.filter.outputs.full_matrix_override }}
     steps:
-      - name: Mark manual runs to execute CI
-        if: ${{ github.event_name == 'workflow_dispatch' }}
+      - name: Mark manual and merge queue runs to execute CI
+        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'merge_group' }}
         id: manual
         run: echo "run_ci=true" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@v6
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'merge_group' }}
         with:
           fetch-depth: 0
 
       - name: Detect changed paths
-        if: ${{ github.event_name != 'workflow_dispatch' }}
+        if: ${{ github.event_name != 'workflow_dispatch' && github.event_name != 'merge_group' }}
         id: filter
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1
         with:
           filters: |
             run_ci:
@@ -70,25 +72,15 @@ jobs:
 
   code-checks:
     needs: changes
-    if: >-
-      ${{
-        needs.changes.outputs.run_ci == 'true' &&
-        (
-          github.event_name == 'workflow_dispatch' ||
-          github.event_name == 'push' ||
-          (
-            github.event_name == 'pull_request' &&
-            (
-              github.event.pull_request.head.repo.full_name != github.repository ||
-              contains(github.event.pull_request.labels.*.name, 'tests:full')
-            )
-          )
-        )
-      }}
+    if: ${{ needs.changes.outputs.run_ci == 'true' }}
     uses: ./.github/workflows/checks.yml
     with:
       run_lint: ${{ github.event_name != 'pull_request' }}
-      force_all_checks: ${{ github.event_name == 'workflow_dispatch' }}
+      force_all_checks: >-
+        ${{
+          github.event_name == 'workflow_dispatch' ||
+          github.event_name == 'merge_group'
+        }}
       run_package_compat: >-
         ${{
           github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,44 @@ on:
       - "!main"
       - "!gh-pages"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      run_ci: ${{ steps.filter.outputs.run_ci }}
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed paths
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            run_ci:
+              - ".github/workflows/ci.yml"
+              - ".github/workflows/checks.yml"
+              - ".pre-commit-config.yaml"
+              - "pyproject.toml"
+              - "uv.lock"
+              - "Dockerfile"
+              - "README.md"
+              - "LICENSE"
+              - "docling/**"
+              - "tests/**"
+              - "docs/examples/**"
+
   code-checks:
-    if: ${{ github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'docling-project/docling' && github.event.pull_request.head.repo.full_name != 'docling-project/docling') }}
+    needs: changes
+    if: ${{ needs.changes.outputs.run_ci == 'true' && (github.event_name == 'push' || (github.event.pull_request.head.repo.full_name != 'docling-project/docling' && github.event.pull_request.head.repo.full_name != 'docling-project/docling')) }}
     uses: ./.github/workflows/checks.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,9 @@ jobs:
   code-checks:
     needs: changes
     if: ${{ needs.changes.outputs.run_ci == 'true' }}
+    permissions:
+      contents: read
+      pull-requests: read
     uses: ./.github/workflows/checks.yml
     with:
       run_lint: ${{ github.event_name != 'pull_request' }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,7 +17,7 @@ jobs:
         - name: Install uv and set the python version
           uses: astral-sh/setup-uv@v7
           with:
-            python-version: ${{ matrix.python-version }}
+            python-version: "3.12"
             enable-cache: true
         - name: Install Python Dependencies
           run: uv sync --frozen --all-extras --all-packages

--- a/.github/workflows/pr-fast-checks.yml
+++ b/.github/workflows/pr-fast-checks.yml
@@ -91,6 +91,10 @@ jobs:
         run: |
           check_script=".github/scripts/run_pr_fast_checks.py"
           if [[ ! -f "${check_script}" ]]; then
+            if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+              echo "::error::Trusted check script is missing from the base checkout."
+              exit 1
+            fi
             check_script="${RUNNER_TEMP}/run_pr_fast_checks.py"
             git show "FETCH_HEAD:.github/scripts/run_pr_fast_checks.py" > "${check_script}"
           fi

--- a/.github/workflows/pr-fast-checks.yml
+++ b/.github/workflows/pr-fast-checks.yml
@@ -89,7 +89,12 @@ jobs:
 
       - name: Run fast lint and typing checks
         run: |
-          .venv/bin/python .github/scripts/run_pr_fast_checks.py \
+          check_script=".github/scripts/run_pr_fast_checks.py"
+          if [[ ! -f "${check_script}" ]]; then
+            check_script="${RUNNER_TEMP}/run_pr_fast_checks.py"
+            git show "FETCH_HEAD:.github/scripts/run_pr_fast_checks.py" > "${check_script}"
+          fi
+          .venv/bin/python "${check_script}" \
             --repo-root "$PWD" \
             --base-ref HEAD \
             --head-ref FETCH_HEAD

--- a/.github/workflows/pr-fast-checks.yml
+++ b/.github/workflows/pr-fast-checks.yml
@@ -30,6 +30,8 @@ jobs:
   lint-and-type:
     runs-on: ubuntu-latest
     steps:
+      # Keep the worktree on the trusted base commit for dependency installation.
+      # The untrusted PR head is fetched separately and only read by the checker.
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/pr-fast-checks.yml
+++ b/.github/workflows/pr-fast-checks.yml
@@ -1,21 +1,6 @@
 name: "Run PR Fast Checks"
 
 on:
-  # Temporary validation trigger for this PR branch. Remove before merge; the
-  # permanent trigger should remain pull_request_target only.
-  pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - ".github/workflows/pr-fast-checks.yml"
-      - ".github/scripts/run_pr_fast_checks.py"
-      - ".pre-commit-config.yaml"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".github/scripts/**/*.py"
-      - "docling/**/*.py"
-      - "tests/**/*.py"
-      - "docs/examples/**/*.py"
-      - "docs/examples/**/*.ipynb"
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:
@@ -70,41 +55,12 @@ jobs:
           python-version: "3.12"
           enable-cache: true
 
-      - name: Install trusted lint and typing dependencies
-        run: |
-          if python3 - <<'PY'
-          import sys
-          import tomllib
-
-          with open("pyproject.toml", "rb") as handle:
-              dependency_groups = tomllib.load(handle).get("dependency-groups", {})
-          sys.exit(0 if "pr-fast-checks" in dependency_groups else 1)
-          PY
-          then
-            uv sync --frozen --only-group pr-fast-checks --no-install-project
-          else
-            if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
-              echo "::error::pr-fast-checks group is missing from the trusted base."
-              exit 1
-            fi
-            echo "pr-fast-checks group is not on the trusted base yet; using PR metadata for temporary pull_request validation."
-            git show "FETCH_HEAD:pyproject.toml" > pyproject.toml
-            git show "FETCH_HEAD:uv.lock" > uv.lock
-            uv sync --frozen --only-group pr-fast-checks --no-install-project
-          fi
+      - name: Install minimal trusted lint and typing dependencies
+        run: uv sync --frozen --only-group pr-fast-checks --no-install-project
 
       - name: Run fast lint and typing checks
         run: |
-          check_script=".github/scripts/run_pr_fast_checks.py"
-          if [[ ! -f "${check_script}" ]]; then
-            if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
-              echo "::error::Trusted check script is missing from the base checkout."
-              exit 1
-            fi
-            check_script="${RUNNER_TEMP}/run_pr_fast_checks.py"
-            git show "FETCH_HEAD:.github/scripts/run_pr_fast_checks.py" > "${check_script}"
-          fi
-          .venv/bin/python "${check_script}" \
+          .venv/bin/python .github/scripts/run_pr_fast_checks.py \
             --repo-root "$PWD" \
             --base-ref HEAD \
             --head-ref FETCH_HEAD

--- a/.github/workflows/pr-fast-checks.yml
+++ b/.github/workflows/pr-fast-checks.yml
@@ -1,6 +1,21 @@
 name: "Run PR Fast Checks"
 
 on:
+  # Temporary validation trigger for this PR branch. Remove before merge; the
+  # permanent trigger should remain pull_request_target only.
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - ".github/workflows/pr-fast-checks.yml"
+      - ".github/scripts/run_pr_fast_checks.py"
+      - ".pre-commit-config.yaml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/scripts/**/*.py"
+      - "docling/**/*.py"
+      - "tests/**/*.py"
+      - "docs/examples/**/*.py"
+      - "docs/examples/**/*.ipynb"
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
     paths:

--- a/.github/workflows/pr-fast-checks.yml
+++ b/.github/workflows/pr-fast-checks.yml
@@ -83,8 +83,14 @@ jobs:
           then
             uv sync --frozen --only-group pr-fast-checks --no-install-project
           else
-            echo "pr-fast-checks group is not on the trusted base yet; falling back to dev."
-            uv sync --frozen --no-default-groups --group dev --no-install-project
+            if [[ "${GITHUB_EVENT_NAME}" != "pull_request" ]]; then
+              echo "::error::pr-fast-checks group is missing from the trusted base."
+              exit 1
+            fi
+            echo "pr-fast-checks group is not on the trusted base yet; using PR metadata for temporary pull_request validation."
+            git show "FETCH_HEAD:pyproject.toml" > pyproject.toml
+            git show "FETCH_HEAD:uv.lock" > uv.lock
+            uv sync --frozen --only-group pr-fast-checks --no-install-project
           fi
 
       - name: Run fast lint and typing checks

--- a/.github/workflows/pr-fast-checks.yml
+++ b/.github/workflows/pr-fast-checks.yml
@@ -1,0 +1,52 @@
+name: "Run PR Fast Checks"
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: read
+
+env:
+  UV_FROZEN: "1"
+
+jobs:
+  lint-and-type:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Fetch PR head commit
+        run: |
+          git fetch --no-tags --depth=1 \
+            "https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git" \
+            "${{ github.event.pull_request.head.ref }}"
+          test "$(git rev-parse FETCH_HEAD)" = "${{ github.event.pull_request.head.sha }}"
+
+      - name: Install uv and set the python version
+        uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+          enable-cache: true
+
+      - name: Install trusted lint and typing dependencies
+        run: uv sync --frozen --no-default-groups --group dev --no-install-project
+
+      - name: Install Ruff
+        run: uv pip install --python .venv/bin/python ruff==0.11.5
+
+      - name: Run fast lint and typing checks
+        run: |
+          .venv/bin/python .github/scripts/run_pr_fast_checks.py \
+            --repo-root "$PWD" \
+            --base-ref HEAD \
+            --head-ref FETCH_HEAD

--- a/.github/workflows/pr-fast-checks.yml
+++ b/.github/workflows/pr-fast-checks.yml
@@ -3,17 +3,6 @@ name: "Run PR Fast Checks"
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
-    paths:
-      - ".github/workflows/pr-fast-checks.yml"
-      - ".github/scripts/run_pr_fast_checks.py"
-      - ".pre-commit-config.yaml"
-      - "pyproject.toml"
-      - "uv.lock"
-      - ".github/scripts/**/*.py"
-      - "docling/**/*.py"
-      - "tests/**/*.py"
-      - "docs/examples/**/*.py"
-      - "docs/examples/**/*.ipynb"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pr-fast-checks.yml
+++ b/.github/workflows/pr-fast-checks.yml
@@ -37,11 +37,15 @@ jobs:
           persist-credentials: false
 
       - name: Fetch PR head commit
+        env:
+          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           git fetch --no-tags --depth=1 \
-            "https://github.com/${{ github.event.pull_request.head.repo.full_name }}.git" \
-            "${{ github.event.pull_request.head.ref }}"
-          test "$(git rev-parse FETCH_HEAD)" = "${{ github.event.pull_request.head.sha }}"
+            "https://github.com/${PR_HEAD_REPO}.git" \
+            "${PR_HEAD_REF}"
+          test "$(git rev-parse FETCH_HEAD)" = "${PR_HEAD_SHA}"
 
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@v7

--- a/.github/workflows/pr-fast-checks.yml
+++ b/.github/workflows/pr-fast-checks.yml
@@ -70,8 +70,22 @@ jobs:
           python-version: "3.12"
           enable-cache: true
 
-      - name: Install minimal trusted lint and typing dependencies
-        run: uv sync --frozen --only-group pr-fast-checks --no-install-project
+      - name: Install trusted lint and typing dependencies
+        run: |
+          if python3 - <<'PY'
+          import sys
+          import tomllib
+
+          with open("pyproject.toml", "rb") as handle:
+              dependency_groups = tomllib.load(handle).get("dependency-groups", {})
+          sys.exit(0 if "pr-fast-checks" in dependency_groups else 1)
+          PY
+          then
+            uv sync --frozen --only-group pr-fast-checks --no-install-project
+          else
+            echo "pr-fast-checks group is not on the trusted base yet; falling back to dev."
+            uv sync --frozen --no-default-groups --group dev --no-install-project
+          fi
 
       - name: Run fast lint and typing checks
         run: |

--- a/.github/workflows/pr-fast-checks.yml
+++ b/.github/workflows/pr-fast-checks.yml
@@ -3,6 +3,17 @@ name: "Run PR Fast Checks"
 on:
   pull_request_target:
     types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - ".github/workflows/pr-fast-checks.yml"
+      - ".github/scripts/run_pr_fast_checks.py"
+      - ".pre-commit-config.yaml"
+      - "pyproject.toml"
+      - "uv.lock"
+      - ".github/scripts/**/*.py"
+      - "docling/**/*.py"
+      - "tests/**/*.py"
+      - "docs/examples/**/*.py"
+      - "docs/examples/**/*.ipynb"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -38,11 +49,8 @@ jobs:
           python-version: "3.12"
           enable-cache: true
 
-      - name: Install trusted lint and typing dependencies
-        run: uv sync --frozen --no-default-groups --group dev --no-install-project
-
-      - name: Install Ruff
-        run: uv pip install --python .venv/bin/python ruff==0.11.5
+      - name: Install minimal trusted lint and typing dependencies
+        run: uv sync --frozen --only-group pr-fast-checks --no-install-project
 
       - name: Run fast lint and typing checks
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,6 +244,13 @@ all = [
 ]
 
 [dependency-groups]
+pr-fast-checks = [
+    "docling-core[chunking] (>=2.73.0,<3.0.0)",
+    "mypy~=1.10",
+    "pydantic (>=2.0.0,<3.0.0)",
+    "pydantic-settings (>=2.3.0,<3.0.0)",
+    "ruff==0.11.5",
+]
 dev = [
   "pre-commit~=3.7",
   "mypy~=1.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,6 +125,13 @@ remote-serving = [
 ]
 
 [dependency-groups]
+pr-fast-checks = [
+    "docling-core[chunking] (>=2.73.0,<3.0.0)",
+    "mypy~=1.10",
+    "pydantic (>=2.0.0,<3.0.0)",
+    "pydantic-settings (>=2.3.0,<3.0.0)",
+    "ruff==0.11.5",
+]
 dev = [
     "pre-commit~=3.7",
     "mypy~=1.10",

--- a/tests/test_run_pr_fast_checks.py
+++ b/tests/test_run_pr_fast_checks.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+
+def load_fast_checks_module() -> ModuleType:
+    module_path = (
+        Path(__file__).resolve().parents[1] / ".github/scripts/run_pr_fast_checks.py"
+    )
+    spec = importlib.util.spec_from_file_location("run_pr_fast_checks", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module spec for {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+fast_checks = load_fast_checks_module()
+
+
+def write_file(repo_root: Path, relative_path: str, content: str = "pass\n") -> None:
+    file_path = repo_root / relative_path
+    file_path.parent.mkdir(parents=True, exist_ok=True)
+    file_path.write_text(content, encoding="utf-8")
+
+
+def test_collect_targets_limits_scope_to_supported_paths(tmp_path: Path) -> None:
+    write_file(tmp_path, "docling/existing_module.py")
+    write_file(tmp_path, "tests/test_fast_checks.py")
+    write_file(tmp_path, "docs/examples/demo.ipynb", "{}\n")
+    write_file(tmp_path, ".github/scripts/helper.py")
+
+    changed_paths = [
+        "README.md",
+        "docling/existing_module.py",
+        "docling/new_module.py",
+        "tests/test_fast_checks.py",
+        "docs/examples/demo.ipynb",
+        ".github/scripts/helper.py",
+        "other/outside_scope.py",
+    ]
+
+    (
+        ruff_targets,
+        mypy_targets,
+        existing_ruff_targets,
+        existing_mypy_targets,
+        used_tooling_smoke_targets,
+    ) = fast_checks.collect_targets(tmp_path, changed_paths)
+
+    assert ruff_targets == [
+        "docling/existing_module.py",
+        "docling/new_module.py",
+        "tests/test_fast_checks.py",
+        "docs/examples/demo.ipynb",
+        ".github/scripts/helper.py",
+    ]
+    assert mypy_targets == [
+        "docling/existing_module.py",
+        "docling/new_module.py",
+        ".github/scripts/helper.py",
+    ]
+    assert existing_ruff_targets == [
+        "docling/existing_module.py",
+        "tests/test_fast_checks.py",
+        "docs/examples/demo.ipynb",
+        ".github/scripts/helper.py",
+    ]
+    assert existing_mypy_targets == [
+        "docling/existing_module.py",
+        ".github/scripts/helper.py",
+    ]
+    assert used_tooling_smoke_targets is False
+
+
+def test_collect_targets_uses_smoke_target_for_tooling_only_changes(
+    tmp_path: Path,
+) -> None:
+    write_file(tmp_path, fast_checks.SMOKE_CHECK_TARGET)
+
+    (
+        ruff_targets,
+        mypy_targets,
+        existing_ruff_targets,
+        existing_mypy_targets,
+        used_tooling_smoke_targets,
+    ) = fast_checks.collect_targets(tmp_path, ["pyproject.toml"])
+
+    assert ruff_targets == [fast_checks.SMOKE_CHECK_TARGET]
+    assert mypy_targets == [fast_checks.SMOKE_CHECK_TARGET]
+    assert existing_ruff_targets == [fast_checks.SMOKE_CHECK_TARGET]
+    assert existing_mypy_targets == [fast_checks.SMOKE_CHECK_TARGET]
+    assert used_tooling_smoke_targets is True
+
+
+def test_collect_targets_skips_unrelated_changes(tmp_path: Path) -> None:
+    (
+        ruff_targets,
+        mypy_targets,
+        existing_ruff_targets,
+        existing_mypy_targets,
+        used_tooling_smoke_targets,
+    ) = fast_checks.collect_targets(tmp_path, ["README.md"])
+
+    assert ruff_targets == []
+    assert mypy_targets == []
+    assert existing_ruff_targets == []
+    assert existing_mypy_targets == []
+    assert used_tooling_smoke_targets is False
+
+
+def test_build_check_units_uses_fast_mypy_flags(monkeypatch) -> None:
+    monkeypatch.setattr(
+        fast_checks,
+        "resolve_executable",
+        lambda repo_root, executable_name: Path(f"/tmp/{executable_name}"),
+    )
+
+    units = fast_checks.build_check_units(Path("/tmp/repo"))
+    mypy_unit = next(unit for unit in units if unit.name == "mypy")
+
+    assert mypy_unit.command == [
+        "/tmp/mypy",
+        "--config-file",
+        "/tmp/repo/pyproject.toml",
+        "--follow-imports",
+        "skip",
+        "--ignore-missing-imports",
+    ]
+
+
+def test_significant_regression_requires_same_successful_target_set() -> None:
+    base = fast_checks.CommandResult(
+        unit_name="mypy",
+        label="base",
+        targets=["docling/module.py"],
+        duration_seconds=3.0,
+        returncode=0,
+        stdout="",
+        stderr="",
+    )
+    head = fast_checks.CommandResult(
+        unit_name="mypy",
+        label="head",
+        targets=["docling/module.py"],
+        duration_seconds=5.2,
+        returncode=0,
+        stdout="",
+        stderr="",
+    )
+    different_targets = fast_checks.CommandResult(
+        unit_name="mypy",
+        label="head",
+        targets=["docling/other.py"],
+        duration_seconds=5.2,
+        returncode=0,
+        stdout="",
+        stderr="",
+    )
+
+    assert fast_checks.is_significant_regression(base, head) is True
+    assert fast_checks.is_significant_regression(base, different_targets) is False

--- a/uv.lock
+++ b/uv.lock
@@ -1239,6 +1239,13 @@ examples = [
     { name = "modelscope" },
     { name = "python-dotenv" },
 ]
+pr-fast-checks = [
+    { name = "docling-core", extra = ["chunking"] },
+    { name = "mypy" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "ruff" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1341,6 +1348,13 @@ examples = [
     { name = "langchain-text-splitters", specifier = ">=0.2" },
     { name = "modelscope", specifier = ">=1.29.0" },
     { name = "python-dotenv", specifier = "~=1.0" },
+]
+pr-fast-checks = [
+    { name = "docling-core", extras = ["chunking"], specifier = ">=2.73.0,<3.0.0" },
+    { name = "mypy", specifier = "~=1.10" },
+    { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
+    { name = "pydantic-settings", specifier = ">=2.3.0,<3.0.0" },
+    { name = "ruff", specifier = "==0.11.5" },
 ]
 
 [[package]]
@@ -6188,6 +6202,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/a4/c2292b95246b9165cc43a0c3757e80995d58bc9b43da5cb47ad6e3535213/rtree-1.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f155bc8d6bac9dcd383481dee8c130947a4866db1d16cb6dff442329a038a0dc", size = 1555140, upload-time = "2025-08-13T19:31:58.031Z" },
     { url = "https://files.pythonhosted.org/packages/74/25/5282c8270bfcd620d3e73beb35b40ac4ab00f0a898d98ebeb41ef0989ec8/rtree-1.4.1-py3-none-win_amd64.whl", hash = "sha256:efe125f416fd27150197ab8521158662943a40f87acab8028a1aac4ad667a489", size = 389358, upload-time = "2025-08-13T19:31:59.247Z" },
     { url = "https://files.pythonhosted.org/packages/3f/50/0a9e7e7afe7339bd5e36911f0ceb15fed51945836ed803ae5afd661057fd/rtree-1.4.1-py3-none-win_arm64.whl", hash = "sha256:3d46f55729b28138e897ffef32f7ce93ac335cb67f9120125ad3742a220800f0", size = 355253, upload-time = "2025-08-13T19:32:00.296Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.11.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/71/5759b2a6b2279bb77fe15b1435b89473631c2cd6374d45ccdb6b785810be/ruff-0.11.5.tar.gz", hash = "sha256:cae2e2439cb88853e421901ec040a758960b576126dab520fa08e9de431d1bef", size = 3976488, upload-time = "2025-04-10T17:13:29.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/db/6efda6381778eec7f35875b5cbefd194904832a1153d68d36d6b269d81a8/ruff-0.11.5-py3-none-linux_armv6l.whl", hash = "sha256:2561294e108eb648e50f210671cc56aee590fb6167b594144401532138c66c7b", size = 10103150, upload-time = "2025-04-10T17:12:37.886Z" },
+    { url = "https://files.pythonhosted.org/packages/44/f2/06cd9006077a8db61956768bc200a8e52515bf33a8f9b671ee527bb10d77/ruff-0.11.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac12884b9e005c12d0bd121f56ccf8033e1614f736f766c118ad60780882a077", size = 10898637, upload-time = "2025-04-10T17:12:41.602Z" },
+    { url = "https://files.pythonhosted.org/packages/18/f5/af390a013c56022fe6f72b95c86eb7b2585c89cc25d63882d3bfe411ecf1/ruff-0.11.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4bfd80a6ec559a5eeb96c33f832418bf0fb96752de0539905cf7b0cc1d31d779", size = 10236012, upload-time = "2025-04-10T17:12:44.584Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ca/b9bf954cfed165e1a0c24b86305d5c8ea75def256707f2448439ac5e0d8b/ruff-0.11.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0947c0a1afa75dcb5db4b34b070ec2bccee869d40e6cc8ab25aca11a7d527794", size = 10415338, upload-time = "2025-04-10T17:12:47.172Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4d/2522dde4e790f1b59885283f8786ab0046958dfd39959c81acc75d347467/ruff-0.11.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ad871ff74b5ec9caa66cb725b85d4ef89b53f8170f47c3406e32ef040400b038", size = 9965277, upload-time = "2025-04-10T17:12:50.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/749f56f150eef71ce2f626a2f6988446c620af2f9ba2a7804295ca450397/ruff-0.11.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e6cf918390cfe46d240732d4d72fa6e18e528ca1f60e318a10835cf2fa3dc19f", size = 11541614, upload-time = "2025-04-10T17:12:53.783Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b2/7d9b8435222485b6aac627d9c29793ba89be40b5de11584ca604b829e960/ruff-0.11.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:56145ee1478582f61c08f21076dc59153310d606ad663acc00ea3ab5b2125f82", size = 12198873, upload-time = "2025-04-10T17:12:56.956Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e0/a1a69ef5ffb5c5f9c31554b27e030a9c468fc6f57055886d27d316dfbabd/ruff-0.11.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e5f66f8f1e8c9fc594cbd66fbc5f246a8d91f916cb9667e80208663ec3728304", size = 11670190, upload-time = "2025-04-10T17:13:00.194Z" },
+    { url = "https://files.pythonhosted.org/packages/05/61/c1c16df6e92975072c07f8b20dad35cd858e8462b8865bc856fe5d6ccb63/ruff-0.11.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80b4df4d335a80315ab9afc81ed1cff62be112bd165e162b5eed8ac55bfc8470", size = 13902301, upload-time = "2025-04-10T17:13:03.246Z" },
+    { url = "https://files.pythonhosted.org/packages/79/89/0af10c8af4363304fd8cb833bd407a2850c760b71edf742c18d5a87bb3ad/ruff-0.11.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3068befab73620b8a0cc2431bd46b3cd619bc17d6f7695a3e1bb166b652c382a", size = 11350132, upload-time = "2025-04-10T17:13:06.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e1/ecb4c687cbf15164dd00e38cf62cbab238cad05dd8b6b0fc68b0c2785e15/ruff-0.11.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5da2e710a9641828e09aa98b92c9ebbc60518fdf3921241326ca3e8f8e55b8b", size = 10312937, upload-time = "2025-04-10T17:13:08.855Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/0e53fe5e500b65934500949361e3cd290c5ba60f0324ed59d15f46479c06/ruff-0.11.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ef39f19cb8ec98cbc762344921e216f3857a06c47412030374fffd413fb8fd3a", size = 9936683, upload-time = "2025-04-10T17:13:11.378Z" },
+    { url = "https://files.pythonhosted.org/packages/04/a8/8183c4da6d35794ae7f76f96261ef5960853cd3f899c2671961f97a27d8e/ruff-0.11.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b2a7cedf47244f431fd11aa5a7e2806dda2e0c365873bda7834e8f7d785ae159", size = 10950217, upload-time = "2025-04-10T17:13:14.565Z" },
+    { url = "https://files.pythonhosted.org/packages/26/88/9b85a5a8af21e46a0639b107fcf9bfc31da4f1d263f2fc7fbe7199b47f0a/ruff-0.11.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:81be52e7519f3d1a0beadcf8e974715b2dfc808ae8ec729ecfc79bddf8dbb783", size = 11404521, upload-time = "2025-04-10T17:13:17.8Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/52/047f35d3b20fd1ae9ccfe28791ef0f3ca0ef0b3e6c1a58badd97d450131b/ruff-0.11.5-py3-none-win32.whl", hash = "sha256:e268da7b40f56e3eca571508a7e567e794f9bfcc0f412c4b607931d3af9c4afe", size = 10320697, upload-time = "2025-04-10T17:13:20.582Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/fe/00c78010e3332a6e92762424cf4c1919065707e962232797d0b57fd8267e/ruff-0.11.5-py3-none-win_amd64.whl", hash = "sha256:6c6dc38af3cfe2863213ea25b6dc616d679205732dc0fb673356c2d69608f800", size = 11378665, upload-time = "2025-04-10T17:13:23.349Z" },
+    { url = "https://files.pythonhosted.org/packages/43/7c/c83fe5cbb70ff017612ff36654edfebec4b1ef79b558b8e5fd933bab836b/ruff-0.11.5-py3-none-win_arm64.whl", hash = "sha256:67e241b4314f4eacf14a601d586026a962f4002a475aa702c69980a38087aa4e", size = 10460287, upload-time = "2025-04-10T17:13:26.538Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1540,6 +1540,13 @@ examples = [
     { name = "modelscope" },
     { name = "python-dotenv" },
 ]
+pr-fast-checks = [
+    { name = "docling-core", extra = ["chunking"] },
+    { name = "mypy" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+    { name = "ruff" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -1652,6 +1659,13 @@ examples = [
     { name = "langchain-text-splitters", specifier = ">=0.2" },
     { name = "modelscope", specifier = ">=1.29.0" },
     { name = "python-dotenv", specifier = "~=1.0" },
+]
+pr-fast-checks = [
+    { name = "docling-core", extras = ["chunking"], specifier = ">=2.73.0,<3.0.0" },
+    { name = "mypy", specifier = "~=1.10" },
+    { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
+    { name = "pydantic-settings", specifier = ">=2.3.0,<3.0.0" },
+    { name = "ruff", specifier = "==0.11.5" },
 ]
 
 [[package]]
@@ -6435,6 +6449,31 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/a4/c2292b95246b9165cc43a0c3757e80995d58bc9b43da5cb47ad6e3535213/rtree-1.4.1-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:f155bc8d6bac9dcd383481dee8c130947a4866db1d16cb6dff442329a038a0dc", size = 1555140, upload-time = "2025-08-13T19:31:58.031Z" },
     { url = "https://files.pythonhosted.org/packages/74/25/5282c8270bfcd620d3e73beb35b40ac4ab00f0a898d98ebeb41ef0989ec8/rtree-1.4.1-py3-none-win_amd64.whl", hash = "sha256:efe125f416fd27150197ab8521158662943a40f87acab8028a1aac4ad667a489", size = 389358, upload-time = "2025-08-13T19:31:59.247Z" },
     { url = "https://files.pythonhosted.org/packages/3f/50/0a9e7e7afe7339bd5e36911f0ceb15fed51945836ed803ae5afd661057fd/rtree-1.4.1-py3-none-win_arm64.whl", hash = "sha256:3d46f55729b28138e897ffef32f7ce93ac335cb67f9120125ad3742a220800f0", size = 355253, upload-time = "2025-08-13T19:32:00.296Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.11.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/71/5759b2a6b2279bb77fe15b1435b89473631c2cd6374d45ccdb6b785810be/ruff-0.11.5.tar.gz", hash = "sha256:cae2e2439cb88853e421901ec040a758960b576126dab520fa08e9de431d1bef", size = 3976488, upload-time = "2025-04-10T17:13:29.369Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/db/6efda6381778eec7f35875b5cbefd194904832a1153d68d36d6b269d81a8/ruff-0.11.5-py3-none-linux_armv6l.whl", hash = "sha256:2561294e108eb648e50f210671cc56aee590fb6167b594144401532138c66c7b", size = 10103150, upload-time = "2025-04-10T17:12:37.886Z" },
+    { url = "https://files.pythonhosted.org/packages/44/f2/06cd9006077a8db61956768bc200a8e52515bf33a8f9b671ee527bb10d77/ruff-0.11.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ac12884b9e005c12d0bd121f56ccf8033e1614f736f766c118ad60780882a077", size = 10898637, upload-time = "2025-04-10T17:12:41.602Z" },
+    { url = "https://files.pythonhosted.org/packages/18/f5/af390a013c56022fe6f72b95c86eb7b2585c89cc25d63882d3bfe411ecf1/ruff-0.11.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:4bfd80a6ec559a5eeb96c33f832418bf0fb96752de0539905cf7b0cc1d31d779", size = 10236012, upload-time = "2025-04-10T17:12:44.584Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ca/b9bf954cfed165e1a0c24b86305d5c8ea75def256707f2448439ac5e0d8b/ruff-0.11.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0947c0a1afa75dcb5db4b34b070ec2bccee869d40e6cc8ab25aca11a7d527794", size = 10415338, upload-time = "2025-04-10T17:12:47.172Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4d/2522dde4e790f1b59885283f8786ab0046958dfd39959c81acc75d347467/ruff-0.11.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ad871ff74b5ec9caa66cb725b85d4ef89b53f8170f47c3406e32ef040400b038", size = 9965277, upload-time = "2025-04-10T17:12:50.628Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/7a/749f56f150eef71ce2f626a2f6988446c620af2f9ba2a7804295ca450397/ruff-0.11.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e6cf918390cfe46d240732d4d72fa6e18e528ca1f60e318a10835cf2fa3dc19f", size = 11541614, upload-time = "2025-04-10T17:12:53.783Z" },
+    { url = "https://files.pythonhosted.org/packages/89/b2/7d9b8435222485b6aac627d9c29793ba89be40b5de11584ca604b829e960/ruff-0.11.5-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:56145ee1478582f61c08f21076dc59153310d606ad663acc00ea3ab5b2125f82", size = 12198873, upload-time = "2025-04-10T17:12:56.956Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e0/a1a69ef5ffb5c5f9c31554b27e030a9c468fc6f57055886d27d316dfbabd/ruff-0.11.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e5f66f8f1e8c9fc594cbd66fbc5f246a8d91f916cb9667e80208663ec3728304", size = 11670190, upload-time = "2025-04-10T17:13:00.194Z" },
+    { url = "https://files.pythonhosted.org/packages/05/61/c1c16df6e92975072c07f8b20dad35cd858e8462b8865bc856fe5d6ccb63/ruff-0.11.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80b4df4d335a80315ab9afc81ed1cff62be112bd165e162b5eed8ac55bfc8470", size = 13902301, upload-time = "2025-04-10T17:13:03.246Z" },
+    { url = "https://files.pythonhosted.org/packages/79/89/0af10c8af4363304fd8cb833bd407a2850c760b71edf742c18d5a87bb3ad/ruff-0.11.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3068befab73620b8a0cc2431bd46b3cd619bc17d6f7695a3e1bb166b652c382a", size = 11350132, upload-time = "2025-04-10T17:13:06.209Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/e1/ecb4c687cbf15164dd00e38cf62cbab238cad05dd8b6b0fc68b0c2785e15/ruff-0.11.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f5da2e710a9641828e09aa98b92c9ebbc60518fdf3921241326ca3e8f8e55b8b", size = 10312937, upload-time = "2025-04-10T17:13:08.855Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/0e53fe5e500b65934500949361e3cd290c5ba60f0324ed59d15f46479c06/ruff-0.11.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ef39f19cb8ec98cbc762344921e216f3857a06c47412030374fffd413fb8fd3a", size = 9936683, upload-time = "2025-04-10T17:13:11.378Z" },
+    { url = "https://files.pythonhosted.org/packages/04/a8/8183c4da6d35794ae7f76f96261ef5960853cd3f899c2671961f97a27d8e/ruff-0.11.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:b2a7cedf47244f431fd11aa5a7e2806dda2e0c365873bda7834e8f7d785ae159", size = 10950217, upload-time = "2025-04-10T17:13:14.565Z" },
+    { url = "https://files.pythonhosted.org/packages/26/88/9b85a5a8af21e46a0639b107fcf9bfc31da4f1d263f2fc7fbe7199b47f0a/ruff-0.11.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:81be52e7519f3d1a0beadcf8e974715b2dfc808ae8ec729ecfc79bddf8dbb783", size = 11404521, upload-time = "2025-04-10T17:13:17.8Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/52/047f35d3b20fd1ae9ccfe28791ef0f3ca0ef0b3e6c1a58badd97d450131b/ruff-0.11.5-py3-none-win32.whl", hash = "sha256:e268da7b40f56e3eca571508a7e567e794f9bfcc0f412c4b607931d3af9c4afe", size = 10320697, upload-time = "2025-04-10T17:13:20.582Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/fe/00c78010e3332a6e92762424cf4c1919065707e962232797d0b57fd8267e/ruff-0.11.5-py3-none-win_amd64.whl", hash = "sha256:6c6dc38af3cfe2863213ea25b6dc616d679205732dc0fb673356c2d69608f800", size = 11378665, upload-time = "2025-04-10T17:13:23.349Z" },
+    { url = "https://files.pythonhosted.org/packages/43/7c/c83fe5cbb70ff017612ff36654edfebec4b1ef79b558b8e5fd933bab836b/ruff-0.11.5-py3-none-win_arm64.whl", hash = "sha256:67e241b4314f4eacf14a601d586026a962f4002a475aa702c69980a38087aa4e", size = 10460287, upload-time = "2025-04-10T17:13:26.538Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add PR concurrency to the CI entry workflows
- add simple path-based change detection before calling the reusable CI and docs workflows
- gate the expensive checks jobs by changed paths while keeping `pyproject.toml`, `uv.lock`, and `Dockerfile` as CI-triggering paths

Part of #3327.

## Testing
- Ruby YAML parse for `.github/workflows/ci.yml`, `.github/workflows/ci-docs.yml`, and `.github/workflows/checks.yml`
- `git diff --check`

## Notes
- this intentionally uses simple path-based skipping only for phase 1
- no GitHub-hosted workflow run was executed locally


```
The action dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d is not allowed in docling-project/docling because all actions must be from a repository owned by docling-project, created by GitHub, or match one of the patterns: DavidAnson/markdownlint-cli2-action@v16, astral-sh/setup-uv@v5, astral-sh/setup-uv@v6, astral-sh/setup-uv@v7, codecov/codecov-action@*, codecov/codecov-action@v2, codecov/codecov-action@v5, demodrive-ai/llms-txt-action@ad720693843126e6a73910a667d0eba37c1dea4b, denoland/setup-deno@*, dependabot/*, docker/*, docker/setup-qemu-action@v3, dorny/test-reporter*, gradle/actions/*, gradle/actions/wrapper-validation@v5, jreleaser/release-action@*, madrapps/jacoco-report@v1.7.2, mikepenz/action-junit-report*, mikepenz/action-junit-report@v4, msys2/setup-msys2@v2, peter-evans/create-pull-request*, pypa/cibuildwheel@*, pypa/gh-action-pypi-publish@release/v1, redhat-actions/buildah-build@*, redhat-actions/push-to-registry@*, sigstore/gh-action-sigstore-python@v3.0.0...
```

we will have to modify the list of allowed CI actions