### PR TITLE
fix: strengthen input validation for METS‑GBS processing

### DIFF
--- a/docling/backend/mets_gbs_backend.py
+++ b/docling/backend/mets_gbs_backend.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from enum import Enum
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, Final, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
 
 from docling_core.types.doc import BoundingBox, CoordOrigin, Size
 from docling_core.types.doc.page import (
@@ -21,22 +21,14 @@ from lxml import etree
 from PIL import Image
 from PIL.Image import Image as PILImage
 
-from docling.backend.abstract_backend import PaginatedDocumentBackend
 from docling.backend.pdf_backend import PdfDocumentBackend, PdfPageBackend
+from docling.datamodel.backend_options import MetsGbsBackendOptions
 from docling.datamodel.base_models import InputFormat
 
 if TYPE_CHECKING:
     from docling.datamodel.document import InputDocument
 
 _log = logging.getLogger(__name__)
-
-MAX_EXTRACT_SIZE: Final[int] = 100 * 1024 * 1024
-"""Maximum size in bytes for extracted files to prevent decompression bombs.
-
-This limit applies to individual files extracted from tar archives during
-METS-GBS document processing. Files exceeding this limit will raise a
-ValueError to prevent resource exhaustion attacks.
-"""
 
 
 def _get_pdf_page_geometry(
@@ -203,9 +195,14 @@ def _extract_confidence(title_str) -> float:
 
 
 class MetsGbsDocumentBackend(PdfDocumentBackend):
-    def __init__(self, in_doc: "InputDocument", path_or_stream: Union[BytesIO, Path]):
-        super().__init__(in_doc, path_or_stream)
-
+    def __init__(
+        self,
+        in_doc: "InputDocument",
+        path_or_stream: Union[BytesIO, Path],
+        options: MetsGbsBackendOptions = MetsGbsBackendOptions(),
+    ):
+        super().__init__(in_doc, path_or_stream, options)
+        self.options: MetsGbsBackendOptions
         self._tar: tarfile.TarFile = (
             tarfile.open(name=self.path_or_stream, mode="r:gz")
             if isinstance(self.path_or_stream, Path)
@@ -213,12 +210,31 @@ class MetsGbsDocumentBackend(PdfDocumentBackend):
         )
         self.root_mets: Optional[etree._Element] = None
         self.page_map: Dict[int, _PageFiles] = {}
+        self._total_bytes_extracted = 0
+        member_count = 0
 
         for member in self._tar.getmembers():
+            member_count += 1
+            if member_count > self.options.max_member_count:
+                raise ValueError(
+                    f"Archive exceeds maximum member count limit of {self.options.max_member_count}"
+                )
+
             if member.name.endswith(".xml"):
                 file = self._tar.extractfile(member)
                 if file is not None:
-                    content = file.read()
+                    content = file.read(self.options.max_file_bytes + 1)
+                    if len(content) > self.options.max_file_bytes:
+                        raise ValueError(
+                            f"XML file {member.name} exceeds size limit of {self.options.max_file_bytes} bytes"
+                        )
+
+                    self._total_bytes_extracted += len(content)
+                    if self._total_bytes_extracted > self.options.max_total_bytes:
+                        raise ValueError(
+                            f"Archive exceeds maximum total extraction size of {self.options.max_total_bytes} bytes"
+                        )
+
                     self.root_mets = self._validate_mets_xml(content)
                     if self.root_mets is not None:
                         break
@@ -315,17 +331,36 @@ class MetsGbsDocumentBackend(PdfDocumentBackend):
         # Security: limit extraction size to prevent decompression bombs
         image_file = self._tar.extractfile(image_info.path)
         assert image_file is not None
-        image_data = image_file.read(MAX_EXTRACT_SIZE + 1)
-        if len(image_data) > MAX_EXTRACT_SIZE:
-            raise ValueError(f"Image file {image_info.path} exceeds size limit")
+        image_data = image_file.read(self.options.max_file_bytes + 1)
+        if len(image_data) > self.options.max_file_bytes:
+            raise ValueError(
+                f"Image file {image_info.path} exceeds individual file size limit of {self.options.max_file_bytes} bytes"
+            )
+
+        # Security: Track total bytes extracted
+        self._total_bytes_extracted += len(image_data)
+        if self._total_bytes_extracted > self.options.max_total_bytes:
+            raise ValueError(
+                f"Total extracted data exceeds maximum limit of {self.options.max_total_bytes} bytes"
+            )
+
         buf = BytesIO(image_data)
         im: PILImage = Image.open(buf)
 
         ocr_file = self._tar.extractfile(ocr_info.path)
         assert ocr_file is not None
-        ocr_content = ocr_file.read(MAX_EXTRACT_SIZE + 1)
-        if len(ocr_content) > MAX_EXTRACT_SIZE:
-            raise ValueError(f"OCR file {ocr_info.path} exceeds size limit")
+        ocr_content = ocr_file.read(self.options.max_file_bytes + 1)
+        if len(ocr_content) > self.options.max_file_bytes:
+            raise ValueError(
+                f"OCR file {ocr_info.path} exceeds individual file size limit of {self.options.max_file_bytes} bytes"
+            )
+
+        # Security: Track total bytes extracted
+        self._total_bytes_extracted += len(ocr_content)
+        if self._total_bytes_extracted > self.options.max_total_bytes:
+            raise ValueError(
+                f"Total extracted data exceeds maximum limit of {self.options.max_total_bytes} bytes"
+            )
 
         parser = etree.HTMLParser(no_network=True)
         ocr_root: etree._Element = etree.fromstring(ocr_content, parser=parser)

--- a/docling/backend/mets_gbs_backend.py
+++ b/docling/backend/mets_gbs_backend.py
@@ -7,7 +7,7 @@ from dataclasses import dataclass
 from enum import Enum
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Dict, List, Optional, Set, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Final, List, Optional, Set, Tuple, Union
 
 from docling_core.types.doc import BoundingBox, CoordOrigin, Size
 from docling_core.types.doc.page import (
@@ -29,6 +29,14 @@ if TYPE_CHECKING:
     from docling.datamodel.document import InputDocument
 
 _log = logging.getLogger(__name__)
+
+MAX_EXTRACT_SIZE: Final[int] = 100 * 1024 * 1024
+"""Maximum size in bytes for extracted files to prevent decompression bombs.
+
+This limit applies to individual files extracted from tar archives during
+METS-GBS document processing. Files exceeding this limit will raise a
+ValueError to prevent resource exhaustion attacks.
+"""
 
 
 def _get_pdf_page_geometry(
@@ -283,7 +291,11 @@ class MetsGbsDocumentBackend(PdfDocumentBackend):
             self.page_map[page_no] = page_files
 
     def _validate_mets_xml(self, xml_string) -> Optional[etree._Element]:
-        root: etree._Element = etree.fromstring(xml_string)
+        # Security: disable entity resolution
+        parser = etree.XMLParser(
+            resolve_entities=False, load_dtd=False, no_network=True
+        )
+        root: etree._Element = etree.fromstring(xml_string, parser=parser)
         if (
             root.tag == "{http://www.loc.gov/METS/}mets"
             and root.get("PROFILE") == "gbs"
@@ -300,14 +312,22 @@ class MetsGbsDocumentBackend(PdfDocumentBackend):
         ocr_info = self.page_map[page_no].coordOCR
         assert ocr_info is not None
 
+        # Security: limit extraction size to prevent decompression bombs
         image_file = self._tar.extractfile(image_info.path)
         assert image_file is not None
-        buf = BytesIO(image_file.read())
+        image_data = image_file.read(MAX_EXTRACT_SIZE + 1)
+        if len(image_data) > MAX_EXTRACT_SIZE:
+            raise ValueError(f"Image file {image_info.path} exceeds size limit")
+        buf = BytesIO(image_data)
         im: PILImage = Image.open(buf)
+
         ocr_file = self._tar.extractfile(ocr_info.path)
         assert ocr_file is not None
-        ocr_content = ocr_file.read()
-        parser = etree.HTMLParser()
+        ocr_content = ocr_file.read(MAX_EXTRACT_SIZE + 1)
+        if len(ocr_content) > MAX_EXTRACT_SIZE:
+            raise ValueError(f"OCR file {ocr_info.path} exceeds size limit")
+
+        parser = etree.HTMLParser(no_network=True)
         ocr_root: etree._Element = etree.fromstring(ocr_content, parser=parser)
 
         line_cells: List[TextCell] = []

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -127,6 +127,27 @@ class PdfBackendOptions(BaseBackendOptions):
     password: Optional[SecretStr] = None
 
 
+class MetsGbsBackendOptions(PdfBackendOptions):
+    """Options specific to the METS-GBS document backend."""
+
+    kind: Annotated[Literal["mets-gbs"], Field(exclude=True, repr=False)] = "mets-gbs"  # type: ignore[assignment]
+    max_total_bytes: Annotated[
+        PositiveInt,
+        Field(
+            description="Maximum cumulative size in bytes of all data extracted from the archive during processing"
+        ),
+    ] = 300 * 1024 * 1024
+    max_file_bytes: Annotated[
+        PositiveInt,
+        Field(
+            description="Maximum size in bytes for any single file extracted from the archive"
+        ),
+    ] = 10 * 1024 * 1024
+    max_member_count: Annotated[
+        PositiveInt, Field(description="Maximum number of archive members to process")
+    ] = 1000
+
+
 class MsExcelBackendOptions(BaseBackendOptions):
     """Options specific to the MS Excel backend."""
 
@@ -194,6 +215,7 @@ BackendOptions = Annotated[
         HTMLBackendOptions,
         MarkdownBackendOptions,
         PdfBackendOptions,
+        MetsGbsBackendOptions,
         MsExcelBackendOptions,
         LatexBackendOptions,
         XBRLBackendOptions,

--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -6,6 +6,7 @@ import platform
 import re
 import sys
 import tarfile
+import warnings
 import zipfile
 from collections.abc import Iterable, Mapping
 from datetime import datetime
@@ -15,6 +16,7 @@ from pathlib import Path, PurePath
 from typing import (
     TYPE_CHECKING,
     Annotated,
+    Final,
     Literal,
     Optional,
     Type,
@@ -753,16 +755,67 @@ class _DocumentConversionInput(BaseModel):
         content = obj if isinstance(obj, Path) else obj.stream
         tar: tarfile.TarFile
         member: tarfile.TarInfo
+
+        METS_MAX_EXTRACT_SIZE: Final[int] = 10 * 1024 * 1024
+        """Maximum size in bytes for individual files during METS-GBS detection.
+
+        This limit applies to individual XML files extracted from tar archives during
+        format detection. Files exceeding this limit are skipped to prevent resource
+        exhaustion attacks.
+        """
+
+        METS_MAX_TOTAL_SIZE: Final[int] = 50 * 1024 * 1024
+        """Maximum total size in bytes for all extracted files during METS-GBS detection.
+
+        This cumulative limit prevents decompression bombs where many small files
+        collectively consume excessive resources. Extraction stops when this limit
+        is reached.
+        """
+
+        METS_MAX_MEMBER_COUNT: Final[int] = 1000
+        """Maximum number of archive members to process during METS-GBS detection.
+
+        This limit prevents attacks using archives with an excessive number of files.
+        Processing stops when this limit is reached.
+        """
+
         with tarfile.open(
             name=content if isinstance(content, Path) else None,
             fileobj=content if isinstance(content, BytesIO) else None,
             mode="r:gz",
         ) as tar:
+            total_size = 0
+            member_count = 0
+
             for member in tar.getmembers():
+                member_count += 1
+                if member_count > METS_MAX_MEMBER_COUNT:
+                    warnings.warn(
+                        f"Archive contains too many members (>{METS_MAX_MEMBER_COUNT}), "
+                        "stopping METS-GBS detection to prevent resource exhaustion"
+                    )
+                    return None
+
+                # check member size before extraction
+                if member.size > METS_MAX_EXTRACT_SIZE:
+                    continue
+
+                total_size += member.size
+                if total_size > METS_MAX_TOTAL_SIZE:
+                    warnings.warn(
+                        f"Archive total size exceeds limit ({METS_MAX_TOTAL_SIZE} bytes), "
+                        "stopping METS-GBS detection to prevent resource exhaustion"
+                    )
+                    return None
+
                 if member.name.endswith(".xml"):
                     file = tar.extractfile(member)
                     if file is not None:
-                        content_str = file.read().decode(errors="ignore")
+                        content_str = file.read(METS_MAX_EXTRACT_SIZE + 1).decode(
+                            errors="ignore"
+                        )
+                        if len(content_str) > METS_MAX_EXTRACT_SIZE:
+                            continue  # Skip if file is too large
                         if "http://www.loc.gov/METS/" in content_str:
                             return "application/mets+xml"
         return None

--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -6,7 +6,6 @@ import platform
 import re
 import sys
 import tarfile
-import warnings
 import zipfile
 from collections.abc import Iterable, Mapping
 from datetime import datetime
@@ -16,7 +15,6 @@ from pathlib import Path, PurePath
 from typing import (
     TYPE_CHECKING,
     Annotated,
-    Final,
     Literal,
     Optional,
     Type,
@@ -63,7 +61,7 @@ from docling.backend.abstract_backend import (
     DeclarativeDocumentBackend,
     PaginatedDocumentBackend,
 )
-from docling.datamodel.backend_options import BackendOptions
+from docling.datamodel.backend_options import BackendOptions, MetsGbsBackendOptions
 from docling.datamodel.base_models import (
     AssembledUnit,
     ConfidenceReport,
@@ -752,70 +750,45 @@ class _DocumentConversionInput(BaseModel):
     def _detect_mets_gbs(
         obj: Union[Path, DocumentStream],
     ) -> Optional[Literal["application/mets+xml"]]:
+        # Use default limits for safe format detection
+        default_options = MetsGbsBackendOptions()
+        max_file_bytes = default_options.max_file_bytes
+        max_member_count = default_options.max_member_count
+
         content = obj if isinstance(obj, Path) else obj.stream
         tar: tarfile.TarFile
         member: tarfile.TarInfo
+        member_count = 0
 
-        METS_MAX_EXTRACT_SIZE: Final[int] = 10 * 1024 * 1024
-        """Maximum size in bytes for individual files during METS-GBS detection.
-
-        This limit applies to individual XML files extracted from tar archives during
-        format detection. Files exceeding this limit are skipped to prevent resource
-        exhaustion attacks.
-        """
-
-        METS_MAX_TOTAL_SIZE: Final[int] = 50 * 1024 * 1024
-        """Maximum total size in bytes for all extracted files during METS-GBS detection.
-
-        This cumulative limit prevents decompression bombs where many small files
-        collectively consume excessive resources. Extraction stops when this limit
-        is reached.
-        """
-
-        METS_MAX_MEMBER_COUNT: Final[int] = 1000
-        """Maximum number of archive members to process during METS-GBS detection.
-
-        This limit prevents attacks using archives with an excessive number of files.
-        Processing stops when this limit is reached.
-        """
-
-        with tarfile.open(
-            name=content if isinstance(content, Path) else None,
-            fileobj=content if isinstance(content, BytesIO) else None,
-            mode="r:gz",
-        ) as tar:
-            total_size = 0
-            member_count = 0
-
-            for member in tar.getmembers():
-                member_count += 1
-                if member_count > METS_MAX_MEMBER_COUNT:
-                    warnings.warn(
-                        f"Archive contains too many members (>{METS_MAX_MEMBER_COUNT}), "
-                        "stopping METS-GBS detection to prevent resource exhaustion"
-                    )
-                    return None
-
-                # check member size before extraction
-                if member.size > METS_MAX_EXTRACT_SIZE:
-                    continue
-
-                total_size += member.size
-                if total_size > METS_MAX_TOTAL_SIZE:
-                    warnings.warn(
-                        f"Archive total size exceeds limit ({METS_MAX_TOTAL_SIZE} bytes), "
-                        "stopping METS-GBS detection to prevent resource exhaustion"
-                    )
-                    return None
-
-                if member.name.endswith(".xml"):
-                    file = tar.extractfile(member)
-                    if file is not None:
-                        content_str = file.read(METS_MAX_EXTRACT_SIZE + 1).decode(
-                            errors="ignore"
+        try:
+            with tarfile.open(
+                name=content if isinstance(content, Path) else None,
+                fileobj=content if isinstance(content, BytesIO) else None,
+                mode="r:gz",
+            ) as tar:
+                for member in tar.getmembers():
+                    member_count += 1
+                    if member_count > max_member_count:
+                        _log.warning(
+                            f"Archive exceeds member count limit ({max_member_count}) during format detection"
                         )
-                        if len(content_str) > METS_MAX_EXTRACT_SIZE:
-                            continue  # Skip if file is too large
-                        if "http://www.loc.gov/METS/" in content_str:
-                            return "application/mets+xml"
+                        return None
+
+                    if member.name.endswith(".xml"):
+                        file = tar.extractfile(member)
+                        if file is not None:
+                            xml_content = file.read(max_file_bytes + 1)
+                            if len(xml_content) > max_file_bytes:
+                                _log.warning(
+                                    f"XML file {member.name} exceeds size limit ({max_file_bytes} bytes) during format detection"
+                                )
+                                continue
+
+                            content_str = xml_content.decode(errors="ignore")
+                            if "http://www.loc.gov/METS/" in content_str:
+                                return "application/mets+xml"
+        except Exception as e:
+            _log.warning(f"Error during METS-GBS format detection: {e}")
+            return None
+
         return None

--- a/docling/document_converter.py
+++ b/docling/document_converter.py
@@ -40,6 +40,7 @@ from docling.datamodel.backend_options import (
     HTMLBackendOptions,
     LatexBackendOptions,
     MarkdownBackendOptions,
+    MetsGbsBackendOptions,
     PdfBackendOptions,
     XBRLBackendOptions,
 )
@@ -148,6 +149,12 @@ class PdfFormatOption(FormatOption):
     pipeline_cls: Type = StandardPdfPipeline
     backend: Type[AbstractDocumentBackend] = DoclingParseDocumentBackend
     backend_options: Optional[PdfBackendOptions] = None
+
+
+class MetsGbsFormatOption(FormatOption):
+    pipeline_cls: Type = StandardPdfPipeline
+    backend: Type[AbstractDocumentBackend] = MetsGbsDocumentBackend
+    backend_options: MetsGbsBackendOptions | None = None
 
 
 class AudioFormatOption(FormatOption):

--- a/tests/test_backend_mets_gbs.py
+++ b/tests/test_backend_mets_gbs.py
@@ -3,6 +3,7 @@ from pathlib import Path
 import pytest
 
 from docling.backend.mets_gbs_backend import MetsGbsDocumentBackend, MetsGbsPageBackend
+from docling.datamodel.backend_options import MetsGbsBackendOptions
 from docling.datamodel.base_models import BoundingBox, InputFormat
 from docling.datamodel.document import InputDocument
 
@@ -74,4 +75,113 @@ def test_num_pages(test_doc_path):
     assert doc_backend.page_count() == 3
 
     # Explicitly clean up resources to prevent race conditions in CI
+    doc_backend.unload()
+
+
+def test_max_file_bytes_limit(test_doc_path):
+    """Test that max_file_bytes limit is enforced during extraction."""
+
+    options = MetsGbsBackendOptions(max_file_bytes=100)
+
+    with pytest.raises(ValueError, match=r"exceeds.*size limit"):
+        InputDocument(
+            path_or_stream=test_doc_path,
+            format=InputFormat.METS_GBS,
+            backend=MetsGbsDocumentBackend,
+            backend_options=options,
+        )
+
+
+def test_max_total_bytes_limit(test_doc_path):
+    """Test that max_total_bytes limit is enforced across all extractions."""
+
+    options = MetsGbsBackendOptions(
+        max_file_bytes=10 * 1024 * 1024,
+        max_total_bytes=1000,
+    )
+
+    with pytest.raises(ValueError, match="exceeds maximum total extraction size"):
+        InputDocument(
+            path_or_stream=test_doc_path,
+            format=InputFormat.METS_GBS,
+            backend=MetsGbsDocumentBackend,
+            backend_options=options,
+        )
+
+
+def test_max_member_count_limit(test_doc_path):
+    """Test that max_member_count limit is enforced during extraction."""
+
+    options = MetsGbsBackendOptions(max_member_count=2)
+
+    with pytest.raises(ValueError, match="exceeds maximum member count limit"):
+        InputDocument(
+            path_or_stream=test_doc_path,
+            format=InputFormat.METS_GBS,
+            backend=MetsGbsDocumentBackend,
+            backend_options=options,
+        )
+
+
+def test_limits_with_valid_values(test_doc_path):
+    """Test that processing succeeds with generous limits."""
+    options = MetsGbsBackendOptions(
+        max_file_bytes=10 * 1024 * 1024,  # 10 MB
+        max_total_bytes=300 * 1024 * 1024,  # 300 MB
+        max_member_count=1000,
+    )
+
+    in_doc = InputDocument(
+        path_or_stream=test_doc_path,
+        format=InputFormat.METS_GBS,
+        backend=MetsGbsDocumentBackend,
+        backend_options=options,
+    )
+
+    assert in_doc.valid
+    doc_backend: MetsGbsDocumentBackend = in_doc._backend
+    assert doc_backend.is_valid()
+    assert doc_backend.page_count() == 3
+
+    page_backend: MetsGbsPageBackend = doc_backend.load_page(0)
+    assert page_backend.is_valid()
+
+    page_backend.unload()
+    doc_backend.unload()
+
+
+def test_total_bytes_tracking_across_pages(test_doc_path):
+    """Test that total bytes are tracked cumulatively across initialization and page loading.
+
+    This test ensures that when max_total_bytes is larger than max_file_bytes,
+    initialization succeeds but page loading eventually fails due to cumulative limit.
+    """
+    options = MetsGbsBackendOptions(
+        max_file_bytes=10 * 1024 * 1024,
+        max_total_bytes=20 * 1024,
+        max_member_count=1000,
+    )
+
+    in_doc = InputDocument(
+        path_or_stream=test_doc_path,
+        format=InputFormat.METS_GBS,
+        backend=MetsGbsDocumentBackend,
+        backend_options=options,
+    )
+
+    assert in_doc.valid
+    doc_backend: MetsGbsDocumentBackend = in_doc._backend
+    assert doc_backend.is_valid()
+
+    page_load_failed = False
+    for page_index in range(doc_backend.page_count()):
+        try:
+            page_backend: MetsGbsPageBackend = doc_backend.load_page(page_index)
+            page_backend.unload()
+        except ValueError as e:
+            assert "Total extracted data exceeds maximum limit" in str(e)
+            page_load_failed = True
+            break
+
+    assert page_load_failed, "Expected page loading to fail due to total bytes limit"
     doc_backend.unload()

--- a/tests/test_input_doc.py
+++ b/tests/test_input_doc.py
@@ -248,6 +248,16 @@ def test_guess_format(tmp_path):
     # Plain .txt file (not USPTO) should be detected as Markdown
     stream = DocumentStream(name="pftaps057006474.txt", stream=BytesIO(b"xyz"))
     assert dci._guess_format(stream) == InputFormat.MD
+
+    # Valid METS-GBS archive
+    mets_gbs_path = Path("./tests/data/mets_gbs/32044009881525_select.tar.gz")
+    if mets_gbs_path.exists():
+        assert dci._guess_format(mets_gbs_path) == InputFormat.METS_GBS
+
+        buf = BytesIO(mets_gbs_path.open("rb").read())
+        stream = DocumentStream(name="32044009881525_select.tar.gz", stream=buf)
+        assert dci._guess_format(stream) == InputFormat.METS_GBS
+
     doc_path = temp_dir / "pftaps_wrong.txt"
     doc_path.write_text("xyz", encoding="utf-8")
     assert dci._guess_format(doc_path) == InputFormat.MD


### PR DESCRIPTION
### Summary

Implements comprehensive resource limits for METS-GBS tar archive extraction to ensure controlled resource usage during document processing. All three configurable limits (`max_file_bytes`, `max_total_bytes`, `max_member_count`) are now properly enforced during both format detection and document processing. These limits can be customized via `MetsGbsBackendOptions` when needed.

### Changes

**Resource Management Enhancements:**
- Enforce `max_member_count` limit to control the number of archive members processed
- Enforce `max_file_bytes` limit for individual file extraction
- Enforce `max_total_bytes` limit with cumulative tracking across initialization and page loading
- Apply default limits during format detection in `_detect_mets_gbs()` with graceful error handling
- Add XML parsing safeguards

**Implementation Details:**
- **`docling/backend/mets_gbs_backend.py`**: Add limit enforcement in `__init__()` and `_parse_page()` with unified byte tracking via `self._total_bytes_extracted`
- **`docling/datamodel/backend_options.py`**: Add three limit fields to `MetsGbsBackendOptions` with clear descriptions
- **`docling/datamodel/document.py`**: Enhance `_detect_mets_gbs()` to enforce limits during format detection
- **`docling/document_converter.py`**: Add `MetsGbsBackendOptions` to format options (from previous commit)

**Test Coverage:**
- Add 5 new tests in `test_backend_mets_gbs.py` validating each limit and cumulative tracking
- Enhance `test_guess_format` in `test_input_doc.py` with METS-GBS detection

**Checklist**

- [x] Documentation updated as needed.  
- [x] Example usage added where relevant.  
- [x] Tests covering the new safeguards added.
