### PR TITLE
fix(docx): preserve custom numbering text prefix in list markers

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -533,8 +533,6 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         placeholders and separators.  Falls back to the default '1.2.3.'
         pattern for plain numeric markers.
         """
-        import re
-
         lvl_element = self._get_level_element(numid, ilvl)
         namespaces = {"w": self._W_NS}
         lvl_text = None

--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -548,8 +548,9 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         # Skip when lvlText is a bare bullet symbol like "o" or "•".
         if lvl_text and re.search(r"%\d+", lvl_text):
             stripped = re.sub(r"%\d+", "", lvl_text)
-            stripped = stripped.strip(" .)()（）：:[]")
+            stripped = stripped.strip(" .)(:[]")
             if stripped:
+
                 def _replace(match):
                     lvl_idx = int(match.group(1)) - 1
                     counter = self.list_counters.get((numid, lvl_idx))

--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -527,7 +527,39 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             self.list_counters[key] = 0
 
     def _build_enum_marker(self, numid: int, ilvl: int) -> str:
-        """Build full hierarchical marker like '1.2.3.'"""
+        """Build enumeration marker from the lvlText template (e.g. 'Proposal %1:').
+
+        Uses lvlText when it contains a text prefix/suffix beyond simple
+        placeholders and separators.  Falls back to the default '1.2.3.'
+        pattern for plain numeric markers.
+        """
+        import re
+
+        lvl_element = self._get_level_element(numid, ilvl)
+        namespaces = {"w": self._W_NS}
+        lvl_text = None
+        if lvl_element is not None:
+            lt = lvl_element.find(".//w:lvlText", namespaces=namespaces)
+            if lt is not None:
+                lvl_text = lt.get(self.XML_KEY)
+
+        # Use lvlText as template only when it contains %N placeholders
+        # alongside non-trivial text (e.g. "Proposal %1:", "Table %1").
+        # Skip when lvlText is a bare bullet symbol like "o" or "•".
+        if lvl_text and re.search(r"%\d+", lvl_text):
+            stripped = re.sub(r"%\d+", "", lvl_text)
+            stripped = stripped.strip(" .)()（）：:[]")
+            if stripped:
+                def _replace(match):
+                    lvl_idx = int(match.group(1)) - 1
+                    counter = self.list_counters.get((numid, lvl_idx))
+                    if counter is None:
+                        counter = self._get_start_value(numid, lvl_idx)
+                    return str(counter)
+
+                return re.sub(r"%(\d+)", _replace, lvl_text)
+
+        # Fallback: default hierarchical '1.2.3.' pattern
         parts = []
         for lvl in range(ilvl + 1):
             counter = self.list_counters.get((numid, lvl))

--- a/tests/test_backend_msword.py
+++ b/tests/test_backend_msword.py
@@ -531,6 +531,78 @@ def test_list_counter_and_enum_marker(docx_paths):
     assert backend.list_counters[(2, 0)] == 1  # unaffected
 
 
+def test_custom_numbering_format_markers(tmp_path):
+    """Test that lvlText templates like 'Proposal %1:' produce correct markers.
+
+    Word documents can define custom numbering formats in the lvlText element,
+    e.g. 'Proposal %1:' or 'Observation %1:'. The marker should preserve the
+    text prefix/suffix and substitute %N with the counter value for level N.
+    """
+    from docx import Document
+    from docx.oxml.ns import qn
+    from docx.oxml import OxmlElement
+
+    doc = Document()
+    body = doc.element.body
+
+    # Add numbering definitions with custom lvlText
+    numbering_part = doc.part.numbering_part
+    numbering = numbering_part.element
+    nsmap = {"w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main"}
+
+    # Create abstractNum with lvlText="Proposal %1:" at level 0
+    abstract_num = OxmlElement("w:abstractNum")
+    abstract_num.set(qn("w:abstractNumId"), "100")
+    lvl = OxmlElement("w:lvl")
+    lvl.set(qn("w:ilvl"), "0")
+    start = OxmlElement("w:start")
+    start.set(qn("w:val"), "1")
+    lvl.append(start)
+    numfmt = OxmlElement("w:numFmt")
+    numfmt.set(qn("w:val"), "decimal")
+    lvl.append(numfmt)
+    lvltext = OxmlElement("w:lvlText")
+    lvltext.set(qn("w:val"), "Proposal %1:")
+    lvl.append(lvltext)
+    abstract_num.append(lvl)
+    numbering.append(abstract_num)
+
+    # Create num referencing abstractNum 100
+    num_elem = OxmlElement("w:num")
+    num_elem.set(qn("w:numId"), "200")
+    abstract_ref = OxmlElement("w:abstractNumId")
+    abstract_ref.set(qn("w:val"), "100")
+    num_elem.append(abstract_ref)
+    numbering.append(num_elem)
+
+    # Save and load through backend
+    docx_path = tmp_path / "custom_numbering.docx"
+    doc.save(str(docx_path))
+
+    in_doc = InputDocument(
+        path_or_stream=docx_path,
+        format=InputFormat.DOCX,
+        backend=MsWordDocumentBackend,
+    )
+    backend = in_doc._backend
+
+    # Simulate counter state and verify markers
+    backend.list_counters[(200, 0)] = 1
+    assert backend._build_enum_marker(200, 0) == "Proposal 1:"
+
+    backend.list_counters[(200, 0)] = 3
+    assert backend._build_enum_marker(200, 0) == "Proposal 3:"
+
+    # Verify plain numeric markers still work (no text prefix)
+    backend.list_counters[(1, 0)] = 5
+    assert backend._build_enum_marker(1, 0) == "5."
+
+    # Verify hierarchical markers still work
+    backend.list_counters[(1, 0)] = 2
+    backend.list_counters[(1, 1)] = 3
+    assert backend._build_enum_marker(1, 1) == "2.3."
+
+
 def test_handle_equations_in_text_returns_original_text_on_mismatch(
     backend, monkeypatch
 ):

--- a/tests/test_backend_msword.py
+++ b/tests/test_backend_msword.py
@@ -539,16 +539,14 @@ def test_custom_numbering_format_markers(tmp_path):
     text prefix/suffix and substitute %N with the counter value for level N.
     """
     from docx import Document
-    from docx.oxml.ns import qn
     from docx.oxml import OxmlElement
+    from docx.oxml.ns import qn
 
     doc = Document()
-    body = doc.element.body
 
     # Add numbering definitions with custom lvlText
     numbering_part = doc.part.numbering_part
     numbering = numbering_part.element
-    nsmap = {"w": "http://schemas.openxmlformats.org/wordprocessingml/2006/main"}
 
     # Create abstractNum with lvlText="Proposal %1:" at level 0
     abstract_num = OxmlElement("w:abstractNum")


### PR DESCRIPTION
<!-- thank you for contributing to docling! -->

**resolves #3313**

## summary

- `_build_enum_marker()` now reads the `lvlText` attribute from the numbering xml to produce markers that preserve custom text prefixes like `"proposal %1:"`, `"observation %1:"`, `"table %1"`, or `"figure %1"`.
- falls back to the existing `"1.2.3."` pattern when `lvltext` contains no text prefix (e.g. plain `"%1)"`).

## before / after

| lvltext | before | after |
|---------|--------|-------|
| `proposal %1:` | `1.` | `proposal 1:` |
| `observation %1:` | `1.` | `observation 1:` |
| `table %1` | `1.` | `table 1` |
| `figure %1` | `1.` | `figure 1` |
| `%1)` (plain) | `1.` | `1.` (unchanged) |