### PR TITLE
ci: share typecheck deps with PR fast checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -244,17 +244,8 @@ all = [
 ]
 
 [dependency-groups]
-pr-fast-checks = [
-    "docling-core[chunking] (>=2.73.0,<3.0.0)",
-    "mypy~=1.10",
-    "pydantic (>=2.0.0,<3.0.0)",
-    "pydantic-settings (>=2.3.0,<3.0.0)",
-    "ruff==0.11.5",
-]
-dev = [
-  "pre-commit~=3.7",
+typecheck = [
   "mypy~=1.10",
-  "tach>=0.34.0,<1",
   "types-setuptools~=70.3",
   "pandas-stubs~=2.1",
   "types-openpyxl~=3.1",
@@ -262,6 +253,19 @@ dev = [
   "boto3-stubs~=1.37",
   "types-urllib3~=1.26",
   "types-tqdm~=4.67",
+  "types-defusedxml>=0.7.0.20250822,<0.8.0",
+]
+pr-fast-checks = [
+  { include-group = "typecheck" },
+  "docling-core[chunking] (>=2.73.0,<3.0.0)",
+  "pydantic (>=2.0.0,<3.0.0)",
+  "pydantic-settings (>=2.3.0,<3.0.0)",
+  "ruff==0.11.5",
+]
+dev = [
+  { include-group = "typecheck" },
+  "pre-commit~=3.7",
+  "tach>=0.34.0,<1",
   "coverage~=7.6",
   "pytest~=8.3",
   "pytest-cov>=6.1.1",
@@ -272,7 +276,6 @@ dev = [
   "ipywidgets~=8.1",
   "nbqa~=1.9",
   "python-semantic-release~=7.32",
-  "types-defusedxml>=0.7.0.20250822,<0.8.0",
 ]
 
 docs = [

--- a/uv.lock
+++ b/uv.lock
@@ -1538,11 +1538,30 @@ examples = [
     { name = "python-dotenv" },
 ]
 pr-fast-checks = [
+    { name = "boto3-stubs" },
     { name = "docling-core", extra = ["chunking"] },
     { name = "mypy" },
+    { name = "pandas-stubs" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "ruff" },
+    { name = "types-defusedxml" },
+    { name = "types-openpyxl" },
+    { name = "types-requests" },
+    { name = "types-setuptools" },
+    { name = "types-tqdm" },
+    { name = "types-urllib3" },
+]
+typecheck = [
+    { name = "boto3-stubs" },
+    { name = "mypy" },
+    { name = "pandas-stubs" },
+    { name = "types-defusedxml" },
+    { name = "types-openpyxl" },
+    { name = "types-requests" },
+    { name = "types-setuptools" },
+    { name = "types-tqdm" },
+    { name = "types-urllib3" },
 ]
 
 [package.metadata]
@@ -1659,11 +1678,30 @@ examples = [
     { name = "python-dotenv", specifier = "~=1.0" },
 ]
 pr-fast-checks = [
+    { name = "boto3-stubs", specifier = "~=1.37" },
     { name = "docling-core", extras = ["chunking"], specifier = ">=2.73.0,<3.0.0" },
     { name = "mypy", specifier = "~=1.10" },
+    { name = "pandas-stubs", specifier = "~=2.1" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.3.0,<3.0.0" },
     { name = "ruff", specifier = "==0.11.5" },
+    { name = "types-defusedxml", specifier = ">=0.7.0.20250822,<0.8.0" },
+    { name = "types-openpyxl", specifier = "~=3.1" },
+    { name = "types-requests", specifier = "~=2.31" },
+    { name = "types-setuptools", specifier = "~=70.3" },
+    { name = "types-tqdm", specifier = "~=4.67" },
+    { name = "types-urllib3", specifier = "~=1.26" },
+]
+typecheck = [
+    { name = "boto3-stubs", specifier = "~=1.37" },
+    { name = "mypy", specifier = "~=1.10" },
+    { name = "pandas-stubs", specifier = "~=2.1" },
+    { name = "types-defusedxml", specifier = ">=0.7.0.20250822,<0.8.0" },
+    { name = "types-openpyxl", specifier = "~=3.1" },
+    { name = "types-requests", specifier = "~=2.31" },
+    { name = "types-setuptools", specifier = "~=70.3" },
+    { name = "types-tqdm", specifier = "~=4.67" },
+    { name = "types-urllib3", specifier = "~=1.26" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add a shared typecheck dependency group for mypy and type stub packages
- make both pr-fast-checks and dev include that shared group
- refresh uv.lock so frozen PR Fast Checks install the included typecheck dependencies

## Why
PR Fast Checks intentionally uses a small environment, but it should not drift from the mypy/stub dependencies used by the regular lint job. PR #3400 exposed that drift: standard lint passed because the dev group installed types-requests, while PR Fast Checks failed on docling/backend/html_backend.py because its smaller group did not install that stub package.

This keeps PR Fast Checks lightweight while avoiding one-off stub additions each time mypy touches a module with a typed dependency.

## Verification
- uv sync --frozen --only-group pr-fast-checks --no-install-project
- verified the pr-fast-checks environment contains mypy, boto3-stubs, pandas-stubs, types-defusedxml, types-openpyxl, types-requests, types-setuptools, types-tqdm, and types-urllib3
- .venv/bin/mypy --config-file pyproject.toml --follow-imports skip --ignore-missing-imports docling/backend/html_backend.py