### PR TITLE
ci: prepare editable docling-parse for docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,15 @@ jobs:
         runs-on: ubuntu-latest
         steps:
         - uses: actions/checkout@v6
+        - name: Checkout editable docling-parse source
+          run: |
+            if ! grep -Rqs '../docling-parse' pyproject.toml uv.lock; then
+              exit 0
+            fi
+
+            if [ ! -d ../docling-parse ]; then
+              git clone --depth=1 https://github.com/docling-project/docling-parse.git ../docling-parse
+            fi
         - name: Install uv and set the python version
           uses: astral-sh/setup-uv@v7
           with:


### PR DESCRIPTION
## Summary
- detect docs builds that use an editable ../docling-parse source
- clone docling-project/docling-parse into the expected sibling path before uv sync
- keep the existing frozen uv install behavior intact

## Verification
- inspected failing docs job 73611235441 from run 25118188355
- reproduced the missing ../docling-parse install failure on PR #3377 merge
- verified uv sync --frozen --all-extras --all-packages --dry-run succeeds after the sibling checkout exists
- parsed .github/workflows/docs.yml with PyYAML
- git diff --check