### PR TITLE
chore: refactor release script to use Python regex for dependency updates

### DIFF
--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -15,13 +15,30 @@ CHGLOG_FILE="${CHGLOG_FILE:-CHANGELOG.md}"
 uvx --from=toml-cli toml set --toml-path=pyproject.toml project.version "${TARGET_VERSION}"
 uvx --from=toml-cli toml set --toml-path=packages/docling/pyproject.toml project.version "${TARGET_VERSION}"
 
-# update docling-slim dependency version in docling package
-uvx --from=toml-cli toml set --toml-path=packages/docling/pyproject.toml "project.dependencies[0]" "docling-slim[standard]==${TARGET_VERSION}"
+# Update all docling-slim dependencies in docling package using Python
+TARGET_VERSION="${TARGET_VERSION}" python3 << 'PYTHON_SCRIPT'
+import os
+import re
+from pathlib import Path
 
-# update all re-exported extras in docling package
-for extra in easyocr tesserocr ocrmac vlm rapidocr asr htmlrender remote-serving onnxruntime xbrl; do
-    uvx --from=toml-cli toml set --toml-path=packages/docling/pyproject.toml "project.optional-dependencies.${extra}[0]" "docling-slim[*]==${TARGET_VERSION}"
-done
+target_version = os.environ['TARGET_VERSION']
+pyproject_path = Path("packages/docling/pyproject.toml")
+
+# Read the file
+content = pyproject_path.read_text()
+
+# Pattern to match docling-slim dependencies with version pinning
+# Matches: docling-slim[extra]==version or docling-slim==version
+pattern = r'(docling-slim(?:\[[^\]]+\])?)==[\d\.]+'
+
+# Replace all occurrences with the new version
+updated_content = re.sub(pattern, rf'\1=={target_version}', content)
+
+# Write back
+pyproject_path.write_text(updated_content)
+
+print(f"Updated all docling-slim dependencies to version {target_version}")
+PYTHON_SCRIPT
 
 UV_FROZEN=0 uv lock --upgrade-package docling --upgrade-package docling-slim
 
@@ -40,13 +57,13 @@ if [ -f "${CHGLOG_FILE}" ]; then
 fi
 mv "${TMP_CHGLOG}" "${CHGLOG_FILE}"
 
-# push changes
-git config --global user.name 'github-actions[bot]'
-git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-git add pyproject.toml packages/docling/pyproject.toml uv.lock "${CHGLOG_FILE}"
-COMMIT_MSG="chore: bump version to ${TARGET_VERSION} [skip ci]"
-git commit -m "${COMMIT_MSG}"
-git push origin main
+# # push changes
+# git config --global user.name 'github-actions[bot]'
+# git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+# git add pyproject.toml packages/docling/pyproject.toml uv.lock "${CHGLOG_FILE}"
+# COMMIT_MSG="chore: bump version to ${TARGET_VERSION} [skip ci]"
+# git commit -m "${COMMIT_MSG}"
+# git push origin main
 
-# create GitHub release (incl. Git tag)
-gh release create "${TARGET_TAG_NAME}" -F "${REL_NOTES}"
+# # create GitHub release (incl. Git tag)
+# gh release create "${TARGET_TAG_NAME}" -F "${REL_NOTES}"

--- a/.github/scripts/release.sh
+++ b/.github/scripts/release.sh
@@ -57,13 +57,13 @@ if [ -f "${CHGLOG_FILE}" ]; then
 fi
 mv "${TMP_CHGLOG}" "${CHGLOG_FILE}"
 
-# # push changes
-# git config --global user.name 'github-actions[bot]'
-# git config --global user.email 'github-actions[bot]@users.noreply.github.com'
-# git add pyproject.toml packages/docling/pyproject.toml uv.lock "${CHGLOG_FILE}"
-# COMMIT_MSG="chore: bump version to ${TARGET_VERSION} [skip ci]"
-# git commit -m "${COMMIT_MSG}"
-# git push origin main
+# push changes
+git config --global user.name 'github-actions[bot]'
+git config --global user.email 'github-actions[bot]@users.noreply.github.com'
+git add pyproject.toml packages/docling/pyproject.toml uv.lock "${CHGLOG_FILE}"
+COMMIT_MSG="chore: bump version to ${TARGET_VERSION} [skip ci]"
+git commit -m "${COMMIT_MSG}"
+git push origin main
 
-# # create GitHub release (incl. Git tag)
-# gh release create "${TARGET_TAG_NAME}" -F "${REL_NOTES}"
+# create GitHub release (incl. Git tag)
+gh release create "${TARGET_TAG_NAME}" -F "${REL_NOTES}"


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

## Description

This PR refactors the release script to improve the handling of `docling-slim` dependency version updates. Instead of using multiple `toml-cli` commands to update individual dependencies and optional extras, the script now uses a Python script with regex pattern matching to update all `docling-slim` dependencies in a single pass.

**Changes:**
- Replaced multiple `toml set` commands with an inline Python script
- Uses regex pattern matching to find and update all `docling-slim` dependencies (with or without extras) in one operation
- Simplifies the maintenance by removing the hardcoded list of extras (easyocr, tesserocr, ocrmac, vlm, rapidocr, asr, htmlrender, remote-serving, onnxruntime, xbrl)
- More robust and maintainable approach that will automatically handle any new extras without script modifications

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.