### PR TITLE
fix(service): allow passing HybridChunkerOptions to chunk()

### DIFF
--- a/docling/service_client/client.py
+++ b/docling/service_client/client.py
@@ -346,7 +346,7 @@ class DoclingServiceClient:
     def chunk(
         self,
         source: SourceType,
-        chunker: ChunkerKind,
+        chunker: ChunkerKind | HybridChunkerOptions | HierarchicalChunkerOptions,
         options: ConvertDocumentsRequestOptions | None = None,
     ) -> ChunkDocumentResponse:
         job = self.submit_chunk(source=source, chunker=chunker, options=options)
@@ -407,7 +407,7 @@ class DoclingServiceClient:
     def submit_chunk(
         self,
         source: SourceType,
-        chunker: ChunkerKind,
+        chunker: ChunkerKind | HybridChunkerOptions | HierarchicalChunkerOptions,
         options: ConvertDocumentsRequestOptions | None = None,
     ) -> ConversionJob[ChunkDocumentResponse]:
         resolved = self._resolve_options(
@@ -572,17 +572,20 @@ class DoclingServiceClient:
     def _submit_chunk_task(
         self,
         source: SourceType,
-        chunker: ChunkerKind,
+        chunker: ChunkerKind | HybridChunkerOptions | HierarchicalChunkerOptions,
         options: ConvertDocumentsRequestOptions,
     ) -> TaskStatusResponse:
+        chunking_options: HybridChunkerOptions | HierarchicalChunkerOptions
+        if isinstance(chunker, (HybridChunkerOptions, HierarchicalChunkerOptions)):
+            chunking_options = chunker
+        elif chunker == ChunkerKind.HYBRID:
+            chunking_options = HybridChunkerOptions()
+        else:
+            chunking_options = HierarchicalChunkerOptions()
+        chunker_kind_value = chunking_options.chunker.value
+
         if isinstance(source, str):
             self._validate_http_source(source)
-            chunking_options: HybridChunkerOptions | HierarchicalChunkerOptions
-            if chunker == ChunkerKind.HYBRID:
-                chunking_options = HybridChunkerOptions()
-            else:
-                chunking_options = HierarchicalChunkerOptions()
-
             payload = {
                 "convert_options": options.model_dump(mode="json", exclude_none=True),
                 "chunking_options": chunking_options.model_dump(
@@ -597,7 +600,7 @@ class DoclingServiceClient:
             }
             response = self._request_with_retry(
                 method="POST",
-                path=f"/v1/chunk/{chunker.value}/source/async",
+                path=f"/v1/chunk/{chunker_kind_value}/source/async",
                 json=payload,
             )
         else:
@@ -608,12 +611,7 @@ class DoclingServiceClient:
                     mode="json", exclude_none=True
                 ).items()
             }
-            chunk_model: HybridChunkerOptions | HierarchicalChunkerOptions
-            if chunker == ChunkerKind.HYBRID:
-                chunk_model = HybridChunkerOptions()
-            else:
-                chunk_model = HierarchicalChunkerOptions()
-            chunk_payload = chunk_model.model_dump(mode="json", exclude_none=True)
+            chunk_payload = chunking_options.model_dump(mode="json", exclude_none=True)
             chunk_payload.pop("chunker", None)
             data.update(
                 {f"chunking_{key}": value for key, value in chunk_payload.items()}
@@ -622,7 +620,7 @@ class DoclingServiceClient:
             data["target_type"] = "inbody"
             response = self._request_with_retry(
                 method="POST",
-                path=f"/v1/chunk/{chunker.value}/file/async",
+                path=f"/v1/chunk/{chunker_kind_value}/file/async",
                 data=data,
                 files=files,
             )

--- a/tests/test_service_client_sdk_unit.py
+++ b/tests/test_service_client_sdk_unit.py
@@ -1297,3 +1297,104 @@ def test_page_range_json_serialization_is_warning_free() -> None:
         "PydanticSerializationUnexpectedValue" not in str(warning.message)
         for warning in caught
     )
+
+
+# ── submit_chunk: ChunkerKind and ChunkerOptions ──────────────────────────────
+
+
+def test_submit_chunk_with_chunker_kind_uses_defaults(tmp_path: Path) -> None:
+    """ChunkerKind.HYBRID still works (backward compat) and sends default options."""
+    from docling.service_client import ChunkerKind
+
+    captured: dict[str, object] = {}
+    sample = tmp_path / "sample.pdf"
+    sample.write_bytes(b"%PDF-1.4\n")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["fields"] = dict(
+            (k, v) for k, v in request.headers.items() if k.startswith("content-")
+        )
+        return httpx.Response(
+            200, json=_status_response("task-chunk-1", "pending").model_dump(mode="json")
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        client._http_client.close()
+        client._http_client = httpx.Client(
+            transport=transport, timeout=client._http_client.timeout
+        )
+        job = client.submit_chunk(source=sample, chunker=ChunkerKind.HYBRID)
+
+    assert job.task_id == "task-chunk-1"
+    assert captured["path"] == "/v1/chunk/hybrid/file/async"
+
+
+def test_submit_chunk_with_hybrid_options_sends_custom_params(tmp_path: Path) -> None:
+    """HybridChunkerOptions with custom tokenizer/max_tokens/merge_peers are transmitted."""
+    from docling.datamodel.service.chunking import HybridChunkerOptions
+
+    captured: dict[str, object] = {}
+    sample = tmp_path / "sample.pdf"
+    sample.write_bytes(b"%PDF-1.4\n")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        captured["body"] = request.content
+        return httpx.Response(
+            200, json=_status_response("task-chunk-2", "pending").model_dump(mode="json")
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    chunker_opts = HybridChunkerOptions(
+        tokenizer="BAAI/bge-m3",
+        max_tokens=2500,
+        merge_peers=True,
+        include_raw_text=True,
+    )
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        client._http_client.close()
+        client._http_client = httpx.Client(
+            transport=transport, timeout=client._http_client.timeout
+        )
+        job = client.submit_chunk(source=sample, chunker=chunker_opts)
+
+    assert job.task_id == "task-chunk-2"
+    assert captured["path"] == "/v1/chunk/hybrid/file/async"
+    body = captured["body"].decode("utf-8")  # type: ignore[union-attr]
+    assert "BAAI/bge-m3" in body
+    assert "2500" in body
+    assert "include_raw_text" in body
+
+
+def test_submit_chunk_with_hierarchical_options(tmp_path: Path) -> None:
+    """HierarchicalChunkerOptions routes to the hierarchical endpoint."""
+    from docling.datamodel.service.chunking import HierarchicalChunkerOptions
+
+    captured: dict[str, object] = {}
+    sample = tmp_path / "sample.pdf"
+    sample.write_bytes(b"%PDF-1.4\n")
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["path"] = request.url.path
+        return httpx.Response(
+            200, json=_status_response("task-chunk-3", "pending").model_dump(mode="json")
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        client._http_client.close()
+        client._http_client = httpx.Client(
+            transport=transport, timeout=client._http_client.timeout
+        )
+        job = client.submit_chunk(
+            source=sample, chunker=HierarchicalChunkerOptions()
+        )
+
+    assert job.task_id == "task-chunk-3"
+    assert captured["path"] == "/v1/chunk/hierarchical/file/async"


### PR DESCRIPTION
## Problem                                                                                                                                 
            
  `chunk()`, `submit_chunk()` and `_submit_chunk_task()` only accepted a `ChunkerKind`                                                       
  enum and always instantiated `HybridChunkerOptions()` with default values internally.                                                    
  This made `tokenizer`, `max_tokens`, `merge_peers` and `include_raw_text` impossible 
  to configure from the client, even though these fields are defined on `HybridChunkerOptions`.                                              
                                                                                               
  ## Fix                                                                                                                                     
                                                                                                                                           
  The three methods now accept either a `ChunkerKind` (unchanged behaviour) or a fully
  instantiated `HybridChunkerOptions` / `HierarchicalChunkerOptions`, which is forwarded                                                     
  as-is to the service endpoint.                                                        
                                                                                                                                             
  ## Tests                                                                                                                                 
          
  Three unit tests added using `httpx.MockTransport`:
  - backward compat: `ChunkerKind.HYBRID` still routes to `/v1/chunk/hybrid/file/async`                                                      
  - custom options: `tokenizer`, `max_tokens`, `include_raw_text` appear in the request body
  - hierarchical: `HierarchicalChunkerOptions` routes to `/v1/chunk/hierarchical/file/async` 