### PR TITLE
fix: fail on empty markdown export

### DIFF
--- a/.github/max-lines-ignore
+++ b/.github/max-lines-ignore
@@ -1,0 +1,1 @@
+docling/cli/main.py

--- a/.github/max-lines-ignore
+++ b/.github/max-lines-ignore
@@ -1,1 +1,0 @@
-docling/cli/main.py

--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -1645,8 +1645,9 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
                     node.find(_BLOCK_TAGS)
                     or node.find("input")
                     or node.find(
-                        lambda item: isinstance(item, Tag)
-                        and self._is_custom_checkbox_tag(item)
+                        lambda item: (
+                            isinstance(item, Tag) and self._is_custom_checkbox_tag(item)
+                        )
                     )
                 )
                 has_pending_form_fields = self._has_pending_form_field_in_subtree(node)
@@ -2202,8 +2203,9 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
                 custom_checkboxes_in_li = [
                     checkbox_tag
                     for checkbox_tag in li.find_all(
-                        lambda item: isinstance(item, Tag)
-                        and self._is_custom_checkbox_tag(item)
+                        lambda item: (
+                            isinstance(item, Tag) and self._is_custom_checkbox_tag(item)
+                        )
                     )
                     if checkbox_tag.find_parent("li") is li
                 ]
@@ -2450,8 +2452,9 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
                     if input_ref is not None:
                         added_refs.append(input_ref)
             for checkbox_tag in tag.find_all(
-                lambda item: isinstance(item, Tag)
-                and self._is_custom_checkbox_tag(item)
+                lambda item: (
+                    isinstance(item, Tag) and self._is_custom_checkbox_tag(item)
+                )
             ):
                 if isinstance(checkbox_tag, Tag):
                     checkbox_ref = self._emit_custom_checkbox(checkbox_tag, doc)
@@ -2788,8 +2791,10 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
             return "fillable"
         if (
             value_tag.find(
-                lambda item: isinstance(item, Tag)
-                and HTMLDocumentBackend._is_checkbox_like_tag(item)
+                lambda item: (
+                    isinstance(item, Tag)
+                    and HTMLDocumentBackend._is_checkbox_like_tag(item)
+                )
             )
             is not None
         ):
@@ -3445,9 +3450,11 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
             return True
         if (
             tag.find(
-                lambda item: isinstance(item, Tag)
-                and item is not tag
-                and self._is_form_semantic_id(self._get_html_id(item))
+                lambda item: (
+                    isinstance(item, Tag)
+                    and item is not tag
+                    and self._is_form_semantic_id(self._get_html_id(item))
+                )
             )
             is not None
         ):

--- a/docling/cli/export_utils.py
+++ b/docling/cli/export_utils.py
@@ -1,0 +1,37 @@
+import re
+from pathlib import Path
+
+from docling_core.types.doc import ImageRefMode
+
+from docling.datamodel.base_models import OutputFormat
+
+_OUTPUT_FORMATS_NOT_SUPPORTING_IMAGE_EMBEDDING = frozenset(
+    {
+        OutputFormat.TEXT,
+        OutputFormat.DOCTAGS,
+        OutputFormat.VTT,
+    }
+)
+
+
+def _should_generate_export_images(
+    image_export_mode: ImageRefMode,
+    to_formats: list[OutputFormat],
+) -> bool:
+    return image_export_mode != ImageRefMode.PLACEHOLDER and any(
+        to_format not in _OUTPUT_FORMATS_NOT_SUPPORTING_IMAGE_EMBEDDING
+        for to_format in to_formats
+    )
+
+
+def _split_list(raw: str | None) -> list[str] | None:
+    if raw is None:
+        return None
+    return re.split(r"[;,]", raw)
+
+
+def _is_empty_output(path: Path) -> bool:
+    try:
+        return not path.exists() or path.stat().st_size == 0
+    except OSError:
+        return True

--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -44,6 +44,11 @@ from docling.backend.image_backend import ImageDocumentBackend
 from docling.backend.mets_gbs_backend import MetsGbsDocumentBackend
 from docling.backend.pdf_backend import PdfDocumentBackend
 from docling.backend.pypdfium2_backend import PyPdfiumDocumentBackend
+from docling.cli.export_utils import (
+    _is_empty_output,
+    _should_generate_export_images,
+    _split_list,
+)
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
 from docling.datamodel.asr_model_specs import (
     WHISPER_BASE,
@@ -240,12 +245,6 @@ def export_documents(
     success_count = 0
     failure_count = 0
 
-    def _is_empty_output(path: Path) -> bool:
-        try:
-            return not path.exists() or path.stat().st_size == 0
-        except OSError:
-            return True
-
     for conv_res in conv_results:
         doc_failed = conv_res.status != ConversionStatus.SUCCESS
         if not doc_failed:
@@ -404,31 +403,6 @@ def export_documents(
 
     _log.info(
         f"Processed {success_count + failure_count} docs, of which {failure_count} failed"
-    )
-
-
-def _split_list(raw: str | None) -> list[str] | None:
-    if raw is None:
-        return None
-    return re.split(r"[;,]", raw)
-
-
-_OUTPUT_FORMATS_NOT_SUPPORTING_IMAGE_EMBEDDING = frozenset(
-    {
-        OutputFormat.TEXT,
-        OutputFormat.DOCTAGS,
-        OutputFormat.VTT,
-    }
-)
-
-
-def _should_generate_export_images(
-    image_export_mode: ImageRefMode,
-    to_formats: list[OutputFormat],
-) -> bool:
-    return image_export_mode != ImageRefMode.PLACEHOLDER and any(
-        to_format not in _OUTPUT_FORMATS_NOT_SUPPORTING_IMAGE_EMBEDDING
-        for to_format in to_formats
     )
 
 

--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -69,6 +69,8 @@ from docling.datamodel.asr_model_specs import (
 from docling.datamodel.backend_options import PdfBackendOptions
 from docling.datamodel.base_models import (
     ConversionStatus,
+    DoclingComponentType,
+    ErrorItem,
     FormatToExtensions,
     InputFormat,
     OutputFormat,
@@ -238,9 +240,15 @@ def export_documents(
     success_count = 0
     failure_count = 0
 
+    def _is_empty_output(path: Path) -> bool:
+        try:
+            return not path.exists() or path.stat().st_size == 0
+        except OSError:
+            return True
+
     for conv_res in conv_results:
-        if conv_res.status == ConversionStatus.SUCCESS:
-            success_count += 1
+        doc_failed = conv_res.status != ConversionStatus.SUCCESS
+        if not doc_failed:
             doc_filename = conv_res.input.file.stem
 
             # Export JSON format:
@@ -310,6 +318,21 @@ def export_documents(
                 conv_res.document.save_as_markdown(
                     filename=fname, image_mode=image_export_mode
                 )
+                if _is_empty_output(fname):
+                    error_message = (
+                        "Markdown export produced empty output for "
+                        f"{conv_res.input.file.name}"
+                    )
+                    _log.error(error_message)
+                    conv_res.errors.append(
+                        ErrorItem(
+                            component_type=DoclingComponentType.DOC_ASSEMBLER,
+                            module_name="export_documents",
+                            error_message=error_message,
+                        )
+                    )
+                    conv_res.status = ConversionStatus.FAILURE
+                    doc_failed = True
 
             # Export Document Tags format:
             if export_doctags:
@@ -367,7 +390,7 @@ def export_documents(
                     r = TimingsT.dump_json(conv_res.timings, indent=2)
                     fp.write(r)
 
-        else:
+        if doc_failed:
             _log.warning(f"Document {conv_res.input.file} failed to convert.")
             if _log.isEnabledFor(logging.INFO):
                 for err in conv_res.errors:
@@ -376,6 +399,8 @@ def export_documents(
                         f"Module: {err.module_name}, Message: {err.error_message}"
                     )
             failure_count += 1
+        else:
+            success_count += 1
 
     _log.info(
         f"Processed {success_count + failure_count} docs, of which {failure_count} failed"

--- a/docling/datamodel/picture_classification_options.py
+++ b/docling/datamodel/picture_classification_options.py
@@ -31,8 +31,10 @@ class DocumentPictureClassifierOptions(
     _keep_deprecated_annotations: bool = True
 
     model_spec: ImageClassificationModelSpec = Field(
-        default_factory=lambda: stage_model_specs.IMAGE_CLASSIFICATION_DOCUMENT_FIGURE.model_spec.model_copy(
-            deep=True
+        default_factory=lambda: (
+            stage_model_specs.IMAGE_CLASSIFICATION_DOCUMENT_FIGURE.model_spec.model_copy(
+                deep=True
+            )
         ),
         description="Image-classification model specification for picture classification.",
     )

--- a/docling/models/stages/page_assemble/page_assemble_model.py
+++ b/docling/models/stages/page_assemble/page_assemble_model.py
@@ -141,8 +141,10 @@ class PageAssembleModel(BasePageModel):
         # captured trailing space is re-emitted so that real word boundaries are
         # preserved (e.g. "Ĳ is" → "IJ is", "hello\uf0a0 world" → "hello world").
         sanitized_text = _LIGATURE_RE.sub(
-            lambda m: _LIGATURE_MAP[m.group(1)]
-            + ("" if "\ufb00" <= m.group(1) <= "\ufb06" else (m.group(2) or "")),
+            lambda m: (
+                _LIGATURE_MAP[m.group(1)]
+                + ("" if "\ufb00" <= m.group(1) <= "\ufb06" else (m.group(2) or ""))
+            ),
             sanitized_text,
         )
 

--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -658,7 +658,7 @@ class LayoutPostprocessor:
 
     def _sort_cells(self, cells: list[TextCell]) -> list[TextCell]:
         """Sort cells in native reading order."""
-        return sorted(cells, key=lambda c: (c.index))
+        return sorted(cells, key=lambda c: c.index)
 
     def _sort_clusters(
         self, clusters: list[Cluster], mode: str = "id"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,8 @@ import pytest
 from docling_core.types.doc import ImageRefMode
 from typer.testing import CliRunner
 
-from docling.cli.main import _should_generate_export_images, app
+from docling.cli.export_utils import _should_generate_export_images
+from docling.cli.main import app
 from docling.datamodel.base_models import OutputFormat
 
 runner = CliRunner()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,7 +4,7 @@ import pytest
 from docling_core.types.doc import ImageRefMode
 from typer.testing import CliRunner
 
-from docling.cli.export_utils import _should_generate_export_images
+from docling.cli.export_utils import _should_generate_export_images, _split_list
 from docling.cli.main import app
 from docling.datamodel.base_models import OutputFormat
 
@@ -169,6 +169,11 @@ def test_image_export_policy_covers_all_output_formats():
 
     assert image_export_formats.isdisjoint(non_image_export_formats)
     assert image_export_formats | non_image_export_formats == set(OutputFormat)
+
+
+def test_split_list_handles_none_and_delimiters():
+    assert _split_list(None) is None
+    assert _split_list("a,b;c") == ["a", "b", "c"]
 
 
 def test_cli_audio_auto_detection(tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -81,6 +81,66 @@ def test_export_documents_marks_empty_markdown_as_failure(tmp_path):
     assert conv_res.errors
 
 
+def test_export_documents_marks_stat_errors_as_failure(tmp_path, monkeypatch):
+    from docling.cli.main import export_documents
+    from docling.datamodel.base_models import ConversionStatus, InputFormat
+    from docling.datamodel.document import (
+        ConversionResult,
+        InputDocument,
+        _DummyBackend,
+    )
+
+    input_path = tmp_path / "input.pdf"
+    input_path.write_bytes(b"%PDF-1.4")
+
+    input_doc = InputDocument(
+        path_or_stream=input_path,
+        format=InputFormat.PDF,
+        backend=_DummyBackend,
+    )
+
+    conv_res = ConversionResult(input=input_doc)
+    conv_res.status = ConversionStatus.SUCCESS
+
+    class DummyDocument:
+        def save_as_markdown(self, *, filename, image_mode):
+            Path(filename).write_text("ok")
+
+    conv_res.document = DummyDocument()
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    original_stat = Path.stat
+
+    def _raise_for_markdown(self):
+        if self.name == "input.md":
+            raise OSError("stat failed")
+        return original_stat(self)
+
+    monkeypatch.setattr(Path, "stat", _raise_for_markdown)
+
+    export_documents(
+        [conv_res],
+        output_dir=output_dir,
+        export_json=False,
+        export_yaml=False,
+        export_html=False,
+        export_html_split_page=False,
+        show_layout=False,
+        export_md=True,
+        export_txt=False,
+        export_doctags=False,
+        export_vtt=False,
+        print_timings=False,
+        export_timings=False,
+        image_export_mode=ImageRefMode.PLACEHOLDER,
+    )
+
+    assert conv_res.status == ConversionStatus.FAILURE
+    assert conv_res.errors
+
+
 @pytest.mark.parametrize(
     ("image_export_mode", "to_formats", "expected"),
     [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -30,6 +30,53 @@ def test_cli_convert(tmp_path):
     assert converted.exists()
 
 
+def test_export_documents_marks_empty_markdown_as_failure(tmp_path):
+    from docling.cli.main import export_documents
+    from docling.datamodel.base_models import ConversionStatus, InputFormat
+    from docling.datamodel.document import ConversionResult, InputDocument, _DummyBackend
+
+    input_path = tmp_path / "input.pdf"
+    input_path.write_bytes(b"%PDF-1.4")
+
+    input_doc = InputDocument(
+        path_or_stream=input_path,
+        format=InputFormat.PDF,
+        backend=_DummyBackend,
+    )
+
+    conv_res = ConversionResult(input=input_doc)
+    conv_res.status = ConversionStatus.SUCCESS
+
+    class DummyDocument:
+        def save_as_markdown(self, *, filename, image_mode):
+            Path(filename).write_text("")
+
+    conv_res.document = DummyDocument()
+
+    output_dir = tmp_path / "out"
+    output_dir.mkdir()
+
+    export_documents(
+        [conv_res],
+        output_dir=output_dir,
+        export_json=False,
+        export_yaml=False,
+        export_html=False,
+        export_html_split_page=False,
+        show_layout=False,
+        export_md=True,
+        export_txt=False,
+        export_doctags=False,
+        export_vtt=False,
+        print_timings=False,
+        export_timings=False,
+        image_export_mode=ImageRefMode.PLACEHOLDER,
+    )
+
+    assert conv_res.status == ConversionStatus.FAILURE
+    assert conv_res.errors
+
+
 @pytest.mark.parametrize(
     ("image_export_mode", "to_formats", "expected"),
     [

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,7 +33,11 @@ def test_cli_convert(tmp_path):
 def test_export_documents_marks_empty_markdown_as_failure(tmp_path):
     from docling.cli.main import export_documents
     from docling.datamodel.base_models import ConversionStatus, InputFormat
-    from docling.datamodel.document import ConversionResult, InputDocument, _DummyBackend
+    from docling.datamodel.document import (
+        ConversionResult,
+        InputDocument,
+        _DummyBackend,
+    )
 
     input_path = tmp_path / "input.pdf"
     input_path.write_bytes(b"%PDF-1.4")


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

**Summary**
- Treat empty Markdown exports as conversion failures and surface an error
- Add a regression test for empty Markdown output

**Issue resolved by this Pull Request:**
Resolves docling-project/docling#3419

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.