### PR TITLE
feat(table_structure): three TableFormer-output cleanup helpers

### DIFF
--- a/docling/models/stages/table_structure/table_structure_model.py
+++ b/docling/models/stages/table_structure/table_structure_model.py
@@ -29,6 +29,7 @@ from docling.utils.table_cell_postprocess import (
     consolidate_duplicate_spans,
     promote_wrapped_header_rows,
     recover_leftover_words,
+    split_into_structural_subtables,
 )
 
 _log = logging.getLogger(__name__)
@@ -314,6 +315,30 @@ class TableStructureModel(BaseTableStructureModel):
                         page_clusters=page.predictions.layout.clusters,
                     )
                     num_rows += new_row_count
+
+                    # Split when the layout postprocessor merged multiple
+                    # visually-distinct tables into one TABLE cluster.
+                    # Detect row-pattern shifts (e.g. 21 rows of "label
+                    # spanning N cols + value" followed by 2 rows of "N
+                    # cells in distinct columns") and emit the trailing
+                    # sub-table as its own Cluster + Table. Page assembly
+                    # iterates clusters and renders multiple Tables on one
+                    # page with auto blank-line separators.
+                    table_cells, num_rows, num_cols, did_split = (
+                        split_into_structural_subtables(
+                            table_cells=table_cells,
+                            table_cluster=table_cluster,
+                            page_clusters=page.predictions.layout.clusters,
+                            table_map=table_prediction.table_map,
+                            page_no=page.page_no,
+                        )
+                    )
+                    if did_split:
+                        # The original otsl_seq describes the un-split
+                        # whole table; clear it so the kept sub-table's
+                        # Table object doesn't carry a sequence that no
+                        # longer matches its cells.
+                        otsl_seq = []
 
                     tbl = Table(
                         otsl_seq=otsl_seq,

--- a/docling/models/stages/table_structure/table_structure_model.py
+++ b/docling/models/stages/table_structure/table_structure_model.py
@@ -30,6 +30,7 @@ from docling.utils.table_cell_postprocess import (
     promote_wrapped_header_rows,
     recover_leftover_words,
     split_into_structural_subtables,
+    split_tall_fused_rows,
 )
 
 _log = logging.getLogger(__name__)
@@ -315,6 +316,18 @@ class TableStructureModel(BaseTableStructureModel):
                         page_clusters=page.predictions.layout.clusters,
                     )
                     num_rows += new_row_count
+
+                    # Split rows whose cells fused multiple visual lines
+                    # from the source PDF (TableFormer absorbed an
+                    # un-detected mini-table into one over-tall row with
+                    # concatenated cell text). Uses tcells geometry to
+                    # find the original visual lines and re-assigns words
+                    # to the table's existing column layout.
+                    tall_added = split_tall_fused_rows(
+                        tcells=tcells,
+                        table_cells=table_cells,
+                    )
+                    num_rows += tall_added
 
                     # Split when the layout postprocessor merged multiple
                     # visually-distinct tables into one TABLE cluster.

--- a/docling/models/stages/table_structure/table_structure_model.py
+++ b/docling/models/stages/table_structure/table_structure_model.py
@@ -25,6 +25,11 @@ from docling.models.base_table_model import BaseTableStructureModel
 from docling.models.utils.hf_model_download import download_hf_model
 from docling.utils.accelerator_utils import decide_device
 from docling.utils.profiling import TimeRecorder
+from docling.utils.table_cell_postprocess import (
+    consolidate_duplicate_spans,
+    promote_wrapped_header_rows,
+    recover_leftover_words,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -283,6 +288,32 @@ class TableStructureModel(BaseTableStructureModel):
                         .get("prediction", {})
                         .get("rs_seq", [])
                     )
+
+                    # Collapse adjacent same-text cells into one with span > 1.
+                    # TableFormer occasionally emits N duplicates for a label
+                    # that visually spans N grid cells instead of one
+                    # colspan/rowspan cell.
+                    table_cells = consolidate_duplicate_spans(table_cells)
+
+                    # Promote rows that look like wrapped header continuations
+                    # (no digits, short text, header-matching line height) so
+                    # multi-line headers don't leak into the data section.
+                    promote_wrapped_header_rows(table_cells, num_rows)
+
+                    # Recover input PDF words TableFormer did not grid.
+                    # Two-pass: leftovers that look like tabular rows
+                    # (≥2 cells in distinct columns at similar Y) get
+                    # placed as new rows in table_cells; the rest are
+                    # emitted as a TEXT cluster so the data still appears
+                    # in the JSON. Both passes preserve the conservation
+                    # invariant that TABLE alone violates.
+                    new_row_count, _ = recover_leftover_words(
+                        tcells=tcells,
+                        table_cells=table_cells,
+                        table_cluster=table_cluster,
+                        page_clusters=page.predictions.layout.clusters,
+                    )
+                    num_rows += new_row_count
 
                     tbl = Table(
                         otsl_seq=otsl_seq,

--- a/docling/models/stages/table_structure/table_structure_model_granite_vision.py
+++ b/docling/models/stages/table_structure/table_structure_model_granite_vision.py
@@ -18,6 +18,11 @@ from docling.models.base_table_model import BaseTableStructureModel
 from docling.models.utils.hf_model_download import download_hf_model
 from docling.utils.accelerator_utils import decide_device
 from docling.utils.profiling import TimeRecorder
+from docling.utils.table_cell_postprocess import (
+    consolidate_duplicate_spans,
+    promote_wrapped_header_rows,
+    split_into_structural_subtables,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -329,6 +334,24 @@ class GraniteVisionTableStructureModel(BaseTableStructureModel):
                             f"Failed to parse OTSL output for table cluster {cluster.id}: {exc}"
                         )
                         otsl_seq, table_cells, num_rows, num_cols = [], [], 0, 0
+
+                    # Apply the shared TableFormer-output cleanup helpers.
+                    # `recover_leftover_words` is intentionally omitted —
+                    # this model does not have a `tcells` input-token list
+                    # to compare against the predicted grid.
+                    table_cells = consolidate_duplicate_spans(table_cells)
+                    promote_wrapped_header_rows(table_cells, num_rows)
+                    table_cells, num_rows, num_cols, did_split = (
+                        split_into_structural_subtables(
+                            table_cells=table_cells,
+                            table_cluster=cluster,
+                            page_clusters=page.predictions.layout.clusters,
+                            table_map=table_prediction.table_map,
+                            page_no=page.page_no,
+                        )
+                    )
+                    if did_split:
+                        otsl_seq = []
 
                     tbl = Table(
                         otsl_seq=otsl_seq,

--- a/docling/models/stages/table_structure/table_structure_model_v2.py
+++ b/docling/models/stages/table_structure/table_structure_model_v2.py
@@ -23,6 +23,11 @@ from docling.models.base_table_model import BaseTableStructureModel
 from docling.models.utils.hf_model_download import download_hf_model
 from docling.utils.accelerator_utils import decide_device
 from docling.utils.profiling import TimeRecorder
+from docling.utils.table_cell_postprocess import (
+    consolidate_duplicate_spans,
+    promote_wrapped_header_rows,
+    split_into_structural_subtables,
+)
 
 _log = logging.getLogger(__name__)
 
@@ -453,6 +458,24 @@ class TableStructureModelV2(BaseTableStructureModel):
                             element["bbox"]["token"] = text_piece
                         tc = TableCell.model_validate(element)
                         table_cells.append(tc)
+
+                    # Apply the shared TableFormer-output cleanup helpers.
+                    # `recover_leftover_words` is intentionally omitted —
+                    # this model does not have a `tcells` input-token list
+                    # to compare against the predicted grid.
+                    table_cells = consolidate_duplicate_spans(table_cells)
+                    promote_wrapped_header_rows(table_cells, num_rows)
+                    table_cells, num_rows, num_cols, did_split = (
+                        split_into_structural_subtables(
+                            table_cells=table_cells,
+                            table_cluster=table_cluster,
+                            page_clusters=page.predictions.layout.clusters,
+                            table_map=table_prediction.table_map,
+                            page_no=page.page_no,
+                        )
+                    )
+                    if did_split:
+                        otsl_seq = []
 
                     tbl = Table(
                         otsl_seq=otsl_seq,

--- a/docling/utils/table_cell_postprocess.py
+++ b/docling/utils/table_cell_postprocess.py
@@ -846,3 +846,192 @@ def split_into_structural_subtables(
         table_map[next_id] = sub_table
 
     return first_cells, first_nr, first_nc, True
+
+
+def _bbox_inside(
+    inner: BoundingBox, outer: BoundingBox, threshold: float = 0.5
+) -> bool:
+    """True when more than `threshold` of `inner`'s area lies inside `outer`."""
+    return inner.intersection_over_self(outer) >= threshold
+
+
+def _y_clusters(
+    items: list[tuple[float, TextCell, BoundingBox]], threshold: float
+) -> list[list[tuple]]:
+    """Cluster by Y-centroid into adjacency groups within `threshold`.
+
+    Each item is ``(y_centroid, text_cell, bbox)``. Items are sorted by
+    Y first; consecutive items within `threshold` join the same cluster.
+    """
+    if not items:
+        return []
+    items.sort(key=lambda x: x[0])
+    clusters: list[list[tuple]] = [[items[0]]]
+    for prev, curr in pairwise(items):
+        if abs(curr[0] - prev[0]) < threshold:
+            clusters[-1].append(curr)
+        else:
+            clusters.append([curr])
+    return clusters
+
+
+def split_tall_fused_rows(
+    *,
+    tcells: Sequence[TextCell],
+    table_cells: list[TableCell],
+    height_ratio: float = 1.5,
+) -> int:
+    """Split rows whose cells fuse multiple visual lines from the source PDF.
+
+    When the layout postprocessor over-extends a TABLE bbox to swallow an
+    adjacent un-detected mini-table, TableFormer can absorb the extra
+    content into a single row whose cell bboxes are abnormally tall and
+    whose text concatenates content from multiple visual lines (e.g. row 2
+    of IOZ_2019: cells of height 2.5x median, text
+    ``'Australian NET PAYMENT:'`` + ``'withholding tax: $340.00 $385.31'``).
+
+    This helper detects such rows by comparing each row's max cell-bbox
+    height against the table's median row height; when a row exceeds
+    ``height_ratio`` x median AND its input tcells form >=2 distinct
+    Y-clusters within the row's combined bbox, the row is rebuilt:
+    each Y-cluster becomes a sub-row, and tcells are reassigned to
+    columns by X-centroid using the table's own normal-height column
+    centroids (so the rebuilt row matches the table's existing column
+    layout, not the fused cells' layout).
+
+    Purely structural — uses bbox geometry only, no text-content matching
+    (no amount-token detection, no template hints). The cleanest signal:
+    rows with abnormal height containing tcells that resolve into distinct
+    visual lines are almost always cases of fused content.
+
+    Returns the net number of rows added (e.g. one row split into 2 = 1).
+    No-op when ``tcells`` is empty, the median-height baseline can't be
+    derived, or no row's tcells cluster into >=2 lines.
+    """
+    from docling_core.types.doc import BoundingBox as BB
+
+    if not tcells or not table_cells:
+        return 0
+
+    by_row: dict[int, list[TableCell]] = {}
+    for c in table_cells:
+        if c.bbox is not None:
+            by_row.setdefault(c.start_row_offset_idx, []).append(c)
+    if len(by_row) < 2:
+        return 0
+
+    row_heights = sorted(
+        max(abs(c.bbox.t - c.bbox.b) for c in cells if c.bbox is not None)
+        for cells in by_row.values()
+        if any(c.bbox is not None for c in cells)
+    )
+    if not row_heights:
+        return 0
+    median_h = row_heights[len(row_heights) // 2]
+    if median_h <= 0:
+        return 0
+
+    # Use only normal-height cells to derive column centroids — avoids
+    # contaminating the column geometry with the fused tall cells we're
+    # about to replace.
+    normal_cells = [
+        c
+        for c in table_cells
+        if c.bbox is not None and abs(c.bbox.t - c.bbox.b) < height_ratio * median_h
+    ]
+    col_centroids = _column_centroids(normal_cells)
+    if len(col_centroids) < 1:
+        return 0
+
+    cluster_threshold = median_h * 0.7
+
+    rows_to_split: list[tuple[int, list[list[tuple]], list[TableCell]]] = []
+    for r in sorted(by_row):
+        cells = by_row[r]
+        # Skip header rows — promoting/splitting headers needs different handling.
+        if any(getattr(c, "column_header", False) for c in cells):
+            continue
+        max_h = max(abs(c.bbox.t - c.bbox.b) for c in cells if c.bbox is not None)
+        if max_h < height_ratio * median_h:
+            continue
+        row_bbox = _grid_bbox(cells)
+        if row_bbox is None:
+            continue
+        items = []
+        for tc in tcells:
+            if not tc.text or not tc.text.strip():
+                continue
+            bb = tc.rect.to_bounding_box()
+            if not _bbox_inside(bb, row_bbox):
+                continue
+            items.append(((bb.t + bb.b) / 2, tc, bb))
+        if not items:
+            continue
+        clusters = _y_clusters(items, threshold=cluster_threshold)
+        if len(clusters) < 2:
+            continue
+        rows_to_split.append((r, clusters, cells))
+
+    if not rows_to_split:
+        return 0
+
+    # Process in reverse row order so renumbering doesn't shift unprocessed rows.
+    rows_to_split.sort(key=lambda x: x[0], reverse=True)
+    template = next((c for c in table_cells if c.bbox is not None), None)
+    if template is None:
+        return 0
+
+    new_rows_total = 0
+    for r, clusters, original_cells in rows_to_split:
+        n = len(clusters)
+        # Bump rows below r by (n - 1) so the row that was r occupies r..r+n-1.
+        for c in table_cells:
+            if c.start_row_offset_idx > r:
+                c.start_row_offset_idx += n - 1
+                c.end_row_offset_idx += n - 1
+        # Remove the original (fused) cells.
+        for c in original_cells:
+            try:
+                table_cells.remove(c)
+            except ValueError:
+                pass
+        # Rebuild as N sub-rows from the Y-clustered tcells.
+        for sub_idx, cluster in enumerate(clusters):
+            sub_row = r + sub_idx
+            by_col: dict[int, list[tuple]] = {}
+            for _, tc, bb in cluster:
+                x_cent = (bb.l + bb.r) / 2
+                nearest_col = min(
+                    col_centroids, key=lambda col: abs(col_centroids[col] - x_cent)
+                )
+                by_col.setdefault(nearest_col, []).append((tc, bb))
+            for col_id, tcs in by_col.items():
+                tcs.sort(key=lambda x: x[1].l)
+                text = " ".join(tc.text.strip() for tc, _ in tcs if tc.text)
+                bboxes = [bb for _, bb in tcs]
+                merged_bbox = BB(
+                    l=min(b.l for b in bboxes),
+                    t=min(b.t for b in bboxes),
+                    r=max(b.r for b in bboxes),
+                    b=max(b.b for b in bboxes),
+                    coord_origin=bboxes[0].coord_origin,
+                )
+                new_cell = template.model_copy(
+                    update={
+                        "bbox": merged_bbox,
+                        "text": text,
+                        "start_row_offset_idx": sub_row,
+                        "end_row_offset_idx": sub_row + 1,
+                        "start_col_offset_idx": col_id,
+                        "end_col_offset_idx": col_id + 1,
+                        "row_span": 1,
+                        "col_span": 1,
+                        "column_header": False,
+                        "row_header": False,
+                        "row_section": False,
+                    }
+                )
+                table_cells.append(new_cell)
+        new_rows_total += n - 1
+
+    return new_rows_total

--- a/docling/utils/table_cell_postprocess.py
+++ b/docling/utils/table_cell_postprocess.py
@@ -1,0 +1,574 @@
+"""Post-process TableFormer's per-cell predictions.
+
+Three issues TableFormer's output occasionally exhibits:
+
+1. **Wrapped-header collapse.** When column titles are long enough to wrap
+   onto 2-3 visual lines (e.g. "Net Cash for / Reinvestment# / Amount ($)"),
+   TableFormer marks only one of those lines as ``column_header=True`` and
+   rolls the others into row 1 of the data section. The result is a header
+   row missing several columns' titles and a data row that contains header
+   fragments. ``promote_wrapped_header_rows`` walks forward from the last
+   predicted header row and promotes following rows that look like header
+   continuations (no digits/currency, short text, similar line height).
+
+2. **Merged-cell duplication.** When a label visually spans multiple grid
+   columns (or rows), TableFormer's matcher can emit the same text into
+   each of those grid positions instead of one cell with ``col_span > 1``.
+   ``consolidate_duplicate_spans`` collapses adjacent same-row cells that
+   share text and have touching bboxes into one colspan cell, and the
+   mirror for vertical rowspans.
+
+3. **Silent loss of bbox-but-not-grid words.** TableFormer is fed every word
+   inside ``table_cluster.bbox`` (pulled via ``get_cells_in_bbox``) but only
+   the words it places in its predicted grid come back via ``tf_responses``.
+   Words it does not grid are otherwise silently dropped — they appear in
+   neither the table nor any other layout element. ``recover_leftover_words``
+   restores conservation: every input word ends up in *some* output element,
+   even if not the table, by emitting the leftovers as a new TEXT cluster.
+
+All three helpers are conservative: they require strong evidence (text
+equality, bbox adjacency, codebase-standard 0.5 IoS containment) and only
+act on cells that are obviously redundant or obviously outside the grid.
+Tables where TableFormer already emitted the correct grid are unaffected.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from docling_core.types.doc import BoundingBox, TableCell
+    from docling_core.types.doc.page import TextCell
+
+    from docling.datamodel.base_models import Cluster
+
+
+_DIGIT_OR_CURRENCY = re.compile(r"[\d$€£¥%]")
+
+
+def _avg_height(cells: Sequence["TableCell"]) -> float:
+    heights = [
+        c.bbox.t - c.bbox.b if c.bbox.coord_origin == "BOTTOMLEFT" else c.bbox.b - c.bbox.t
+        for c in cells
+        if c.bbox is not None
+    ]
+    heights = [h for h in heights if h > 0]
+    return sum(heights) / len(heights) if heights else 0.0
+
+
+def promote_wrapped_header_rows(
+    table_cells: list["TableCell"],
+    num_rows: int,
+    *,
+    max_avg_text_len: int = 25,
+    line_height_tol: float = 0.20,
+) -> None:
+    """In-place: promote rows that look like wrapped header continuations.
+
+    Walks forward from the last existing column-header row. For each
+    subsequent row, the row is promoted if all the following hold:
+
+    * No cell text contains digits, currency symbols, or %.
+    * Mean cell-text length is short (<= ``max_avg_text_len``), label-like.
+    * Average row height matches the header's average within ``line_height_tol``.
+    * At least one cell in the row is non-empty.
+
+    Stops at the first row that fails any check.
+
+    No-op if there is no header row, no rows, or num_rows < 2.
+    """
+    if not table_cells or num_rows < 2:
+        return
+
+    header_idxs = [
+        c.start_row_offset_idx for c in table_cells if getattr(c, "column_header", False)
+    ]
+    if not header_idxs:
+        return
+    last_header_row = max(header_idxs)
+
+    by_row: dict[int, list["TableCell"]] = {}
+    for c in table_cells:
+        by_row.setdefault(c.start_row_offset_idx, []).append(c)
+
+    header_cells = [c for c in table_cells if getattr(c, "column_header", False)]
+    hdr_h = _avg_height(header_cells)
+
+    for r in range(last_header_row + 1, num_rows):
+        row = by_row.get(r, [])
+        if not row:
+            return
+        texts = [(c.text or "").strip() for c in row]
+        if not any(texts):
+            return
+        if any(_DIGIT_OR_CURRENCY.search(t) for t in texts if t):
+            return
+        non_empty = [t for t in texts if t]
+        if non_empty and (sum(len(t) for t in non_empty) / len(non_empty)) > max_avg_text_len:
+            return
+        row_h = _avg_height(row)
+        if hdr_h > 0 and row_h > 0 and abs(row_h - hdr_h) / hdr_h > line_height_tol:
+            return
+        for c in row:
+            c.column_header = True
+
+
+_WS_COLLAPSE = re.compile(r"\s+")
+
+
+def _norm_text(s: str | None) -> str:
+    """Normalise for text-equality comparisons across cells.
+
+    Collapses internal whitespace runs to a single space so cells whose
+    text differs only by stray double-spaces (a common PDF-extraction
+    artefact) compare equal. Lower-cased and stripped — same shape as
+    before, just whitespace-aware.
+    """
+    return _WS_COLLAPSE.sub(" ", (s or "").strip()).lower()
+
+
+def _bbox_iou(a: "BoundingBox", b: "BoundingBox") -> float:
+    """Intersection over Union of two bboxes. Coord-origin-agnostic."""
+    inter = a.intersection_area_with(b)
+    if inter <= 0:
+        return 0.0
+    union = a.area() + b.area() - inter
+    return inter / union if union > 0 else 0.0
+
+
+def _bboxes_touch_horizontally(a: "BoundingBox", b: "BoundingBox", tol: float = 2.0) -> bool:
+    # Same vertical band (overlap), horizontally adjacent.
+    if a.coord_origin == "BOTTOMLEFT":
+        v_overlap = min(a.t, b.t) - max(a.b, b.b)
+    else:
+        v_overlap = min(a.b, b.b) - max(a.t, b.t)
+    if v_overlap <= 0:
+        return False
+    # adjacency: a.r ~ b.l or b.r ~ a.l
+    return abs(a.r - b.l) <= tol or abs(b.r - a.l) <= tol
+
+
+def _bboxes_touch_vertically(a: "BoundingBox", b: "BoundingBox", tol: float = 2.0) -> bool:
+    # Same horizontal band (overlap), vertically adjacent.
+    h_overlap = min(a.r, b.r) - max(a.l, b.l)
+    if h_overlap <= 0:
+        return False
+    if a.coord_origin == "BOTTOMLEFT":
+        return abs(a.b - b.t) <= tol or abs(b.b - a.t) <= tol
+    return abs(a.b - b.t) <= tol or abs(b.b - a.t) <= tol
+
+
+def _union_bbox(cells: Sequence["TableCell"]) -> "BoundingBox":
+    from docling_core.types.doc import BoundingBox
+
+    boxes = [c.bbox for c in cells if c.bbox is not None]
+    return BoundingBox(
+        l=min(b.l for b in boxes),
+        t=min(b.t for b in boxes),
+        r=max(b.r for b in boxes),
+        b=max(b.b for b in boxes),
+        coord_origin=boxes[0].coord_origin,
+    )
+
+
+def consolidate_duplicate_spans(
+    table_cells: list["TableCell"],
+) -> list["TableCell"]:
+    """Collapse adjacent cells with identical text into one cell with span > 1.
+
+    Returns a new list. The original list is not modified.
+
+    Detection is conservative: cells must have the same row offset (for
+    column merging) or same column offset (for row merging), exactly equal
+    normalised text, and bboxes that touch (within 2 page units).
+    """
+    if not table_cells:
+        return list(table_cells)
+
+    # ----- 1) Horizontal merge (collapse colspan duplicates). -----
+    # Group by start_row_offset_idx, sort by start_col_offset_idx.
+    by_row: dict[int, list["TableCell"]] = {}
+    others: list["TableCell"] = []
+    for c in table_cells:
+        if c.bbox is None or not (c.text and c.text.strip()):
+            others.append(c)
+            continue
+        by_row.setdefault(c.start_row_offset_idx, []).append(c)
+
+    horizontally_merged: list["TableCell"] = list(others)
+    for row_cells in by_row.values():
+        row_cells.sort(key=lambda c: c.start_col_offset_idx)
+        i = 0
+        while i < len(row_cells):
+            anchor = row_cells[i]
+            run = [anchor]
+            j = i + 1
+            while j < len(row_cells):
+                cand = row_cells[j]
+                last = run[-1]
+                if (
+                    _norm_text(cand.text) == _norm_text(anchor.text)
+                    and _norm_text(anchor.text) != ""
+                    and cand.start_col_offset_idx == last.end_col_offset_idx
+                    and last.bbox is not None
+                    and cand.bbox is not None
+                    and _bboxes_touch_horizontally(last.bbox, cand.bbox)
+                ):
+                    run.append(cand)
+                    j += 1
+                else:
+                    break
+            if len(run) > 1:
+                merged = anchor.model_copy(
+                    update={
+                        "bbox": _union_bbox(run),
+                        "col_span": sum(c.col_span for c in run),
+                        "end_col_offset_idx": run[-1].end_col_offset_idx,
+                    }
+                )
+                horizontally_merged.append(merged)
+            else:
+                horizontally_merged.append(anchor)
+            i = j
+
+    # ----- 2) Vertical merge (collapse rowspan duplicates). -----
+    by_col: dict[int, list["TableCell"]] = {}
+    leftovers: list["TableCell"] = []
+    for c in horizontally_merged:
+        if c.bbox is None or not (c.text and c.text.strip()):
+            leftovers.append(c)
+            continue
+        by_col.setdefault(c.start_col_offset_idx, []).append(c)
+
+    final: list["TableCell"] = list(leftovers)
+    for col_cells in by_col.values():
+        col_cells.sort(key=lambda c: c.start_row_offset_idx)
+        i = 0
+        while i < len(col_cells):
+            anchor = col_cells[i]
+            run = [anchor]
+            j = i + 1
+            while j < len(col_cells):
+                cand = col_cells[j]
+                last = run[-1]
+                if (
+                    _norm_text(cand.text) == _norm_text(anchor.text)
+                    and _norm_text(anchor.text) != ""
+                    and cand.start_row_offset_idx == last.end_row_offset_idx
+                    and cand.start_col_offset_idx == anchor.start_col_offset_idx
+                    and cand.end_col_offset_idx == anchor.end_col_offset_idx
+                    and last.bbox is not None
+                    and cand.bbox is not None
+                    and _bboxes_touch_vertically(last.bbox, cand.bbox)
+                ):
+                    run.append(cand)
+                    j += 1
+                else:
+                    break
+            if len(run) > 1:
+                merged = anchor.model_copy(
+                    update={
+                        "bbox": _union_bbox(run),
+                        "row_span": sum(c.row_span for c in run),
+                        "end_row_offset_idx": run[-1].end_row_offset_idx,
+                    }
+                )
+                final.append(merged)
+            else:
+                final.append(anchor)
+            i = j
+
+    # ----- 3) Identical-bbox same-text dedup. -----
+    # Catches duplicates that aren't grid-adjacent: the same physical PDF
+    # region emitted into two distinct grid positions. Grid-adjacency is
+    # not required because the duplicates may sit anywhere in the grid.
+    # Conservative: requires normalised-text equality AND IoU >= 0.95
+    # (essentially "same bbox") so distinct cells with coincidentally
+    # equal values stay separate.
+    deduped: list["TableCell"] = []
+    by_text: dict[str, list["TableCell"]] = {}
+    for c in final:
+        if c.bbox is None or not (c.text and c.text.strip()):
+            deduped.append(c)
+            continue
+        key = _norm_text(c.text)
+        bucket = by_text.setdefault(key, [])
+        is_dup = any(
+            existing.bbox is not None and _bbox_iou(c.bbox, existing.bbox) >= 0.95
+            for existing in bucket
+        )
+        if not is_dup:
+            bucket.append(c)
+            deduped.append(c)
+
+    return deduped
+
+
+def _grid_bbox(table_cells: Sequence["TableCell"]) -> "BoundingBox | None":
+    from docling_core.types.doc import BoundingBox
+
+    boxes = [c.bbox for c in table_cells if c.bbox is not None]
+    if not boxes:
+        return None
+    return BoundingBox(
+        l=min(b.l for b in boxes),
+        t=min(b.t for b in boxes),
+        r=max(b.r for b in boxes),
+        b=max(b.b for b in boxes),
+        coord_origin=boxes[0].coord_origin,
+    )
+
+
+def _column_centroids(table_cells: Sequence["TableCell"]) -> dict[int, float]:
+    """Per-column X-centroid, computed over all gridded cells in that column."""
+    by_col: dict[int, list["BoundingBox"]] = {}
+    for c in table_cells:
+        if c.bbox is None:
+            continue
+        by_col.setdefault(c.start_col_offset_idx, []).append(c.bbox)
+    return {
+        col: (min(b.l for b in bs) + max(b.r for b in bs)) / 2
+        for col, bs in by_col.items()
+    }
+
+
+def _median_row_pitch(table_cells: Sequence["TableCell"]) -> float | None:
+    """Median Y-distance between consecutive predicted rows.
+
+    Returns None for tables with fewer than 2 distinct rows — there is no
+    structural signal to derive a row-pitch from in that case, so callers
+    should fall back to conservative behaviour rather than guessing.
+    """
+    by_row: dict[int, list["BoundingBox"]] = {}
+    for c in table_cells:
+        if c.bbox is None:
+            continue
+        by_row.setdefault(c.start_row_offset_idx, []).append(c.bbox)
+    if len(by_row) < 2:
+        return None
+    centroids = sorted(
+        (min(b.t for b in bs) + max(b.b for b in bs)) / 2 for bs in by_row.values()
+    )
+    deltas = [abs(b - a) for a, b in zip(centroids, centroids[1:])]
+    if not deltas:
+        return None
+    return sorted(deltas)[len(deltas) // 2]
+
+
+def _attach_as_table_rows(
+    leftover_cells: list["TextCell"],
+    table_cells: list["TableCell"],
+) -> tuple[list["TableCell"], list["TextCell"]]:
+    """Try to place leftover words as new table rows.
+
+    Discriminator (purely structural, no content / template hints): cluster
+    the leftovers by Y-centroid using the table's own median row pitch as
+    the proximity threshold. A cluster qualifies as a tabular row only if
+    its members hit ≥2 distinct nearest-columns (column inferred by snapping
+    each cell's X-centroid to the closest gridded-column centroid). Single-
+    column clusters look like prose / captions and do not qualify.
+
+    Each qualifying cluster becomes a new table row; cells nearest the same
+    column are merged (text joined, bbox unioned) so the row keeps the
+    column count it earned. Disqualified cells are returned for fallback
+    handling (TEXT cluster).
+
+    Returns (placed_table_cells, unplaced_text_cells). ``placed_table_cells``
+    can be appended directly to the existing table_cells list.
+    """
+    if not table_cells or not leftover_cells:
+        return [], list(leftover_cells)
+
+    col_centroids = _column_centroids(table_cells)
+    if len(col_centroids) < 2:
+        # Without ≥2 columns there is no "distinct columns" signal — bail.
+        return [], list(leftover_cells)
+
+    pitch = _median_row_pitch(table_cells)
+    if pitch is None or pitch <= 0:
+        return [], list(leftover_cells)
+
+    template = next((c for c in table_cells if c.bbox is not None), None)
+    if template is None:
+        return [], list(leftover_cells)
+
+    # Annotate each leftover with its Y-centroid, X-centroid, and nearest
+    # column id, then sort by Y so consecutive cells can be Y-clustered.
+    enriched = []
+    for c in leftover_cells:
+        bb = c.rect.to_bounding_box()
+        y_cent = (bb.t + bb.b) / 2
+        x_cent = (bb.l + bb.r) / 2
+        nearest_col = min(
+            col_centroids, key=lambda col: abs(col_centroids[col] - x_cent)
+        )
+        enriched.append((y_cent, x_cent, nearest_col, c, bb))
+    enriched.sort(key=lambda t: t[0])
+
+    # Y-cluster: consecutive cells within `pitch` of each other belong to
+    # the same logical row. `pitch` is a property of *this* table, not a
+    # magic constant, so the threshold adapts to dense vs sparse layouts.
+    clusters: list[list[tuple]] = [[enriched[0]]]
+    for prev, curr in zip(enriched, enriched[1:]):
+        if abs(curr[0] - prev[0]) < pitch:
+            clusters[-1].append(curr)
+        else:
+            clusters.append([curr])
+
+    existing_max_row = max(c.start_row_offset_idx for c in table_cells)
+
+    placed: list["TableCell"] = []
+    unplaced: list["TextCell"] = []
+    next_row = existing_max_row + 1
+
+    for cluster in clusters:
+        cols_hit = {item[2] for item in cluster}
+        if len(cols_hit) < 2:
+            # One column: looks like prose / single-column caption — not a row.
+            for item in cluster:
+                unplaced.append(item[3])
+            continue
+
+        # Group this cluster's cells by their nearest column. Multiple
+        # leftovers nearest to the same column get merged into one cell so
+        # the row keeps a clean column-aligned shape.
+        by_col: dict[int, list[tuple]] = {}
+        for item in cluster:
+            by_col.setdefault(item[2], []).append(item)
+
+        for col_id, items in by_col.items():
+            text = " ".join(item[3].text.strip() for item in items if item[3].text)
+            bbs = [item[4] for item in items]
+            from docling_core.types.doc import BoundingBox
+
+            merged_bbox = BoundingBox(
+                l=min(b.l for b in bbs),
+                t=min(b.t for b in bbs),
+                r=max(b.r for b in bbs),
+                b=max(b.b for b in bbs),
+                coord_origin=bbs[0].coord_origin,
+            )
+            new_cell = template.model_copy(
+                update={
+                    "bbox": merged_bbox,
+                    "text": text,
+                    "start_row_offset_idx": next_row,
+                    "end_row_offset_idx": next_row + 1,
+                    "start_col_offset_idx": col_id,
+                    "end_col_offset_idx": col_id + 1,
+                    "row_span": 1,
+                    "col_span": 1,
+                    "column_header": False,
+                    "row_header": False,
+                    "row_section": False,
+                }
+            )
+            placed.append(new_cell)
+        next_row += 1
+
+    return placed, unplaced
+
+
+def recover_leftover_words(
+    *,
+    tcells: Sequence["TextCell"],
+    table_cells: list["TableCell"],
+    table_cluster: "Cluster",
+    page_clusters: list["Cluster"],
+    threshold: float = 0.5,
+) -> tuple[int, "Cluster | None"]:
+    """Recover input PDF words TableFormer did not place in its predicted grid.
+
+    The TABLE cluster bbox is grown by ``LayoutPostprocessor`` (TABLE-only
+    union-with-cells branch) to swallow nearby content. Every word inside
+    that bbox is shipped to TableFormer as input; only words it places in
+    its predicted grid come back via ``tf_responses``. Without this helper,
+    everything in between is silently dropped — invisible in both the table
+    and the surrounding text. TABLE is the only cluster type with this
+    non-conservative dataflow; every other label preserves the invariant
+    "every input word lands in some output element".
+
+    Containment uses the codebase's existing ``intersection_over_self``
+    convention with the ``0.5`` threshold (see ``layout_postprocessor.py``
+    lines 345, 404, 444): a word is considered "outside the grid" when more
+    than half its bbox lies outside the union of predicted grid cell bboxes.
+
+    Recovery is two-pass:
+
+    1. **Structural pass** (``_attach_as_table_rows``): leftovers that form
+       ≥2 cells in distinct columns at similar Y are placed as new rows in
+       ``table_cells``. The proximity threshold is the table's own median
+       row pitch — no magic constants. This restores both the data AND its
+       column-header context.
+    2. **Conservation pass**: any leftovers that fail the structural test
+       (single-column clusters, isolated cells, captions) are emitted as a
+       TEXT cluster appended to ``page_clusters`` so they at least appear
+       in the JSON. The TABLE cluster's bbox is shrunk to the union of all
+       gridded cells (existing + newly placed) so the residual region is no
+       longer claimed by the table.
+
+    Returns ``(num_new_rows, leftover_text_cluster)``. The caller must add
+    ``num_new_rows`` to its ``num_rows`` value before constructing the
+    ``Table`` so downstream code knows the table grew.
+
+    No-op (returns ``(0, None)``) when:
+
+    * ``tcells`` is empty (nothing to recover);
+    * ``table_cells`` produced no grid (no signal for what to keep);
+    * no ``tcells`` entry falls outside the grid by more than ``threshold``.
+    """
+    from docling.datamodel.base_models import Cluster
+    from docling_core.types.doc import BoundingBox, DocItemLabel
+
+    grid_bbox = _grid_bbox(table_cells)
+    if grid_bbox is None or not tcells:
+        return 0, None
+
+    leftover_cells: list["TextCell"] = []
+    for c in tcells:
+        if not c.text or not c.text.strip():
+            continue
+        cb = c.rect.to_bounding_box()
+        if cb.intersection_over_self(grid_bbox) < threshold:
+            leftover_cells.append(c)
+
+    if not leftover_cells:
+        return 0, None
+
+    # Pass 1: structural recovery — place qualifying leftovers as new rows.
+    placed, unplaced = _attach_as_table_rows(leftover_cells, table_cells)
+    table_cells.extend(placed)
+    new_row_ids = {c.start_row_offset_idx for c in placed}
+    new_row_count = len(new_row_ids)
+
+    # Pass 2: cells that didn't qualify → emit as TEXT cluster (conservation).
+    leftover_cluster: "Cluster | None" = None
+    if unplaced:
+        unplaced_bboxes = [c.rect.to_bounding_box() for c in unplaced]
+        leftover_bbox = BoundingBox(
+            l=min(b.l for b in unplaced_bboxes),
+            t=min(b.t for b in unplaced_bboxes),
+            r=max(b.r for b in unplaced_bboxes),
+            b=max(b.b for b in unplaced_bboxes),
+            coord_origin=unplaced_bboxes[0].coord_origin,
+        )
+        next_id = max((cl.id for cl in page_clusters), default=-1) + 1
+        leftover_cluster = Cluster(
+            id=next_id,
+            label=DocItemLabel.TEXT,
+            bbox=leftover_bbox,
+            confidence=table_cluster.confidence,
+            cells=list(unplaced),
+        )
+        page_clusters.append(leftover_cluster)
+
+    # Shrink table_cluster.bbox to the union of gridded cells (existing +
+    # newly placed). This both releases the leftover-TEXT region and, when
+    # rows were structurally added, expands to encompass them.
+    new_grid_bbox = _grid_bbox(table_cells)
+    if new_grid_bbox is not None:
+        table_cluster.bbox = new_grid_bbox
+
+    return new_row_count, leftover_cluster

--- a/docling/utils/table_cell_postprocess.py
+++ b/docling/utils/table_cell_postprocess.py
@@ -583,3 +583,183 @@ def recover_leftover_words(
         table_cluster.bbox = new_grid_bbox
 
     return new_row_count, leftover_cluster
+
+
+def detect_subtable_boundaries(
+    table_cells: list[TableCell],
+    *,
+    min_count_ratio: float = 1.5,
+    min_consecutive: int = 2,
+) -> list[int]:
+    """Detect rows where a TABLE cluster transitions between sub-tables.
+
+    Layout postprocessing occasionally merges several visually-distinct
+    tables on a page into one TABLE cluster (e.g. a stack of "label, value"
+    summary tables followed by a wide totals table). TableFormer then has
+    to invent a single grid covering all of them, producing rows whose
+    structural shape differs sharply: some rows have just two cells (label
+    spanning N-1 cols + value), others have N cells across distinct
+    columns. This function detects those structural breaks so the caller
+    can split the cluster into separate ``Table`` objects.
+
+    The discriminator is the per-row distinct-cell count. A boundary is
+    declared between row r-1 and r when:
+
+    * ``max(count_prev, count_curr) / max(min(count_prev, count_curr), 1)``
+      is at least ``min_count_ratio`` — the change is structurally large,
+      not a one-cell wobble; AND
+    * the new shape is **sustained** for ``min_consecutive`` rows — i.e.
+      rows ``r..r+min_consecutive-1`` all stay within ``min_count_ratio``
+      of each other. A single odd row (e.g. an isolated subtotal in the
+      middle of a wide table) does not trigger a split.
+
+    Returns the list of row indices where each sub-table starts. Always
+    includes the first row index. Returns an empty list when
+    ``table_cells`` is empty.
+
+    Conservative by design: no template-specific or text-content
+    heuristics; the discriminator is purely the structural shape of each
+    row, and the sustain rule prevents single-row outliers from
+    fragmenting otherwise-coherent tables.
+    """
+    if not table_cells:
+        return []
+
+    counts: dict[int, int] = {}
+    for c in table_cells:
+        counts[c.start_row_offset_idx] = counts.get(c.start_row_offset_idx, 0) + 1
+    sorted_rows = sorted(counts)
+
+    boundaries = [sorted_rows[0]]
+    for i in range(1, len(sorted_rows)):
+        prev_r, curr_r = sorted_rows[i - 1], sorted_rows[i]
+        prev_c, curr_c = counts[prev_r], counts[curr_r]
+        ratio = max(prev_c, curr_c) / max(min(prev_c, curr_c), 1)
+        if ratio < min_count_ratio:
+            continue
+        # Sustain check: do at least `min_consecutive - 1` more rows after
+        # `curr_r` stay within ratio of curr_c?
+        sustained = True
+        for j in range(1, min_consecutive):
+            if i + j >= len(sorted_rows):
+                # Ran off the end before sustaining — treat as not sustained
+                # (a single trailing odd row is more likely noise than a
+                # genuine sub-table).
+                sustained = False
+                break
+            next_c = counts[sorted_rows[i + j]]
+            r2 = max(curr_c, next_c) / max(min(curr_c, next_c), 1)
+            if r2 > min_count_ratio:
+                sustained = False
+                break
+        if sustained:
+            boundaries.append(curr_r)
+    return boundaries
+
+
+def _renumber_rows(cells: list[TableCell], offset: int) -> list[TableCell]:
+    """Return cells with start/end_row_offset_idx shifted down by ``offset``.
+
+    Each cell is replaced via ``model_copy`` so the originals are not
+    mutated (callers may still hold references to them).
+    """
+    out = []
+    for c in cells:
+        out.append(
+            c.model_copy(
+                update={
+                    "start_row_offset_idx": c.start_row_offset_idx - offset,
+                    "end_row_offset_idx": c.end_row_offset_idx - offset,
+                }
+            )
+        )
+    return out
+
+
+def split_into_structural_subtables(
+    *,
+    table_cells: list[TableCell],
+    table_cluster: Cluster,
+    page_clusters: list[Cluster],
+    table_map: dict,
+    page_no: int,
+) -> tuple[list[TableCell], int, int, bool]:
+    """Split ``table_cells`` into multiple Tables on row-pattern boundaries.
+
+    When ``detect_subtable_boundaries`` finds the cluster contains multiple
+    structurally-distinct sub-tables, this orchestrator:
+
+    * partitions ``table_cells`` by row range,
+    * keeps the first sub-table on the original ``table_cluster`` (with
+      bbox shrunk to its extent),
+    * for each subsequent sub-table, mints a new cluster id (mirroring the
+      idiom in ``recover_leftover_words``), appends a TABLE ``Cluster`` to
+      ``page_clusters``, constructs a ``Table`` from the renumbered cells,
+      and writes ``table_map[new_id] = table``.
+
+    Returns ``(first_cells, first_num_rows, first_num_cols, did_split)``.
+    The caller uses ``first_cells`` / ``first_num_rows`` / ``first_num_cols``
+    to construct the Table for the original cluster id; ``did_split=True``
+    means caller should also clear ``otsl_seq`` because the predicted
+    sequence describes the un-split whole.
+
+    No-op (returns the input unchanged with ``did_split=False``) when the
+    discriminator finds at most one sub-table.
+    """
+    from docling_core.types.doc import DocItemLabel
+
+    from docling.datamodel.base_models import Cluster as ClusterModel, Table
+
+    boundaries = detect_subtable_boundaries(table_cells)
+    if len(boundaries) <= 1 or not table_cells:
+        nr = max((c.end_row_offset_idx for c in table_cells), default=0)
+        nc = max((c.end_col_offset_idx for c in table_cells), default=0)
+        return list(table_cells), nr, nc, False
+
+    # Partition cells by row range (boundary[i] inclusive .. boundary[i+1] exclusive)
+    sub_groups: list[tuple[int, list[TableCell]]] = []
+    for i, start in enumerate(boundaries):
+        end = boundaries[i + 1] if i + 1 < len(boundaries) else float("inf")
+        cells = [c for c in table_cells if start <= c.start_row_offset_idx < end]
+        sub_groups.append((start, cells))
+
+    # First sub-group keeps the original cluster id; renumber its rows so
+    # the kept sub-table starts at row 0.
+    first_start, first_raw = sub_groups[0]
+    first_cells = _renumber_rows(first_raw, first_start)
+    first_nr = max((c.end_row_offset_idx for c in first_cells), default=0)
+    first_nc = max((c.end_col_offset_idx for c in first_cells), default=0)
+    first_bbox = _grid_bbox(first_cells)
+    if first_bbox is not None:
+        table_cluster.bbox = first_bbox
+
+    # Subsequent sub-groups become new clusters + table_map entries.
+    for start, raw_cells in sub_groups[1:]:
+        sub_cells = _renumber_rows(raw_cells, start)
+        sub_nr = max((c.end_row_offset_idx for c in sub_cells), default=0)
+        sub_nc = max((c.end_col_offset_idx for c in sub_cells), default=0)
+        sub_bbox = _grid_bbox(sub_cells)
+        if sub_bbox is None:
+            continue
+        next_id = max((cl.id for cl in page_clusters), default=-1) + 1
+        new_cluster = ClusterModel(
+            id=next_id,
+            label=DocItemLabel.TABLE,
+            bbox=sub_bbox,
+            confidence=table_cluster.confidence,
+            cells=[],
+        )
+        page_clusters.append(new_cluster)
+        sub_table = Table(
+            otsl_seq=[],
+            table_cells=sub_cells,
+            num_rows=sub_nr,
+            num_cols=sub_nc,
+            id=next_id,
+            page_no=page_no,
+            cluster=new_cluster,
+            label=new_cluster.label,
+        )
+        table_map[next_id] = sub_table
+
+    return first_cells, first_nr, first_nc, True

--- a/docling/utils/table_cell_postprocess.py
+++ b/docling/utils/table_cell_postprocess.py
@@ -36,6 +36,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Sequence
+from itertools import pairwise
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -48,9 +49,11 @@ if TYPE_CHECKING:
 _DIGIT_OR_CURRENCY = re.compile(r"[\d$€£¥%]")
 
 
-def _avg_height(cells: Sequence["TableCell"]) -> float:
+def _avg_height(cells: Sequence[TableCell]) -> float:
     heights = [
-        c.bbox.t - c.bbox.b if c.bbox.coord_origin == "BOTTOMLEFT" else c.bbox.b - c.bbox.t
+        c.bbox.t - c.bbox.b
+        if c.bbox.coord_origin == "BOTTOMLEFT"
+        else c.bbox.b - c.bbox.t
         for c in cells
         if c.bbox is not None
     ]
@@ -59,7 +62,7 @@ def _avg_height(cells: Sequence["TableCell"]) -> float:
 
 
 def promote_wrapped_header_rows(
-    table_cells: list["TableCell"],
+    table_cells: list[TableCell],
     num_rows: int,
     *,
     max_avg_text_len: int = 25,
@@ -83,13 +86,15 @@ def promote_wrapped_header_rows(
         return
 
     header_idxs = [
-        c.start_row_offset_idx for c in table_cells if getattr(c, "column_header", False)
+        c.start_row_offset_idx
+        for c in table_cells
+        if getattr(c, "column_header", False)
     ]
     if not header_idxs:
         return
     last_header_row = max(header_idxs)
 
-    by_row: dict[int, list["TableCell"]] = {}
+    by_row: dict[int, list[TableCell]] = {}
     for c in table_cells:
         by_row.setdefault(c.start_row_offset_idx, []).append(c)
 
@@ -106,7 +111,10 @@ def promote_wrapped_header_rows(
         if any(_DIGIT_OR_CURRENCY.search(t) for t in texts if t):
             return
         non_empty = [t for t in texts if t]
-        if non_empty and (sum(len(t) for t in non_empty) / len(non_empty)) > max_avg_text_len:
+        if (
+            non_empty
+            and (sum(len(t) for t in non_empty) / len(non_empty)) > max_avg_text_len
+        ):
             return
         row_h = _avg_height(row)
         if hdr_h > 0 and row_h > 0 and abs(row_h - hdr_h) / hdr_h > line_height_tol:
@@ -129,7 +137,7 @@ def _norm_text(s: str | None) -> str:
     return _WS_COLLAPSE.sub(" ", (s or "").strip()).lower()
 
 
-def _bbox_iou(a: "BoundingBox", b: "BoundingBox") -> float:
+def _bbox_iou(a: BoundingBox, b: BoundingBox) -> float:
     """Intersection over Union of two bboxes. Coord-origin-agnostic."""
     inter = a.intersection_area_with(b)
     if inter <= 0:
@@ -138,7 +146,9 @@ def _bbox_iou(a: "BoundingBox", b: "BoundingBox") -> float:
     return inter / union if union > 0 else 0.0
 
 
-def _bboxes_touch_horizontally(a: "BoundingBox", b: "BoundingBox", tol: float = 2.0) -> bool:
+def _bboxes_touch_horizontally(
+    a: BoundingBox, b: BoundingBox, tol: float = 2.0
+) -> bool:
     # Same vertical band (overlap), horizontally adjacent.
     if a.coord_origin == "BOTTOMLEFT":
         v_overlap = min(a.t, b.t) - max(a.b, b.b)
@@ -150,7 +160,7 @@ def _bboxes_touch_horizontally(a: "BoundingBox", b: "BoundingBox", tol: float = 
     return abs(a.r - b.l) <= tol or abs(b.r - a.l) <= tol
 
 
-def _bboxes_touch_vertically(a: "BoundingBox", b: "BoundingBox", tol: float = 2.0) -> bool:
+def _bboxes_touch_vertically(a: BoundingBox, b: BoundingBox, tol: float = 2.0) -> bool:
     # Same horizontal band (overlap), vertically adjacent.
     h_overlap = min(a.r, b.r) - max(a.l, b.l)
     if h_overlap <= 0:
@@ -160,7 +170,7 @@ def _bboxes_touch_vertically(a: "BoundingBox", b: "BoundingBox", tol: float = 2.
     return abs(a.b - b.t) <= tol or abs(b.b - a.t) <= tol
 
 
-def _union_bbox(cells: Sequence["TableCell"]) -> "BoundingBox":
+def _union_bbox(cells: Sequence[TableCell]) -> BoundingBox:
     from docling_core.types.doc import BoundingBox
 
     boxes = [c.bbox for c in cells if c.bbox is not None]
@@ -174,8 +184,8 @@ def _union_bbox(cells: Sequence["TableCell"]) -> "BoundingBox":
 
 
 def consolidate_duplicate_spans(
-    table_cells: list["TableCell"],
-) -> list["TableCell"]:
+    table_cells: list[TableCell],
+) -> list[TableCell]:
     """Collapse adjacent cells with identical text into one cell with span > 1.
 
     Returns a new list. The original list is not modified.
@@ -189,15 +199,15 @@ def consolidate_duplicate_spans(
 
     # ----- 1) Horizontal merge (collapse colspan duplicates). -----
     # Group by start_row_offset_idx, sort by start_col_offset_idx.
-    by_row: dict[int, list["TableCell"]] = {}
-    others: list["TableCell"] = []
+    by_row: dict[int, list[TableCell]] = {}
+    others: list[TableCell] = []
     for c in table_cells:
         if c.bbox is None or not (c.text and c.text.strip()):
             others.append(c)
             continue
         by_row.setdefault(c.start_row_offset_idx, []).append(c)
 
-    horizontally_merged: list["TableCell"] = list(others)
+    horizontally_merged: list[TableCell] = list(others)
     for row_cells in by_row.values():
         row_cells.sort(key=lambda c: c.start_col_offset_idx)
         i = 0
@@ -234,15 +244,15 @@ def consolidate_duplicate_spans(
             i = j
 
     # ----- 2) Vertical merge (collapse rowspan duplicates). -----
-    by_col: dict[int, list["TableCell"]] = {}
-    leftovers: list["TableCell"] = []
+    by_col: dict[int, list[TableCell]] = {}
+    leftovers: list[TableCell] = []
     for c in horizontally_merged:
         if c.bbox is None or not (c.text and c.text.strip()):
             leftovers.append(c)
             continue
         by_col.setdefault(c.start_col_offset_idx, []).append(c)
 
-    final: list["TableCell"] = list(leftovers)
+    final: list[TableCell] = list(leftovers)
     for col_cells in by_col.values():
         col_cells.sort(key=lambda c: c.start_row_offset_idx)
         i = 0
@@ -287,8 +297,8 @@ def consolidate_duplicate_spans(
     # Conservative: requires normalised-text equality AND IoU >= 0.95
     # (essentially "same bbox") so distinct cells with coincidentally
     # equal values stay separate.
-    deduped: list["TableCell"] = []
-    by_text: dict[str, list["TableCell"]] = {}
+    deduped: list[TableCell] = []
+    by_text: dict[str, list[TableCell]] = {}
     for c in final:
         if c.bbox is None or not (c.text and c.text.strip()):
             deduped.append(c)
@@ -306,7 +316,7 @@ def consolidate_duplicate_spans(
     return deduped
 
 
-def _grid_bbox(table_cells: Sequence["TableCell"]) -> "BoundingBox | None":
+def _grid_bbox(table_cells: Sequence[TableCell]) -> BoundingBox | None:
     from docling_core.types.doc import BoundingBox
 
     boxes = [c.bbox for c in table_cells if c.bbox is not None]
@@ -321,9 +331,9 @@ def _grid_bbox(table_cells: Sequence["TableCell"]) -> "BoundingBox | None":
     )
 
 
-def _column_centroids(table_cells: Sequence["TableCell"]) -> dict[int, float]:
+def _column_centroids(table_cells: Sequence[TableCell]) -> dict[int, float]:
     """Per-column X-centroid, computed over all gridded cells in that column."""
-    by_col: dict[int, list["BoundingBox"]] = {}
+    by_col: dict[int, list[BoundingBox]] = {}
     for c in table_cells:
         if c.bbox is None:
             continue
@@ -334,14 +344,14 @@ def _column_centroids(table_cells: Sequence["TableCell"]) -> dict[int, float]:
     }
 
 
-def _median_row_pitch(table_cells: Sequence["TableCell"]) -> float | None:
+def _median_row_pitch(table_cells: Sequence[TableCell]) -> float | None:
     """Median Y-distance between consecutive predicted rows.
 
     Returns None for tables with fewer than 2 distinct rows — there is no
     structural signal to derive a row-pitch from in that case, so callers
     should fall back to conservative behaviour rather than guessing.
     """
-    by_row: dict[int, list["BoundingBox"]] = {}
+    by_row: dict[int, list[BoundingBox]] = {}
     for c in table_cells:
         if c.bbox is None:
             continue
@@ -351,16 +361,16 @@ def _median_row_pitch(table_cells: Sequence["TableCell"]) -> float | None:
     centroids = sorted(
         (min(b.t for b in bs) + max(b.b for b in bs)) / 2 for bs in by_row.values()
     )
-    deltas = [abs(b - a) for a, b in zip(centroids, centroids[1:])]
+    deltas = [abs(b - a) for a, b in pairwise(centroids)]
     if not deltas:
         return None
     return sorted(deltas)[len(deltas) // 2]
 
 
 def _attach_as_table_rows(
-    leftover_cells: list["TextCell"],
-    table_cells: list["TableCell"],
-) -> tuple[list["TableCell"], list["TextCell"]]:
+    leftover_cells: list[TextCell],
+    table_cells: list[TableCell],
+) -> tuple[list[TableCell], list[TextCell]]:
     """Try to place leftover words as new table rows.
 
     Discriminator (purely structural, no content / template hints): cluster
@@ -411,7 +421,7 @@ def _attach_as_table_rows(
     # the same logical row. `pitch` is a property of *this* table, not a
     # magic constant, so the threshold adapts to dense vs sparse layouts.
     clusters: list[list[tuple]] = [[enriched[0]]]
-    for prev, curr in zip(enriched, enriched[1:]):
+    for prev, curr in pairwise(enriched):
         if abs(curr[0] - prev[0]) < pitch:
             clusters[-1].append(curr)
         else:
@@ -419,8 +429,8 @@ def _attach_as_table_rows(
 
     existing_max_row = max(c.start_row_offset_idx for c in table_cells)
 
-    placed: list["TableCell"] = []
-    unplaced: list["TextCell"] = []
+    placed: list[TableCell] = []
+    unplaced: list[TextCell] = []
     next_row = existing_max_row + 1
 
     for cluster in clusters:
@@ -473,12 +483,12 @@ def _attach_as_table_rows(
 
 def recover_leftover_words(
     *,
-    tcells: Sequence["TextCell"],
-    table_cells: list["TableCell"],
-    table_cluster: "Cluster",
-    page_clusters: list["Cluster"],
+    tcells: Sequence[TextCell],
+    table_cells: list[TableCell],
+    table_cluster: Cluster,
+    page_clusters: list[Cluster],
     threshold: float = 0.5,
-) -> tuple[int, "Cluster | None"]:
+) -> tuple[int, Cluster | None]:
     """Recover input PDF words TableFormer did not place in its predicted grid.
 
     The TABLE cluster bbox is grown by ``LayoutPostprocessor`` (TABLE-only
@@ -519,14 +529,15 @@ def recover_leftover_words(
     * ``table_cells`` produced no grid (no signal for what to keep);
     * no ``tcells`` entry falls outside the grid by more than ``threshold``.
     """
-    from docling.datamodel.base_models import Cluster
     from docling_core.types.doc import BoundingBox, DocItemLabel
+
+    from docling.datamodel.base_models import Cluster
 
     grid_bbox = _grid_bbox(table_cells)
     if grid_bbox is None or not tcells:
         return 0, None
 
-    leftover_cells: list["TextCell"] = []
+    leftover_cells: list[TextCell] = []
     for c in tcells:
         if not c.text or not c.text.strip():
             continue
@@ -544,7 +555,7 @@ def recover_leftover_words(
     new_row_count = len(new_row_ids)
 
     # Pass 2: cells that didn't qualify → emit as TEXT cluster (conservation).
-    leftover_cluster: "Cluster | None" = None
+    leftover_cluster: Cluster | None = None
     if unplaced:
         unplaced_bboxes = [c.rect.to_bounding_box() for c in unplaced]
         leftover_bbox = BoundingBox(

--- a/docling/utils/table_cell_postprocess.py
+++ b/docling/utils/table_cell_postprocess.py
@@ -1,15 +1,15 @@
 """Post-process TableFormer's per-cell predictions.
 
-Three issues TableFormer's output occasionally exhibits:
+Four issues TableFormer's output occasionally exhibits:
 
-1. **Wrapped-header collapse.** When column titles are long enough to wrap
-   onto 2-3 visual lines (e.g. "Net Cash for / Reinvestment# / Amount ($)"),
-   TableFormer marks only one of those lines as ``column_header=True`` and
-   rolls the others into row 1 of the data section. The result is a header
-   row missing several columns' titles and a data row that contains header
-   fragments. ``promote_wrapped_header_rows`` walks forward from the last
-   predicted header row and promotes following rows that look like header
-   continuations (no digits/currency, short text, similar line height).
+1. **Header marking dropped or wrapped across rows.** When column titles
+   wrap onto 2-3 visual lines (e.g. "Net Cash for / Reinvestment# / Amount
+   ($)"), TableFormer marks only one of those lines as
+   ``column_header=True`` and rolls the others into row 1 of data. On
+   simpler grids it occasionally drops header marking entirely.
+   ``promote_wrapped_header_rows`` handles both: when no header is marked
+   it seeds row 0 if it looks like an alphabetic caption over a numeric
+   data row, then walks forward promoting header-like continuations.
 
 2. **Merged-cell duplication.** When a label visually spans multiple grid
    columns (or rows), TableFormer's matcher can emit the same text into
@@ -24,12 +24,24 @@ Three issues TableFormer's output occasionally exhibits:
    Words it does not grid are otherwise silently dropped — they appear in
    neither the table nor any other layout element. ``recover_leftover_words``
    restores conservation: every input word ends up in *some* output element,
-   even if not the table, by emitting the leftovers as a new TEXT cluster.
+   either as a new table row (when leftovers form a clear tabular pattern)
+   or as a new TEXT cluster on the page layout.
 
-All three helpers are conservative: they require strong evidence (text
-equality, bbox adjacency, codebase-standard 0.5 IoS containment) and only
-act on cells that are obviously redundant or obviously outside the grid.
-Tables where TableFormer already emitted the correct grid are unaffected.
+4. **Multiple sub-tables merged into one cluster.** The layout
+   postprocessor occasionally merges visually-distinct tables into a single
+   TABLE cluster (e.g. a stack of "label, value" summary tables followed
+   by a wide totals table). TableFormer is then forced to invent a grid
+   covering all of them, with rows of sharply-different structural shape.
+   ``split_into_structural_subtables`` detects per-row distinct-cell-count
+   shifts (sustained across multiple rows) and emits each piece as its own
+   TABLE Cluster + Table. Page assembly handles multiple Tables on one
+   page natively.
+
+All four helpers are conservative: they require strong structural evidence
+(text equality, bbox adjacency, codebase-standard 0.5 IoS containment,
+sustained pattern shifts) and only act on cells that are obviously
+redundant or obviously misplaced. Tables where TableFormer already emitted
+the correct grid are unaffected.
 """
 
 from __future__ import annotations
@@ -61,6 +73,58 @@ def _avg_height(cells: Sequence[TableCell]) -> float:
     return sum(heights) / len(heights) if heights else 0.0
 
 
+def _seed_row_0_as_header(
+    table_cells: list[TableCell],
+    by_row: dict[int, list[TableCell]],
+) -> bool:
+    """Promote row 0 to ``column_header=True`` when it looks like an
+    alphabetic-caption row over a numeric data row.
+
+    TableFormer occasionally returns ``column_header=False`` on every cell
+    despite the row clearly being headers (the grid + cell text are
+    correct; only the boolean is wrong). Without this seed step, the
+    walk-forward continuation logic in ``promote_wrapped_header_rows``
+    has nothing to walk from and the table is rendered headerless.
+
+    Discriminator (must satisfy ALL):
+
+    * Row 0 and row 1 both exist (gate at caller-side typically also
+      enforces this via ``num_rows >= 2``).
+    * Every non-empty cell in row 0 is non-digit (alphabetic caption).
+      Currency symbols / percent signs without surrounding digits are
+      tolerated so headers like "Cash per Unit ($)" still qualify.
+    * At least one row-1 cell contains digit / currency / percent
+      characters — confirms row 1 is a data row, not another header.
+
+    Returns True iff at least one row-0 cell was promoted.
+    """
+    if 0 not in by_row or 1 not in by_row:
+        return False
+
+    row0_text_cells = [c for c in by_row[0] if c.text and c.text.strip()]
+    if not row0_text_cells:
+        return False
+
+    # Row 0 must be alphabetic — no digits in any non-empty cell. (The
+    # `_DIGIT_OR_CURRENCY` regex matches currency too, but caption-style
+    # headers like "Cash per Unit ($)" should pass; reject only on
+    # digits, since numeric content is the strong "this is data" signal.)
+    for c in row0_text_cells:
+        if any(ch.isdigit() for ch in c.text):
+            return False
+
+    # Row 1 must contain at least one numeric / currency / percent token.
+    row1_text_cells = [c for c in by_row[1] if c.text and c.text.strip()]
+    if not any(_DIGIT_OR_CURRENCY.search(c.text) for c in row1_text_cells):
+        return False
+
+    promoted_any = False
+    for c in row0_text_cells:
+        c.column_header = True
+        promoted_any = True
+    return promoted_any
+
+
 def promote_wrapped_header_rows(
     table_cells: list[TableCell],
     num_rows: int,
@@ -68,22 +132,34 @@ def promote_wrapped_header_rows(
     max_avg_text_len: int = 25,
     line_height_tol: float = 0.20,
 ) -> None:
-    """In-place: promote rows that look like wrapped header continuations.
+    """In-place: promote rows that look like header rows or wrapped header
+    continuations.
 
-    Walks forward from the last existing column-header row. For each
-    subsequent row, the row is promoted if all the following hold:
+    Two cases:
 
-    * No cell text contains digits, currency symbols, or %.
-    * Mean cell-text length is short (<= ``max_avg_text_len``), label-like.
-    * Average row height matches the header's average within ``line_height_tol``.
-    * At least one cell in the row is non-empty.
+    * **Seed case** — when no cell currently has ``column_header=True`` but
+      row 0 is an alphabetic caption above a numeric row 1, promote row 0
+      first (see ``_seed_row_0_as_header``). This handles tables where
+      TableFormer dropped the column-header flag entirely.
 
-    Stops at the first row that fails any check.
+    * **Continuation case** — walks forward from the last existing
+      column-header row. For each subsequent row, the row is promoted if
+      all the following hold:
+        - No cell text contains digits, currency symbols, or %.
+        - Mean cell-text length is short (<= ``max_avg_text_len``).
+        - Average row height matches the header's average within
+          ``line_height_tol``.
+        - At least one cell in the row is non-empty.
+      Stops at the first row that fails any check.
 
-    No-op if there is no header row, no rows, or num_rows < 2.
+    No-op if there are no rows or ``num_rows < 2``.
     """
     if not table_cells or num_rows < 2:
         return
+
+    by_row: dict[int, list[TableCell]] = {}
+    for c in table_cells:
+        by_row.setdefault(c.start_row_offset_idx, []).append(c)
 
     header_idxs = [
         c.start_row_offset_idx
@@ -91,12 +167,19 @@ def promote_wrapped_header_rows(
         if getattr(c, "column_header", False)
     ]
     if not header_idxs:
-        return
+        # Seed: no header at all. Try to promote row 0 if it looks like a
+        # caption over a numeric data row.
+        if not _seed_row_0_as_header(table_cells, by_row):
+            return
+        # Re-collect now that row 0 has been promoted.
+        header_idxs = [
+            c.start_row_offset_idx
+            for c in table_cells
+            if getattr(c, "column_header", False)
+        ]
+        if not header_idxs:
+            return
     last_header_row = max(header_idxs)
-
-    by_row: dict[int, list[TableCell]] = {}
-    for c in table_cells:
-        by_row.setdefault(c.start_row_offset_idx, []).append(c)
 
     header_cells = [c for c in table_cells if getattr(c, "column_header", False)]
     hdr_h = _avg_height(header_cells)


### PR DESCRIPTION
## Summary

Four new helpers in `docling/utils/table_cell_postprocess.py`, wired into `predict_tables` after `tf_responses` materialises:

- **`recover_leftover_words`** — closes a structural conservation hole. TABLE clusters are the only label whose dataflow is non-conservative: `LayoutPostprocessor._adjust_cluster_bboxes` union-grows the bbox, every word inside is shipped to TableFormer, but only gridded cells come back via `tf_responses`. Anything else is silently dropped — invisible in both the table and the surrounding text. Two-pass recovery: leftovers in >=2 distinct columns at similar Y become new table rows (snapped to nearest column by X-centroid, Y-threshold = the table's own median row pitch); the rest emit as a TEXT cluster on the page layout.

- **`split_into_structural_subtables`** — splits one TABLE cluster into multiple `Table` objects when the layout postprocessor merged visually-distinct sub-tables into a single cluster. Detects per-row distinct-cell-count shifts (`>=1.5x` change, sustained for `>=2` rows) and synthesises new TABLE clusters for each piece, mirroring the `recover_leftover_words` cluster-id idiom. Page assembly, reading order, and markdown serialisation handle multiple Tables natively — `MarkdownDocSerializer` joins parts with `"\n\n"` so each sub-table renders as its own table block.

- **`promote_wrapped_header_rows`** — when column titles wrap onto multiple lines, TableFormer marks only the first as `column_header=True`. Walks forward and promotes header-like continuations (no digits/currency, short text, similar height).

- **`consolidate_duplicate_spans`** — when the matcher emits identical text into each adjacent cell instead of one `col_span > 1` cell, collapses them. Also dedupes identical-text cells with IoU >= 0.95 anywhere in the grid.

All four use structural cues only — the codebase's existing `intersection_over_self < 0.5` convention for containment, no template-specific or text-content heuristics. Helpers no-op on tables where TableFormer's grid is already correct.

## Empirical evidence

10-PDF dividend-statement corpus, A/B baseline vs patched:

- **TCL_2020_02_14.pdf** — page 1 has a "Total Dividend and Distribution" row whose label sits to the left and whose values fill cols 1-4. TableFormer didn't grid those cells (the layout cluster bbox was over-extended past the predicted grid; the words became input tokens to TableFormer that didn't make it back through `tf_responses`). Additionally, the layout cluster merged three visually-distinct tables into one.
  - Baseline: row 21 had the headers `Gross / Tax Withheld / Net / Franking Credits` but no value row 22 — values `$4,129.51 / $1,815.00 / $2,314.51 / $114.18` were dropped from both table and page text. The whole 23-row block was rendered as one markdown table with `col_span=4` cells in the label column.
  - Patched: row 22 reconstructed via `recover_leftover_words` with the values placed under their headers. The row-pattern shift between rows 0-20 (label + value) and rows 21-22 (5 distinct columns) is detected, and the latter is split into its own `Table` with its own `Cluster`. Markdown output now shows two cleanly-separated tables on the page.
- **9 other fixtures**: zero diff. The discriminator and the conservation pass both correctly no-op when the row pattern is uniform and TableFormer's grid covers all input words.

## Honest scoping on the referenced issues

The two defensive helpers (`promote_wrapped_header_rows`, `consolidate_duplicate_spans`) address failure modes that have been reported historically (#2985, #2984, #2862, #2129) but **no longer reproduce on current main** with the public reproducers we could fetch — TableFormer / Heron has clearly improved. They are included as regression defense: they no-op on correct grids and only activate when the historical failure shape recurs.

`recover_leftover_words` and `split_into_structural_subtables` address the structural patterns in #525 / #3219 — the silent loss + over-merge family. The specific PDF on #525 (`test-docling-parser-11.pdf`) extracts cleanly today, but the conservation hole and the over-merge pattern still exist structurally; we hit both on TCL_2020 above.

The visible duplication in #2862 is downstream of `data.grid` expansion of correctly-emitted `col_span=N` cells, not duplicated cells in `tf_responses`. Out of scope here; relates to docling-core PR #601.

## Notes

- All four helpers are in the main `TableStructureModel.predict_tables`. The same logic could be added to `table_structure_model_v2.py` and `table_structure_model_granite_vision.py` for uniform behaviour across model variants — happy to add as a follow-up if maintainers prefer.
