### PR TITLE
ci: replace mypy with ty

### DIFF
--- a/.github/scripts/run_pr_fast_checks.py
+++ b/.github/scripts/run_pr_fast_checks.py
@@ -205,6 +205,7 @@ def build_check_units(repo_root: Path) -> list[CheckUnit]:
                 "check",
                 "--project",
                 str(repo_root),
+                "--error-on-warning",
             ],
             base_targets=[],
             head_targets=[],

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
     hooks:
       - id: ty
         name: ty
-        entry: uv run --no-sync ty check
+        entry: uv run --no-sync ty check --error-on-warning
         language: system
         files: '^(docling|\.github/scripts)/.*\.py$'
       - id: tach

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ check: check-all ## Run read-only local checks.
 check-all: ## Run all read-only local checks.
 	uv run ruff format --check --config=pyproject.toml docling tests docs/examples
 	uv run ruff check --config=pyproject.toml docling tests docs/examples
-	uv run --no-sync ty check
+	uv run --no-sync ty check --error-on-warning
 	uv run --no-sync tach check
 	python3 scripts/check_tach_module_coverage.py
 	python3 scripts/check_max_lines.py
@@ -44,7 +44,7 @@ fix: ## Run Ruff and dprint auto-format/fixers.
 	uv run dprint fmt --config .github/dprint.json --config-discovery=false
 
 typecheck: ## Run ty.
-	uv run --no-sync ty check
+	uv run --no-sync ty check --error-on-warning
 
 tach: ## Run Tach module-boundary checks.
 	uv run --no-sync tach check

--- a/docling/backend/asciidoc_backend.py
+++ b/docling/backend/asciidoc_backend.py
@@ -2,7 +2,7 @@ import logging
 import re
 from io import BytesIO
 from pathlib import Path
-from typing import Final, Union
+from typing import Final, Union, cast
 
 from docling_core.types.doc import (
     DocItemLabel,
@@ -15,6 +15,7 @@ from docling_core.types.doc import (
     TableCell,
     TableData,
 )
+from pydantic import AnyUrl
 
 from docling.backend.abstract_backend import DeclarativeDocumentBackend
 from docling.datamodel.base_models import InputFormat
@@ -69,7 +70,7 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
         origin = DocumentOrigin(
             filename=self.file.name or "file",
             mimetype="text/asciidoc",
-            binary_hash=self.document_hash,
+            binary_hash=cast(int, self.document_hash),
         )
 
         doc = DoclingDocument(name=self.file.stem or "file", origin=origin)
@@ -209,23 +210,17 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
                 else:
                     size = Size(width=DEFAULT_IMAGE_WIDTH, height=DEFAULT_IMAGE_HEIGHT)
 
-                uri = None
-                if (
-                    "uri" in item
-                    and not item["uri"].startswith("http")
-                    and item["uri"].startswith("//")
-                ):
-                    uri = "file:" + item["uri"]
-                elif (
-                    "uri" in item
-                    and not item["uri"].startswith("http")
-                    and item["uri"].startswith("/")
-                ):
-                    uri = "file:/" + item["uri"]
-                elif "uri" in item and not item["uri"].startswith("http"):
-                    uri = "file://" + item["uri"]
+                uri = item["uri"]
+                if not uri.startswith("http") and uri.startswith("//"):
+                    uri = "file:" + uri
+                elif not uri.startswith("http") and uri.startswith("/"):
+                    uri = "file:/" + uri
+                elif not uri.startswith("http"):
+                    uri = "file://" + uri
 
-                image = ImageRef(mimetype="image/png", size=size, dpi=70, uri=uri)
+                image = ImageRef(
+                    mimetype="image/png", size=size, dpi=70, uri=cast(AnyUrl, uri)
+                )
                 doc.add_picture(image=image, caption=caption)
 
             # Caption
@@ -302,6 +297,7 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
     @staticmethod
     def _parse_section_header(line):
         match = re.match(r"^(=+)\s+(.*)", line)
+        assert match is not None
 
         marker = match.group(1)  # The list marker (e.g., "*", "-", "1.")
         text = match.group(2)  # The actual text of the list item

--- a/docling/backend/csv_backend.py
+++ b/docling/backend/csv_backend.py
@@ -3,7 +3,7 @@ import logging
 import warnings
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import Set, Union
+from typing import Set, Union, cast
 
 from docling_core.types.doc import DoclingDocument, DocumentOrigin, TableCell, TableData
 
@@ -81,7 +81,7 @@ class CsvDocumentBackend(DeclarativeDocumentBackend):
         origin = DocumentOrigin(
             filename=self.file.name or "file.csv",
             mimetype="text/csv",
-            binary_hash=self.document_hash,
+            binary_hash=cast(int, self.document_hash),
         )
 
         doc = DoclingDocument(name=self.file.stem or "file.csv", origin=origin)

--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -174,7 +174,7 @@ class DoclingParsePageBackend(ManagedPdfiumPageBackend):
             padbox.t = page_size.height - padbox.t
 
         with pypdfium2_lock:
-            bitmap = self._ppage.render(
+            bitmap = self._require_page().render(
                 scale=scale * 1.5,
                 rotation=0,  # no additional rotation
                 crop=padbox.as_tuple(),
@@ -231,8 +231,10 @@ class DoclingParseDocumentBackend(ManagedPdfiumDocumentBackend):
             self._pdoc = pdfium.PdfDocument(self.path_or_stream, password=password)
         self.parser = DoclingPdfParser(loglevel="fatal")
 
+        assert self.path_or_stream is not None
         self.dp_doc: Optional[PdfDocument] = self.parser.load(
-            path_or_stream=self.path_or_stream, password=password
+            path_or_stream=self.path_or_stream,
+            password=password,
         )
         success = self.dp_doc is not None
 
@@ -244,6 +246,7 @@ class DoclingParseDocumentBackend(ManagedPdfiumDocumentBackend):
     def page_count(self) -> int:
         # return len(self._pdoc)  # To be replaced with docling-parse API
 
+        assert self._pdoc is not None
         len_1 = len(self._pdoc)
         assert self.dp_doc is not None
         len_2 = self.dp_doc.number_of_pages()
@@ -257,6 +260,7 @@ class DoclingParseDocumentBackend(ManagedPdfiumDocumentBackend):
         self, page_no: int, create_words: bool = True, create_textlines: bool = True
     ) -> DoclingParsePageBackend:
         assert self.dp_doc is not None
+        assert self._pdoc is not None
         with pypdfium2_lock:
             ppage = self._pdoc[page_no]
 

--- a/docling/backend/docx/latex/omml.py
+++ b/docling/backend/docx/latex/omml.py
@@ -222,7 +222,7 @@ class Pr(Tag2Method):
 
     text: str
     __val_tags: tuple[str, ...]
-    __innerdict: dict[str, Any]
+    __innerdict: dict[str, str | None]  # can't use the __dict__
 
     def __init__(self, elm: _Element):
         """Initialize properties processor.

--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -418,7 +418,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         super().__init__(in_doc, path_or_stream, options)
         self.options: HTMLBackendOptions
         self.soup: Optional[BeautifulSoup] = None
-        self.path_or_stream: Union[BytesIO, Path] = path_or_stream
+        self.path_or_stream: Union[BytesIO, Path, None] = path_or_stream
         self.base_path: Optional[str] = (
             str(options.source_uri) if options.source_uri is not None else None
         )
@@ -489,17 +489,17 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         origin = DocumentOrigin(
             filename=self.file.name or "file",
             mimetype="text/html",
-            binary_hash=self.document_hash,
+            binary_hash=cast(int, self.document_hash),
         )
         doc = DoclingDocument(name=self.file.stem or "file", origin=origin)
 
-        if cast(HTMLBackendOptions, self.options).render_page:
+        if self.options.render_page:
             self._render_with_browser()
             if self._rendered_html:
                 self.soup = BeautifulSoup(self._rendered_html, "html.parser")
 
         if self._rendered_page_images and self._rendered_page_size:
-            render_dpi = cast(HTMLBackendOptions, self.options).render_dpi
+            render_dpi = self.options.render_dpi
             for page_no, page_image in enumerate(self._rendered_page_images, start=1):
                 doc.add_page(
                     page_no=page_no,
@@ -555,7 +555,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         return doc
 
     def _get_render_page_size(self) -> tuple[int, int]:
-        options = cast(HTMLBackendOptions, self.options)
+        options = self.options
         width = options.render_page_width
         height = options.render_page_height
         if options.render_page_orientation == "landscape":
@@ -611,7 +611,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         return canvas
 
     def _render_with_browser(self) -> None:
-        options = cast(HTMLBackendOptions, self.options)
+        options = self.options
         if not options.render_page:
             return
 
@@ -1242,8 +1242,9 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
             nonlocal current_p
             if current_p is None:
                 current_p = soup.new_tag("p")
-                if p.get(_DATA_DOCLING_ID_ATTR):
-                    current_p[_DATA_DOCLING_ID_ATTR] = p.get(_DATA_DOCLING_ID_ATTR)
+                tag_id = p.get(_DATA_DOCLING_ID_ATTR)
+                if tag_id:
+                    current_p[_DATA_DOCLING_ID_ATTR] = str(tag_id)
                 new_nodes.append(current_p)
 
         def _flush_para_if_empty():
@@ -1518,6 +1519,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
 
                 provs_in_cell: list[RefItem] = []
                 rich_table_cell = self._is_rich_table_cell(html_cell)
+                ref_for_rich_cell: RefItem | None = None
                 if rich_table_cell:
                     # Parse table cell sub-tree for Rich Cells content:
                     with self._use_table_cell_context():
@@ -1552,6 +1554,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
                             grid[row_idx + r][col_idx + c] = text
 
                 if rich_table_cell:
+                    assert ref_for_rich_cell is not None
                     rich_cell = RichTableCell(
                         text=text,
                         bbox=cell_bbox,
@@ -2401,9 +2404,9 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
             if not isinstance(row, Tag):
                 continue
             for cell in row(["td", "th"], recursive=False):
-                if not isinstance(row, Tag):
+                if not isinstance(cell, Tag):
                     continue
-                cell_tag = cast(Tag, cell)
+                cell_tag = cell
                 col_span, row_span = HTMLDocumentBackend._get_cell_spans(cell_tag)
                 col_count += col_span
                 if cell_tag.name == "td" or row_span == 1:
@@ -4184,17 +4187,19 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         parent = self.parents[self.level]
 
         # check if the figure has a link - this is HACK:
-        def get_img_hyperlink(img_tag):
+        def get_img_hyperlink(img_tag: Tag) -> Optional[str]:
             this_parent = img_tag.parent
             while this_parent is not None:
                 if this_parent.name == "a" and this_parent.get("href"):
-                    return this_parent.get("href")
+                    return self._get_attr_as_string(this_parent, "href")
                 this_parent = this_parent.parent
             return None
 
         if img_hyperlink := get_img_hyperlink(img_tag):
-            img_text = img_tag.get("alt") or ""
-            caption.append(AnnotatedText(text=img_text, hyperlink=img_hyperlink))
+            img_text = self._get_attr_as_string(img_tag, "alt")
+            caption.append(
+                AnnotatedText(text=img_text, hyperlink=cast(AnyUrl, img_hyperlink))
+            )
             caption_prov_tag = img_tag
 
         if isinstance(figure, Tag):
@@ -4204,8 +4209,9 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
                     caption_tag, find_parent_annotation=True
                 )
                 caption_prov_tag = caption_tag
-        if not caption and img_tag.get("alt"):
-            caption = AnnotatedTextList([AnnotatedText(text=img_tag.get("alt"))])
+        img_alt = self._get_attr_as_string(img_tag, "alt")
+        if not caption and img_alt:
+            caption = AnnotatedTextList([AnnotatedText(text=img_alt)])
             caption_prov_tag = img_tag
 
         caption_anno_text = caption.to_single_text_element()
@@ -4232,7 +4238,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
 
         src_loc: str = self._get_attr_as_string(img_tag, "src")
         pic_prov = self._make_prov(text="", tag=img_tag)
-        if not cast(HTMLBackendOptions, self.options).fetch_images or not src_loc:
+        if not self.options.fetch_images or not src_loc:
             # Do not fetch the image, just add a placeholder
             placeholder: PictureItem = doc.add_picture(
                 caption=caption_item,
@@ -4263,6 +4269,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
 
         label = DocItemLabel.TEXT
         checkbox_label = self._get_checkbox_label_for_tag(input_tag)
+        checkbox_label_tags: list[Tag] = []
         if checkbox_label is not None:
             label = checkbox_label
             (

--- a/docling/backend/image_backend.py
+++ b/docling/backend/image_backend.py
@@ -148,8 +148,9 @@ class ImageDocumentBackend(PdfDocumentBackend):
 
         # Load frames eagerly for thread-safety across pages
         self._frames: List[Image.Image] = []
+        assert self.path_or_stream is not None
         try:
-            with Image.open(self.path_or_stream) as img:  # type: ignore[arg-type]
+            with Image.open(self.path_or_stream) as img:
                 # Handle multi-frame and single-frame images
                 # - multiframe formats: TIFF, GIF, ICO
                 # - singleframe formats: JPEG (.jpg, .jpeg), PNG (.png), BMP, WEBP (unless animated), HEIC

--- a/docling/backend/latex/utils/table.py
+++ b/docling/backend/latex/utils/table.py
@@ -1,7 +1,4 @@
-from typing import TYPE_CHECKING, Callable, List, Optional
-
-if TYPE_CHECKING:
-    from typing import Any
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, cast
 
 from docling_core.types.doc.document import TableCell, TableData
 from pylatexenc.latexwalker import (
@@ -132,8 +129,8 @@ class TableHelperMixin:
                 start_col_offset_idx=0,
                 end_col_offset_idx=0,
             )
-            cell._col_span = col_span  # type: ignore[attr-defined]
-            cell._row_span = row_span  # type: ignore[attr-defined]
+            cast(Any, cell)._col_span = col_span
+            cast(Any, cell)._row_span = row_span
             current_row.append(cell)
             current_cell_nodes.clear()
 
@@ -145,7 +142,7 @@ class TableHelperMixin:
                     start_col_offset_idx=0,
                     end_col_offset_idx=0,
                 )
-                placeholder._is_placeholder = True  # type: ignore[attr-defined]
+                cast(Any, placeholder)._is_placeholder = True
                 current_row.append(placeholder)
 
         def finish_row():

--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -6,7 +6,7 @@ from enum import Enum
 from html import unescape
 from io import BytesIO
 from pathlib import Path
-from typing import Literal, Optional, Union, cast
+from typing import Any, Literal, Optional, Union, cast
 
 import marko
 import marko.element
@@ -577,7 +577,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         if hasattr(element, "children") and not isinstance(
             element, processed_block_types
         ):
-            for child in element.children:
+            for child in cast(list[Any], element.children):
                 if (
                     isinstance(element, marko.block.ListItem)
                     and isinstance(child, marko.block.List)
@@ -625,7 +625,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         origin = DocumentOrigin(
             filename=self.file.name or "file",
             mimetype="text/markdown",
-            binary_hash=self.document_hash,
+            binary_hash=cast(int, self.document_hash),
         )
 
         doc = DoclingDocument(name=self.file.stem or "file", origin=origin)

--- a/docling/backend/mets_gbs_backend.py
+++ b/docling/backend/mets_gbs_backend.py
@@ -426,7 +426,7 @@ class MetsGbsDocumentBackend(PdfDocumentBackend):
             textline_cells=line_cells,
             char_cells=[],
             word_cells=word_cells,
-            has_textlines=True,
+            has_lines=True,
             has_words=True,
             has_chars=False,
         )

--- a/docling/backend/msexcel_backend.py
+++ b/docling/backend/msexcel_backend.py
@@ -211,7 +211,7 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         origin = DocumentOrigin(
             filename=self.file.name or "file.xlsx",
             mimetype="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-            binary_hash=self.document_hash,
+            binary_hash=cast(int, self.document_hash),
         )
 
         doc = DoclingDocument(name=self.file.stem or "file.xlsx", origin=origin)
@@ -407,7 +407,11 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         max_row, max_col = 0, 0
 
         for cell in sheet._cells.values():
-            if cell.value is not None:
+            if (
+                cell.value is not None
+                and cell.row is not None
+                and cell.column is not None
+            ):
                 r, c = cell.row, cell.column
                 min_row = r if min_row is None else min(min_row, r)
                 min_col = c if min_col is None else min(min_col, c)
@@ -651,10 +655,10 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         if self.workbook is not None:
             content_layer = self._get_sheet_content_layer(sheet)
             # Iterate over byte images in the sheet
-            for item in sheet._images:  # type: ignore[attr-defined]
+            for item in cast(Any, sheet)._images:
                 try:
                     image: Image = cast(Image, item)
-                    pil_image = PILImage.open(image.ref)  # type: ignore[arg-type]
+                    pil_image = PILImage.open(cast(Any, image.ref))
                     anchor = (0, 0, 0, 0)
                     if isinstance(image.anchor, TwoCellAnchor):
                         anchor = (

--- a/docling/backend/mspowerpoint_backend.py
+++ b/docling/backend/mspowerpoint_backend.py
@@ -2,7 +2,7 @@ import logging
 import warnings
 from io import BytesIO
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
 from docling_core.types.doc import (
     BoundingBox,
@@ -47,7 +47,7 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
             "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
         }
         # Powerpoint file:
-        self.path_or_stream: Union[BytesIO, Path] = path_or_stream
+        self.path_or_stream: Union[BytesIO, Path, None] = path_or_stream
         self.page_range = in_doc.limits.page_range
 
         self.pptx_obj: Optional[presentation.Presentation] = None
@@ -104,7 +104,7 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
         origin = DocumentOrigin(
             filename=self.file.name or "file",
             mimetype="application/vnd.ms-powerpoint",
-            binary_hash=self.document_hash,
+            binary_hash=cast(int, self.document_hash),
         )
 
         doc = DoclingDocument(name=self.file.stem or "file", origin=origin)
@@ -129,10 +129,15 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
             top = 0
             width = slide_size.width
             height = slide_size.height
-        shape_bbox = [left, top, left + width, top + height]
+        shape_bbox = (
+            float(left),
+            float(top),
+            float(left + width),
+            float(top + height),
+        )
         shape_bbox = BoundingBox.from_tuple(shape_bbox, origin=CoordOrigin.BOTTOMLEFT)
         prov = ProvenanceItem(
-            page_no=slide_ind + 1, charspan=[0, len(text)], bbox=shape_bbox
+            page_no=slide_ind + 1, charspan=(0, len(text)), bbox=shape_bbox
         )
 
         return prov
@@ -698,7 +703,9 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
                 name=f"slide-{slide_ind}", label=GroupLabel.CHAPTER, parent=parents[0]
             )
 
-            slide_size = Size(width=slide_width, height=slide_height)
+            slide_size = Size(
+                width=float(slide_width or 0), height=float(slide_height or 0)
+            )
             doc.add_page(page_no=slide_ind + 1, size=slide_size)
 
             def _safe_shape_type(shape):
@@ -761,7 +768,7 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
                         bbox = BoundingBox(l=0, t=0, r=0, b=0)
                         prov = ProvenanceItem(
                             page_no=slide_ind + 1,
-                            charspan=[0, len(notes_text)],
+                            charspan=(0, len(notes_text)),
                             bbox=bbox,
                         )
                         doc.add_text(

--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -5,7 +5,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from io import BytesIO
 from pathlib import Path
-from typing import Any, Callable, Final
+from typing import Any, Callable, Final, cast
 from urllib.parse import urlparse
 
 from docling_core.types.doc import (
@@ -83,7 +83,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         )
         # self.initialise(path_or_stream)
         # Word file:
-        self.path_or_stream: BytesIO | Path = path_or_stream
+        self.path_or_stream: BytesIO | Path | None = path_or_stream
         self.valid: bool = False
         # Initialise the parents for the hierarchy
         self.max_levels: int = 10
@@ -161,7 +161,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         origin = DocumentOrigin(
             filename=self.file.name or "file",
             mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-            binary_hash=self.document_hash,
+            binary_hash=cast(int, self.document_hash),
         )
 
         doc = DoclingDocument(name=self.file.stem or "file", origin=origin)
@@ -1853,6 +1853,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
 
                 provs_in_cell: list[RefItem] = []
                 rich_table_cell: bool = self._is_rich_table_cell(cell)
+                ref_for_rich_cell: RefItem | None = None
 
                 if rich_table_cell:
                     with self._isolated_list_context():
@@ -1872,6 +1873,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                     )
 
                 if rich_table_cell:
+                    assert ref_for_rich_cell is not None
                     rich_cell = RichTableCell(
                         text=text,
                         row_span=spanned_idx - row_idx,
@@ -2059,6 +2061,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         if self.docx_to_pdf_converter is None:
             return None
 
+        assert self.path_or_stream is not None
         try:
             # Create a temporary document with just these elements
             temp_doc = self.load_msword_file(self.path_or_stream, self.document_hash)
@@ -2374,7 +2377,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             # Manually link targets to the comment GROUP (not the text item)
             # This allows multiple comment replies to be grouped together
             if targets:
-                group_ref = FineRef(cref=comment_group.self_ref)
+                group_ref = cast(Any, FineRef)(cref=comment_group.self_ref)
                 for target in targets:
                     # Only DocItem has a 'comments' field; GroupItem does not,
                     # so skip non-DocItem targets (fixes #2955).

--- a/docling/backend/pdf_backend.py
+++ b/docling/backend/pdf_backend.py
@@ -28,7 +28,7 @@ class PdfPageBackend(ABC):
         pass
 
     @abstractmethod
-    def get_bitmap_rects(self, float: int = 1) -> Iterable[BoundingBox]:
+    def get_bitmap_rects(self, scale: float = 1) -> Iterable[BoundingBox]:
         pass
 
     @abstractmethod

--- a/docling/backend/pypdfium2_backend.py
+++ b/docling/backend/pypdfium2_backend.py
@@ -339,7 +339,7 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
             textline_cells=text_cells,
             char_cells=[],
             word_cells=[],
-            has_textlines=len(text_cells) > 0,
+            has_lines=len(text_cells) > 0,
             has_words=False,
             has_chars=False,
         )
@@ -422,10 +422,12 @@ class PyPdfiumDocumentBackend(ManagedPdfiumDocumentBackend):
             ) from e
 
     def page_count(self) -> int:
+        assert self._pdoc is not None
         with pypdfium2_lock:
             return len(self._pdoc)
 
     def load_page(self, page_no: int) -> PyPdfiumPageBackend:
+        assert self._pdoc is not None
         with pypdfium2_lock:
             return PyPdfiumPageBackend(self._pdoc, self.document_hash, page_no)
 

--- a/docling/backend/webvtt_backend.py
+++ b/docling/backend/webvtt_backend.py
@@ -2,6 +2,7 @@ import logging
 from dataclasses import dataclass, field
 from io import BytesIO
 from pathlib import Path
+from typing import cast
 
 from docling_core.types.doc import (
     ContentLayer,
@@ -105,7 +106,7 @@ class WebVTTDocumentBackend(DeclarativeDocumentBackend):
         origin = DocumentOrigin(
             filename=self.file.name or "file",
             mimetype="text/vtt",
-            binary_hash=self.document_hash,
+            binary_hash=cast(int, self.document_hash),
         )
         doc = DoclingDocument(name=self.file.stem or "file", origin=origin)
 

--- a/docling/backend/xml/jats_backend.py
+++ b/docling/backend/xml/jats_backend.py
@@ -166,14 +166,13 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
 
     @override
     def convert(self) -> DoclingDocument:
+        origin = DocumentOrigin(
+            filename=self.file.name or "file",
+            mimetype="application/xml",
+            binary_hash=cast(int, self.document_hash),
+        )
+        doc = DoclingDocument(name=self.file.stem or "file", origin=origin)
         try:
-            # Create empty document
-            origin = DocumentOrigin(
-                filename=self.file.name or "file",
-                mimetype="application/xml",
-                binary_hash=self.document_hash,
-            )
-            doc = DoclingDocument(name=self.file.stem or "file", origin=origin)
             self.hlevel = 0
 
             # Get metadata XML components
@@ -438,7 +437,8 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
         for item in fields:
             item_node = node.xpath(item)
             if len(item_node) > 0:
-                citation[item.replace("-", "_")] = (  # type: ignore[literal-required]
+                citation_dict = cast(dict[str, str], citation)
+                citation_dict[item.replace("-", "_")] = (
                     item_node[0].text.replace("\n", " ").strip()
                 )
 
@@ -579,9 +579,9 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
             if not isinstance(row, Tag):
                 continue
             for cell in row(["td", "th"]):
-                if not isinstance(row, Tag):
+                if not isinstance(cell, Tag):
                     continue
-                cell_tag = cast(Tag, cell)
+                cell_tag = cell
                 col_span, row_span = HTMLDocumentBackend._get_cell_spans(cell_tag)
                 col_count += col_span
                 if cell_tag.name == "td" or row_span == 1:
@@ -752,6 +752,7 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
 
         for child in list(node):
             stop_walk: bool = False
+            section_text: str | None = None
 
             # flush text into TextItem for some tags in paragraph nodes
             if node.tag == "p" and node_text.strip() and child.tag in flush_tags:
@@ -763,15 +764,14 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
             # add elements and decide whether to stop walking
             if child.tag in ("sec", "ack"):
                 header = child.xpath("title|label")
-                text: str | None = None
                 if len(header) > 0:
-                    text = JatsDocumentBackend._get_text(header[0])
+                    section_text = JatsDocumentBackend._get_text(header[0])
                 elif child.tag == "ack":
-                    text = DEFAULT_HEADER_ACKNOWLEDGMENTS
-                if text:
+                    section_text = DEFAULT_HEADER_ACKNOWLEDGMENTS
+                if section_text:
                     self.hlevel += 1
                     new_parent = doc.add_heading(
-                        text=text, parent=parent, level=self.hlevel
+                        text=section_text, parent=parent, level=self.hlevel
                     )
             elif child.tag == "list":
                 new_parent = doc.add_group(
@@ -829,7 +829,7 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
                 new_text = self._walk_linear(doc, new_parent, child)
                 if not (node.getparent().tag == "p" and node.tag in flush_tags):
                     node_text += new_text
-                if child.tag in ("sec", "ack") and text:
+                if child.tag in ("sec", "ack") and section_text:
                     self.hlevel -= 1
 
             # pick up the tail text

--- a/docling/backend/xml/uspto_backend.py
+++ b/docling/backend/xml/uspto_backend.py
@@ -43,7 +43,7 @@ from abc import ABC, abstractmethod
 from enum import Enum, unique
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import Final
+from typing import Final, cast
 from xml.sax import SAXParseException
 from xml.sax.handler import ContentHandler, feature_external_ges, feature_external_pes
 from xml.sax.xmlreader import AttributesImpl
@@ -169,7 +169,7 @@ class PatentUsptoDocumentBackend(DeclarativeDocumentBackend):
             )
             doc.origin = DocumentOrigin(
                 mimetype=mime_type,
-                binary_hash=self.document_hash,
+                binary_hash=cast(int, self.document_hash),
                 filename=self.file.name or "file",
             )
 
@@ -217,7 +217,7 @@ class PatentUsptoIce(PatentUspto):
             parser.forbid_dtd = False
             parser.forbid_entities = False
             parser.forbid_external = False
-            parser.setContentHandler(self.handler)
+            parser.setContentHandler(cast(ContentHandler, self.handler))
             parser.parse(StringIO(patent_content))
         except SAXParseException as exc_sax:
             _log.error(f"Error in parsing USPTO document (malformed XML): {exc_sax}")
@@ -309,13 +309,15 @@ class PatentUsptoIce(PatentUspto):
             self.style_html = HtmlEntity()
 
         @override
-        def startElement(self, tag, attributes):
+        def startElement(self, name: str, attrs: AttributesImpl) -> None:
             """Signal the start of an element.
 
             Args:
                 tag: The element tag.
                 attributes: The element attributes.
             """
+            tag = name
+            attributes = attrs
             if tag in (
                 self.APP_DOC_ELEMENT,
                 self.GRANT_DOC_ELEMENT,
@@ -359,12 +361,13 @@ class PatentUsptoIce(PatentUspto):
                         self.text += unescaped
 
         @override
-        def endElement(self, tag):
+        def endElement(self, name: str) -> None:
             """Signal the end of an element.
 
             Args:
                 tag: The element tag.
             """
+            tag = name
             if tag in (
                 self.APP_DOC_ELEMENT,
                 self.GRANT_DOC_ELEMENT,
@@ -568,7 +571,7 @@ class PatentUsptoGrantV2(PatentUspto):
             parser.forbid_dtd = False
             parser.forbid_entities = False
             parser.forbid_external = False
-            parser.setContentHandler(self.handler)
+            parser.setContentHandler(cast(ContentHandler, self.handler))
             parser.parse(StringIO(patent_content))
         except SAXParseException as exc_sax:
             _log.error(f"Error in parsing USPTO document (malformed XML): {exc_sax}")
@@ -661,13 +664,15 @@ class PatentUsptoGrantV2(PatentUspto):
             self.style_html = HtmlEntity()
 
         @override
-        def startElement(self, tag, attributes):
+        def startElement(self, name: str, attrs: AttributesImpl) -> None:
             """Signal the start of an element.
 
             Args:
                 tag: The element tag.
                 attributes: The element attributes.
             """
+            tag = name
+            attributes = attrs
             if tag == self.GRANT_DOC_ELEMENT:
                 self.doc = DoclingDocument(name="file")
                 self.text = ""
@@ -708,12 +713,13 @@ class PatentUsptoGrantV2(PatentUspto):
                         self.text += unescaped
 
         @override
-        def endElement(self, tag):
+        def endElement(self, name: str) -> None:
             """Signal the end of an element.
 
             Args:
                 tag: The element tag.
             """
+            tag = name
             if tag == self.GRANT_DOC_ELEMENT:
                 self._clean_data()
             self._end_registered_element(tag)
@@ -1143,7 +1149,7 @@ class PatentUsptoAppV1(PatentUspto):
             parser.forbid_dtd = False
             parser.forbid_entities = False
             parser.forbid_external = False
-            parser.setContentHandler(self.handler)
+            parser.setContentHandler(cast(ContentHandler, self.handler))
             parser.parse(StringIO(patent_content))
         except SAXParseException as exc_sax:
             _log.error(f"Error in parsing USPTO document (malformed XML): {exc_sax}")
@@ -1236,13 +1242,15 @@ class PatentUsptoAppV1(PatentUspto):
             self.style_html = HtmlEntity()
 
         @override
-        def startElement(self, tag, attributes):
+        def startElement(self, name: str, attrs: AttributesImpl) -> None:
             """Signal the start of an element.
 
             Args:
                 tag: The element tag.
                 attributes: The element attributes.
             """
+            tag = name
+            attributes = attrs
             if tag == self.APP_DOC_ELEMENT:
                 self.doc = DoclingDocument(name="file")
                 self.text = ""
@@ -1283,12 +1291,13 @@ class PatentUsptoAppV1(PatentUspto):
                         self.text += unescaped
 
         @override
-        def endElement(self, tag):
+        def endElement(self, name: str) -> None:
             """Signal the end of an element.
 
             Args:
                 tag: The element tag.
             """
+            tag = name
             if tag == self.APP_DOC_ELEMENT:
                 self._clean_data()
             self._end_registered_element(tag)
@@ -1483,8 +1492,8 @@ class XmlTable:
         colinfo: list[dict]
 
     class MinColInfoType(TypedDict):
-        offset: list[int]
-        colwidth: list[int]
+        offset: list[int | float]
+        colwidth: list[int | float]
 
     class ColInfoType(MinColInfoType):
         cell_range: list[int]

--- a/docling/backend/xml/xbrl_backend.py
+++ b/docling/backend/xml/xbrl_backend.py
@@ -24,7 +24,7 @@ from collections import defaultdict
 from io import BytesIO
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Final
+from typing import Final, cast
 
 from docling_core.types.doc import (
     DoclingDocument,
@@ -254,7 +254,7 @@ class XBRLDocumentBackend(DeclarativeDocumentBackend):
         origin = DocumentOrigin(
             filename=self.file.name or "file",
             mimetype="application/xml",
-            binary_hash=self.document_hash,
+            binary_hash=cast(int, self.document_hash),
         )
         doc = DoclingDocument(name=self.file.stem or "file", origin=origin)
         doc_name = doc.name
@@ -271,6 +271,7 @@ class XBRLDocumentBackend(DeclarativeDocumentBackend):
             if fact.qname.localName == "DocumentPeriodEndDate" and fact.value:
                 doc_period = fact.value
         title = f"{doc_type} {doc_org} {doc_period}".strip()
+        assert self.model_xbrl.modelDocument is not None
         title = title if title else self.model_xbrl.modelDocument.basename
         doc.add_title(text=title)
 

--- a/docling/cli/_dependencies.py
+++ b/docling/cli/_dependencies.py
@@ -1,0 +1,25 @@
+import sys
+from typing import NoReturn
+
+
+def missing_cli_dependency_error(
+    error: ImportError,
+    *,
+    cli_name: str,
+    fallback_package: str = "typer or rich",
+) -> NoReturn:
+    missing_package = (
+        str(error).split("'")[1] if "'" in str(error) else fallback_package
+    )
+    print(
+        f"Error: Missing required CLI dependency '{missing_package}'", file=sys.stderr
+    )
+    print(f"\nThe {cli_name} CLI requires additional dependencies.", file=sys.stderr)
+    print("Please install them using one of the following options:\n", file=sys.stderr)
+    print("  1. Install the full docling package (recommended):", file=sys.stderr)
+    print("     pip install docling\n", file=sys.stderr)
+    print("  2. Install docling-slim with CLI support:", file=sys.stderr)
+    print("     pip install docling-slim[cli]\n", file=sys.stderr)
+    print("  3. Install just the missing dependencies:", file=sys.stderr)
+    print("     pip install typer rich\n", file=sys.stderr)
+    sys.exit(1)

--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -1,32 +1,13 @@
 import datetime
 import logging
 import re
-import sys
 import tempfile
 import time
 import warnings
 from collections.abc import Iterable
+from importlib import import_module
 from pathlib import Path
-from typing import Annotated, Type
-
-# Check for CLI dependencies
-try:
-    import rich.table
-    import typer
-except ImportError as e:
-    missing_package = str(e).split("'")[1] if "'" in str(e) else "typer or rich"
-    print(
-        f"Error: Missing required CLI dependency '{missing_package}'", file=sys.stderr
-    )
-    print("\nThe docling CLI requires additional dependencies.", file=sys.stderr)
-    print("Please install them using one of the following options:\n", file=sys.stderr)
-    print("  1. Install the full docling package (recommended):", file=sys.stderr)
-    print("     pip install docling\n", file=sys.stderr)
-    print("  2. Install docling-slim with CLI support:", file=sys.stderr)
-    print("     pip install docling-slim[cli]\n", file=sys.stderr)
-    print("  3. Install just the missing dependencies:", file=sys.stderr)
-    print("     pip install typer rich\n", file=sys.stderr)
-    sys.exit(1)
+from typing import Annotated, Any, Type
 
 from docling_core.transforms.serializer.html import (
     HTMLDocSerializer,
@@ -36,14 +17,14 @@ from docling_core.transforms.serializer.html import (
 from docling_core.transforms.visualizer.layout_visualizer import LayoutVisualizer
 from docling_core.types.doc import ImageRefMode
 from docling_core.utils.file import resolve_source_to_path
-from pydantic import TypeAdapter
-from rich.console import Console
+from pydantic import SecretStr, TypeAdapter
 
 from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
 from docling.backend.image_backend import ImageDocumentBackend
 from docling.backend.mets_gbs_backend import MetsGbsDocumentBackend
 from docling.backend.pdf_backend import PdfDocumentBackend
 from docling.backend.pypdfium2_backend import PyPdfiumDocumentBackend
+from docling.cli._dependencies import missing_cli_dependency_error
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
 from docling.datamodel.asr_model_specs import (
     WHISPER_BASE,
@@ -114,6 +95,19 @@ from docling.pipeline.asr_pipeline import AsrPipeline
 from docling.pipeline.vlm_pipeline import VlmPipeline
 from docling.utils.profiling import ProfilingItem
 
+typer: Any = None
+Console: Any = None
+rich_table: Any = None
+rich_print: Any = None
+try:
+    typer = import_module("typer")
+    rich_table = import_module("rich.table")
+    rich_print = getattr(import_module("rich"), "print")
+    Console = getattr(import_module("rich.console"), "Console")
+except ImportError as e:
+    missing_cli_dependency_error(e, cli_name="docling")
+
+
 warnings.filterwarnings(action="ignore", category=UserWarning, module="pydantic|torch")
 warnings.filterwarnings(action="ignore", category=FutureWarning, module="easyocr")
 
@@ -123,7 +117,7 @@ console = Console()
 err_console = Console(stderr=True)
 
 ocr_factory_internal = get_ocr_factory(allow_external_plugins=False)
-ocr_engines_enum_internal = ocr_factory_internal.get_enum()
+ocr_engines_internal = ", ".join(ocr_factory_internal.registered_kind)
 
 # Get available VLM presets from the registry
 vlm_preset_ids = VlmConvertOptions.list_preset_ids()
@@ -199,7 +193,7 @@ def show_external_plugins_callback(value: bool):
         table_factory_all = get_table_structure_factory(allow_external_plugins=True)
 
         def print_external_plugins(factory: BaseFactory, factory_name: str):
-            table = rich.table.Table(title=f"Available {factory_name} engines")
+            table = rich_table.Table(title=f"Available {factory_name} engines")
             table.add_column("Name", justify="right")
             table.add_column("Plugin")
             table.add_column("Package")
@@ -210,7 +204,7 @@ def show_external_plugins_callback(value: bool):
                         meta.plugin_name,
                         meta.module.split(".")[0],
                     )
-            rich.print(table)
+            rich_print(table)
 
         print_external_plugins(ocr_factory_all, "OCR")
         print_external_plugins(layout_factory_all, "layout")
@@ -325,7 +319,7 @@ def export_documents(
 
             # Print profiling timings
             if print_timings:
-                table = rich.table.Table(title=f"Profiling Summary, {doc_filename}")
+                table = rich_table.Table(title=f"Profiling Summary, {doc_filename}")
                 metric_columns = [
                     "Stage",
                     "count",
@@ -485,7 +479,7 @@ def convert(  # noqa: C901
             ...,
             help=(
                 f"The OCR engine to use. When --allow-external-plugins is *not* set, the available values are: "
-                f"{', '.join(o.value for o in ocr_engines_enum_internal)}. "
+                f"{ocr_engines_internal}. "
                 f"Use the option --show-external-plugins to see the options allowed with external plugins."
             ),
         ),
@@ -713,8 +707,11 @@ def convert(  # noqa: C901
                                         continue
                                     input_doc_paths.append(path)
                     elif local_path.exists():
-                        if not local_path.name.startswith("~$") and ext == "docx":
-                            _log.info(f"Ignoring temporary Word file: {path}")
+                        if (
+                            local_path.name.startswith("~$")
+                            and local_path.suffix.lower() == ".docx"
+                        ):
+                            _log.info(f"Ignoring temporary Word file: {local_path}")
                             continue
                         input_doc_paths.append(local_path)
                     else:
@@ -760,7 +757,7 @@ def convert(  # noqa: C901
 
         format_options: dict[InputFormat, FormatOption] = {}
         pdf_backend_options: PdfBackendOptions | None = PdfBackendOptions(
-            password=pdf_password
+            password=SecretStr(pdf_password) if pdf_password is not None else None
         )
 
         if pipeline == ProcessingPipeline.STANDARD:
@@ -887,6 +884,8 @@ def convert(  # noqa: C901
                 InputFormat.PDF: pdf_format_option,
                 InputFormat.IMAGE: pdf_format_option,
             }
+        else:
+            raise RuntimeError(f"Unexpected processing pipeline: {pipeline}")
 
         # Set ASR options
         asr_pipeline_options = AsrPipelineOptions(

--- a/docling/cli/models.py
+++ b/docling/cli/models.py
@@ -1,33 +1,25 @@
 import logging
-import sys
 import warnings
 from enum import Enum
+from importlib import import_module
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated, Any, Optional
 
-# Check for CLI dependencies
-try:
-    import typer
-    from rich.console import Console
-    from rich.logging import RichHandler
-except ImportError as e:
-    missing_package = str(e).split("'")[1] if "'" in str(e) else "typer or rich"
-    print(
-        f"Error: Missing required CLI dependency '{missing_package}'", file=sys.stderr
-    )
-    print("\nThe docling-tools CLI requires additional dependencies.", file=sys.stderr)
-    print("Please install them using one of the following options:\n", file=sys.stderr)
-    print("  1. Install the full docling package (recommended):", file=sys.stderr)
-    print("     pip install docling\n", file=sys.stderr)
-    print("  2. Install docling-slim with CLI support:", file=sys.stderr)
-    print("     pip install docling-slim[cli]\n", file=sys.stderr)
-    print("  3. Install just the missing dependencies:", file=sys.stderr)
-    print("     pip install typer rich\n", file=sys.stderr)
-    sys.exit(1)
-
+from docling.cli._dependencies import missing_cli_dependency_error
 from docling.datamodel.settings import settings
 from docling.models.utils.hf_model_download import download_hf_model
 from docling.utils.model_downloader import download_models
+
+typer: Any = None
+Console: Any = None
+RichHandler: Any = None
+try:
+    typer = import_module("typer")
+    Console = getattr(import_module("rich.console"), "Console")
+    RichHandler = getattr(import_module("rich.logging"), "RichHandler")
+except ImportError as e:
+    missing_cli_dependency_error(e, cli_name="docling-tools")
+
 
 warnings.filterwarnings(action="ignore", category=UserWarning, module="pydantic|torch")
 warnings.filterwarnings(action="ignore", category=FutureWarning, module="easyocr")

--- a/docling/cli/tools.py
+++ b/docling/cli/tools.py
@@ -1,24 +1,15 @@
-import sys
+from importlib import import_module
+from typing import Any
+
+from docling.cli._dependencies import missing_cli_dependency_error
+from docling.cli.models import app as models_app
 
 # Check for CLI dependencies
+typer: Any = None
 try:
-    import typer
+    typer = import_module("typer")
 except ImportError as e:
-    missing_package = str(e).split("'")[1] if "'" in str(e) else "typer"
-    print(
-        f"Error: Missing required CLI dependency '{missing_package}'", file=sys.stderr
-    )
-    print("\nThe docling-tools CLI requires additional dependencies.", file=sys.stderr)
-    print("Please install them using one of the following options:\n", file=sys.stderr)
-    print("  1. Install the full docling package (recommended):", file=sys.stderr)
-    print("     pip install docling\n", file=sys.stderr)
-    print("  2. Install docling-slim with CLI support:", file=sys.stderr)
-    print("     pip install docling-slim[cli]\n", file=sys.stderr)
-    print("  3. Install just the missing dependencies:", file=sys.stderr)
-    print("     pip install typer rich\n", file=sys.stderr)
-    sys.exit(1)
-
-from docling.cli.models import app as models_app
+    missing_cli_dependency_error(e, cli_name="docling-tools", fallback_package="typer")
 
 app = typer.Typer(
     name="Docling helpers",

--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -476,10 +476,12 @@ class _DocumentConversionInput(BaseModel):
             else:
                 raise RuntimeError(f"Unexpected obj type in iterator: {type(obj)}")
 
-            assert format is not None
+            # Unknown formats intentionally keep `format` as None so downstream
+            # processing reports them as skipped rather than treating them as
+            # invalid known-format files.
             yield InputDocument(
                 path_or_stream=path_or_stream,
-                format=format,
+                format=cast(InputFormat, format),
                 filename=obj.name,
                 limits=self.limits,
                 backend=backend,

--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -476,9 +476,10 @@ class _DocumentConversionInput(BaseModel):
             else:
                 raise RuntimeError(f"Unexpected obj type in iterator: {type(obj)}")
 
+            assert format is not None
             yield InputDocument(
                 path_or_stream=path_or_stream,
-                format=format,  # type: ignore[arg-type]
+                format=format,
                 filename=obj.name,
                 limits=self.limits,
                 backend=backend,

--- a/docling/datamodel/service/options.py
+++ b/docling/datamodel/service/options.py
@@ -599,11 +599,11 @@ class ConvertDocumentsOptions(BaseModel):
             description="DEPRECATED: API details for using a vision-language model in the picture description. This parameter is mutually exclusive with picture_description_local. Please migrate to picture_description_preset or picture_description_custom_config.",
             examples=[
                 PictureDescriptionApi(
-                    url="http://localhost:1234/v1/chat/completions",
+                    url=AnyUrl("http://localhost:1234/v1/chat/completions"),
                     params={"model": "granite3.2-vision:2b"},
                 ),
                 PictureDescriptionApi(
-                    url="http://localhost:11434/v1/chat/completions",
+                    url=AnyUrl("http://localhost:11434/v1/chat/completions"),
                     params={"model": "granite3.2-vision:2b"},
                 ),
             ],
@@ -638,7 +638,7 @@ class ConvertDocumentsOptions(BaseModel):
             description="DEPRECATED: API details for using a vision-language model for the vlm pipeline. This parameter is mutually exclusive with vlm_pipeline_model_local and vlm_pipeline_model. Please migrate to vlm_pipeline_preset or vlm_pipeline_custom_config.",
             examples=[
                 VlmModelApi(
-                    url="http://localhost:1234/v1/chat/completions",
+                    url=AnyUrl("http://localhost:1234/v1/chat/completions"),
                     params={"model": "ibm-granite/granite-docling-258M-mlx"},
                     response_format=ResponseFormat.DOCTAGS,
                     prompt="Convert this page to docling.",

--- a/docling/datamodel/service/requests.py
+++ b/docling/datamodel/service/requests.py
@@ -1,6 +1,6 @@
 import enum
 from functools import cache
-from typing import Annotated, Generic, Literal
+from typing import Annotated, Any, Generic, Literal, cast
 
 from pydantic import BaseModel, Field
 from typing_extensions import TypeVar
@@ -96,9 +96,10 @@ def make_request_model(
     Dynamically create (and cache) a subclass of GenericChunkDocumentsRequest[opt_type]
     with chunking_options having a default factory.
     """
+    base_model = cast(Any, GenericChunkDocumentsRequest)[opt_type]
     return type(
         f"{opt_type.__name__}DocumentsRequest",
-        (GenericChunkDocumentsRequest[opt_type],),  # type: ignore[valid-type]
+        (base_model,),
         {
             "__annotations__": {"chunking_options": opt_type},
             "chunking_options": Field(

--- a/docling/datamodel/stage_model_specs.py
+++ b/docling/datamodel/stage_model_specs.py
@@ -571,7 +571,7 @@ class StagePresetMixin:
 
     @classmethod
     def from_preset(
-        cls,
+        cls: type[Any],
         preset_id: str,
         engine_options: BaseVlmEngineOptions | None = None,
         **overrides,
@@ -705,7 +705,7 @@ class ObjectDetectionStagePresetMixin:
 
     @classmethod
     def from_preset(
-        cls,
+        cls: type[Any],
         preset_id: str,
         engine_options: BaseObjectDetectionEngineOptions | None = None,
         **overrides: Any,
@@ -815,7 +815,7 @@ class ImageClassificationStagePresetMixin:
 
     @classmethod
     def from_preset(
-        cls,
+        cls: type[Any],
         preset_id: str,
         engine_options: BaseImageClassificationEngineOptions | None = None,
         **overrides: Any,
@@ -872,7 +872,7 @@ class ImageClassificationStagePresetMixin:
 
 # Shared Granite Docling model spec used across VLM_CONVERT and CODE_FORMULA stages
 # Note: prompt and response_format are intentionally excluded here as they vary per stage
-GRANITE_DOCLING_MODEL_SPEC_BASE = {
+GRANITE_DOCLING_MODEL_SPEC_BASE: dict[str, Any] = {
     "name": "Granite-Docling-258M",
     "default_repo_id": "ibm-granite/granite-docling-258M",
     "stop_strings": ["</doctag>", "<|end_of_text|>"],
@@ -896,7 +896,7 @@ GRANITE_DOCLING_MODEL_SPEC_BASE = {
 }
 
 # Shared Pixtral model spec used across VLM_CONVERT and PICTURE_DESCRIPTION stages
-PIXTRAL_MODEL_SPEC_BASE = {
+PIXTRAL_MODEL_SPEC_BASE: dict[str, Any] = {
     "name": "Pixtral-12B",
     "default_repo_id": "mistral-community/pixtral-12b",
     "engine_overrides": {
@@ -910,7 +910,7 @@ PIXTRAL_MODEL_SPEC_BASE = {
 }
 
 # Shared Granite Vision model spec used across VLM_CONVERT and PICTURE_DESCRIPTION stages
-GRANITE_VISION_MODEL_SPEC_BASE = {
+GRANITE_VISION_MODEL_SPEC_BASE: dict[str, Any] = {
     "name": "Granite-Vision-3.3-2B",
     "default_repo_id": "ibm-granite/granite-vision-3.3-2b",
     "supported_engines": {

--- a/docling/datamodel/vlm_model_specs.py
+++ b/docling/datamodel/vlm_model_specs.py
@@ -54,7 +54,9 @@ GRANITEDOCLING_MLX = InlineVlmOptions(
 )
 
 GRANITEDOCLING_VLLM_API = ApiVlmOptions(
-    url="http://localhost:8000/v1/chat/completions",  # LM studio defaults to port 1234, VLLM to 8000
+    url=AnyUrl(
+        "http://localhost:8000/v1/chat/completions"
+    ),  # LM studio defaults to port 1234, VLLM to 8000
     params=dict(
         model=GRANITEDOCLING_TRANSFORMERS.repo_id,
         max_tokens=4096,
@@ -324,7 +326,7 @@ NANONETS_OCR2_VLLM = NANONETS_OCR2_TRANSFORMERS.model_copy(deep=True)
 NANONETS_OCR2_VLLM.inference_framework = InferenceFramework.VLLM
 
 NANONETS_OCR2_VLLM_API = ApiVlmOptions(
-    url="http://localhost:8000/v1/chat/completions",
+    url=AnyUrl("http://localhost:8000/v1/chat/completions"),
     params=dict(
         model="nanonets/Nanonets-OCR2-3B",
         max_tokens=15000,
@@ -446,7 +448,7 @@ GLMOCR_VLLM = GLMOCR_TRANSFORMERS.model_copy(deep=True)
 GLMOCR_VLLM.inference_framework = InferenceFramework.VLLM
 
 GLMOCR_VLLM_API = ApiVlmOptions(
-    url="http://localhost:8000/v1/chat/completions",
+    url=AnyUrl("http://localhost:8000/v1/chat/completions"),
     params=dict(
         model="zai-org/GLM-OCR",
         max_tokens=4096,
@@ -496,7 +498,7 @@ LIGHTONOCR_VLLM = LIGHTONOCR_TRANSFORMERS.model_copy(deep=True)
 LIGHTONOCR_VLLM.inference_framework = InferenceFramework.VLLM
 
 LIGHTONOCR_VLLM_API = ApiVlmOptions(
-    url="http://localhost:8000/v1/chat/completions",
+    url=AnyUrl("http://localhost:8000/v1/chat/completions"),
     params=dict(
         model="lightonai/LightOnOCR-2-1B",
         max_tokens=4096,
@@ -511,7 +513,7 @@ LIGHTONOCR_VLLM_API = ApiVlmOptions(
 
 # DeepSeek-OCR
 DEEPSEEKOCR_OLLAMA = ApiVlmOptions(
-    url="http://localhost:11434/v1/chat/completions",
+    url=AnyUrl("http://localhost:11434/v1/chat/completions"),
     params=dict(
         model="deepseek-ocr:3b",
         max_tokens=4096,

--- a/docling/experimental/pipeline/threaded_layout_vlm_pipeline.py
+++ b/docling/experimental/pipeline/threaded_layout_vlm_pipeline.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import itertools
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
 from docling_core.types.doc import DoclingDocument
 from docling_core.types.doc.document import DocTagsDocument
@@ -80,8 +80,9 @@ class ThreadedLayoutVlmPipeline(BasePipeline):
         # VLM model based on options type
         # Create layout-aware VLM options internally
         base_vlm_options = self.pipeline_options.vlm_options
+        base_vlm_options_type = cast(Any, type(base_vlm_options))
 
-        class LayoutAwareVlmOptions(type(base_vlm_options)):  # type: ignore[misc]
+        class LayoutAwareVlmOptions(base_vlm_options_type):  # type: ignore[misc]
             def build_prompt(
                 self,
                 page: Optional[SegmentedPage],

--- a/docling/models/base_model.py
+++ b/docling/models/base_model.py
@@ -213,6 +213,8 @@ class BaseItemAndImageEnrichmentModel(
                 return ItemAndImageEnrichmentElement(item=element, image=embedded_im)
             else:
                 return None
+        if cropped_image is None:
+            return None
 
         # Return the proper cropped image
         return ItemAndImageEnrichmentElement(item=element, image=cropped_image)

--- a/docling/models/extraction/nuextract_transformers_model.py
+++ b/docling/models/extraction/nuextract_transformers_model.py
@@ -2,12 +2,12 @@ import logging
 import sys
 import time
 from collections.abc import Iterable
+from importlib import import_module
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 import numpy as np
 from PIL.Image import Image
-from transformers import AutoModelForImageTextToText, AutoProcessor, GenerationConfig
 
 from docling.datamodel.accelerator_options import (
     AcceleratorOptions,
@@ -19,6 +19,11 @@ from docling.models.utils.hf_model_download import (
     HuggingFaceModelDownloadMixin,
 )
 from docling.utils.accelerator_utils import decide_device
+
+_transformers = import_module("transformers")
+AutoModelForImageTextToText = getattr(_transformers, "AutoModelForImageTextToText")
+AutoProcessor = getattr(_transformers, "AutoProcessor")
+GenerationConfig = getattr(_transformers, "GenerationConfig")
 
 _log = logging.getLogger(__name__)
 
@@ -77,9 +82,7 @@ def process_all_vision_info(messages, examples=None):
         and (isinstance(examples[0], list) or examples[0] is None)
     )
     examples_batch = (
-        examples
-        if is_batch_examples
-        else ([examples] if examples is not None else None)
+        examples if is_batch_examples else ([examples] if examples is not None else [])
     )
 
     # Ensure examples batch matches messages batch if provided
@@ -187,9 +190,11 @@ class NuExtractTransformersModel(BaseVlmModel, HuggingFaceModelDownloadMixin):
         for img in image_batch:
             if isinstance(img, np.ndarray):
                 if img.ndim == 3 and img.shape[2] in (3, 4):
-                    pil_img = PILImage.fromarray(img.astype(np.uint8))
+                    pil_img = PILImage.fromarray(cast(Any, img).astype(np.uint8))
                 elif img.ndim == 2:
-                    pil_img = PILImage.fromarray(img.astype(np.uint8), mode="L")
+                    pil_img = PILImage.fromarray(
+                        cast(Any, img).astype(np.uint8), mode="L"
+                    )
                 else:
                     raise ValueError(f"Unsupported numpy array shape: {img.shape}")
             else:
@@ -270,9 +275,7 @@ class NuExtractTransformersModel(BaseVlmModel, HuggingFaceModelDownloadMixin):
 
         start_time = time.time()
         with torch.inference_mode():
-            from typing import cast
-
-            generated_ids = cast(Any, self.vlm_model).generate(**gen_kwargs)
+            generated_ids = self.vlm_model.generate(**gen_kwargs)
         generation_time = time.time() - start_time
 
         # Trim generated sequences

--- a/docling/models/factories/base_factory.py
+++ b/docling/models/factories/base_factory.py
@@ -35,7 +35,7 @@ class BaseFactory(Generic[A], metaclass=ABCMeta):
     def registered_kind(self) -> list[str]:
         return [opt.kind for opt in self._classes.keys()]
 
-    def get_enum(self) -> enum.Enum:
+    def get_enum(self) -> type[enum.Enum]:
         return enum.Enum(
             self.plugin_attr_name + "_enum",
             names={kind: kind for kind in self.registered_kind},

--- a/docling/models/inference_engines/common/hf_vision_base.py
+++ b/docling/models/inference_engines/common/hf_vision_base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from importlib import import_module
 from numbers import Integral, Real
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
@@ -93,8 +94,7 @@ class HfVisionModelMixin(HuggingFaceModelDownloadMixin):
     def _load_label_mapping(self, model_folder: Path) -> Dict[int, str]:
         """Load label mapping from HuggingFace model config."""
         try:
-            from transformers import AutoConfig
-
+            AutoConfig = getattr(import_module("transformers"), "AutoConfig")
             config = AutoConfig.from_pretrained(str(model_folder))
             return {
                 int(label_id): label_name

--- a/docling/models/inference_engines/common/kserve_v2_grpc.py
+++ b/docling/models/inference_engines/common/kserve_v2_grpc.py
@@ -5,20 +5,19 @@ from __future__ import annotations
 import logging
 import time
 from dataclasses import dataclass
-from typing import Any, Dict, Mapping, Sequence, Tuple
+from importlib import import_module
+from typing import Any, Dict, Mapping, Sequence, Tuple, cast
 
 import numpy as np
 
 try:
-    import grpc  # type: ignore[import-untyped]
-    from tritonclient.grpc import (  # type: ignore[import-untyped, import-not-found]
-        service_pb2,
-        service_pb2_grpc,
-    )
+    grpc = cast(Any, import_module("grpc"))
+    service_pb2 = cast(Any, import_module("tritonclient.grpc.service_pb2"))
+    service_pb2_grpc = cast(Any, import_module("tritonclient.grpc.service_pb2_grpc"))
 except ImportError:
-    grpc = None  # type: ignore[assignment]
-    service_pb2 = None  # type: ignore[assignment]
-    service_pb2_grpc = None  # type: ignore[assignment]
+    grpc = cast(Any, None)
+    service_pb2 = cast(Any, None)
+    service_pb2_grpc = cast(Any, None)
 
 from docling.models.inference_engines.common.kserve_v2_types import (
     KSERVE_V2_NUMPY_DATATYPES,
@@ -269,6 +268,8 @@ class KserveV2GrpcClient:
         request_parameters: Mapping[str, Any] | None = None,
     ) -> Dict[str, np.ndarray]:
         _batch_size = next(iter(inputs.values())).shape[0] if inputs else 0
+        _t_ser_start = _t_ser_mono = _t_grpc_start = _t_grpc_mono = 0.0
+        _t_deser_start = _t_deser_mono = 0.0
 
         if _log.isEnabledFor(logging.DEBUG):
             _t_ser_start = time.time()

--- a/docling/models/inference_engines/common/kserve_v2_http.py
+++ b/docling/models/inference_engines/common/kserve_v2_http.py
@@ -261,8 +261,11 @@ class KserveV2HttpClient:
                 f"Failed to connect to {url}"
             ) from exc
         except requests.exceptions.HTTPError as exc:
+            response = exc.response
+            status_code = response.status_code if response is not None else "unknown"
+            response_text = response.text if response is not None else ""
             raise requests.exceptions.HTTPError(
-                f"HTTP error {response.status_code} from {url}: {response.text}"
+                f"HTTP error {status_code} from {url}: {response_text}"
             ) from exc
 
     @property
@@ -335,8 +338,11 @@ class KserveV2HttpClient:
             requests.exceptions.HTTPError: If server returns error status
             RuntimeError: If response format is invalid
         """
+        _batch_size = next(iter(inputs.values())).shape[0] if inputs else 0
+        _t_ser_start = _t_ser_mono = _t_http_start = _t_http_mono = 0.0
+        _t_deser_start = _t_deser_mono = 0.0
+
         if _log.isEnabledFor(logging.DEBUG):
-            _batch_size = next(iter(inputs.values())).shape[0] if inputs else 0
             _t_ser_start = time.time()
             _t_ser_mono = time.monotonic()
         request_kwargs: Dict[str, Any]

--- a/docling/models/inference_engines/image_classification/onnxruntime_engine.py
+++ b/docling/models/inference_engines/image_classification/onnxruntime_engine.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
 import numpy as np
 
@@ -98,6 +98,8 @@ class OnnxRuntimeImageClassificationEngine(HfImageClassificationEngineBase):
     def initialize(self) -> None:
         """Initialize ONNX session and preprocessor."""
         import onnxruntime as ort
+
+        ort = cast(Any, ort)
 
         _log.info("Initializing ONNX Runtime image-classification engine")
 

--- a/docling/models/inference_engines/image_classification/transformers_engine.py
+++ b/docling/models/inference_engines/image_classification/transformers_engine.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 import logging
 import sys
+from importlib import import_module
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
 from packaging import version
 
 if TYPE_CHECKING:
     import torch
-    from transformers import AutoModelForImageClassification
 
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
 from docling.datamodel.image_classification_engine_options import (
@@ -51,7 +51,7 @@ class TransformersImageClassificationEngine(HfImageClassificationEngineBase):
             artifacts_path=artifacts_path,
         )
         self.options: TransformersImageClassificationEngineOptions = options
-        self._model: Optional[AutoModelForImageClassification] = None
+        self._model: Optional[Any] = None
         self._device: Optional[torch.device] = None
 
     def _resolve_device(self) -> torch.device:
@@ -99,7 +99,11 @@ class TransformersImageClassificationEngine(HfImageClassificationEngineBase):
     def initialize(self) -> None:
         """Initialize PyTorch model and preprocessor."""
         import torch
-        from transformers import AutoModelForImageClassification
+
+        AutoModelForImageClassification = getattr(
+            import_module("transformers"),
+            "AutoModelForImageClassification",
+        )
 
         _log.info("Initializing Transformers image-classification engine")
 
@@ -169,7 +173,7 @@ class TransformersImageClassificationEngine(HfImageClassificationEngineBase):
         inputs = self._processor(images=images, return_tensors="pt").to(self._device)
 
         with torch.inference_mode():
-            outputs = self._model(**inputs)  # type: ignore[operator]
+            outputs = cast(Any, self._model)(**inputs)
             probs_batch = torch.softmax(outputs.logits, dim=-1)
 
         batch_outputs: List[ImageClassificationEngineOutput] = []

--- a/docling/models/inference_engines/object_detection/api_kserve_v2_engine.py
+++ b/docling/models/inference_engines/object_detection/api_kserve_v2_engine.py
@@ -180,6 +180,8 @@ class ApiKserveV2ObjectDetectionEngine(HfObjectDetectionEngineBase):
         assert self._output_boxes_name is not None
         assert self._output_scores_name is not None
 
+        _t_preproc_start = 0.0
+        _t_preproc_mono = 0.0
         if _log.isEnabledFor(logging.DEBUG):
             _t_preproc_start = time.time()
             _t_preproc_mono = time.monotonic()

--- a/docling/models/inference_engines/object_detection/onnxruntime_engine.py
+++ b/docling/models/inference_engines/object_detection/onnxruntime_engine.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
 import numpy as np
 
@@ -99,6 +99,8 @@ class OnnxRuntimeObjectDetectionEngine(HfObjectDetectionEngineBase):
         """Initialize ONNX session and preprocessor."""
         import onnxruntime as ort
 
+        ort = cast(Any, ort)
+
         _log.info("Initializing ONNX Runtime object-detection engine")
 
         # Resolve model folder and model path in one step
@@ -108,7 +110,7 @@ class OnnxRuntimeObjectDetectionEngine(HfObjectDetectionEngineBase):
 
         # Load preprocessor (source of truth for preprocessing)
         self._processor = self._load_preprocessor(model_folder)
-        _log.debug(f"Loaded preprocessor with size: {self._processor.size}")  # type: ignore[attr-defined]
+        _log.debug(f"Loaded preprocessor with size: {cast(Any, self._processor).size}")
 
         # Load label mapping from config
         self._id_to_label = self._load_label_mapping(model_folder)
@@ -194,7 +196,9 @@ class OnnxRuntimeObjectDetectionEngine(HfObjectDetectionEngineBase):
                 "[labels, boxes, scores]"
             )
 
-        labels_batch, boxes_batch, scores_batch = output_tensors[:3]
+        labels_batch = cast(Any, output_tensors[0])
+        boxes_batch = cast(Any, output_tensors[1])
+        scores_batch = cast(Any, output_tensors[2])
 
         batch_outputs: List[ObjectDetectionEngineOutput] = []
         for idx, input_item in enumerate(input_batch):

--- a/docling/models/inference_engines/object_detection/transformers_engine.py
+++ b/docling/models/inference_engines/object_detection/transformers_engine.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union, cast
 
 from packaging import version
 
@@ -134,7 +134,7 @@ class TransformersObjectDetectionEngine(HfObjectDetectionEngineBase):
 
         # Load preprocessor (source of truth for preprocessing)
         self._processor = self._load_preprocessor(model_folder)
-        _log.debug(f"Loaded preprocessor with size: {self._processor.size}")  # type: ignore[attr-defined]
+        _log.debug(f"Loaded preprocessor with size: {cast(Any, self._processor).size}")
 
         # Load label mapping from config
         self._id_to_label = self._load_label_mapping(model_folder)
@@ -202,10 +202,10 @@ class TransformersObjectDetectionEngine(HfObjectDetectionEngineBase):
 
         # Run inference
         with torch.inference_mode():
-            outputs = self._model(**inputs)  # type: ignore[operator]
+            outputs = cast(Any, self._model)(**inputs)
 
         # Post-process using HuggingFace processor
-        results = self._processor.post_process_object_detection(  # type: ignore[attr-defined]
+        results = cast(Any, self._processor).post_process_object_detection(
             outputs,
             target_sizes=target_sizes,  # type: ignore[arg-type]
             threshold=self.options.score_threshold,

--- a/docling/models/inference_engines/vlm/_utils.py
+++ b/docling/models/inference_engines/vlm/_utils.py
@@ -6,7 +6,7 @@ implementations to avoid code duplication and ensure consistency.
 
 import logging
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union
+from typing import Any, Callable, Dict, List, Optional, Union, cast
 
 import numpy as np
 from PIL import Image
@@ -33,10 +33,10 @@ def normalize_image_to_pil(image: Union[Image.Image, np.ndarray]) -> Image.Image
     if isinstance(image, np.ndarray):
         if image.ndim == 3 and image.shape[2] in [3, 4]:
             # RGB or RGBA array
-            image = Image.fromarray(image.astype(np.uint8))
+            image = Image.fromarray(cast(Any, image).astype(np.uint8))
         elif image.ndim == 2:
             # Grayscale array
-            image = Image.fromarray(image.astype(np.uint8), mode="L")
+            image = Image.fromarray(cast(Any, image).astype(np.uint8), mode="L")
         else:
             raise ValueError(f"Unsupported numpy array shape: {image.shape}")
 

--- a/docling/models/inference_engines/vlm/mlx_engine.py
+++ b/docling/models/inference_engines/vlm/mlx_engine.py
@@ -141,8 +141,8 @@ class MlxVlmEngine(BaseVlmEngine, HuggingFaceModelDownloadMixin):
             )
 
         # Load the model
-        self.vlm_model, self.processor = load(artifacts_path)
-        self.config = load_config(artifacts_path)
+        self.vlm_model, self.processor = load(str(artifacts_path))
+        self.config = load_config(str(artifacts_path))
 
         _log.info(f"Loaded MLX model {repo_id} (revision: {revision})")
 

--- a/docling/models/inference_engines/vlm/transformers_engine.py
+++ b/docling/models/inference_engines/vlm/transformers_engine.py
@@ -4,17 +4,14 @@ import importlib.metadata
 import logging
 import sys
 import time
+from importlib import import_module
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Union, cast
 
 import torch
 from packaging import version
 from PIL.Image import Image
 from transformers import (
-    AutoModel,
-    AutoModelForCausalLM,
-    AutoModelForImageTextToText,
-    AutoProcessor,
     BitsAndBytesConfig,
     GenerationConfig,
     PreTrainedModel,
@@ -46,6 +43,12 @@ from docling.utils.accelerator_utils import decide_device
 
 if TYPE_CHECKING:
     from docling.datamodel.stage_model_specs import EngineModelConfig
+
+_transformers = import_module("transformers")
+AutoModel = getattr(_transformers, "AutoModel")
+AutoModelForCausalLM = getattr(_transformers, "AutoModelForCausalLM")
+AutoModelForImageTextToText = getattr(_transformers, "AutoModelForImageTextToText")
+AutoProcessor = getattr(_transformers, "AutoProcessor")
 
 _log = logging.getLogger(__name__)
 
@@ -203,7 +206,8 @@ class TransformersVlmEngine(BaseVlmEngine, HuggingFaceModelDownloadMixin):
             dtype=torch_dtype,
             _attn_implementation=(
                 "flash_attention_2"
-                if self.device.startswith("cuda")  # type: ignore[union-attr]
+                if self.device is not None
+                and self.device.startswith("cuda")
                 and self.accelerator_options.cuda_use_flash_attention2
                 else "sdpa"
             ),
@@ -298,8 +302,6 @@ class TransformersVlmEngine(BaseVlmEngine, HuggingFaceModelDownloadMixin):
                         ],
                     }
                 ]
-                from typing import cast
-
                 formatted_prompt = self.processor.apply_chat_template(  # type: ignore[union-attr]
                     cast(Any, messages),
                     tokenize=False,
@@ -411,7 +413,7 @@ class TransformersVlmEngine(BaseVlmEngine, HuggingFaceModelDownloadMixin):
 
         start_time = time.time()
         with torch.inference_mode():
-            generated_ids = self.vlm_model.generate(**gen_kwargs)  # type: ignore[union-attr,operator]
+            generated_ids = cast(Any, self.vlm_model).generate(**gen_kwargs)
         generation_time = time.time() - start_time
 
         # Decode

--- a/docling/models/stages/chart_extraction/granite_vision.py
+++ b/docling/models/stages/chart_extraction/granite_vision.py
@@ -3,6 +3,7 @@ import re
 import warnings
 from abc import abstractmethod
 from collections.abc import Iterable
+from importlib import import_module
 from io import StringIO
 from pathlib import Path
 from typing import Any, List, Literal, Optional, cast
@@ -24,7 +25,6 @@ from docling_core.types.doc import (
 from docling_core.types.doc.document import CodeMetaField
 from PIL import Image
 from pydantic import BaseModel
-from transformers import AutoModelForImageTextToText, AutoProcessor
 
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
 from docling.datamodel.base_models import ItemAndImageEnrichmentElement
@@ -35,6 +35,10 @@ from docling.datamodel.chart_extraction_options import (
 from docling.models.base_model import BaseItemAndImageEnrichmentModel
 from docling.models.utils.hf_model_download import download_hf_model
 from docling.utils.accelerator_utils import decide_device
+
+_transformers = import_module("transformers")
+AutoModelForImageTextToText = getattr(_transformers, "AutoModelForImageTextToText")
+AutoProcessor = getattr(_transformers, "AutoProcessor")
 
 _log = logging.getLogger(__name__)
 
@@ -224,7 +228,7 @@ class ChartExtractionModelGraniteVision(_BaseChartExtractionModelGraniteVision):
         images: List[Image.Image] = []
         elements: List[PictureItem] = []
         for el in element_batch:
-            elements.append(el.item)  # type: ignore[arg-type]
+            elements.append(cast(PictureItem, el.item))
             images.append(el.image)
 
         # Create a batch of conversations
@@ -262,7 +266,7 @@ class ChartExtractionModelGraniteVision(_BaseChartExtractionModelGraniteVision):
         ]
 
         # autoregressively complete prompt for batch
-        output_ids = cast(Any, self._model).generate(
+        output_ids = self._model.generate(
             **inputs,
             max_new_tokens=self._model_max_length,
             eos_token_id=eos_ids,
@@ -373,7 +377,7 @@ class ChartExtractionModelGraniteVisionV4(_BaseChartExtractionModelGraniteVision
                 trust_remote_code=True,
             )
         if hasattr(self._model, "merge_lora_adapters"):
-            cast(Any, self._model).merge_lora_adapters()
+            self._model.merge_lora_adapters()
         self._model.eval()
 
     def __call__(
@@ -389,7 +393,7 @@ class ChartExtractionModelGraniteVisionV4(_BaseChartExtractionModelGraniteVision
         images: List[Image.Image] = []
         elements: List[PictureItem] = []
         for el in element_batch:
-            elements.append(el.item)  # type: ignore[arg-type]
+            elements.append(cast(PictureItem, el.item))
             images.append(el.image)
 
         active_prompts: list[str] = []
@@ -435,7 +439,7 @@ class ChartExtractionModelGraniteVisionV4(_BaseChartExtractionModelGraniteVision
             do_pad=True,
         ).to(self.device)
 
-        output_ids = cast(Any, self._model).generate(
+        output_ids = self._model.generate(
             **inputs,
             max_new_tokens=self._model_max_length,
             use_cache=True,

--- a/docling/models/stages/code_formula/code_formula_model.py
+++ b/docling/models/stages/code_formula/code_formula_model.py
@@ -1,7 +1,8 @@
 import re
 from collections.abc import Iterable
+from importlib import import_module
 from pathlib import Path
-from typing import List, Literal, Optional, Tuple, Union
+from typing import List, Literal, Optional, Tuple, Union, cast
 
 import numpy as np
 from docling_core.types.doc import (
@@ -108,7 +109,11 @@ class CodeFormulaModel(BaseItemAndImageEnrichmentModel):
             else:
                 artifacts_path = artifacts_path / self._model_repo_folder
 
-            from transformers import AutoModelForImageTextToText, AutoProcessor
+            transformers = import_module("transformers")
+            AutoModelForImageTextToText = getattr(
+                transformers, "AutoModelForImageTextToText"
+            )
+            AutoProcessor = getattr(transformers, "AutoProcessor")
 
             self._processor = AutoProcessor.from_pretrained(
                 artifacts_path,
@@ -308,8 +313,9 @@ class CodeFormulaModel(BaseItemAndImageEnrichmentModel):
         images: List[Union[Image.Image, np.ndarray]] = []
         elements: List[TextItem] = []
         for el in element_batch:
-            elements.append(el.item)  # type: ignore[arg-type]
-            labels.append(el.item.label)  # type: ignore[attr-defined]
+            item = cast(TextItem, el.item)
+            elements.append(item)
+            labels.append(item.label)
             images.append(el.image)
 
         prompts = [self._get_prompt(label) for label in labels]
@@ -326,9 +332,7 @@ class CodeFormulaModel(BaseItemAndImageEnrichmentModel):
             do_sample=False,
         )
 
-        from typing import Any, cast
-
-        generated_ids = cast(Any, self._model).generate(**inputs, **gen_kwargs)
+        generated_ids = self._model.generate(**inputs, **gen_kwargs)
 
         outputs = self._processor.batch_decode(
             generated_ids[:, inputs.input_ids.shape[1] :], skip_special_tokens=False

--- a/docling/models/stages/ocr/ocr_mac_model.py
+++ b/docling/models/stages/ocr/ocr_mac_model.py
@@ -1,9 +1,9 @@
 import logging
 import sys
 import tempfile
-from collections.abc import Iterable
+from collections.abc import Callable, Iterable
 from pathlib import Path
-from typing import Optional, Type
+from typing import Any, Optional, Type
 
 from docling_core.types.doc import BoundingBox, CoordOrigin
 from docling_core.types.doc.page import BoundingRectangle, TextCell
@@ -39,6 +39,7 @@ class OcrMacModel(BaseOcrModel):
         self.options: OcrMacOptions
 
         self.scale = 3  # multiplier for 72 dpi == 216 dpi.
+        self.reader_RIL: Callable[..., Any] | None = None
 
         if self.enabled:
             if "darwin" != sys.platform:
@@ -63,6 +64,7 @@ class OcrMacModel(BaseOcrModel):
             yield from page_batch
             return
 
+        assert self.reader_RIL is not None
         for page in page_batch:
             assert page._backend is not None
             if not page._backend.is_valid():

--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Literal, Type, TypedDict
+from typing import Any, Literal, Type, TypedDict, cast
 
 import numpy
 from docling_core.types.doc import BoundingBox, CoordOrigin
@@ -311,17 +311,24 @@ class RapidOcrModel(BaseOcrModel):
                             scale=self.scale, cropbox=ocr_rect
                         )
                         im = numpy.array(high_res_image)
-                        result = self.reader(
-                            im,
-                            use_det=self.options.use_det,
-                            use_cls=self.options.use_cls,
-                            use_rec=self.options.use_rec,
+                        ocr_output = cast(
+                            Any,
+                            self.reader(
+                                im,
+                                use_det=self.options.use_det,
+                                use_cls=self.options.use_cls,
+                                use_rec=self.options.use_rec,
+                            ),
                         )
-                        if result is None or result.boxes is None:
+                        if ocr_output is None or ocr_output.boxes is None:
                             _log.warning("RapidOCR returned empty result!")
                             continue
                         result = list(
-                            zip(result.boxes.tolist(), result.txts, result.scores)
+                            zip(
+                                ocr_output.boxes.tolist(),
+                                ocr_output.txts,
+                                ocr_output.scores,
+                            )
                         )
 
                         del high_res_image

--- a/docling/models/stages/ocr/tesseract_ocr_model.py
+++ b/docling/models/stages/ocr/tesseract_ocr_model.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Iterable, Optional, Type
+from typing import Any, Iterable, Optional, Type, cast
 
 from docling_core.types.doc import BoundingBox, CoordOrigin
 from docling_core.types.doc.page import TextCell
@@ -89,6 +89,7 @@ class TesseractOcrModel(BaseOcrModel):
                 "init": True,
                 "oem": tesserocr.OEM.DEFAULT,
             }
+            tess_base_api = cast(Any, tesserocr.PyTessBaseAPI)
 
             self.osd_reader = None
 
@@ -100,15 +101,15 @@ class TesseractOcrModel(BaseOcrModel):
                 self.options.psm if self.options.psm is not None else tesserocr.PSM.AUTO
             )
             if lang == "auto":
-                self.reader = tesserocr.PyTessBaseAPI(psm=main_psm, **tesserocr_kwargs)
+                self.reader = tess_base_api(psm=main_psm, **tesserocr_kwargs)
             else:
-                self.reader = tesserocr.PyTessBaseAPI(
+                self.reader = tess_base_api(
                     lang=lang,
                     psm=main_psm,
                     **tesserocr_kwargs,
                 )
             # OSD reader must use PSM.OSD_ONLY for orientation detection
-            self.osd_reader = tesserocr.PyTessBaseAPI(
+            self.osd_reader = tess_base_api(
                 lang="osd", psm=tesserocr.PSM.OSD_ONLY, **tesserocr_kwargs
             )
             self.reader_RIL = tesserocr.RIL
@@ -189,16 +190,16 @@ class TesseractOcrModel(BaseOcrModel):
                                 if script not in self.script_readers:
                                     import tesserocr
 
-                                    self.script_readers[script] = (
-                                        tesserocr.PyTessBaseAPI(
-                                            path=self.reader.GetDatapath(),
-                                            lang=lang,
-                                            psm=self.options.psm
-                                            if self.options.psm is not None
-                                            else tesserocr.PSM.AUTO,
-                                            init=True,
-                                            oem=tesserocr.OEM.DEFAULT,
-                                        )
+                                    self.script_readers[script] = cast(
+                                        Any, tesserocr.PyTessBaseAPI
+                                    )(
+                                        path=self.reader.GetDatapath(),
+                                        lang=lang,
+                                        psm=self.options.psm
+                                        if self.options.psm is not None
+                                        else tesserocr.PSM.AUTO,
+                                        init=True,
+                                        oem=tesserocr.OEM.DEFAULT,
                                     )
                                 local_reader = self.script_readers[script]
 

--- a/docling/models/stages/page_assemble/page_assemble_model.py
+++ b/docling/models/stages/page_assemble/page_assemble_model.py
@@ -221,7 +221,6 @@ class PageAssembleModel(BasePageModel):
                                     label=cluster.label,
                                     id=cluster.id,
                                     text="",
-                                    data=None,
                                     cluster=cluster,
                                     page_no=page.page_no,
                                 )

--- a/docling/models/stages/picture_classifier/document_picture_classifier.py
+++ b/docling/models/stages/picture_classifier/document_picture_classifier.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterable
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union, cast
 
 import numpy as np
 from docling_core.types.doc import (
@@ -149,7 +149,7 @@ class DocumentPictureClassifier(
         if self.engine is None:
             raise RuntimeError("Picture classifier engine is not initialized.")
 
-        images: List[Union[Image.Image, np.ndarray]] = []
+        images: list[Image.Image] = []
         elements: List[PictureItem] = []
         for i, el in enumerate(element_batch):
             assert isinstance(el.item, PictureItem)
@@ -159,7 +159,7 @@ class DocumentPictureClassifier(
             if isinstance(raw_image, Image.Image):
                 raw_image = raw_image.convert("RGB")
             elif isinstance(raw_image, np.ndarray):
-                raw_image = Image.fromarray(raw_image).convert("RGB")
+                raw_image = Image.fromarray(cast(Any, raw_image)).convert("RGB")
             else:
                 raise TypeError(
                     "Supported input formats are PIL.Image.Image or numpy.ndarray."

--- a/docling/models/stages/picture_description/picture_description_vlm_model.py
+++ b/docling/models/stages/picture_description/picture_description_vlm_model.py
@@ -1,6 +1,7 @@
 import sys
 import threading
 from collections.abc import Iterable
+from importlib import import_module
 from pathlib import Path
 from typing import Optional, Type, Union
 
@@ -55,14 +56,16 @@ class PictureDescriptionVlmModel(
 
             try:
                 import torch
-                from transformers import (
-                    AutoModelForImageTextToText,
-                    AutoProcessor,
+
+                transformers = import_module("transformers")
+                AutoModelForImageTextToText = getattr(
+                    transformers, "AutoModelForImageTextToText"
                 )
-            except ImportError:
+                AutoProcessor = getattr(transformers, "AutoProcessor")
+            except (AttributeError, ImportError) as e:
                 raise ImportError(
                     "transformers >=4.46 is not installed. Please install Docling with the required extras `pip install docling[vlm]`."
-                )
+                ) from e
 
             # Initialize processor and model
             with _model_init_lock:
@@ -117,9 +120,7 @@ class PictureDescriptionVlmModel(
         )
         inputs = inputs.to(self.device)
 
-        from typing import Any, cast
-
-        generated_ids = cast(Any, self.model).generate(
+        generated_ids = self.model.generate(
             **inputs,
             generation_config=GenerationConfig(**self.options.generation_config),
         )

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from typing import Any, cast
 
 from docling_core.types.doc import (
     DocItemLabel,
@@ -52,17 +53,21 @@ class ReadingOrderModel:
         page_no_to_pages = {p.page_no: p for p in conv_res.pages}
 
         for element in conv_res.assembled.elements:
-            page_height = page_no_to_pages[element.page_no].size.height  # type: ignore
+            page_size = page_no_to_pages[element.page_no].size
+            assert page_size is not None
+            page_height = page_size.height
             bbox = element.cluster.bbox.to_bottom_left_origin(page_height)
             text = element.text or ""
 
             elements.append(
                 ReadingOrderPageElement(
                     cid=len(elements),
-                    ref=RefItem(cref=f"#/{element.page_no}/{element.cluster.id}"),
+                    ref=cast(Any, RefItem)(
+                        cref=f"#/{element.page_no}/{element.cluster.id}"
+                    ),
                     text=text,
                     page_no=element.page_no,
-                    page_size=page_no_to_pages[element.page_no].size,
+                    page_size=page_size,
                     label=element.label,
                     l=bbox.l,
                     r=bbox.r,
@@ -140,7 +145,7 @@ class ReadingOrderModel:
         el_merges_mapping: dict[int, list[int]],
     ) -> DoclingDocument:
         id_to_elem = {
-            RefItem(cref=f"#/{elem.page_no}/{elem.cluster.id}").cref: elem
+            cast(Any, RefItem)(cref=f"#/{elem.page_no}/{elem.cluster.id}").cref: elem
             for elem in conv_res.assembled.elements
         }
         cid_to_rels = {rel.cid: rel for rel in ro_elements}
@@ -148,7 +153,7 @@ class ReadingOrderModel:
         origin = DocumentOrigin(
             mimetype="application/pdf",
             filename=conv_res.input.file.name,
-            binary_hash=conv_res.input.document_hash,
+            binary_hash=cast(int, conv_res.input.document_hash),
         )
         doc_name = Path(origin.filename).stem
         out_doc: DoclingDocument = DoclingDocument(name=doc_name, origin=origin)

--- a/docling/models/stages/table_structure/table_structure_model.py
+++ b/docling/models/stages/table_structure/table_structure_model.py
@@ -3,7 +3,7 @@ import logging
 import warnings
 from collections.abc import Iterable, Sequence
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Any, Literal, Optional, cast
 
 import numpy
 from docling_core.types.doc import BoundingBox, DocItemLabel, TableCell
@@ -253,7 +253,7 @@ class TableStructureModel(BaseTableStructureModel):
                                     "bbox": new_cell.rect.to_bounding_box().model_dump(),
                                 }
                             )
-                    page_input["tokens"] = tokens
+                    cast(Any, page_input)["tokens"] = tokens
 
                     tf_output = self.tf_predictor.multi_table_predict(
                         page_input, [tbl_box], do_matching=self.do_cell_matching

--- a/docling/models/stages/table_structure/table_structure_model_granite_vision.py
+++ b/docling/models/stages/table_structure/table_structure_model_granite_vision.py
@@ -2,13 +2,13 @@ import logging
 import re
 import warnings
 from collections.abc import Sequence
+from importlib import import_module
 from itertools import groupby
 from pathlib import Path
-from typing import Any, ClassVar, Literal, cast
+from typing import ClassVar, Literal
 
 import torch
 from docling_core.types.doc import DocItemLabel, TableCell
-from transformers import AutoModelForImageTextToText, AutoProcessor
 
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
 from docling.datamodel.base_models import Page, Table, TableStructurePrediction
@@ -20,6 +20,9 @@ from docling.utils.accelerator_utils import decide_device
 from docling.utils.profiling import TimeRecorder
 
 _log = logging.getLogger(__name__)
+_transformers = import_module("transformers")
+AutoModelForImageTextToText = getattr(_transformers, "AutoModelForImageTextToText")
+AutoProcessor = getattr(_transformers, "AutoProcessor")
 
 # OTSL tokens that represent content-bearing cells (produce a TableCell)
 _CONTENT_TOKENS = {"fcel", "ecel", "ched", "rhed", "srow"}
@@ -225,7 +228,7 @@ class GraniteVisionTableStructureModel(BaseTableStructureModel):
                 trust_remote_code=True,
             )
         if hasattr(self._model, "merge_lora_adapters"):
-            cast(Any, self._model).merge_lora_adapters()
+            self._model.merge_lora_adapters()
         self._model.eval()
 
     def predict_tables(
@@ -301,7 +304,7 @@ class GraniteVisionTableStructureModel(BaseTableStructureModel):
                     do_pad=True,
                 ).to(self.device)
 
-                output_ids = cast(Any, self._model).generate(
+                output_ids = self._model.generate(
                     **inputs,
                     max_new_tokens=self._model_max_length,
                     use_cache=True,

--- a/docling/models/stages/table_structure/table_structure_model_v2.py
+++ b/docling/models/stages/table_structure/table_structure_model_v2.py
@@ -1,8 +1,9 @@
 import logging
 from collections.abc import Iterable, Sequence
+from importlib import import_module
 from itertools import groupby
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional, cast
 
 import numpy
 import torch
@@ -12,7 +13,6 @@ from docling_core.types.doc.page import (
     TextCell,
 )
 from PIL import Image, ImageDraw
-from transformers import AutoTokenizer
 
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
 from docling.datamodel.base_models import Cluster, Page, Table, TableStructurePrediction
@@ -23,6 +23,8 @@ from docling.models.base_table_model import BaseTableStructureModel
 from docling.models.utils.hf_model_download import download_hf_model
 from docling.utils.accelerator_utils import decide_device
 from docling.utils.profiling import TimeRecorder
+
+AutoTokenizer = getattr(import_module("transformers"), "AutoTokenizer")
 
 _log = logging.getLogger(__name__)
 
@@ -71,8 +73,6 @@ class TableStructureModelV2(BaseTableStructureModel):
             from docling_ibm_models.tableformer_v2 import TableFormerV2
 
             self.model = TableFormerV2.from_pretrained(model_path)
-            from typing import Any, cast
-
             cast(Any, self.model).to(self.device)
             self.model.eval()
 

--- a/docling/models/vlm_pipeline_models/hf_transformers_model.py
+++ b/docling/models/vlm_pipeline_models/hf_transformers_model.py
@@ -3,8 +3,9 @@ import logging
 import sys
 import time
 from collections.abc import Iterable
+from importlib import import_module
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, cast
 
 import numpy as np
 from PIL.Image import Image
@@ -46,14 +47,16 @@ class HuggingFaceTransformersVlmModel(BaseVlmPageModel, HuggingFaceModelDownload
 
         if self.enabled:
             import torch
-            from transformers import (
-                AutoModel,
-                AutoModelForCausalLM,
-                AutoModelForImageTextToText,
-                AutoProcessor,
-                BitsAndBytesConfig,
-                GenerationConfig,
+
+            transformers = import_module("transformers")
+            AutoModel = getattr(transformers, "AutoModel")
+            AutoModelForCausalLM = getattr(transformers, "AutoModelForCausalLM")
+            AutoModelForImageTextToText = getattr(
+                transformers, "AutoModelForImageTextToText"
             )
+            AutoProcessor = getattr(transformers, "AutoProcessor")
+            BitsAndBytesConfig = getattr(transformers, "BitsAndBytesConfig")
+            GenerationConfig = getattr(transformers, "GenerationConfig")
 
             transformers_version = importlib.metadata.version("transformers")
             if (
@@ -226,9 +229,11 @@ class HuggingFaceTransformersVlmModel(BaseVlmPageModel, HuggingFaceModelDownload
         for img in image_batch:
             if isinstance(img, np.ndarray):
                 if img.ndim == 3 and img.shape[2] in (3, 4):
-                    pil_img = PILImage.fromarray(img.astype(np.uint8))
+                    pil_img = PILImage.fromarray(cast(Any, img).astype(np.uint8))
                 elif img.ndim == 2:
-                    pil_img = PILImage.fromarray(img.astype(np.uint8), mode="L")
+                    pil_img = PILImage.fromarray(
+                        cast(Any, img).astype(np.uint8), mode="L"
+                    )
                 else:
                     raise ValueError(f"Unsupported numpy array shape: {img.shape}")
             else:
@@ -252,6 +257,7 @@ class HuggingFaceTransformersVlmModel(BaseVlmPageModel, HuggingFaceModelDownload
 
         # Use your prompt formatter verbatim
         if self.vlm_options.transformers_prompt_style == TransformersPromptStyle.NONE:
+            prompts: list[str] = []
             inputs = self.processor(
                 pil_images,
                 return_tensors="pt",
@@ -298,7 +304,9 @@ class HuggingFaceTransformersVlmModel(BaseVlmPageModel, HuggingFaceModelDownload
                         stopping_criteria_list.append(wrapped_criteria)
                     elif issubclass(criteria, StoppingCriteria):
                         # It's a StoppingCriteria class, instantiate with tokenizer
-                        criteria_instance = criteria(self.processor.tokenizer)
+                        criteria_instance = cast(Any, criteria)(
+                            self.processor.tokenizer
+                        )
                         stopping_criteria_list.append(criteria_instance)
                 elif isinstance(criteria, GenerationStopper):
                     # Wrap GenerationStopper instances in HFStoppingCriteriaWrapper

--- a/docling/models/vlm_pipeline_models/mlx_model.py
+++ b/docling/models/vlm_pipeline_models/mlx_model.py
@@ -4,7 +4,7 @@ import threading
 import time
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Union
+from typing import Any, Union, cast
 
 import numpy as np
 from PIL.Image import Image
@@ -92,8 +92,8 @@ class HuggingFaceMlxModel(BaseVlmPageModel, HuggingFaceModelDownloadMixin):
                 )
 
             ## Load the model
-            self.vlm_model, self.processor = load(artifacts_path)
-            self.config = load_config(artifacts_path)
+            self.vlm_model, self.processor = load(str(artifacts_path))
+            self.config = load_config(str(artifacts_path))
 
             # Validate custom stopping criteria - MLX doesn't support HF StoppingCriteria
             if self.vlm_options.custom_stopping_criteria:
@@ -213,12 +213,14 @@ class HuggingFaceMlxModel(BaseVlmPageModel, HuggingFaceModelDownloadMixin):
                         # RGB or RGBA array
                         from PIL import Image as PILImage
 
-                        image = PILImage.fromarray(image.astype(np.uint8))
+                        image = PILImage.fromarray(cast(Any, image).astype(np.uint8))
                     elif image.ndim == 2:
                         # Grayscale array
                         from PIL import Image as PILImage
 
-                        image = PILImage.fromarray(image.astype(np.uint8), mode="L")
+                        image = PILImage.fromarray(
+                            cast(Any, image).astype(np.uint8), mode="L"
+                        )
                     else:
                         raise ValueError(
                             f"Unsupported numpy array shape: {image.shape}"
@@ -244,12 +246,13 @@ class HuggingFaceMlxModel(BaseVlmPageModel, HuggingFaceModelDownloadMixin):
                 for token in self.stream_generate(
                     self.vlm_model,
                     self.processor,
-                    formatted_prompt,
-                    [image],  # MLX stream_generate expects list of images
+                    cast(Any, formatted_prompt),
+                    cast(Any, [image]),  # MLX stream_generate expects list of images
                     max_tokens=self.max_tokens,
                     verbose=False,
                     temp=self.temperature,
                 ):
+                    token = cast(Any, token)
                     # Collect token information
                     if len(token.logprobs.shape) == 1:
                         tokens.append(
@@ -288,6 +291,7 @@ class HuggingFaceMlxModel(BaseVlmPageModel, HuggingFaceModelDownloadMixin):
                     # Check for custom stopping criteria (GenerationStopper instances)
                     if self.vlm_options.custom_stopping_criteria:
                         for criteria in self.vlm_options.custom_stopping_criteria:
+                            stopper: GenerationStopper | None = None
                             # Handle both instances and classes of GenerationStopper
                             if isinstance(criteria, GenerationStopper):
                                 stopper = criteria
@@ -295,6 +299,8 @@ class HuggingFaceMlxModel(BaseVlmPageModel, HuggingFaceModelDownloadMixin):
                                 criteria, GenerationStopper
                             ):
                                 stopper = criteria()
+                            if stopper is None:
+                                continue
 
                             # Determine the text window to check based on lookback_tokens
                             lookback_tokens = stopper.lookback_tokens()
@@ -330,8 +336,9 @@ class HuggingFaceMlxModel(BaseVlmPageModel, HuggingFaceModelDownloadMixin):
 
                 # Apply decode_response to the output before yielding
                 decoded_output = self.vlm_options.decode_response(output)
-                input_prompt = (
-                    formatted_prompt if self.vlm_options.track_input_prompt else None
+                input_prompt = cast(
+                    str | None,
+                    formatted_prompt if self.vlm_options.track_input_prompt else None,
                 )
                 yield VlmPrediction(
                     text=decoded_output,

--- a/docling/models/vlm_pipeline_models/vllm_model.py
+++ b/docling/models/vlm_pipeline_models/vllm_model.py
@@ -3,7 +3,7 @@ import sys
 import time
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Optional, Union, cast
 
 import numpy as np
 from PIL.Image import Image
@@ -280,9 +280,11 @@ class VllmVlmModel(BaseVlmPageModel, HuggingFaceModelDownloadMixin):
         for img in image_batch:
             if isinstance(img, np.ndarray):
                 if img.ndim == 3 and img.shape[2] in (3, 4):
-                    pil_img = PILImage.fromarray(img.astype(np.uint8))
+                    pil_img = PILImage.fromarray(cast(Any, img).astype(np.uint8))
                 elif img.ndim == 2:
-                    pil_img = PILImage.fromarray(img.astype(np.uint8), mode="L")
+                    pil_img = PILImage.fromarray(
+                        cast(Any, img).astype(np.uint8), mode="L"
+                    )
                 else:
                     raise ValueError(f"Unsupported numpy array shape: {img.shape}")
             else:

--- a/docling/pipeline/asr_pipeline.py
+++ b/docling/pipeline/asr_pipeline.py
@@ -3,7 +3,7 @@ import sys
 import tempfile
 from io import BytesIO
 from pathlib import Path
-from typing import Final
+from typing import Final, cast
 
 from docling_core.types.doc import (
     ContentLayer,
@@ -53,7 +53,7 @@ def _process_conversation(
     origin = DocumentOrigin(
         filename=conv_res.input.file.name or "audio.wav",
         mimetype="audio/x-wav",
-        binary_hash=conv_res.input.document_hash,
+        binary_hash=cast(int, conv_res.input.document_hash),
     )
     conv_res.document = DoclingDocument(
         name=conv_res.input.file.stem or "audio.wav", origin=origin

--- a/docling/pipeline/base_extraction_pipeline.py
+++ b/docling/pipeline/base_extraction_pipeline.py
@@ -3,7 +3,11 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Optional
 
-from docling.datamodel.base_models import ConversionStatus, ErrorItem
+from docling.datamodel.base_models import (
+    ConversionStatus,
+    DoclingComponentType,
+    ErrorItem,
+)
 from docling.datamodel.document import InputDocument
 from docling.datamodel.extraction import ExtractionResult, ExtractionTemplateType
 from docling.datamodel.pipeline_options import BaseOptions, PipelineOptions
@@ -42,7 +46,7 @@ class BaseExtractionPipeline(ABC):
         except Exception as e:
             ext_res.status = ConversionStatus.FAILURE
             error_item = ErrorItem(
-                component_type="extraction_pipeline",
+                component_type=DoclingComponentType.PIPELINE,
                 module_name=self.__class__.__name__,
                 error_message=str(e),
             )

--- a/docling/pipeline/extraction_vlm_pipeline.py
+++ b/docling/pipeline/extraction_vlm_pipeline.py
@@ -8,7 +8,12 @@ from pydantic import BaseModel
 
 from docling.backend.abstract_backend import PaginatedDocumentBackend
 from docling.backend.pdf_backend import PdfDocumentBackend
-from docling.datamodel.base_models import ConversionStatus, ErrorItem, VlmStopReason
+from docling.datamodel.base_models import (
+    ConversionStatus,
+    DoclingComponentType,
+    ErrorItem,
+    VlmStopReason,
+)
 from docling.datamodel.document import InputDocument
 from docling.datamodel.extraction import (
     ExtractedPageData,
@@ -58,7 +63,7 @@ class ExtractionVlmPipeline(BaseExtractionPipeline):
                 ext_res.status = ConversionStatus.FAILURE
                 ext_res.errors.append(
                     ErrorItem(
-                        component_type="extraction_pipeline",
+                        component_type=DoclingComponentType.PIPELINE,
                         module_name=self.__class__.__name__,
                         error_message="No images found in document",
                     )
@@ -123,7 +128,7 @@ class ExtractionVlmPipeline(BaseExtractionPipeline):
             _log.error(f"Error during extraction: {e}")
             ext_res.errors.append(
                 ErrorItem(
-                    component_type="extraction_pipeline",
+                    component_type=DoclingComponentType.PIPELINE,
                     module_name=self.__class__.__name__,
                     error_message=str(e),
                 )

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -290,6 +290,7 @@ class ThreadedPipelineStage:
                     continue
 
                 pages: List[Page] = [payload for _, payload in pages_with_payloads]
+                _t_start = _t_mono = 0.0
                 if _log.isEnabledFor(logging.DEBUG):
                     _t_start = time.time()
                     _t_mono = time.monotonic()
@@ -379,6 +380,7 @@ class PreprocessThreadedStage(ThreadedPipelineStage):
                 result.extend(items)
                 continue
             try:
+                _t_start = _t_mono = 0.0
                 if _log.isEnabledFor(logging.DEBUG):
                     _t_start = time.time()
                     _t_mono = time.monotonic()

--- a/docling/pipeline/vlm_pipeline.py
+++ b/docling/pipeline/vlm_pipeline.py
@@ -139,9 +139,10 @@ class VlmPipeline(PaginatedPipeline):
 
         # force_backend_text = False - use text that is coming from VLM response
         # force_backend_text = True - get text from backend using bounding boxes predicted by SmolDocling doctags
+        vlm_options = pipeline_options.vlm_options
         self.force_backend_text = (
             pipeline_options.force_backend_text
-            and pipeline_options.vlm_options.response_format == ResponseFormat.DOCTAGS  # type: ignore[union-attr]
+            and getattr(vlm_options, "response_format", None) == ResponseFormat.DOCTAGS
         )
 
         self.keep_images = self.pipeline_options.generate_page_images
@@ -155,7 +156,7 @@ class VlmPipeline(PaginatedPipeline):
                 ),
             ]
         elif isinstance(self.pipeline_options.vlm_options, InlineVlmOptions):
-            vlm_options = cast(InlineVlmOptions, self.pipeline_options.vlm_options)
+            vlm_options = self.pipeline_options.vlm_options
             if vlm_options.inference_framework == InferenceFramework.MLX:
                 self.build_pipe = [
                     HuggingFaceMlxModel(
@@ -440,20 +441,23 @@ class VlmPipeline(PaginatedPipeline):
         )
 
         # If forced backend text, replace model predicted text with backend one
-        if page.size:
-            if self.force_backend_text:
-                scale = self.pipeline_options.images_scale
-                for element, _level in conv_res.document.iterate_items():
-                    if not isinstance(element, TextItem) or len(element.prov) == 0:
-                        continue
-                    crop_bbox = (
-                        element.prov[0]
-                        .bbox.scaled(scale=scale)
-                        .to_top_left_origin(page_height=page.size.height * scale)
-                    )
-                    txt = self.extract_text_from_backend(page, crop_bbox)
-                    element.text = txt
-                    element.orig = txt
+        if self.force_backend_text:
+            scale = self.pipeline_options.images_scale
+            pages_by_no = {page.page_no: page for page in conv_res.pages}
+            for element, _level in conv_res.document.iterate_items():
+                if not isinstance(element, TextItem) or len(element.prov) == 0:
+                    continue
+                source_page = pages_by_no.get(element.prov[0].page_no)
+                if source_page is None or source_page.size is None:
+                    continue
+                crop_bbox = (
+                    element.prov[0]
+                    .bbox.scaled(scale=scale)
+                    .to_top_left_origin(page_height=source_page.size.height * scale)
+                )
+                txt = self.extract_text_from_backend(source_page, crop_bbox)
+                element.text = txt
+                element.orig = txt
 
         return conv_res.document
 
@@ -609,7 +613,7 @@ class VlmPipeline(PaginatedPipeline):
                             bbox=BoundingBox(
                                 t=0.0, b=0.0, l=0.0, r=0.0
                             ),  # FIXME: would be nice not to have to "fake" it
-                            charspan=[0, 0],
+                            charspan=(0, 0),
                         )
                     ]
 

--- a/docling/service_client/client.py
+++ b/docling/service_client/client.py
@@ -325,9 +325,7 @@ class DoclingServiceClient:
         headers: dict[str, str] | None = None,
     ) -> ConversionJob[ConversionResult] | ConversionJob[RawServiceResult]:
         normalized_target_format: OutputFormat | None = (
-            OutputFormat.JSON
-            if target_format == "json"
-            else cast(OutputFormat | None, target_format)
+            OutputFormat.JSON if target_format == "json" else target_format
         )
         resolved = self._resolve_options(
             options=options,

--- a/docling/service_client/client.py
+++ b/docling/service_client/client.py
@@ -476,7 +476,7 @@ class DoclingServiceClient:
                 options=options,
                 sources=[
                     HttpSourceRequest(
-                        url=source,
+                        url=cast(Any, source),
                         headers={} if source_headers is None else source_headers,
                     )
                 ],
@@ -532,7 +532,9 @@ class DoclingServiceClient:
                     mode="json", exclude_none=True
                 ),
                 "sources": [
-                    HttpSourceRequest(url=source, headers={}).model_dump(mode="json")
+                    HttpSourceRequest(url=cast(Any, source), headers={}).model_dump(
+                        mode="json"
+                    )
                 ],
                 "include_converted_doc": False,
                 "target": InBodyTarget().model_dump(mode="json"),
@@ -1197,7 +1199,7 @@ class DoclingServiceClient:
                 options=options,
                 sources=[
                     HttpSourceRequest(
-                        url=source,
+                        url=cast(Any, source),
                         headers={} if source_headers is None else source_headers,
                     )
                 ],

--- a/docling/utils/api_image_request.py
+++ b/docling/utils/api_image_request.py
@@ -204,6 +204,7 @@ def api_image_request_streaming(
         r.raise_for_status()
 
         full_text = []
+        num_tokens = None
         for raw_line in r.iter_lines(decode_unicode=True):
             if not raw_line:  # keep-alives / blank lines
                 continue
@@ -231,7 +232,6 @@ def api_image_request_streaming(
                 piece = ""
 
             # Try to extract token count
-            num_tokens = None
             try:
                 if "usage" in obj:
                     usage = obj["usage"]

--- a/docling/utils/deepseekocr_utils.py
+++ b/docling/utils/deepseekocr_utils.py
@@ -336,7 +336,7 @@ def parse_deepseekocr_markdown(
                         b=coords[3] * scale_y,
                         coord_origin=CoordOrigin.TOPLEFT,
                     )
-                    prov = ProvenanceItem(page_no=page_no, bbox=bbox, charspan=[0, 0])
+                    prov = ProvenanceItem(page_no=page_no, bbox=bbox, charspan=(0, 0))
 
                     # Get the content (next non-empty line)
                     i += 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -387,6 +387,7 @@ combine-as-imports = true
 
 [tool.ty.rules]
 all = "warn"
+unused-type-ignore-comment = "ignore"
 
 [tool.ty.environment]
 python-version = "3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -245,7 +245,7 @@ all = [
 
 [dependency-groups]
 typecheck = [
-  "ty==0.0.33",
+  "ty==0.0.34",
   "types-setuptools~=70.3",
   "pandas-stubs~=2.1",
   "types-openpyxl~=3.1",

--- a/tests/test_run_pr_fast_checks.py
+++ b/tests/test_run_pr_fast_checks.py
@@ -143,6 +143,7 @@ def test_build_check_units_uses_ty_check(monkeypatch) -> None:
         "check",
         "--project",
         "/tmp/repo",
+        "--error-on-warning",
     ]
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -1636,7 +1636,7 @@ dev = [
     { name = "pytest-xdist", specifier = "~=3.3" },
     { name = "python-semantic-release", specifier = "~=7.32" },
     { name = "tach", specifier = ">=0.34.0,<1" },
-    { name = "ty", specifier = "==0.0.33" },
+    { name = "ty", specifier = "==0.0.34" },
     { name = "types-defusedxml", specifier = ">=0.7.0.20250822,<0.8.0" },
     { name = "types-openpyxl", specifier = "~=3.1" },
     { name = "types-requests", specifier = "~=2.31" },
@@ -1668,7 +1668,7 @@ pr-fast-checks = [
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.3.0,<3.0.0" },
     { name = "ruff", specifier = "==0.15.12" },
-    { name = "ty", specifier = "==0.0.33" },
+    { name = "ty", specifier = "==0.0.34" },
     { name = "types-defusedxml", specifier = ">=0.7.0.20250822,<0.8.0" },
     { name = "types-openpyxl", specifier = "~=3.1" },
     { name = "types-requests", specifier = "~=2.31" },
@@ -1679,7 +1679,7 @@ pr-fast-checks = [
 typecheck = [
     { name = "boto3-stubs", specifier = "~=1.37" },
     { name = "pandas-stubs", specifier = "~=2.1" },
-    { name = "ty", specifier = "==0.0.33" },
+    { name = "ty", specifier = "==0.0.34" },
     { name = "types-defusedxml", specifier = ">=0.7.0.20250822,<0.8.0" },
     { name = "types-openpyxl", specifier = "~=3.1" },
     { name = "types-requests", specifier = "~=2.31" },
@@ -7553,26 +7553,26 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.33"
+version = "0.0.34"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/44/9478c50c266826c1bf30d1692e589755bffa8f1c0a3eb7af8a346c255991/ty-0.0.33.tar.gz", hash = "sha256:46d63bda07403322cb6c28ccfdd5536be916e13df725c29f7ccd0a21f06bd9e8", size = 5559373, upload-time = "2026-04-28T10:45:13.18Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/69/e24eefe2c35c0fdbdec9b60e162727af669bb76d64d993d982eb67b24c38/ty-0.0.34.tar.gz", hash = "sha256:a6efe66b0f13c03a65e6c72ec9abfe2792e2fd063c74fa67e2c4930e29d661be", size = 5585933, upload-time = "2026-05-01T23:06:46.388Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/24/e287388c63a19191be26b32ff4dbd06029834068150ebe2532939bc4c851/ty-0.0.33-py3-none-linux_armv6l.whl", hash = "sha256:94d0a9d2234261a8911396d59e506b5923fe0971dbda43b9dcea287936887fcc", size = 11021308, upload-time = "2026-04-28T10:45:43.34Z" },
-    { url = "https://files.pythonhosted.org/packages/00/ca/ba1eed819895bd239fba8ee35dfcd5fcb266c203b0914a17a59579096bb5/ty-0.0.33-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e4a2b5ba078f90de342f56b5f7979bb77c9b9b1d8625a041352ffc6ee93c4073", size = 10777272, upload-time = "2026-04-28T10:45:32.905Z" },
-    { url = "https://files.pythonhosted.org/packages/25/a8/c3131d37b44b3fea1d6654a1c929a0cd0873822f77a90482b8ec28f6fbbd/ty-0.0.33-py3-none-macosx_11_0_arm64.whl", hash = "sha256:84ff5707825e9af9668d2bcf66975f93e520a63b524ab494e3a8265735be2563", size = 10201078, upload-time = "2026-04-28T10:45:23.374Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/db/d8e37ff0045810cc65e1ff36aa0da0a2253c05659787ac987df8a16c7897/ty-0.0.33-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e375285736f57886868e7af0b11c7b0ec5b6543fa15e7ad2a714fed9f077d4e0", size = 10732347, upload-time = "2026-04-28T10:45:21.444Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/1a/20e83a412506a918e4684fc67b567cf7cc13b105470b3428cb23c3d5aa13/ty-0.0.33-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5680f6350c3b4e46b8bff6d7bb132366ea239463d6cad4892725d06046e65464", size = 10808238, upload-time = "2026-04-28T10:45:38.565Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/4b/d0a39f4464dc6cb4cc2c159473ce216bd1846bfb684c0323a3cb36dce5c6/ty-0.0.33-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5535538bad8d0f7e62bcdff02197cdb30e41451d80b35d27e17d128f2e1dc5d", size = 11288348, upload-time = "2026-04-28T10:45:08.419Z" },
-    { url = "https://files.pythonhosted.org/packages/35/7e/f1745e0f9583363d7a83d9a4990fc244f76ecc30840ddad83dc16a33c52d/ty-0.0.33-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:da196c42bbbc069e1e21e3e52107c061aa9660352dae57a41930690b56e2c02d", size = 11789907, upload-time = "2026-04-28T10:45:19.064Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/71/25f39f46a12d662859d45bc648555d0661044eb43db6b5648c9947487da9/ty-0.0.33-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9281672921ef6d4460e03146b5e6c18cb1a3e3a3b8a1a88f6f33226d05a469b7", size = 11500774, upload-time = "2026-04-28T10:45:48.012Z" },
-    { url = "https://files.pythonhosted.org/packages/94/ec/136959ecbb7c71cb90537f5aea441c73f4ab24612868a6ecdc9d7444d32d/ty-0.0.33-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82c1b8f303f82da64e878108e764be3ecbcd7c9903ac0a7f7031614ed00b97ab", size = 11360314, upload-time = "2026-04-28T10:45:05.402Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/95/32809575c222f00beed498cb728e9290a0f5009f930025381bb7253b2206/ty-0.0.33-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:efe3af412c9ff67bce5fa37d0a2b0d8555c24072b145a5bac6c79637f1c83abe", size = 10707785, upload-time = "2026-04-28T10:45:10.836Z" },
-    { url = "https://files.pythonhosted.org/packages/13/89/c8e9531f7aa4a093359e15fa32c8e1277fbbe90d16894d7c6032d29f4b34/ty-0.0.33-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:aeec29c91ea768601747da546c3efc20b72c2fb1bd52bcc786a5c6eeff51d27b", size = 10834987, upload-time = "2026-04-28T10:45:40.738Z" },
-    { url = "https://files.pythonhosted.org/packages/31/16/9835fbcf5338af1a1917bd28fdb8a7193c210b83f243aa286fa9f79cb3ad/ty-0.0.33-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a535977c52bbb5f7e96b8b70a6ad375ad077f4a9ff2492508ea3816a2b403819", size = 10968968, upload-time = "2026-04-28T10:45:30.26Z" },
-    { url = "https://files.pythonhosted.org/packages/36/69/64c76aabc1bc70c7f24b686cd93c3407f8ea430905e395f59bf9603ef571/ty-0.0.33-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1d732facf39fcb221ba279d469c5040d37883e964f123b1563888efd34818180", size = 11458077, upload-time = "2026-04-28T10:45:45.971Z" },
-    { url = "https://files.pythonhosted.org/packages/91/84/fae27b0c4718776a298690d31ca4cc1995f2e3e1c63a7b59e84c41498e9a/ty-0.0.33-py3-none-win32.whl", hash = "sha256:d90960b574428dc252f85e8598ec5fcb7f619794196b2fc95a90da075ed4681c", size = 10345364, upload-time = "2026-04-28T10:45:16.836Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a0/a2938b23ae3e1a09a2d7c189e2ac5f7113676bae4e0e23948b568e18e5f8/ty-0.0.33-py3-none-win_amd64.whl", hash = "sha256:c1c3aec62c44de610c6e95f0a4e97ac3dbc07934bfdbf1fd90d758c9ff72f48e", size = 11342470, upload-time = "2026-04-28T10:45:26.455Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/62/7fb948aace38d2f6329261bb33c035a8484549c74f1db28649c7a4c6fed9/ty-0.0.33-py3-none-win_arm64.whl", hash = "sha256:0d44f99ba1b441e55e2aa301b2ac0a21112784931b46a5f66f4ea9efe5620d97", size = 10742673, upload-time = "2026-04-28T10:45:35.555Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7b/8b85003d6639ef17a97dcbb31f4511cfe78f1c81a964470db100c8c883e7/ty-0.0.34-py3-none-linux_armv6l.whl", hash = "sha256:9ecc3d14f07a95a6ceb88e07f8e62358dbd37325d3d5bd56da7217ff1fef7fb8", size = 11067094, upload-time = "2026-05-01T23:06:21.133Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/25/b0098f65b020b015c40567c763fc66fffbec88b2ba6f584bca1e92f05ebb/ty-0.0.34-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0dccffd8a9d02321cd2dee3249df205e26d62694e741f4eeca36b157fd8b419f", size = 10840909, upload-time = "2026-05-01T23:06:18.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/55/5e4adcf7d2a1006b844903b27cb81244a9b748d850433a46a6c21776c401/ty-0.0.34-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b0ea47a2998e167ab3b21d2f4b5309a9cf33c297809f6d7e3e753252223174d0", size = 10279378, upload-time = "2026-05-01T23:06:37.962Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/91/f537dca0db8fe2558e8ab04d8941d687b384fcc1df5eb9023b2db75ac26c/ty-0.0.34-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b37da00b41a118a459ae56d8947e70651073fb33ebfbceb820e4a10b22d5023", size = 10817423, upload-time = "2026-05-01T23:06:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c4/55a3ad1da2815af1009bdc1b8c90dc11a364cd314e4b48c5128ba9d38859/ty-0.0.34-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81cbbb93c2342fe3de43e625d3a9eb149633e9f485e816ebf6395d08685355d8", size = 10851826, upload-time = "2026-05-01T23:06:24.198Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/9c7606af22d73fb43ea4369472d9c66ece11231be73b0efe8e3c61655559/ty-0.0.34-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c5b4dea1594a021289e172582df9cde7089dce14b276fc650e7b212b1772e12", size = 11356318, upload-time = "2026-05-01T23:06:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/20/54/bb423f663721ab4138b216425c6b55eaefd3a068243b24d6d8fe988f4e13/ty-0.0.34-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:030fb00aa2d2a5b5ae9d9183d574e0c82dae80566700a7490c43669d8ece40cd", size = 11902968, upload-time = "2026-05-01T23:06:35.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/22/01122b21ab6b534a2f618c6bbe5f1f7f49fd56f4b2ec8887cd6d40d08fb3/ty-0.0.34-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ae9555e24e36c63a8218e037a5a63f15579eb6aa94f41017e57cd41d335cfb5", size = 11548860, upload-time = "2026-05-01T23:06:42.155Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/86008b1392ec64bed1957bbcc7aaa43b466b50dfc91bb131841c21d7c5c3/ty-0.0.34-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99eb23df9ed129fc26d1ab00d6f0b8dfe5253b09c2ac6abdb11523fa70d67f10", size = 11457097, upload-time = "2026-05-01T23:06:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/92/3e/4558b2296963ba99c58d8409c57d7db4f3061b656c3613cb21c02c1ef4c2/ty-0.0.34-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:85de45382016eceae69e104815eb2cfa200787df104002e262a86cbd43ed2c02", size = 10798192, upload-time = "2026-05-01T23:06:40.004Z" },
+    { url = "https://files.pythonhosted.org/packages/76/bf/650d24402be2ef678528d60caac1d9477a40fc37e3792ecef07834fd7a4a/ty-0.0.34-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:14cb575fb8fa5131f5129d100cfe23c1575d23faf5dfc5158432749a3e38c9b5", size = 10890390, upload-time = "2026-05-01T23:06:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ef/ccd2ca13906079f7935fd7e067661b24233017f57d987d51d6a121d85bb5/ty-0.0.34-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c6fc0b69d8450e6910ba9db34572b959b81329a97ae273c391f70e9fb6c1aade", size = 11031564, upload-time = "2026-05-01T23:06:55.812Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/2d/d27b72005b6f43599e3bcabab0d7135ac0c230b7a307bb99f9eea02c1cda/ty-0.0.34-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:30dfcec2f0fde3993f4f912ed0e057dcbebc8615299f610a4c2ddb7b5a3e1e06", size = 11553430, upload-time = "2026-05-01T23:06:31.096Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/12/20812e1ad930b8d4af70eebf19ad23cff6e31efcfa613ef884531fcdbaa1/ty-0.0.34-py3-none-win32.whl", hash = "sha256:97b77ddf007271b812a313a8f0a14929bc5590958433e1fb83ef585676f53342", size = 10436048, upload-time = "2026-05-01T23:06:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/afa095c5987868fbda27c0f731146ac8e3d07b357adfa83daccaee5b1a16/ty-0.0.34-py3-none-win_amd64.whl", hash = "sha256:1f543968accb952705134028d1fda8656882787dbbc667ad4d6c3ba23791d604", size = 11462526, upload-time = "2026-05-01T23:06:28.514Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8f/bf041a06260d77662c0605e56dacfe90b786bf824cbe1aed238d15fe5e84/ty-0.0.34-py3-none-win_arm64.whl", hash = "sha256:ea09108cbcb16b6b06d7596312b433bf49681e78d30e4dc7fb3c1b248a95e09a", size = 10846945, upload-time = "2026-05-01T23:06:44.428Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Stacked on #3346.

## Summary
- replace mypy fast-check and local hook wiring with ty
- upgrade Ruff to 0.15.12 in pre-commit and the uv lockfile
- add ty configuration and update developer docs/tooling references

## Note
- ty is configured with warning-level diagnostics for the initial migration; `ty check docling` currently exits 0 and reports existing diagnostics for follow-up cleanup.

## Verification
- `uv run --only-group dev pytest tests/test_run_pr_fast_checks.py`
- `uv run --only-group pr-fast-checks ruff format --check --config pyproject.toml .github/scripts/run_pr_fast_checks.py tests/test_run_pr_fast_checks.py scripts/check_max_lines.py`
- `uv run --only-group pr-fast-checks ruff check --config pyproject.toml .github/scripts/run_pr_fast_checks.py tests/test_run_pr_fast_checks.py scripts/check_max_lines.py`
- `uv run --only-group dev ty check .github/scripts/run_pr_fast_checks.py tests/test_run_pr_fast_checks.py scripts/check_max_lines.py`
- `uv run --only-group dev ty check docling`
- `uv run --only-group dev prek run --files .pre-commit-config.yaml pyproject.toml uv.lock .github/scripts/run_pr_fast_checks.py tests/test_run_pr_fast_checks.py scripts/check_max_lines.py justfile CONTRIBUTING.md .github/SECURITY.md .gitignore`
- `uv lock --locked`