### PR TITLE
ci: run heavy examples only manually

### DIFF
--- a/.github/workflows/ci-heavy-examples.yml
+++ b/.github/workflows/ci-heavy-examples.yml
@@ -1,16 +1,7 @@
 name: "Run Heavy Examples CI"
 
 on:
-  # Heavy examples are expensive (~45-60min). Do not run on every PR push.
-  # Run on main merges, nightly, on-demand via workflow_dispatch, or when a PR
-  # is explicitly labeled `tests:full` / `tests:heavy-examples`.
-  pull_request:
-    types: [labeled]
-  push:
-    branches:
-      - "main"
-  schedule:
-    - cron: "47 5 * * *"
+  # Heavy examples are expensive (~45-60min). Run them only on demand.
   workflow_dispatch:
 
 concurrency:
@@ -24,12 +15,6 @@ env:
 
 jobs:
   run-heavy-examples:
-    if: >-
-      ${{
-        github.event_name != 'pull_request' ||
-        contains(github.event.pull_request.labels.*.name, 'tests:full') ||
-        contains(github.event.pull_request.labels.*.name, 'tests:heavy-examples')
-      }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:

--- a/.github/workflows/ci-heavy-examples.yml
+++ b/.github/workflows/ci-heavy-examples.yml
@@ -1,7 +1,10 @@
 name: "Run Heavy Examples CI"
 
 on:
-  # Heavy examples are expensive (~45-60min). Run them only on demand.
+  # Heavy examples are expensive (~45-60min). Run them only on demand or when a
+  # PR is explicitly labeled `tests:full` / `tests:heavy-examples`.
+  pull_request:
+    types: [labeled]
   workflow_dispatch:
 
 concurrency:
@@ -15,6 +18,12 @@ env:
 
 jobs:
   run-heavy-examples:
+    if: >-
+      ${{
+        github.event_name != 'pull_request' ||
+        contains(github.event.pull_request.labels.*.name, 'tests:full') ||
+        contains(github.event.pull_request.labels.*.name, 'tests:heavy-examples')
+      }}
     runs-on: ubuntu-latest
     timeout-minutes: 90
     strategy:


### PR DESCRIPTION
## Summary
- make Heavy Examples CI trigger only via manual workflow_dispatch
- remove automatic runs from main pushes and PR labels
- keep the heavy example job unchanged for on-demand execution

## Validation
- uv run prek run --files .github/workflows/ci-heavy-examples.yml
- uv run python -c "import pathlib, yaml; yaml.safe_load(pathlib.Path('.github/workflows/ci-heavy-examples.yml').read_text(encoding='utf-8'))"

Triggered by scheduled run: https://github.com/docling-project/docling/actions/runs/25205398032