### PR TITLE
ci: unify Python version to 3.10 across single-version CI lanes

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -149,7 +149,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-ubuntu-ci
@@ -182,7 +182,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/setup-ubuntu-ci
         with:
-          python_version: "3.12"
+          python_version: "3.10"
           uv_sync_args: --frozen --only-group dev --no-install-project
 
       - name: Check module coverage
@@ -339,7 +339,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -385,7 +385,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -545,7 +545,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.10"]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
@@ -583,7 +583,7 @@ jobs:
     timeout-minutes: 15
     strategy:
       matrix:
-        python-version: ["3.12"]
+        python-version: ["3.10"]
     steps:
       - name: Download all the dists
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/pr-fast-checks.yml
+++ b/.github/workflows/pr-fast-checks.yml
@@ -46,7 +46,7 @@ jobs:
 
       - uses: ./.github/actions/setup-ubuntu-ci
         with:
-          python_version: "3.12"
+          python_version: "3.10"
           uv_sync_args: --frozen --only-group pr-fast-checks --no-install-project
 
       - name: Run fast lint and typing checks


### PR DESCRIPTION
## Summary

Several CI jobs are hardcoded to Python 3.12 while the default CI matrix and the project's minimum supported version is 3.10. As a result, PR runs (e.g. #3414) report a mix of 3.10 and 3.12 checks, which hides 3.10-specific issues behind 3.12-only lanes and adds noise to the CI summary.

This PR aligns the single-version CI lanes to **3.10** so they match the default `DEFAULT_PYTHON_VERSIONS` matrix in `ci.yml`.

### Changes

`.github/workflows/checks.yml`:
- `lint`: 3.12 → 3.10
- `tach`: 3.12 → 3.10
- `run-tests-windows`: 3.12 → 3.10
- `run-tests-macos`: 3.12 → 3.10
- `build-package`: 3.12 → 3.10
- `test-package`: 3.12 → 3.10

`.github/workflows/pr-fast-checks.yml`:
- `lint-and-type`: 3.12 → 3.10

### Intentionally left as-is

- `cd.yml` and `pypi.yml` keep their `3.12` pins — those target the release/publish toolchain (semantic-release, wheel publish) rather than the CI verification matrix, and the full multi-version verification still runs against `["3.10", "3.11", "3.12", "3.13", "3.14"]` via `code-checks` in `cd.yml`.
- The full Python matrix (`run-tests-core`, `run-tests-ml`, package compatibility import jobs) is unchanged and still iterates over all supported versions when triggered.

## Test plan

- [ ] CI on this PR runs all single-version lanes against 3.10 only (no 3.12 lanes mixed in for lint/tach/windows/macos/build/test-package/pr-fast-checks).
- [ ] Full matrix verification on `tests:full` label or `cd.yml` continues to cover 3.10–3.14.
- [ ] No regressions in lint/tach/build/test-package on 3.10.

🤖 Generated with [Claude Code](https://claude.com/claude-code)