### PR TITLE
ci: add stable required status checks

### DIFF
--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -44,3 +44,41 @@ jobs:
     uses: ./.github/workflows/docs.yml
     with:
       deploy: false
+
+  docs-status:
+    if: ${{ always() }}
+    needs:
+      - changes
+      - build-docs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Check docs result
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          RUN_DOCS: ${{ needs.changes.outputs.run_docs }}
+          BUILD_DOCS_RESULT: ${{ needs.build-docs.result }}
+        run: |
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error title=Docs changes job failed::changes result was $CHANGES_RESULT"
+            exit 1
+          fi
+
+          if [ "$RUN_DOCS" != "true" ]; then
+            if [ "$BUILD_DOCS_RESULT" = "skipped" ]; then
+              echo "Docs checks are not required for this change set."
+              exit 0
+            fi
+
+            echo "::error title=Unexpected docs result::build-docs result was $BUILD_DOCS_RESULT while run_docs=$RUN_DOCS"
+            exit 1
+          fi
+
+          if [ "$BUILD_DOCS_RESULT" = "success" ]; then
+            echo "Docs checks passed."
+            exit 0
+          fi
+
+          echo "::error title=Docs checks failed::build-docs result was $BUILD_DOCS_RESULT"
+          exit 1

--- a/.github/workflows/ci-docs.yml
+++ b/.github/workflows/ci-docs.yml
@@ -57,7 +57,6 @@ jobs:
       - name: Check docs result
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
-          RUN_DOCS: ${{ needs.changes.outputs.run_docs }}
           BUILD_DOCS_RESULT: ${{ needs.build-docs.result }}
         run: |
           if [ "$CHANGES_RESULT" != "success" ]; then
@@ -65,20 +64,15 @@ jobs:
             exit 1
           fi
 
-          if [ "$RUN_DOCS" != "true" ]; then
-            if [ "$BUILD_DOCS_RESULT" = "skipped" ]; then
+          case "$BUILD_DOCS_RESULT" in
+            success)
+              echo "Docs checks passed."
+              ;;
+            skipped)
               echo "Docs checks are not required for this change set."
-              exit 0
-            fi
-
-            echo "::error title=Unexpected docs result::build-docs result was $BUILD_DOCS_RESULT while run_docs=$RUN_DOCS"
-            exit 1
-          fi
-
-          if [ "$BUILD_DOCS_RESULT" = "success" ]; then
-            echo "Docs checks passed."
-            exit 0
-          fi
-
-          echo "::error title=Docs checks failed::build-docs result was $BUILD_DOCS_RESULT"
-          exit 1
+              ;;
+            *)
+              echo "::error title=Docs checks failed::build-docs result was $BUILD_DOCS_RESULT"
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,3 +116,41 @@ jobs:
         }}
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  ci-status:
+    if: ${{ always() }}
+    needs:
+      - changes
+      - code-checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: Check CI result
+        env:
+          CHANGES_RESULT: ${{ needs.changes.result }}
+          RUN_CI: ${{ needs.changes.outputs.run_ci }}
+          CODE_CHECKS_RESULT: ${{ needs.code-checks.result }}
+        run: |
+          if [ "$CHANGES_RESULT" != "success" ]; then
+            echo "::error title=CI changes job failed::changes result was $CHANGES_RESULT"
+            exit 1
+          fi
+
+          if [ "$RUN_CI" != "true" ]; then
+            if [ "$CODE_CHECKS_RESULT" = "skipped" ]; then
+              echo "CI checks are not required for this change set."
+              exit 0
+            fi
+
+            echo "::error title=Unexpected CI result::code-checks result was $CODE_CHECKS_RESULT while run_ci=$RUN_CI"
+            exit 1
+          fi
+
+          if [ "$CODE_CHECKS_RESULT" = "success" ]; then
+            echo "CI checks passed."
+            exit 0
+          fi
+
+          echo "::error title=CI checks failed::code-checks result was $CODE_CHECKS_RESULT"
+          exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,6 @@ jobs:
       - name: Check CI result
         env:
           CHANGES_RESULT: ${{ needs.changes.result }}
-          RUN_CI: ${{ needs.changes.outputs.run_ci }}
           CODE_CHECKS_RESULT: ${{ needs.code-checks.result }}
         run: |
           if [ "$CHANGES_RESULT" != "success" ]; then
@@ -137,20 +136,15 @@ jobs:
             exit 1
           fi
 
-          if [ "$RUN_CI" != "true" ]; then
-            if [ "$CODE_CHECKS_RESULT" = "skipped" ]; then
+          case "$CODE_CHECKS_RESULT" in
+            success)
+              echo "CI checks passed."
+              ;;
+            skipped)
               echo "CI checks are not required for this change set."
-              exit 0
-            fi
-
-            echo "::error title=Unexpected CI result::code-checks result was $CODE_CHECKS_RESULT while run_ci=$RUN_CI"
-            exit 1
-          fi
-
-          if [ "$CODE_CHECKS_RESULT" = "success" ]; then
-            echo "CI checks passed."
-            exit 0
-          fi
-
-          echo "::error title=CI checks failed::code-checks result was $CODE_CHECKS_RESULT"
-          exit 1
+              ;;
+            *)
+              echo "::error title=CI checks failed::code-checks result was $CODE_CHECKS_RESULT"
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
## Summary

- add a stable `ci-status` check that always reports for the Run CI workflow
- add a stable `docs-status` check that always reports for the docs workflow
- make those checks validate the conditional downstream jobs while allowing intentional path-filter skips

## Why

GitHub required checks are matched by exact check context. Conditional and matrix jobs can report different contexts depending on whether they run, for example unsuffixed skipped jobs versus suffixed matrix jobs. These sentinel checks give branch protection stable contexts to require.

## Validation

- Parsed `.github/workflows/ci.yml` and `.github/workflows/ci-docs.yml` with PyYAML
- `git diff --check`
