### PR TITLE
feat(vlm): upgrade Granite Vision model to 4.1 for table + chart extraction

### DIFF
--- a/docling/models/stages/chart_extraction/granite_vision.py
+++ b/docling/models/stages/chart_extraction/granite_vision.py
@@ -338,9 +338,9 @@ class ChartExtractionModelGraniteVision(_BaseChartExtractionModelGraniteVision):
 
 
 class ChartExtractionModelGraniteVisionV4(_BaseChartExtractionModelGraniteVision):
-    _model_repo_folder = "ibm-granite--granite-4.0-3b-vision"
-    _model_repo_id = "ibm-granite/granite-4.0-3b-vision"
-    _model_repo_revision = "f0d034897bae1cd438c961c8c170a3a3089ebf01"
+    _model_repo_folder = "ibm-granite--granite-vision-4.1-4b"
+    _model_repo_id = "ibm-granite/granite-vision-4.1-4b"
+    _model_repo_revision = "dd48e97503de471803850df70843cf9eb5da8712"
 
     def _load_model(self, artifacts_path: Path) -> None:
         with warnings.catch_warnings():
@@ -365,7 +365,8 @@ class ChartExtractionModelGraniteVisionV4(_BaseChartExtractionModelGraniteVision
                 dtype=torch.bfloat16,
                 trust_remote_code=True,
             )
-        cast(Any, self._model).merge_lora_adapters()
+        if hasattr(self._model, "merge_lora_adapters"):
+            cast(Any, self._model).merge_lora_adapters()
         self._model.eval()
 
     def __call__(

--- a/docling/models/stages/chart_extraction/granite_vision.py
+++ b/docling/models/stages/chart_extraction/granite_vision.py
@@ -54,6 +54,7 @@ class _BaseChartExtractionModelGraniteVision(BaseItemAndImageEnrichmentModel):
     ):
         self.enabled = enabled
         self.options = options
+        self.accelerator_options = accelerator_options
 
         if self.enabled:
             self.device = decide_device(
@@ -363,6 +364,12 @@ class ChartExtractionModelGraniteVisionV4(_BaseChartExtractionModelGraniteVision
                 artifacts_path,
                 device_map=self.device,
                 dtype=torch.bfloat16,
+                _attn_implementation=(
+                    "flash_attention_2"
+                    if self.device.startswith("cuda")
+                    and self.accelerator_options.cuda_use_flash_attention2
+                    else "sdpa"
+                ),
                 trust_remote_code=True,
             )
         if hasattr(self._model, "merge_lora_adapters"):

--- a/docling/models/stages/chart_extraction/granite_vision.py
+++ b/docling/models/stages/chart_extraction/granite_vision.py
@@ -483,11 +483,15 @@ class ChartExtractionModelGraniteVisionV4(_BaseChartExtractionModelGraniteVision
             yield item
 
     def _extract_csv_to_dataframe(self, decoded_text: str) -> pd.DataFrame:
-        # decoded_text is already the raw generated output (no conversation wrapper)
+        # decoded_text is already the raw generated output (no conversation wrapper).
+        # Prefer a fenced ```csv ... ``` block, but fall back to bare CSV if the
+        # model omits the fence (observed with granite-vision-4.1-4b).
         csv_match = re.search(r"```csv\s*\n(.*?)\n```", decoded_text, re.DOTALL)
-        if not csv_match:
-            raise ValueError("No ```csv``` block found in model output")
-        csv_content = csv_match.group(1).strip()
+        if csv_match:
+            csv_content = csv_match.group(1).strip()
+        else:
+            csv_content = re.sub(r"^```+(?:csv)?\s*", "", decoded_text.strip())
+            csv_content = re.sub(r"```+\s*$", "", csv_content).strip()
         try:
             return pd.read_csv(StringIO(csv_content), header=None)
         except Exception as e:

--- a/docling/models/stages/table_structure/table_structure_model_granite_vision.py
+++ b/docling/models/stages/table_structure/table_structure_model_granite_vision.py
@@ -140,11 +140,11 @@ def _parse_otsl_output(
 
 
 class GraniteVisionTableStructureModel(BaseTableStructureModel):
-    """Table structure model using ibm-granite/granite-4.0-3b-vision with <tables_otsl>."""
+    """Table structure model using ibm-granite/granite-vision-4.1-4b with <tables_otsl>."""
 
-    _model_repo_id: ClassVar[str] = "ibm-granite/granite-4.0-3b-vision"
-    _model_repo_folder: ClassVar[str] = "ibm-granite--granite-4.0-3b-vision"
-    _model_repo_revision: ClassVar[str] = "f0d034897bae1cd438c961c8c170a3a3089ebf01"
+    _model_repo_id: ClassVar[str] = "ibm-granite/granite-vision-4.1-4b"
+    _model_repo_folder: ClassVar[str] = "ibm-granite--granite-vision-4.1-4b"
+    _model_repo_revision: ClassVar[str] = "dd48e97503de471803850df70843cf9eb5da8712"
 
     def __init__(
         self,
@@ -224,7 +224,8 @@ class GraniteVisionTableStructureModel(BaseTableStructureModel):
                 ),
                 trust_remote_code=True,
             )
-        cast(Any, self._model).merge_lora_adapters()
+        if hasattr(self._model, "merge_lora_adapters"):
+            cast(Any, self._model).merge_lora_adapters()
         self._model.eval()
 
     def predict_tables(

--- a/docling/utils/model_downloader.py
+++ b/docling/utils/model_downloader.py
@@ -174,7 +174,7 @@ def download_models(
         )
 
     if with_granite_chart_extraction_v4:
-        _log.info("Downloading Granite Vision 4.0 Charts Extraction model...")
+        _log.info("Downloading Granite Vision 4.1 Charts Extraction model...")
         ChartExtractionModelGraniteVisionV4.download_models(
             local_dir=output_dir
             / ChartExtractionModelGraniteVisionV4._model_repo_folder,

--- a/docs/examples/granite_vision_table_structure.py
+++ b/docs/examples/granite_vision_table_structure.py
@@ -17,7 +17,7 @@
 # - Defaults to `tests/data/pdf/2206.01062.pdf`. Change `input_doc_path` as needed.
 #
 # Notes
-# - The Granite Vision model (`ibm-granite/granite-4.0-3b-vision`) is downloaded
+# - The Granite Vision model (`ibm-granite/granite-vision-4.1-4b`) is downloaded
 #   automatically from HuggingFace on first run.
 # - The model outputs table structure in OTSL (Open Table Structure Language) format,
 #   which Docling parses into structured table cells.

--- a/docs/usage/model_catalog.md
+++ b/docs/usage/model_catalog.md
@@ -88,7 +88,7 @@ The following table shows all processing stages in Docling, their model families
       <td rowspan="3">Vision-Language Model<br/>(Granite Vision)</td>
       <td>
         <ul>
-          <li><code>granite-4.0-3b-vision</code></li>
+          <li><code>granite-vision-4.1-4b</code></li>
         </ul>
       </td>
     </tr>


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

Swaps both VLM-powered stages (chart extraction V4, table structure) from `ibm-granite/granite-4.0-3b-vision` to `ibm-granite/granite-vision-4.1-4b`, plus small follow-ups uncovered while validating the swap.                                                          
                                                                                                                                                                                                                                                                            
  ## Changes                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                            
  - **Model swap (both stages)**                                                                                                                                                                                                                                            
    - `ChartExtractionModelGraniteVisionV4`: `granite-4.0-3b-vision` → `granite-vision-4.1-4b`
    - `GraniteVisionTableStructureModel`: `granite-4.0-3b-vision` → `granite-vision-4.1-4b`                                                                                                                                                                                 
    - `merge_lora_adapters()` is now `hasattr`-guarded since 4.1 weights are pre-merged.                                                                                                                                                                                    
  - **V4 chart loader honors `cuda_use_flash_attention2`**                                                                                                                                                                                                                  
    - Mirrors the table-structure loader so both models pass `_attn_implementation` based on `AcceleratorOptions`. Avoids cuDNN backend failures seen on some torch/cuDNN stacks with the default SDPA path.                                                                
    - `accelerator_options` is now stored on the base class so subclasses can read it.                                                                                                                                                                                      
  - **V4 chart CSV parsing is more tolerant**                                                                                                                                                                                                                               
    - `granite-vision-4.1-4b` occasionally emits raw CSV without a ```csv``` code fence for the `<chart2csv>` prompt. `_extract_csv_to_dataframe` now falls back to the unfenced text (mirroring the v3 class), instead of raising `ValueError` and dropping the chart's    
  `tabular_chart` metadata.                                                                                                                                                                                                                                                 
  - **Docs / catalog**                                                                                                                                                                                                                                                      
    - `docs/examples/granite_vision_table_structure.py` docstring mentions `granite-vision-4.1-4b`.                                                                                                                                                                         
    - Docs catalog entry updated to `granite-vision-4.1-4b`.                                                                                                                                                                                                                
    - Fix stale "Granite Vision 4.0" log message in the model downloader.                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                   
                                                         
  **Checklist:**                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                            
  - [x] Documentation has been updated, if necessary.
  - [x] Examples have been added, if necessary.                                                                                                                                                                                                                             
  - [ ] Tests have been added, if necessary.          
