### PR TITLE
fix(pptx)!: assign pptx notes to ContentLayer.NOTES

### DIFF
--- a/docling/backend/mspowerpoint_backend.py
+++ b/docling/backend/mspowerpoint_backend.py
@@ -756,7 +756,7 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
                             parent=parent_slide,
                             text=notes_text,
                             prov=prov,
-                            content_layer=ContentLayer.FURNITURE,
+                            content_layer=ContentLayer.NOTES,
                         )
 
         return doc

--- a/tests/data/groundtruth/docling_v2/powerpoint_sample.pptx.json
+++ b/tests/data/groundtruth/docling_v2/powerpoint_sample.pptx.json
@@ -463,7 +463,7 @@
         "$ref": "#/groups/1"
       },
       "children": [],
-      "content_layer": "furniture",
+      "content_layer": "notes",
       "label": "text",
       "prov": [
         {
@@ -979,7 +979,7 @@
         "$ref": "#/groups/3"
       },
       "children": [],
-      "content_layer": "furniture",
+      "content_layer": "notes",
       "label": "text",
       "prov": [
         {


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

Assign pptx notes to ContentLayer.NOTES instead of ContentLayer.FURNITURE.

Resolves #3340

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
