### PR TITLE
ci: diff PR fast checks against merge ref

### DIFF
--- a/.github/workflows/pr-fast-checks.yml
+++ b/.github/workflows/pr-fast-checks.yml
@@ -20,23 +20,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # Keep the worktree on the trusted base commit for dependency installation.
-      # The untrusted PR head is fetched separately and only read by the checker.
+      # The untrusted PR merge commit is fetched separately and only read by the checker.
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.base.sha }}
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Fetch PR head commit
+      - name: Fetch PR merge commit
         env:
-          PR_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
-          PR_HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          git fetch --no-tags --depth=1 \
-            "https://github.com/${PR_HEAD_REPO}.git" \
-            "${PR_HEAD_REF}"
-          test "$(git rev-parse FETCH_HEAD)" = "${PR_HEAD_SHA}"
+          git fetch --no-tags --depth=2 origin "pull/${PR_NUMBER}/merge"
+          test "$(git rev-parse FETCH_HEAD^1)" = "${PR_BASE_SHA}"
+          test "$(git rev-parse FETCH_HEAD^2)" = "${PR_HEAD_SHA}"
 
       - name: Install uv and set the python version
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Summary
- fetch the GitHub PR merge ref for pull_request_target fast checks instead of the raw PR head ref
- verify the fetched merge commit parents match the expected base and head SHAs
- keep dependency installation on the trusted base checkout while making changed-file detection reflect the PR as merged into current main

## Why
PR #3382 was branched before the new fast-check workflow landed. Comparing current main directly to the stale PR head made the checker inspect unrelated files that only differ because main moved, which surfaced pre-existing mypy issues outside the PR's actual change set. Using pull/<number>/merge keeps the target set to the PR changes on current main.

This is separate from --all-extras: uv rejects combining --only-group pr-fast-checks with --all-extras, and the visible types-requests stub is in the dev group rather than a project extra.

## Verification
- .venv/bin/pytest tests/test_run_pr_fast_checks.py
- .venv/bin/python .github/scripts/run_pr_fast_checks.py --repo-root "/Users/geoheil/development/forked-oss/docling" --base-ref HEAD --head-ref origin/pr/3382/merge
- fetched pull/3382/merge with depth=2 and verified FETCH_HEAD^1/FETCH_HEAD^2 match the expected base/head SHAs