### PR TITLE
chore: breaking release guards

### DIFF
--- a/.github/mergify.yml
+++ b/.github/mergify.yml
@@ -6,6 +6,13 @@ merge_protections:
     success_conditions:
       - "title ~= ^(fix|feat|docs|style|refactor|perf|test|build|ci|chore|revert)(?:\\(.+\\\
         ))?(!)?:"
+  - name: Require three reviewers for breaking changes
+    description: Breaking changes require additional scrutiny with 3 approvers
+    if:
+      - base = main
+      - "title ~= !:"
+    success_conditions:
+      - "#approved-reviews-by >= 3"
   - name: Require two reviewer for test updates
     description: When test data is updated, we require two reviewers
     if:


### PR DESCRIPTION
To safe-guard the semantic release automation we will require three approvers for PRs which are flagged as breaking changes, i.e. the ones which will bump a major docling version.


<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
