### PR TITLE
refactor: fix mutable default arguments in backend __init__ methods

### DIFF
--- a/docling/backend/abstract_backend.py
+++ b/docling/backend/abstract_backend.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from docling_core.types.doc import DoclingDocument
 
@@ -22,13 +22,13 @@ class AbstractDocumentBackend(ABC):
         self,
         in_doc: "InputDocument",
         path_or_stream: Union[BytesIO, Path],
-        options: BaseBackendOptions = BaseBackendOptions(),
+        options: Optional[BaseBackendOptions] = None,
     ):
         self.file = in_doc.file
         self.path_or_stream = path_or_stream
         self.document_hash = in_doc.document_hash
         self.input_format = in_doc.format
-        self.options = options
+        self.options = BaseBackendOptions() if options is None else options
 
     @abstractmethod
     def is_valid(self) -> bool:
@@ -75,8 +75,10 @@ class DeclarativeDocumentBackend(AbstractDocumentBackend):
         self,
         in_doc: "InputDocument",
         path_or_stream: Union[BytesIO, Path],
-        options: BackendOptions = DeclarativeBackendOptions(),
+        options: Optional[BackendOptions] = None,
     ) -> None:
+        if options is None:
+            options = DeclarativeBackendOptions()
         super().__init__(in_doc, path_or_stream, options)
 
     @abstractmethod

--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -218,8 +218,10 @@ class DoclingParseDocumentBackend(ManagedPdfiumDocumentBackend):
         self,
         in_doc: "InputDocument",
         path_or_stream: Union[BytesIO, Path],
-        options: PdfBackendOptions = PdfBackendOptions(),
+        options: Optional[PdfBackendOptions] = None,
     ):
+        if options is None:
+            options = PdfBackendOptions()
         super().__init__(in_doc, path_or_stream, options)
 
         password = (

--- a/docling/backend/docling_parse_v2_backend.py
+++ b/docling/backend/docling_parse_v2_backend.py
@@ -1,7 +1,7 @@
 import warnings
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
 from docling.datamodel.backend_options import PdfBackendOptions
@@ -15,8 +15,10 @@ class DoclingParseV2DocumentBackend(DoclingParseDocumentBackend):
         self,
         in_doc: "InputDocument",
         path_or_stream: Union[BytesIO, Path],
-        options: PdfBackendOptions = PdfBackendOptions(),
+        options: Optional[PdfBackendOptions] = None,
     ):
+        if options is None:
+            options = PdfBackendOptions()
         warnings.warn(
             "DoclingParseV2DocumentBackend was removed in docling 2.74.0 and will raise an "
             "error in a future release. Use DoclingParseDocumentBackend instead.",

--- a/docling/backend/docling_parse_v4_backend.py
+++ b/docling/backend/docling_parse_v4_backend.py
@@ -1,7 +1,7 @@
 import warnings
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
 from docling.datamodel.backend_options import PdfBackendOptions
@@ -15,8 +15,10 @@ class DoclingParseV4DocumentBackend(DoclingParseDocumentBackend):
         self,
         in_doc: "InputDocument",
         path_or_stream: Union[BytesIO, Path],
-        options: PdfBackendOptions = PdfBackendOptions(),
+        options: Optional[PdfBackendOptions] = None,
     ):
+        if options is None:
+            options = PdfBackendOptions()
         warnings.warn(
             "DoclingParseV4DocumentBackend was removed in docling 2.74.0 and will raise an "
             "error in a future release. Use DoclingParseDocumentBackend instead.",

--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -409,8 +409,10 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         self,
         in_doc: InputDocument,
         path_or_stream: Union[BytesIO, Path],
-        options: HTMLBackendOptions = HTMLBackendOptions(),
+        options: Optional[HTMLBackendOptions] = None,
     ):
+        if options is None:
+            options = HTMLBackendOptions()
         super().__init__(in_doc, path_or_stream, options)
         self.options: HTMLBackendOptions
         self.soup: Optional[BeautifulSoup] = None

--- a/docling/backend/image_backend.py
+++ b/docling/backend/image_backend.py
@@ -1,7 +1,7 @@
 import logging
 from io import BytesIO
 from pathlib import Path
-from typing import Iterable, List, Union
+from typing import Iterable, List, Optional, Union
 
 from docling_core.types.doc import BoundingBox, CoordOrigin
 from docling_core.types.doc.page import (
@@ -133,8 +133,10 @@ class ImageDocumentBackend(PdfDocumentBackend):
         self,
         in_doc: InputDocument,
         path_or_stream: Union[BytesIO, Path],
-        options: PdfBackendOptions = PdfBackendOptions(),
+        options: Optional[PdfBackendOptions] = None,
     ):
+        if options is None:
+            options = PdfBackendOptions()
         # Bypass PdfDocumentBackend.__init__ to avoid image→PDF conversion
         AbstractDocumentBackend.__init__(self, in_doc, path_or_stream, options)
         self.options: PdfBackendOptions = options

--- a/docling/backend/latex/backend.py
+++ b/docling/backend/latex/backend.py
@@ -2,7 +2,7 @@ import logging
 import threading
 from io import BytesIO
 from pathlib import Path
-from typing import Union
+from typing import Optional, Union
 
 from docling_core.types.doc import DocItemLabel, DoclingDocument, NodeItem
 from docling_core.types.doc.document import Formatting
@@ -41,8 +41,10 @@ class LatexDocumentBackend(
         self,
         in_doc: InputDocument,
         path_or_stream: Union[BytesIO, Path],
-        options: LatexBackendOptions = LatexBackendOptions(),
+        options: Optional[LatexBackendOptions] = None,
     ):
+        if options is None:
+            options = LatexBackendOptions()
         super().__init__(in_doc, path_or_stream, options)
         self.labels: dict[str, bool] = {}
         self._custom_macros: dict[str, str] = {}

--- a/docling/backend/managed_pdfium_backend.py
+++ b/docling/backend/managed_pdfium_backend.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from io import BytesIO
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from docling.backend.pdf_backend import PdfDocumentBackend, PdfPageBackend
 from docling.datamodel.backend_options import PdfBackendOptions
@@ -19,8 +19,10 @@ class ManagedPdfiumDocumentBackend(PdfDocumentBackend, ABC):
         self,
         in_doc: InputDocument,
         path_or_stream: Union[BytesIO, Path],
-        options: PdfBackendOptions = PdfBackendOptions(),
+        options: Optional[PdfBackendOptions] = None,
     ) -> None:
+        if options is None:
+            options = PdfBackendOptions()
         super().__init__(in_doc, path_or_stream, options)
         self._closed = False
 

--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -127,8 +127,10 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         self,
         in_doc: InputDocument,
         path_or_stream: Union[BytesIO, Path],
-        options: MarkdownBackendOptions = MarkdownBackendOptions(),
+        options: Optional[MarkdownBackendOptions] = None,
     ):
+        if options is None:
+            options = MarkdownBackendOptions()
         super().__init__(in_doc, path_or_stream, options)
 
         _log.debug("Starting MarkdownDocumentBackend...")

--- a/docling/backend/mets_gbs_backend.py
+++ b/docling/backend/mets_gbs_backend.py
@@ -199,8 +199,10 @@ class MetsGbsDocumentBackend(PdfDocumentBackend):
         self,
         in_doc: "InputDocument",
         path_or_stream: Union[BytesIO, Path],
-        options: MetsGbsBackendOptions = MetsGbsBackendOptions(),
+        options: Optional[MetsGbsBackendOptions] = None,
     ):
+        if options is None:
+            options = MetsGbsBackendOptions()
         super().__init__(in_doc, path_or_stream, options)
         self.options: MetsGbsBackendOptions
         self._tar: tarfile.TarFile = (

--- a/docling/backend/msexcel_backend.py
+++ b/docling/backend/msexcel_backend.py
@@ -123,7 +123,7 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         self,
         in_doc: "InputDocument",
         path_or_stream: Union[BytesIO, Path],
-        options: MsExcelBackendOptions = MsExcelBackendOptions(),
+        options: Optional[MsExcelBackendOptions] = None,
     ) -> None:
         """Initialize the MsExcelDocumentBackend object.
 
@@ -135,6 +135,8 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         Raises:
             RuntimeError: An error occurred parsing the file.
         """
+        if options is None:
+            options = MsExcelBackendOptions()
         super().__init__(in_doc, path_or_stream, options)
 
         # Initialise the parents for the hierarchy

--- a/docling/backend/pdf_backend.py
+++ b/docling/backend/pdf_backend.py
@@ -55,8 +55,10 @@ class PdfDocumentBackend(PaginatedDocumentBackend):
         self,
         in_doc: InputDocument,
         path_or_stream: Union[BytesIO, Path],
-        options: PdfBackendOptions = PdfBackendOptions(),
+        options: Optional[PdfBackendOptions] = None,
     ):
+        if options is None:
+            options = PdfBackendOptions()
         super().__init__(in_doc, path_or_stream, options)
         self.options: PdfBackendOptions
 

--- a/docling/backend/pypdfium2_backend.py
+++ b/docling/backend/pypdfium2_backend.py
@@ -404,8 +404,10 @@ class PyPdfiumDocumentBackend(ManagedPdfiumDocumentBackend):
         self,
         in_doc: "InputDocument",
         path_or_stream: Union[BytesIO, Path],
-        options: PdfBackendOptions = PdfBackendOptions(),
+        options: Optional[PdfBackendOptions] = None,
     ):
+        if options is None:
+            options = PdfBackendOptions()
         super().__init__(in_doc, path_or_stream, options)
 
         password = (

--- a/docling/backend/xml/xbrl_backend.py
+++ b/docling/backend/xml/xbrl_backend.py
@@ -84,8 +84,10 @@ class XBRLDocumentBackend(DeclarativeDocumentBackend):
         self,
         in_doc: InputDocument,
         path_or_stream: BytesIO | Path,
-        options: XBRLBackendOptions = XBRLBackendOptions(),
+        options: XBRLBackendOptions | None = None,
     ) -> None:
+        if options is None:
+            options = XBRLBackendOptions()
         # Check if arelle is available before proceeding
         if not _XBRL_AVAILABLE:
             raise ImportError(


### PR DESCRIPTION
Replace mutable default arguments (e.g., `options=SomeOptions()`) with `None` and initialize inside functions to prevent shared state issues. Affects 15 backend classes across the codebase.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
