### PR TITLE
feat(extraction): add Granite Vision 4.1 as alternative KVP extraction model

### DIFF
--- a/docling/datamodel/extraction_options.py
+++ b/docling/datamodel/extraction_options.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+
+class ExtractionPromptStyle(str, Enum):
+    NUEXTRACT = "nuextract"
+    GRANITE_VISION = "granite_vision"

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -26,6 +26,7 @@ from docling.datamodel.chart_extraction_options import (
     ChartExtractionModelKind,
     ChartExtractionModelOptions,
 )
+from docling.datamodel.extraction_options import ExtractionPromptStyle
 from docling.datamodel.kserve_v2_options import KserveV2OptionsMixin
 from docling.datamodel.layout_model_specs import (
     DOCLING_LAYOUT_EGRET_LARGE,
@@ -57,6 +58,7 @@ from docling.datamodel.stage_model_specs import (
 )
 from docling.datamodel.vlm_engine_options import BaseVlmEngineOptions
 from docling.datamodel.vlm_model_specs import (
+    GRANITE_VISION_4_1_TRANSFORMERS,
     GRANITE_VISION_OLLAMA as granite_vision_vlm_ollama_conversion_options,
     GRANITE_VISION_TRANSFORMERS as granite_vision_vlm_conversion_options,
     NU_EXTRACT_2B_TRANSFORMERS,
@@ -1458,6 +1460,10 @@ class VlmExtractionPipelineOptions(PipelineOptions):
     NuExtract-2B) to extract structured data fields from document images.
     Unlike `VlmPipelineOptions` which converts pages to document format,
     this pipeline targets extraction of specific entities or key-value pairs.
+
+    Supported models:
+        - ``NU_EXTRACT_2B_TRANSFORMERS`` (default) with ``ExtractionPromptStyle.NUEXTRACT``
+        - ``GRANITE_VISION_4_1_TRANSFORMERS`` with ``ExtractionPromptStyle.GRANITE_VISION``
     """
 
     vlm_options: Annotated[
@@ -1469,6 +1475,16 @@ class VlmExtractionPipelineOptions(PipelineOptions):
             )
         ),
     ] = NU_EXTRACT_2B_TRANSFORMERS
+
+    extraction_prompt_style: Annotated[
+        "ExtractionPromptStyle",
+        Field(
+            description=(
+                "Prompt style to use for extraction. Determines how the template "
+                "is formatted and passed to the model."
+            )
+        ),
+    ] = ExtractionPromptStyle.NUEXTRACT
 
 
 class PdfPipelineOptions(PaginatedPipelineOptions):

--- a/docling/datamodel/vlm_model_specs.py
+++ b/docling/datamodel/vlm_model_specs.py
@@ -544,6 +544,26 @@ NU_EXTRACT_2B_TRANSFORMERS = InlineVlmOptions(
     temperature=0.0,
 )
 
+# Granite Vision 4.1
+GRANITE_VISION_4_1_TRANSFORMERS = InlineVlmOptions(
+    repo_id="ibm-granite/granite-vision-4.1-4b",
+    revision="dd48e97503de471803850df70843cf9eb5da8712",
+    prompt="",  # Template is passed separately via extract()
+    torch_dtype="bfloat16",
+    inference_framework=InferenceFramework.TRANSFORMERS,
+    transformers_model_type=TransformersModelType.AUTOMODEL_IMAGETEXTTOTEXT,
+    response_format=ResponseFormat.PLAINTEXT,
+    supported_devices=[
+        AcceleratorDevice.CPU,
+        AcceleratorDevice.CUDA,
+        AcceleratorDevice.MPS,
+        AcceleratorDevice.XPU,
+    ],
+    scale=2.0,
+    temperature=0.0,
+    trust_remote_code=True,
+)
+
 
 class VlmModelType(str, Enum):
     SMOLDOCLING = "smoldocling"

--- a/docling/models/extraction/prompt_utils.py
+++ b/docling/models/extraction/prompt_utils.py
@@ -1,0 +1,160 @@
+"""Prompt construction utilities for the extraction pipeline.
+
+Each function takes a processor, images, and templates and returns
+tokenized inputs ready for model.generate().
+"""
+
+from typing import Any
+
+from PIL.Image import Image
+
+
+def build_nuextract_inputs(
+    processor: Any,
+    images: list[Image],
+    templates: list[str],
+    device: str,
+    extra_processor_kwargs: dict[str, Any],
+) -> dict[str, Any]:
+    """Build inputs using the NuExtract-specific template format.
+
+    Requires qwen-vl-utils for vision processing.
+    """
+    try:
+        from qwen_vl_utils import process_vision_info
+    except ImportError:
+        raise ImportError(
+            "qwen-vl-utils is required for NuExtract extraction. "
+            "Please install it with: pip install qwen-vl-utils"
+        )
+
+    inputs = []
+    for pil_img, template in zip(images, templates):
+        inputs.append(
+            {
+                "document": {"type": "image", "image": pil_img},
+                "template": template,
+            }
+        )
+
+    messages = [[{"role": "user", "content": [x["document"]]}] for x in inputs]
+
+    texts = [
+        processor.tokenizer.apply_chat_template(
+            messages[i],
+            template=x["template"],
+            tokenize=False,
+            add_generation_prompt=True,
+        )
+        for i, x in enumerate(inputs)
+    ]
+
+    image_inputs = _process_all_vision_info(messages)
+
+    processor_inputs = processor(
+        text=texts,
+        images=image_inputs,
+        padding=True,
+        return_tensors="pt",
+        **extra_processor_kwargs,
+    )
+    return {k: v.to(device) for k, v in processor_inputs.items()}
+
+
+def build_granite_vision_inputs(
+    processor: Any,
+    images: list[Image],
+    templates: list[str],
+    device: str,
+) -> dict[str, Any]:
+    """Build inputs using standard chat conversation format with extraction prompt."""
+    extraction_prompts = [_build_extraction_prompt(t) for t in templates]
+
+    conversations = [
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image"},
+                    {"type": "text", "text": ep},
+                ],
+            }
+        ]
+        for ep in extraction_prompts
+    ]
+    texts = [
+        processor.apply_chat_template(conv, tokenize=False, add_generation_prompt=True)
+        for conv in conversations
+    ]
+    processor_inputs = processor(
+        text=texts,
+        images=images,
+        return_tensors="pt",
+        padding=True,
+        do_pad=True,
+    )
+    return {k: v.to(device) for k, v in processor_inputs.items()}
+
+
+def _build_extraction_prompt(template: str) -> str:
+    return (
+        "Extract structured data from this document image.\n"
+        "Return a JSON object matching this schema:\n\n"
+        f"{template}\n\n"
+        "Return null for fields you cannot find in the document.\n"
+        "Return ONLY valid JSON, no other text."
+    )
+
+
+def _process_all_vision_info(messages: list, examples: list | None = None) -> Any:
+    """Process vision info from messages using qwen-vl-utils.
+
+    Adapted from NuExtract source code.
+    """
+    from qwen_vl_utils import fetch_image, process_vision_info
+
+    def extract_example_images(example_item: Any) -> list:
+        if not example_item:
+            return []
+        examples_to_process = (
+            example_item if isinstance(example_item, list) else [example_item]
+        )
+        images = []
+        for example in examples_to_process:
+            if (
+                isinstance(example.get("input"), dict)
+                and example["input"].get("type") == "image"
+            ):
+                images.append(fetch_image(example["input"]))
+        return images
+
+    is_batch = messages and isinstance(messages[0], list)
+    messages_batch = messages if is_batch else [messages]
+    is_batch_examples = (
+        examples
+        and isinstance(examples, list)
+        and (isinstance(examples[0], list) or examples[0] is None)
+    )
+    examples_batch = (
+        examples
+        if is_batch_examples
+        else ([examples] if examples is not None else None)
+    )
+
+    if examples and examples_batch is not None:
+        if len(examples_batch) != len(messages_batch):
+            if not is_batch and len(examples_batch) == 1:
+                pass
+            else:
+                raise ValueError(
+                    "Examples batch length must match messages batch length"
+                )
+
+    all_images = []
+    for i, message_group in enumerate(messages_batch):
+        if examples and examples_batch is not None and i < len(examples_batch):
+            all_images.extend(extract_example_images(examples_batch[i]))
+        input_message_images = process_vision_info(message_group)[0] or []
+        all_images.extend(input_message_images)
+
+    return all_images if all_images else None

--- a/docling/models/extraction/transformers_extraction_model.py
+++ b/docling/models/extraction/transformers_extraction_model.py
@@ -1,0 +1,213 @@
+import logging
+import sys
+import time
+import warnings
+from collections.abc import Iterable
+from pathlib import Path
+from typing import Any, Optional, Union, cast
+
+import numpy as np
+import torch
+from PIL.Image import Image
+from transformers import AutoModelForImageTextToText, AutoProcessor, GenerationConfig
+
+from docling.datamodel.accelerator_options import AcceleratorOptions
+from docling.datamodel.base_models import VlmPrediction, VlmStopReason
+from docling.datamodel.extraction_options import ExtractionPromptStyle
+from docling.datamodel.pipeline_options_vlm_model import InlineVlmOptions
+from docling.models.base_model import BaseVlmModel
+from docling.models.extraction.prompt_utils import (
+    build_granite_vision_inputs,
+    build_nuextract_inputs,
+)
+from docling.models.utils.hf_model_download import HuggingFaceModelDownloadMixin
+from docling.utils.accelerator_utils import decide_device
+
+_log = logging.getLogger(__name__)
+
+
+class TransformersExtractionModel(BaseVlmModel, HuggingFaceModelDownloadMixin):
+    """Unified extraction model supporting multiple prompt styles."""
+
+    def __init__(
+        self,
+        enabled: bool,
+        artifacts_path: Optional[Path],
+        accelerator_options: AcceleratorOptions,
+        vlm_options: InlineVlmOptions,
+        prompt_style: ExtractionPromptStyle = ExtractionPromptStyle.NUEXTRACT,
+    ):
+        self.enabled = enabled
+        self.vlm_options = vlm_options
+        self.prompt_style = prompt_style
+
+        if self.enabled:
+            self.device = decide_device(
+                accelerator_options.device,
+                supported_devices=vlm_options.supported_devices,
+            )
+            _log.debug(
+                f"Available device for extraction VLM ({prompt_style.value}): "
+                f"{self.device}"
+            )
+
+            self.max_new_tokens = vlm_options.max_new_tokens
+            self.temperature = vlm_options.temperature
+
+            repo_cache_folder = vlm_options.repo_id.replace("/", "--")
+
+            if artifacts_path is None:
+                artifacts_path = self.download_models(
+                    repo_id=self.vlm_options.repo_id,
+                    revision=self.vlm_options.revision,
+                )
+            elif (artifacts_path / repo_cache_folder).exists():
+                artifacts_path = artifacts_path / repo_cache_folder
+
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message=".*torch_dtype.*deprecated.*",
+                    category=UserWarning,
+                )
+                warnings.filterwarnings(
+                    "ignore",
+                    message=".*incorrect regex pattern.*",
+                    category=UserWarning,
+                )
+                self.processor = AutoProcessor.from_pretrained(
+                    artifacts_path,
+                    trust_remote_code=vlm_options.trust_remote_code,
+                    use_fast=True,
+                )
+                self.vlm_model = AutoModelForImageTextToText.from_pretrained(
+                    artifacts_path,
+                    device_map=self.device,
+                    dtype=vlm_options.torch_dtype or torch.bfloat16,
+                    _attn_implementation=(
+                        "flash_attention_2"
+                        if self.device.startswith("cuda")
+                        and accelerator_options.cuda_use_flash_attention2
+                        else "sdpa"
+                    ),
+                    trust_remote_code=vlm_options.trust_remote_code,
+                )
+
+            if hasattr(self.vlm_model, "merge_lora_adapters"):
+                cast(Any, self.vlm_model).merge_lora_adapters()
+
+            if prompt_style == ExtractionPromptStyle.NUEXTRACT and sys.version_info < (
+                3,
+                14,
+            ):
+                self.vlm_model = torch.compile(self.vlm_model)  # type: ignore
+            else:
+                self.vlm_model.eval()
+
+            self.generation_config: Optional[GenerationConfig] = None
+            if prompt_style == ExtractionPromptStyle.NUEXTRACT:
+                self.processor.tokenizer.padding_side = "left"
+                self.generation_config = GenerationConfig.from_pretrained(
+                    artifacts_path
+                )
+
+    def process_images(
+        self,
+        image_batch: Iterable[Union[Image, np.ndarray]],
+        prompt: Union[str, list[str]],
+    ) -> Iterable[VlmPrediction]:
+        from PIL import Image as PILImage
+
+        pil_images: list[Image] = []
+        for img in image_batch:
+            if isinstance(img, np.ndarray):
+                if img.ndim == 3 and img.shape[2] in (3, 4):
+                    pil_img = PILImage.fromarray(img.astype(np.uint8))
+                elif img.ndim == 2:
+                    pil_img = PILImage.fromarray(img.astype(np.uint8), mode="L")
+                else:
+                    raise ValueError(f"Unsupported numpy array shape: {img.shape}")
+            else:
+                pil_img = img
+            if pil_img.mode != "RGB":
+                pil_img = pil_img.convert("RGB")
+            pil_images.append(pil_img)
+
+        if not pil_images:
+            return
+
+        if isinstance(prompt, str):
+            templates = [prompt] * len(pil_images)
+        else:
+            if len(prompt) != len(pil_images):
+                raise ValueError(
+                    f"Number of prompts ({len(prompt)}) must match "
+                    f"number of images ({len(pil_images)})"
+                )
+            templates = prompt
+
+        # Build tokenized inputs based on prompt style
+        if self.prompt_style == ExtractionPromptStyle.NUEXTRACT:
+            processor_inputs = build_nuextract_inputs(
+                processor=self.processor,
+                images=pil_images,
+                templates=templates,
+                device=self.device,
+                extra_processor_kwargs=self.vlm_options.extra_processor_kwargs,
+            )
+        else:
+            processor_inputs = build_granite_vision_inputs(
+                processor=self.processor,
+                images=pil_images,
+                templates=templates,
+                device=self.device,
+            )
+
+        # Generate
+        gen_kwargs: dict[str, Any] = {
+            **processor_inputs,
+            "max_new_tokens": self.max_new_tokens,
+        }
+        if self.generation_config is not None:
+            gen_kwargs["generation_config"] = self.generation_config
+            gen_kwargs.update(self.vlm_options.extra_generation_config)
+        else:
+            gen_kwargs["use_cache"] = True
+
+        if self.temperature > 0:
+            gen_kwargs["do_sample"] = True
+            gen_kwargs["temperature"] = self.temperature
+        else:
+            gen_kwargs["do_sample"] = False
+
+        start_time = time.time()
+        with torch.inference_mode():
+            generated_ids = cast(Any, self.vlm_model).generate(**gen_kwargs)
+        generation_time = time.time() - start_time
+
+        # Decode
+        input_len = processor_inputs["input_ids"].shape[1]
+        trimmed_sequences = generated_ids[:, input_len:]
+
+        decoded_texts: list[str] = self.processor.batch_decode(
+            trimmed_sequences,
+            skip_special_tokens=True,
+            clean_up_tokenization_spaces=False,
+        )
+
+        num_tokens = None
+        if generated_ids.shape[0] > 0:
+            num_tokens = int(generated_ids[0].shape[0])
+            _log.debug(
+                f"Generated {num_tokens} tokens in {generation_time:.2f}s "
+                f"for batch size {generated_ids.shape[0]}."
+            )
+
+        for text in decoded_texts:
+            decoded_text = self.vlm_options.decode_response(text)
+            yield VlmPrediction(
+                text=decoded_text,
+                generation_time=generation_time,
+                num_tokens=num_tokens,
+                stop_reason=VlmStopReason.UNSPECIFIED,
+            )

--- a/docling/pipeline/extraction_vlm_pipeline.py
+++ b/docling/pipeline/extraction_vlm_pipeline.py
@@ -20,8 +20,8 @@ from docling.datamodel.pipeline_options import (
     VlmExtractionPipelineOptions,
 )
 from docling.datamodel.settings import settings
-from docling.models.extraction.nuextract_transformers_model import (
-    NuExtractTransformersModel,
+from docling.models.extraction.transformers_extraction_model import (
+    TransformersExtractionModel,
 )
 from docling.pipeline.base_extraction_pipeline import BaseExtractionPipeline
 from docling.utils.accelerator_utils import decide_device
@@ -33,16 +33,15 @@ class ExtractionVlmPipeline(BaseExtractionPipeline):
     def __init__(self, pipeline_options: VlmExtractionPipelineOptions):
         super().__init__(pipeline_options)
 
-        # Initialize VLM model with default options
         self.accelerator_options = pipeline_options.accelerator_options
         self.pipeline_options: VlmExtractionPipelineOptions
 
-        # Create VLM model instance
-        self.vlm_model = NuExtractTransformersModel(
+        self.vlm_model = TransformersExtractionModel(
             enabled=True,
-            artifacts_path=self.artifacts_path,  # Will download automatically
+            artifacts_path=self.artifacts_path,
             accelerator_options=self.accelerator_options,
             vlm_options=pipeline_options.vlm_options,
+            prompt_style=pipeline_options.extraction_prompt_style,
         )
 
     def _extract_data(

--- a/tests/test_granite_vision_extraction.py
+++ b/tests/test_granite_vision_extraction.py
@@ -1,0 +1,63 @@
+"""Unit tests for extraction model prompt style dispatch."""
+
+from unittest.mock import patch
+
+from docling.datamodel.extraction_options import ExtractionPromptStyle
+from docling.datamodel.pipeline_options import VlmExtractionPipelineOptions
+from docling.datamodel.vlm_model_specs import (
+    GRANITE_VISION_4_1_TRANSFORMERS,
+    NU_EXTRACT_2B_TRANSFORMERS,
+)
+from docling.models.extraction.prompt_utils import _build_extraction_prompt
+
+
+def test_granite_vision_spec_has_correct_repo_id() -> None:
+    """Verify the Granite Vision 4.1 spec points to the correct model."""
+    assert (
+        GRANITE_VISION_4_1_TRANSFORMERS.repo_id == "ibm-granite/granite-vision-4.1-4b"
+    )
+    assert GRANITE_VISION_4_1_TRANSFORMERS.trust_remote_code is True
+
+
+def test_default_prompt_style_is_nuextract() -> None:
+    """Verify default extraction_prompt_style is NUEXTRACT."""
+    options = VlmExtractionPipelineOptions()
+    assert options.extraction_prompt_style == ExtractionPromptStyle.NUEXTRACT
+
+
+def test_granite_vision_prompt_style_option() -> None:
+    """Verify Granite Vision prompt style can be set in options."""
+    options = VlmExtractionPipelineOptions(
+        vlm_options=GRANITE_VISION_4_1_TRANSFORMERS,
+        extraction_prompt_style=ExtractionPromptStyle.GRANITE_VISION,
+    )
+    assert options.extraction_prompt_style == ExtractionPromptStyle.GRANITE_VISION
+    assert options.vlm_options.repo_id == "ibm-granite/granite-vision-4.1-4b"
+
+
+@patch(
+    "docling.pipeline.extraction_vlm_pipeline.TransformersExtractionModel",
+)
+def test_pipeline_passes_prompt_style_to_model(mock_model_cls: object) -> None:
+    """Verify pipeline passes extraction_prompt_style to the model."""
+    from docling.pipeline.extraction_vlm_pipeline import ExtractionVlmPipeline
+
+    options = VlmExtractionPipelineOptions(
+        vlm_options=GRANITE_VISION_4_1_TRANSFORMERS,
+        extraction_prompt_style=ExtractionPromptStyle.GRANITE_VISION,
+    )
+    _ = ExtractionVlmPipeline(pipeline_options=options)
+    mock_model_cls.assert_called_once()  # type: ignore[union-attr]
+    call_kwargs = mock_model_cls.call_args[1]  # type: ignore[union-attr]
+    assert call_kwargs["prompt_style"] == ExtractionPromptStyle.GRANITE_VISION
+
+
+def test_build_extraction_prompt() -> None:
+    """Verify the extraction prompt is formatted correctly."""
+    template = '{"name": "string", "age": "integer"}'
+    prompt = _build_extraction_prompt(template)
+
+    assert template in prompt
+    assert "Extract structured data" in prompt
+    assert "Return ONLY valid JSON" in prompt
+    assert "Return null for fields" in prompt


### PR DESCRIPTION
## Summary
- Add `GraniteVisionExtractionModel` as an alternative to NuExtract-2B in the VLM extraction pipeline
- Add `GRANITE_VISION_4_1_TRANSFORMERS` model spec for `ibm-granite/granite-vision-4.1-4b`
- Make `ExtractionVlmPipeline` model selection dynamic based on `vlm_options.repo_id`

## Usage
```python
from docling.datamodel.vlm_model_specs import GRANITE_VISION_4_1_TRANSFORMERS
from docling.datamodel.pipeline_options import VlmExtractionPipelineOptions

extractor = DocumentExtractor(
    extraction_format_options={
        InputFormat.IMAGE: ExtractionFormatOption(
            pipeline_cls=ExtractionVlmPipeline,
            pipeline_options=VlmExtractionPipelineOptions(
                vlm_options=GRANITE_VISION_4_1_TRANSFORMERS,
            ),
            backend=ImageDocumentBackend,
        ),
    },
)
result = extractor.extract(source="invoice.pdf", template={"bill_no": "string", "total": "float"})
```

## Test plan
- [x] Unit tests for model spec validation, pipeline routing, and prompt formatting
- [x] Manual extraction test on Swiss QR-Bill image with simple and nested templates