### PR TITLE
fix: add minimum size for cropped images in get_page_image method

### DIFF
--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -183,7 +183,10 @@ class DoclingParsePageBackend(ManagedPdfiumPageBackend):
             bitmap.close()
         # We resize the image from 1.5x the given scale to make it sharper.
         image = image.resize(
-            size=(round(cropbox.width * scale), round(cropbox.height * scale))
+            size=(
+                max(1, round(cropbox.width * scale)),
+                max(1, round(cropbox.height * scale))
+            )
         )
 
         return image

--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -185,7 +185,7 @@ class DoclingParsePageBackend(ManagedPdfiumPageBackend):
         image = image.resize(
             size=(
                 max(1, round(cropbox.width * scale)),
-                max(1, round(cropbox.height * scale))
+                max(1, round(cropbox.height * scale)),
             )
         )
 


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Description:**
When cropping page images for embedded images, crop box dimensions can be very small (less than 1 pixel). When resizing this crop at the requested scale, the width or height can round to zero.

This causes PIL.Image.resize to fail with OpenCV error:
  `(-215:Assertion failed) !ssize.empty() in function 'resize'`

Examples:
  - crop box width = 0.3 pixels  → round(0.3) = 0  → resize fails
  - crop box height = 0.7 pixels → round(0.7) = 1  → resize works
  - crop box width = 0.4, height = 0.3 → (0, 0) → both fail → crash


**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
