### PR TITLE
ci: avoid mutable PR merge refs in fast checks

### DIFF
--- a/.github/workflows/pr-fast-checks.yml
+++ b/.github/workflows/pr-fast-checks.yml
@@ -28,15 +28,21 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
-      - name: Fetch PR merge commit
+      # Build the merge result from the event's immutable base/head SHAs.
+      # GitHub's refs/pull/<n>/merge ref is mutable and can be regenerated on a
+      # newer base while an older pull_request_target run is still starting.
+      - name: Build PR merge tree
+        id: pr-merge
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          git fetch --no-tags --depth=2 origin "pull/${PR_NUMBER}/merge"
-          test "$(git rev-parse FETCH_HEAD^1)" = "${PR_BASE_SHA}"
-          test "$(git rev-parse FETCH_HEAD^2)" = "${PR_HEAD_SHA}"
+          git fetch --no-tags --depth=1 origin "pull/${PR_NUMBER}/head"
+          test "$(git rev-parse HEAD)" = "${PR_BASE_SHA}"
+          test "$(git rev-parse FETCH_HEAD)" = "${PR_HEAD_SHA}"
+          merge_tree="$(git merge-tree --write-tree --merge-base "${PR_BASE_SHA}" "${PR_BASE_SHA}" "${PR_HEAD_SHA}")"
+          echo "merge_tree=${merge_tree}" >> "${GITHUB_OUTPUT}"
 
       - uses: ./.github/actions/setup-ubuntu-ci
         with:
@@ -48,4 +54,4 @@ jobs:
           .venv/bin/python .github/scripts/run_pr_fast_checks.py \
             --repo-root "$PWD" \
             --base-ref HEAD \
-            --head-ref FETCH_HEAD
+            --head-ref "${{ steps.pr-merge.outputs.merge_tree }}"

--- a/tests/test_run_pr_fast_checks.py
+++ b/tests/test_run_pr_fast_checks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import subprocess
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -27,6 +28,17 @@ def write_file(repo_root: Path, relative_path: str, content: str = "pass\n") -> 
     file_path = repo_root / relative_path
     file_path.parent.mkdir(parents=True, exist_ok=True)
     file_path.write_text(content, encoding="utf-8")
+
+
+def run_git(repo_root: Path, *args: str) -> str:
+    completed = subprocess.run(
+        ["git", *args],
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return completed.stdout.strip()
 
 
 def test_collect_targets_limits_scope_to_supported_paths(tmp_path: Path) -> None:
@@ -132,6 +144,49 @@ def test_build_check_units_uses_fast_mypy_flags(monkeypatch) -> None:
         "skip",
         "--ignore-missing-imports",
     ]
+
+
+def test_git_helpers_accept_synthetic_merge_tree(tmp_path: Path) -> None:
+    run_git(tmp_path, "init")
+    run_git(tmp_path, "config", "user.name", "Test User")
+    run_git(tmp_path, "config", "user.email", "test@example.com")
+
+    write_file(tmp_path, "docling/module.py", "VALUE = 1\n")
+    run_git(tmp_path, "add", ".")
+    run_git(tmp_path, "commit", "-m", "base")
+    base_ref = run_git(tmp_path, "rev-parse", "HEAD")
+
+    run_git(tmp_path, "switch", "-c", "pr")
+    write_file(tmp_path, "docling/module.py", "VALUE = 2\n")
+    write_file(tmp_path, "tests/test_module.py", "def test_value():\n    pass\n")
+    run_git(tmp_path, "add", ".")
+    run_git(tmp_path, "commit", "-m", "pr")
+    head_ref = run_git(tmp_path, "rev-parse", "HEAD")
+
+    merge_tree = run_git(
+        tmp_path,
+        "merge-tree",
+        "--write-tree",
+        "--merge-base",
+        base_ref,
+        base_ref,
+        head_ref,
+    )
+
+    assert fast_checks.get_changed_paths(tmp_path, base_ref, merge_tree) == [
+        "docling/module.py",
+        "tests/test_module.py",
+    ]
+
+    run_git(tmp_path, "switch", "--detach", base_ref)
+    fast_checks.overlay_head_files(
+        tmp_path,
+        merge_tree,
+        ["docling/module.py", "tests/test_module.py"],
+    )
+
+    assert (tmp_path / "docling/module.py").read_text(encoding="utf-8") == "VALUE = 2\n"
+    assert (tmp_path / "tests/test_module.py").exists()
 
 
 def test_significant_regression_requires_same_successful_target_set() -> None:

--- a/tests/test_run_pr_fast_checks.py
+++ b/tests/test_run_pr_fast_checks.py
@@ -6,6 +6,8 @@ import sys
 from pathlib import Path
 from types import ModuleType
 
+import pytest
+
 
 def load_fast_checks_module() -> ModuleType:
     module_path = (
@@ -146,6 +148,10 @@ def test_build_check_units_uses_fast_mypy_flags(monkeypatch) -> None:
     ]
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="PR fast checks run on Ubuntu CI.",
+)
 def test_git_helpers_accept_synthetic_merge_tree(tmp_path: Path) -> None:
     run_git(tmp_path, "init")
     run_git(tmp_path, "config", "user.name", "Test User")


### PR DESCRIPTION
## Summary
- build the PR fast-check merge result locally from the event base/head SHAs
- stop depending on GitHub's mutable refs/pull/<n>/merge ref during pull_request_target runs
- add coverage for diffing and overlaying files from a synthetic merge tree

## Testing
- uv run pytest tests/test_run_pr_fast_checks.py
- uv run prek run --files .github/workflows/pr-fast-checks.yml tests/test_run_pr_fast_checks.py

to fix stuff like https://github.com/docling-project/docling/actions/runs/25298421837/job/74160985731?pr=3366