### PR TITLE
feat(service_client): add AsyncDoclingServiceClient

### DIFF
--- a/docling/service_client/__init__.py
+++ b/docling/service_client/__init__.py
@@ -1,5 +1,6 @@
 """Client SDK for interacting with docling-serve."""
 
+from docling.service_client.async_client import AsyncDoclingServiceClient
 from docling.service_client.client import (
     DEFAULT_MAX_CONCURRENCY,
     MAX_CONCURRENCY_LIMIT,
@@ -20,11 +21,13 @@ from docling.service_client.exceptions import (
     TaskTimeoutError,
     UsageLimitExceededError,
 )
-from docling.service_client.job import ConversionJob
+from docling.service_client.job import AsyncConversionJob, ConversionJob
 
 __all__ = [
     "DEFAULT_MAX_CONCURRENCY",
     "MAX_CONCURRENCY_LIMIT",
+    "AsyncConversionJob",
+    "AsyncDoclingServiceClient",
     "ChunkerKind",
     "ConversionError",
     "ConversionItem",

--- a/docling/service_client/_base.py
+++ b/docling/service_client/_base.py
@@ -1,0 +1,570 @@
+"""Shared config and pure helpers for the docling-serve clients.
+
+Both the synchronous `DoclingServiceClient` and the asynchronous
+`AsyncDoclingServiceClient` inherit from `_BaseClient`. Pure helpers that
+do not perform HTTP I/O (URL building, source description, options
+resolution, retry/error decisions, result assembly) live here so that the
+two clients share a single source of truth for their behavior.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from email.utils import parsedate_to_datetime
+from enum import Enum
+from io import BytesIO
+from pathlib import Path, PurePath
+from typing import Any, TypeAlias
+from urllib.parse import urlencode, urlparse
+
+import httpx
+from docling_core.types.doc import DoclingDocument
+from docling_core.types.io import DocumentStream
+from pydantic import ValidationError
+
+from docling.backend.noop_backend import NoOpBackend
+from docling.datamodel.base_models import (
+    ConversionStatus,
+    DoclingComponentType,
+    ErrorItem,
+    FormatToExtensions,
+    InputFormat,
+    OutputFormat,
+)
+from docling.datamodel.document import AssembledUnit, ConversionResult, InputDocument
+from docling.datamodel.service.options import (
+    ConvertDocumentsOptions as ConvertDocumentsRequestOptions,
+)
+from docling.datamodel.service.responses import (
+    ConvertDocumentResponse,
+    TaskStatusResponse,
+    UsageLimitExceededResponse,
+)
+from docling.datamodel.settings import DocumentLimits, PageRange
+from docling.service_client.exceptions import (
+    ConversionError,
+    ResultExpiredError,
+    ResultNotReadyError,
+    ServiceError,
+    ServiceUnavailableError,
+    TaskNotFoundError,
+    UsageLimitExceededError,
+)
+from docling.service_client.watchers import is_terminal_task_status
+
+SourceType: TypeAlias = Path | str | DocumentStream
+logger = logging.getLogger(__name__)
+
+
+class ExperimentalWarning(UserWarning):
+    """Warning emitted by experimental features."""
+
+
+SUCCESS_CONVERSION_STATUSES: set[ConversionStatus] = {
+    ConversionStatus.SUCCESS,
+    ConversionStatus.PARTIAL_SUCCESS,
+}
+DEFAULT_MAX_CONCURRENCY = 8
+MAX_CONCURRENCY_LIMIT = 512
+SUBMIT_AND_RETRIEVE_MANY_MAX_IN_FLIGHT_WEBSOCKETS = 64
+HTTP_RETRY_BACKOFF_BASE_SECONDS = 1.0
+
+
+@dataclass(frozen=True, slots=True)
+class RawServiceResult:
+    """Typed wrapper for non-JSON result payloads."""
+
+    content: bytes
+    content_type: str
+    filename: str | None = None
+
+
+@dataclass(slots=True)
+class ConversionItem:
+    source: SourceType
+    options: ConvertDocumentsRequestOptions | None = None
+    headers: dict[str, str] | None = None
+    source_headers: dict[str, str] | None = None
+    metadata: Any = None
+
+
+@dataclass(slots=True)
+class _ResolvedOptions:
+    options: ConvertDocumentsRequestOptions
+    limits: DocumentLimits
+
+
+@dataclass(slots=True)
+class _SourceDescriptor:
+    source_name: str
+    input_format: InputFormat
+    file_size: int | None
+
+
+class StatusWatcherKind(str, Enum):
+    WEBSOCKET = "websocket"
+    POLLING = "polling"
+
+
+class ChunkerKind(str, Enum):
+    HYBRID = "hybrid"
+    HIERARCHICAL = "hierarchical"
+
+
+class _BaseClient:
+    """Shared config and pure helpers for docling-serve clients."""
+
+    def __init__(
+        self,
+        url: str,
+        api_key: str = "",
+        options: ConvertDocumentsRequestOptions | None = None,
+        status_watcher: StatusWatcherKind = StatusWatcherKind.WEBSOCKET,
+        ws_fallback_to_poll: bool = True,
+        poll_server_wait: float = 5.0,
+        poll_client_interval: float | None = None,
+        job_timeout: float = 300.0,
+        max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+        http_retries: int = 3,
+        http_connect_timeout: float = 10.0,
+        http_read_timeout: float = 60.0,
+    ) -> None:
+        self._base_url = self._normalize_base_url(url)
+        self._api_key = api_key
+        self._extension_to_format = self._build_extension_to_format_map()
+        self._default_options = (
+            options.model_copy(deep=True)
+            if options is not None
+            else ConvertDocumentsRequestOptions()
+        )
+        self._status_watcher_kind = status_watcher
+        self._ws_fallback_to_poll = ws_fallback_to_poll
+        self._poll_server_wait = poll_server_wait
+        self._poll_client_interval = (
+            poll_server_wait if poll_client_interval is None else poll_client_interval
+        )
+        self._job_timeout = job_timeout
+        self._max_concurrency = self._validate_concurrency(
+            max_concurrency, name="max_concurrency"
+        )
+        self._http_retries = http_retries
+        self._http_connect_timeout = http_connect_timeout
+        self._http_read_timeout = http_read_timeout
+
+    # --- options resolution --------------------------------------------------
+
+    def _resolve_options(
+        self,
+        options: ConvertDocumentsRequestOptions | None,
+        max_num_pages: int | None,
+        max_file_size: int | None,
+        page_range: PageRange | None,
+    ) -> _ResolvedOptions:
+        merged = self._default_options.model_copy(deep=True)
+        if options is not None and options.model_fields_set:
+            # Only override fields explicitly set by the caller, preserving client defaults
+            # for everything else. Using model_fields_set (vs exclude_none) means callers
+            # can explicitly set a field to None to clear a client default.
+            explicit = {
+                field: getattr(options, field) for field in options.model_fields_set
+            }
+            merged = merged.model_copy(update=explicit, deep=True)
+
+        effective_range = merged.page_range if page_range is None else page_range
+        if max_num_pages is not None:
+            effective_range = (
+                effective_range[0],
+                min(effective_range[1], max_num_pages),
+            )
+        merged.page_range = effective_range
+
+        limits = DocumentLimits(
+            max_num_pages=sys.maxsize if max_num_pages is None else max_num_pages,
+            max_file_size=sys.maxsize if max_file_size is None else max_file_size,
+            page_range=effective_range,
+        )
+        return _ResolvedOptions(options=merged, limits=limits)
+
+    def _options_for_target_format(
+        self,
+        options: ConvertDocumentsRequestOptions,
+        target_format: OutputFormat | None,
+    ) -> tuple[ConvertDocumentsRequestOptions, bool]:
+        if target_format is None or target_format == OutputFormat.JSON:
+            formats = list(options.to_formats)
+            if OutputFormat.JSON not in formats:
+                formats.append(OutputFormat.JSON)
+            return options.model_copy(update={"to_formats": formats}, deep=True), False
+        return options.model_copy(
+            update={"to_formats": [target_format]}, deep=True
+        ), True
+
+    @staticmethod
+    def _validate_concurrency(value: int, *, name: str) -> int:
+        if value < 1 or value > MAX_CONCURRENCY_LIMIT:
+            raise ValueError(
+                f"{name} must be between 1 and {MAX_CONCURRENCY_LIMIT}, got {value}."
+            )
+        return value
+
+    def _effective_concurrency(self, override: int | None) -> int:
+        if override is None:
+            return self._max_concurrency
+        return self._validate_concurrency(override, name="max_concurrency")
+
+    # --- source description --------------------------------------------------
+
+    def _describe_source(self, source: SourceType) -> _SourceDescriptor:
+        if isinstance(source, Path):
+            return _SourceDescriptor(
+                source_name=source.name,
+                input_format=self._guess_input_format(source.name),
+                file_size=source.stat().st_size,
+            )
+        if isinstance(source, DocumentStream):
+            return _SourceDescriptor(
+                source_name=source.name,
+                input_format=self._guess_input_format(source.name),
+                file_size=len(source.stream.getbuffer()),
+            )
+
+        parsed = urlparse(source)
+        filename = Path(parsed.path).name if parsed.path else "document"
+        return _SourceDescriptor(
+            source_name=filename,
+            input_format=self._guess_input_format(filename),
+            file_size=None,
+        )
+
+    def _source_name(self, source: SourceType) -> str:
+        return self._describe_source(source).source_name
+
+    def _guess_input_format(self, name: str) -> InputFormat:
+        lowered = name.lower()
+        extension = (
+            "tar.gz" if lowered.endswith(".tar.gz") else Path(name).suffix[1:].lower()
+        )
+        if extension in self._extension_to_format:
+            return self._extension_to_format[extension]
+        return InputFormat.PDF
+
+    def _validate_http_source(self, source: str) -> None:
+        parsed = urlparse(source)
+        if parsed.scheme not in {"http", "https"}:
+            raise ValueError("String sources must be HTTP or HTTPS URLs.")
+
+    def _build_extension_to_format_map(self) -> dict[str, InputFormat]:
+        extension_to_format: dict[str, InputFormat] = {}
+        for input_format, extensions in FormatToExtensions.items():
+            for extension in extensions:
+                extension_to_format.setdefault(extension.lower(), input_format)
+        return extension_to_format
+
+    # --- result assembly -----------------------------------------------------
+
+    def _preflight_limits(
+        self,
+        descriptor: _SourceDescriptor,
+        limits: DocumentLimits,
+    ) -> ConversionResult | None:
+        if limits.max_file_size >= sys.maxsize:
+            return None
+
+        size = descriptor.file_size
+        if size is None or size <= limits.max_file_size:
+            return None
+
+        message = f"Input size {size} exceeds max_file_size limit {limits.max_file_size} bytes."
+        return self._build_failed_conversion_result(
+            descriptor=descriptor,
+            limits=limits,
+            error_message=message,
+            status=ConversionStatus.SKIPPED,
+        )
+
+    def _build_conversion_result(
+        self,
+        payload: ConvertDocumentResponse,
+        descriptor: _SourceDescriptor,
+        limits: DocumentLimits,
+    ) -> ConversionResult:
+        source_name = payload.document.filename or descriptor.source_name
+        input_doc = self._build_input_document(
+            source_name=source_name,
+            input_format=descriptor.input_format,
+            file_size=descriptor.file_size,
+            limits=limits,
+        )
+        document = payload.document.json_content
+        if document is None:
+            document = DoclingDocument(name=Path(source_name).stem)
+
+        return ConversionResult(
+            input=input_doc,
+            assembled=AssembledUnit(),
+            status=payload.status,
+            errors=payload.errors,
+            timings=payload.timings,
+            document=document,
+        )
+
+    def _build_failed_conversion_result(
+        self,
+        descriptor: _SourceDescriptor,
+        limits: DocumentLimits,
+        error_message: str,
+        status: ConversionStatus,
+    ) -> ConversionResult:
+        input_doc = self._build_input_document(
+            source_name=descriptor.source_name,
+            input_format=descriptor.input_format,
+            file_size=descriptor.file_size,
+            limits=limits,
+        )
+        error = ErrorItem(
+            component_type=DoclingComponentType.USER_INPUT,
+            module_name="docling.service_client",
+            error_message=error_message,
+        )
+        return ConversionResult(
+            input=input_doc,
+            assembled=AssembledUnit(),
+            status=status,
+            errors=[error],
+            document=DoclingDocument(name=Path(descriptor.source_name).stem),
+        )
+
+    def _build_input_document(
+        self,
+        source_name: str,
+        input_format: InputFormat,
+        file_size: int | None,
+        limits: DocumentLimits,
+    ) -> InputDocument:
+        # Build a lightweight InputDocument for compatibility results without
+        # invoking expensive parsing backends.
+        input_doc = InputDocument(
+            path_or_stream=BytesIO(b"x"),
+            format=input_format,
+            backend=NoOpBackend,
+            filename=source_name,
+            limits=limits,
+        )
+        input_doc.file = PurePath(source_name)
+        input_doc.document_hash = source_name
+        input_doc.filesize = file_size
+        input_doc.page_count = 0
+        return input_doc
+
+    def _decode_raw_result(self, response: httpx.Response) -> RawServiceResult:
+        content_type = response.headers.get("content-type", "application/octet-stream")
+        filename = self._filename_from_headers(response.headers)
+        return RawServiceResult(
+            content=response.content,
+            content_type=content_type,
+            filename=filename,
+        )
+
+    def _filename_from_headers(self, headers: httpx.Headers) -> str | None:
+        disposition = headers.get("content-disposition")
+        if disposition is None:
+            return None
+        match = re.search(r'filename="?(?P<name>[^";]+)"?', disposition)
+        if match is None:
+            return None
+        return match.group("name")
+
+    def _failure_message(self, result: ConversionResult) -> str:
+        if result.errors:
+            messages = "; ".join(item.error_message for item in result.errors)
+            return (
+                f"Conversion failed for {result.input.file} with status "
+                f"{result.status.value}. Errors: {messages}"
+            )
+        return f"Conversion failed for {result.input.file} with status {result.status.value}."
+
+    # --- retry policy --------------------------------------------------------
+
+    def _check_retry(
+        self,
+        response: httpx.Response,
+        attempt: int,
+        max_retries: int,
+    ) -> tuple[httpx.Response | None, float]:
+        """Return (response, 0.0) to yield, (None, delay) to retry after delay, or raise."""
+        if response.status_code == 500:
+            return self._retry_with_exponential_backoff(
+                response=response,
+                attempt=attempt,
+                max_retries=max_retries,
+                error_message="Service returned HTTP 500 after retries.",
+            )
+        if response.status_code in {429, 503}:
+            return self._retry_with_retry_after_header(
+                response=response,
+                attempt=attempt,
+                max_retries=max_retries,
+            )
+        return response, 0.0
+
+    def _retry_with_exponential_backoff(
+        self,
+        response: httpx.Response,
+        attempt: int,
+        max_retries: int,
+        error_message: str,
+    ) -> tuple[httpx.Response | None, float]:
+        if attempt < max_retries:
+            return None, self._exponential_backoff_delay(attempt)
+        raise ServiceUnavailableError(
+            error_message,
+            status_code=response.status_code,
+            detail=self._http_error_detail(response),
+        )
+
+    def _retry_with_retry_after_header(
+        self,
+        response: httpx.Response,
+        attempt: int,
+        max_retries: int,
+    ) -> tuple[httpx.Response | None, float]:
+        retry_after_delay = self._retry_after_delay_seconds(response)
+        if retry_after_delay is None:
+            return response, 0.0
+        if attempt < max_retries:
+            return None, retry_after_delay
+        raise ServiceUnavailableError(
+            f"Service returned HTTP {response.status_code} after retries.",
+            status_code=response.status_code,
+            detail=self._http_error_detail(response),
+        )
+
+    def _exponential_backoff_delay(self, attempt: int) -> float:
+        return HTTP_RETRY_BACKOFF_BASE_SECONDS * (2**attempt)
+
+    def _retry_after_delay_seconds(self, response: httpx.Response) -> float | None:
+        retry_after_header = response.headers.get("Retry-After")
+        if retry_after_header is None:
+            return None
+
+        try:
+            return max(0.0, float(retry_after_header))
+        except ValueError:
+            pass
+
+        try:
+            retry_at = parsedate_to_datetime(retry_after_header)
+        except (TypeError, ValueError, IndexError, OverflowError):
+            return None
+
+        now = datetime.now(tz=retry_at.tzinfo or timezone.utc)
+        return max(0.0, (retry_at - now).total_seconds())
+
+    # --- error mapping -------------------------------------------------------
+
+    def _raise_for_result_404(
+        self,
+        task_id: str,
+        response: httpx.Response,
+        last_status: TaskStatusResponse | None,
+    ) -> None:
+        detail = self._http_error_detail(response)
+        if detail == "Task not found.":
+            raise TaskNotFoundError(f"Task {task_id} was not found.")
+        if detail is not None and detail.startswith("Task result not found"):
+            if last_status is not None and is_terminal_task_status(last_status):
+                if last_status.task_status == "failure":
+                    message = last_status.error_message or f"Task {task_id} failed."
+                    raise ConversionError(message)
+                raise ResultExpiredError(f"Result for task {task_id} has expired.")
+            raise ResultNotReadyError(f"Result for task {task_id} is not ready.")
+        raise ServiceError(
+            "Unexpected result lookup error.",
+            status_code=response.status_code,
+            detail=detail,
+        )
+
+    def _raise_for_generic_http_error(
+        self,
+        response: httpx.Response,
+        message: str,
+    ) -> None:
+        if response.status_code == 402:
+            usage_limit = self._parse_usage_limit_exceeded_response(response)
+            raise UsageLimitExceededError(
+                message,
+                status_code=response.status_code,
+                detail=None if usage_limit is None else usage_limit.message,
+                current_usage=(
+                    None if usage_limit is None else usage_limit.details.currentUsage
+                ),
+                limit=None if usage_limit is None else usage_limit.details.limit,
+            )
+
+        detail = self._http_error_detail(response)
+        if 400 <= response.status_code < 500:
+            raise ServiceError(message, status_code=response.status_code, detail=detail)
+        raise ServiceUnavailableError(
+            message,
+            status_code=response.status_code,
+            detail=detail,
+        )
+
+    def _parse_usage_limit_exceeded_response(
+        self,
+        response: httpx.Response,
+    ) -> UsageLimitExceededResponse | None:
+        try:
+            return UsageLimitExceededResponse.model_validate_json(response.text)
+        except (ValidationError, ValueError):
+            return None
+
+    def _http_error_detail(self, response: httpx.Response) -> str | None:
+        try:
+            detail = response.json().get("detail")
+        except Exception:
+            return None
+        return detail if isinstance(detail, str) else None
+
+    # --- URL building --------------------------------------------------------
+
+    def _url(self, path: str) -> str:
+        if path.startswith("/"):
+            return f"{self._base_url}{path}"
+        return f"{self._base_url}/{path}"
+
+    def _build_ws_status_url(self, task_id: str) -> str:
+        parsed = urlparse(self._base_url)
+        ws_scheme = "wss" if parsed.scheme == "https" else "ws"
+        ws_url = f"{ws_scheme}://{parsed.netloc}{parsed.path}/v1/status/ws/{task_id}"
+        if not self._api_key:
+            return ws_url
+        return f"{ws_url}?{urlencode({'api_key': self._api_key})}"
+
+    @staticmethod
+    def _normalize_base_url(url: str) -> str:
+        parsed = urlparse(url)
+        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+            raise ValueError("Client URL must be an absolute http(s) base URL.")
+        if parsed.query or parsed.fragment:
+            raise ValueError(
+                "Client URL must not include query or fragment components."
+            )
+        path = parsed.path.rstrip("/")
+        if path.endswith("/v1"):
+            raise ValueError(
+                "Client URL must be the service base URL, not include /v1."
+            )
+        return f"{parsed.scheme}://{parsed.netloc}{path}"
+
+    # --- misc ----------------------------------------------------------------
+
+    @staticmethod
+    def _normalize_exception(exc: BaseException) -> Exception:
+        if isinstance(exc, Exception):
+            return exc
+        return RuntimeError(str(exc))

--- a/docling/service_client/async_client.py
+++ b/docling/service_client/async_client.py
@@ -1,0 +1,838 @@
+"""Asynchronous client SDK for docling-serve."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import mimetypes
+import warnings
+from collections.abc import AsyncIterator, Iterable
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import IO, Any, Literal, cast, overload
+
+import httpx
+from docling_core.types.io import DocumentStream
+
+from docling.datamodel.base_models import (
+    ConversionStatus,
+    OutputFormat,
+)
+from docling.datamodel.document import ConversionResult
+from docling.datamodel.service.chunking import (
+    HierarchicalChunkerOptions,
+    HybridChunkerOptions,
+)
+from docling.datamodel.service.options import (
+    ConvertDocumentsOptions as ConvertDocumentsRequestOptions,
+)
+from docling.datamodel.service.requests import (
+    ConvertDocumentsRequest,
+    HttpSourceRequest,
+)
+from docling.datamodel.service.responses import (
+    ChunkDocumentResponse,
+    ConvertDocumentResponse,
+    HealthCheckResponse,
+    TaskStatusResponse,
+)
+from docling.datamodel.service.targets import InBodyTarget, ZipTarget
+from docling.datamodel.settings import DocumentLimits, PageRange
+from docling.service_client._base import (
+    DEFAULT_MAX_CONCURRENCY,
+    SUCCESS_CONVERSION_STATUSES,
+    ChunkerKind,
+    ConversionItem,
+    ExperimentalWarning,
+    RawServiceResult,
+    SourceType,
+    StatusWatcherKind,
+    _BaseClient,
+    _ResolvedOptions,
+    _SourceDescriptor,
+)
+from docling.service_client._scheduler import _run_bounded
+from docling.service_client.exceptions import (
+    ConversionError,
+    ServiceUnavailableError,
+    TaskNotFoundError,
+)
+from docling.service_client.job import AsyncConversionJob, _AsyncJobHandlers
+from docling.service_client.watchers import (
+    AsyncPollingWatcher,
+    AsyncStatusWatcher,
+    AsyncWebSocketWatcher,
+)
+
+logger = logging.getLogger(__name__)
+
+
+__all__ = ["AsyncDoclingServiceClient"]
+
+
+@dataclass(slots=True)
+class _ConvertAllItemMetadata:
+    source_index: int
+    descriptor: _SourceDescriptor
+
+
+class AsyncDoclingServiceClient(_BaseClient):
+    """Async client for docling-serve compatibility and task APIs."""
+
+    def __init__(
+        self,
+        url: str,
+        api_key: str = "",
+        options: ConvertDocumentsRequestOptions | None = None,
+        status_watcher: StatusWatcherKind = StatusWatcherKind.WEBSOCKET,
+        ws_fallback_to_poll: bool = True,
+        poll_server_wait: float = 5.0,
+        poll_client_interval: float | None = None,
+        job_timeout: float = 300.0,
+        max_concurrency: int = DEFAULT_MAX_CONCURRENCY,
+        http_retries: int = 3,
+        http_connect_timeout: float = 10.0,
+        http_read_timeout: float = 60.0,
+    ) -> None:
+        super().__init__(
+            url=url,
+            api_key=api_key,
+            options=options,
+            status_watcher=status_watcher,
+            ws_fallback_to_poll=ws_fallback_to_poll,
+            poll_server_wait=poll_server_wait,
+            poll_client_interval=poll_client_interval,
+            job_timeout=job_timeout,
+            max_concurrency=max_concurrency,
+            http_retries=http_retries,
+            http_connect_timeout=http_connect_timeout,
+            http_read_timeout=http_read_timeout,
+        )
+
+        warnings.warn(
+            "AsyncDoclingServiceClient is experimental and may change in future releases.",
+            ExperimentalWarning,
+            stacklevel=2,
+        )
+
+        timeout = httpx.Timeout(
+            connect=http_connect_timeout,
+            read=http_read_timeout,
+            write=http_read_timeout,
+            pool=http_read_timeout,
+        )
+        headers: dict[str, str] = {}
+        if api_key:
+            headers["X-Api-Key"] = api_key
+        self._http_client = httpx.AsyncClient(timeout=timeout, headers=headers)
+
+        ws_headers = {"X-Api-Key": api_key} if api_key else {}
+        self._polling_watcher = AsyncPollingWatcher(
+            poll_status=self._poll_task_status,
+            poll_server_wait=self._poll_server_wait,
+            poll_client_interval=self._poll_client_interval,
+            default_timeout=self._job_timeout,
+        )
+        self._ws_watcher = AsyncWebSocketWatcher(
+            ws_url_for_task=self._build_ws_status_url,
+            poll_fallback=self._polling_watcher,
+            fallback_to_poll=self._ws_fallback_to_poll,
+            connect_timeout=self._http_connect_timeout,
+            default_timeout=self._job_timeout,
+            additional_headers=ws_headers,
+        )
+
+    async def __aenter__(self) -> AsyncDoclingServiceClient:
+        return self
+
+    async def __aexit__(
+        self, exc_type: object, exc_val: object, exc_tb: object
+    ) -> None:
+        await self.aclose()
+
+    async def aclose(self) -> None:
+        """Release HTTP resources owned by this client."""
+        await self._http_client.aclose()
+
+    async def convert(
+        self,
+        source: SourceType,
+        headers: dict[str, str] | None = None,
+        max_num_pages: int | None = None,
+        max_file_size: int | None = None,
+        page_range: PageRange | None = None,
+        options: ConvertDocumentsRequestOptions | None = None,
+        raises_on_error: bool = True,
+    ) -> ConversionResult:
+        resolved = self._resolve_options(
+            options=options,
+            max_num_pages=max_num_pages,
+            max_file_size=max_file_size,
+            page_range=page_range,
+        )
+        result = await self._convert_single(
+            source=source,
+            headers=headers,
+            resolved=resolved,
+        )
+        if raises_on_error and result.status not in SUCCESS_CONVERSION_STATUSES:
+            raise ConversionError(self._failure_message(result))
+        return result
+
+    async def convert_all(
+        self,
+        sources: Iterable[SourceType],
+        headers: dict[str, str] | None = None,
+        max_num_pages: int | None = None,
+        max_file_size: int | None = None,
+        page_range: PageRange | None = None,
+        options: ConvertDocumentsRequestOptions | None = None,
+        max_concurrency: int | None = None,
+    ) -> AsyncIterator[ConversionResult]:
+        resolved = self._resolve_options(
+            options=options,
+            max_num_pages=max_num_pages,
+            max_file_size=max_file_size,
+            page_range=page_range,
+        )
+        effective_cap = self._effective_concurrency(max_concurrency)
+        submit_options, _ = self._options_for_target_format(
+            resolved.options, OutputFormat.JSON
+        )
+        async for result in self._convert_all_impl(
+            sources=sources,
+            headers=headers,
+            resolved=resolved,
+            submit_options=submit_options,
+            in_flight=effective_cap,
+        ):
+            yield result
+
+    async def submit_and_retrieve_many(
+        self,
+        items: Iterable[ConversionItem],
+        max_in_flight: int = DEFAULT_MAX_CONCURRENCY,
+        ordered: bool = False,
+    ) -> AsyncIterator[tuple[ConversionItem, ConvertDocumentResponse | Exception]]:
+        validated_in_flight = self._validate_concurrency(
+            max_in_flight, name="max_in_flight"
+        )
+        async for outcome in self._submit_and_retrieve_many_impl(
+            item_list=items,
+            max_in_flight=validated_in_flight,
+            ordered=ordered,
+        ):
+            yield outcome
+
+    async def chunk(
+        self,
+        source: SourceType,
+        chunker: ChunkerKind,
+        options: ConvertDocumentsRequestOptions | None = None,
+    ) -> ChunkDocumentResponse:
+        job = await self.submit_chunk(source=source, chunker=chunker, options=options)
+        return await job.result(timeout=self._job_timeout)
+
+    @overload
+    async def submit(
+        self,
+        source: SourceType,
+        options: ConvertDocumentsRequestOptions | None = None,
+        target_format: None | Literal["json"] = None,
+        headers: dict[str, str] | None = None,
+    ) -> AsyncConversionJob[ConversionResult]: ...
+
+    @overload
+    async def submit(
+        self,
+        source: SourceType,
+        options: ConvertDocumentsRequestOptions | None = None,
+        target_format: OutputFormat = ...,
+        headers: dict[str, str] | None = None,
+    ) -> AsyncConversionJob[RawServiceResult]: ...
+
+    async def submit(
+        self,
+        source: SourceType,
+        options: ConvertDocumentsRequestOptions | None = None,
+        target_format: OutputFormat | Literal["json"] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> AsyncConversionJob[ConversionResult] | AsyncConversionJob[RawServiceResult]:
+        normalized_target_format: OutputFormat | None = (
+            OutputFormat.JSON
+            if target_format == "json"
+            else cast(OutputFormat | None, target_format)
+        )
+        resolved = self._resolve_options(
+            options=options,
+            max_num_pages=None,
+            max_file_size=None,
+            page_range=None,
+        )
+        submit_options, raw_result = self._options_for_target_format(
+            resolved.options, normalized_target_format
+        )
+        return await self._submit_conversion_job(
+            source=source,
+            source_headers=None,
+            options=submit_options,
+            limits=resolved.limits,
+            raw_result=raw_result,
+            request_headers=headers,
+        )
+
+    async def submit_chunk(
+        self,
+        source: SourceType,
+        chunker: ChunkerKind,
+        options: ConvertDocumentsRequestOptions | None = None,
+    ) -> AsyncConversionJob[ChunkDocumentResponse]:
+        resolved = self._resolve_options(
+            options=options,
+            max_num_pages=None,
+            max_file_size=None,
+            page_range=None,
+        )
+        initial_status = await self._submit_chunk_task(
+            source=source,
+            chunker=chunker,
+            options=resolved.options,
+        )
+        handlers = _AsyncJobHandlers[ChunkDocumentResponse](
+            poll=self._poll_task_status,
+            watch=self._watch_task_updates,
+            wait=self._wait_for_terminal_status,
+            fetch_result=lambda task_id, last_status: self._fetch_chunk_result(
+                task_id=task_id,
+                last_status=last_status,
+            ),
+        )
+        return AsyncConversionJob(
+            task_id=initial_status.task_id,
+            submitted_at=datetime.now(tz=timezone.utc),
+            handlers=handlers,
+            initial_status=initial_status,
+        )
+
+    async def health(self) -> HealthCheckResponse:
+        response = await self._request_with_retry("GET", "/health", retries=0)
+        if response.status_code != 200:
+            self._raise_for_generic_http_error(response, "Health check request failed.")
+        return HealthCheckResponse.model_validate_json(response.text)
+
+    async def version(self) -> dict[str, Any]:
+        response = await self._request_with_retry("GET", "/version", retries=0)
+        if response.status_code != 200:
+            self._raise_for_generic_http_error(response, "Version request failed.")
+        return response.json()
+
+    # --- internals -----------------------------------------------------------
+
+    async def _convert_single(
+        self,
+        source: SourceType,
+        headers: dict[str, str] | None,
+        resolved: _ResolvedOptions,
+    ) -> ConversionResult:
+        descriptor = self._describe_source(source)
+        preflight = self._preflight_limits(
+            descriptor=descriptor, limits=resolved.limits
+        )
+        if preflight is not None:
+            return preflight
+
+        submit_options, _ = self._options_for_target_format(
+            resolved.options, OutputFormat.JSON
+        )
+        job = cast(
+            AsyncConversionJob[ConversionResult],
+            await self._submit_conversion_job(
+                source=source,
+                source_headers=headers,
+                options=submit_options,
+                limits=resolved.limits,
+                raw_result=False,
+                descriptor=descriptor,
+            ),
+        )
+        return await job.result(timeout=self._job_timeout)
+
+    async def _submit_conversion_job(
+        self,
+        source: SourceType,
+        source_headers: dict[str, str] | None,
+        options: ConvertDocumentsRequestOptions,
+        limits: DocumentLimits,
+        raw_result: bool,
+        descriptor: _SourceDescriptor | None = None,
+        request_headers: dict[str, str] | None = None,
+    ) -> AsyncConversionJob[ConversionResult] | AsyncConversionJob[RawServiceResult]:
+        descriptor = descriptor or self._describe_source(source)
+        initial_status = await self._submit_convert_task(
+            source=source,
+            source_headers=source_headers,
+            options=options,
+            raw_result=raw_result,
+            request_headers=request_headers,
+        )
+        handlers = _AsyncJobHandlers[Any](
+            poll=self._poll_task_status,
+            watch=self._watch_task_updates,
+            wait=self._wait_for_terminal_status,
+            fetch_result=lambda task_id, last_status: self._fetch_convert_result(
+                task_id=task_id,
+                descriptor=descriptor,
+                limits=limits,
+                raw_result=raw_result,
+                last_status=last_status,
+            ),
+        )
+        return AsyncConversionJob(
+            task_id=initial_status.task_id,
+            submitted_at=datetime.now(tz=timezone.utc),
+            handlers=handlers,
+            initial_status=initial_status,
+        )
+
+    async def _submit_convert_task(
+        self,
+        source: SourceType,
+        source_headers: dict[str, str] | None,
+        options: ConvertDocumentsRequestOptions,
+        raw_result: bool,
+        request_headers: dict[str, str] | None = None,
+    ) -> TaskStatusResponse:
+        source_name = self._source_name(source)
+        logger.info("Submitting convert task for source=%s", source_name)
+        target = ZipTarget() if raw_result else InBodyTarget()
+        if isinstance(source, str):
+            self._validate_http_source(source)
+            request = ConvertDocumentsRequest(
+                options=options,
+                sources=[
+                    HttpSourceRequest(
+                        url=source,
+                        headers={} if source_headers is None else source_headers,
+                    )
+                ],
+                target=target,
+            )
+            response = await self._request_with_retry(
+                method="POST",
+                path="/v1/convert/source/async",
+                json=request.model_dump(mode="json"),
+                headers=request_headers,
+            )
+        else:
+            files = await self._source_to_upload_files(source)
+            data = options.model_dump(mode="json", exclude_none=True)
+            data["target_type"] = "zip" if raw_result else "inbody"
+            response = await self._request_with_retry(
+                method="POST",
+                path="/v1/convert/file/async",
+                data=data,
+                files=files,
+                headers=request_headers,
+            )
+
+        if response.status_code != 200:
+            self._raise_for_generic_http_error(response, "Task submission failed.")
+        status = TaskStatusResponse.model_validate_json(response.text)
+        logger.info(
+            "Submitted convert task for source=%s task_id=%s status=%s position=%s",
+            source_name,
+            status.task_id,
+            status.task_status,
+            status.task_position,
+        )
+        return status
+
+    async def _submit_chunk_task(
+        self,
+        source: SourceType,
+        chunker: ChunkerKind,
+        options: ConvertDocumentsRequestOptions,
+    ) -> TaskStatusResponse:
+        if isinstance(source, str):
+            self._validate_http_source(source)
+            chunking_options: HybridChunkerOptions | HierarchicalChunkerOptions
+            if chunker == ChunkerKind.HYBRID:
+                chunking_options = HybridChunkerOptions()
+            else:
+                chunking_options = HierarchicalChunkerOptions()
+
+            payload = {
+                "convert_options": options.model_dump(mode="json", exclude_none=True),
+                "chunking_options": chunking_options.model_dump(
+                    mode="json", exclude_none=True
+                ),
+                "sources": [
+                    HttpSourceRequest(url=source, headers={}).model_dump(mode="json")
+                ],
+                "include_converted_doc": False,
+                "target": InBodyTarget().model_dump(mode="json"),
+                "callbacks": [],
+            }
+            response = await self._request_with_retry(
+                method="POST",
+                path=f"/v1/chunk/{chunker.value}/source/async",
+                json=payload,
+            )
+        else:
+            files = await self._source_to_upload_files(source)
+            data: dict[str, Any] = {
+                f"convert_{key}": value
+                for key, value in options.model_dump(
+                    mode="json", exclude_none=True
+                ).items()
+            }
+            chunk_model: HybridChunkerOptions | HierarchicalChunkerOptions
+            if chunker == ChunkerKind.HYBRID:
+                chunk_model = HybridChunkerOptions()
+            else:
+                chunk_model = HierarchicalChunkerOptions()
+            chunk_payload = chunk_model.model_dump(mode="json", exclude_none=True)
+            chunk_payload.pop("chunker", None)
+            data.update(
+                {f"chunking_{key}": value for key, value in chunk_payload.items()}
+            )
+            data["include_converted_doc"] = False
+            data["target_type"] = "inbody"
+            response = await self._request_with_retry(
+                method="POST",
+                path=f"/v1/chunk/{chunker.value}/file/async",
+                data=data,
+                files=files,
+            )
+
+        if response.status_code != 200:
+            self._raise_for_generic_http_error(
+                response, "Chunk task submission failed."
+            )
+        return TaskStatusResponse.model_validate_json(response.text)
+
+    async def _poll_task_status(self, task_id: str, wait: float) -> TaskStatusResponse:
+        response = await self._request_with_retry(
+            method="GET",
+            path=f"/v1/status/poll/{task_id}",
+            params={"wait": wait},
+        )
+        if response.status_code == 404:
+            raise TaskNotFoundError(f"Task {task_id} was not found.")
+        if response.status_code != 200:
+            self._raise_for_generic_http_error(
+                response, f"Polling task {task_id} failed."
+            )
+        return TaskStatusResponse.model_validate_json(response.text)
+
+    def _watch_task_updates(
+        self,
+        task_id: str,
+        timeout: float | None,
+    ) -> AsyncIterator[TaskStatusResponse]:
+        watcher = self._status_watcher()
+        return watcher.iter_updates(task_id=task_id, timeout=timeout)
+
+    async def _wait_for_terminal_status(
+        self,
+        task_id: str,
+        timeout: float | None,
+    ) -> TaskStatusResponse:
+        watcher = self._status_watcher()
+        return await watcher.wait_for_terminal(task_id=task_id, timeout=timeout)
+
+    def _status_watcher(self) -> AsyncStatusWatcher:
+        if self._status_watcher_kind == StatusWatcherKind.POLLING:
+            return self._polling_watcher
+        return self._ws_watcher
+
+    async def _fetch_convert_result(
+        self,
+        task_id: str,
+        descriptor: _SourceDescriptor,
+        limits: DocumentLimits,
+        raw_result: bool,
+        last_status: TaskStatusResponse | None,
+    ) -> ConversionResult | RawServiceResult:
+        if raw_result:
+            response = await self._request_with_retry(
+                method="GET",
+                path=f"/v1/result/{task_id}",
+            )
+            if response.status_code == 404:
+                self._raise_for_result_404(
+                    task_id=task_id, response=response, last_status=last_status
+                )
+            if response.status_code != 200:
+                self._raise_for_generic_http_error(
+                    response, f"Fetching result for task {task_id} failed."
+                )
+            return self._decode_raw_result(response)
+
+        payload = await self._fetch_convert_result_payload(
+            task_id=task_id,
+            last_status=last_status,
+        )
+        return self._build_conversion_result(
+            payload=payload, descriptor=descriptor, limits=limits
+        )
+
+    async def _fetch_result_response(
+        self,
+        task_id: str,
+        last_status: TaskStatusResponse | None,
+        *,
+        error_message: str,
+    ) -> httpx.Response:
+        response = await self._request_with_retry(
+            method="GET",
+            path=f"/v1/result/{task_id}",
+        )
+        if response.status_code == 404:
+            self._raise_for_result_404(
+                task_id=task_id, response=response, last_status=last_status
+            )
+        if response.status_code != 200:
+            self._raise_for_generic_http_error(response, error_message)
+        return response
+
+    async def _fetch_convert_result_payload(
+        self,
+        task_id: str,
+        last_status: TaskStatusResponse | None,
+    ) -> ConvertDocumentResponse:
+        response = await self._fetch_result_response(
+            task_id=task_id,
+            last_status=last_status,
+            error_message=f"Fetching result for task {task_id} failed.",
+        )
+        return ConvertDocumentResponse.model_validate_json(response.text)
+
+    async def _fetch_chunk_result(
+        self,
+        task_id: str,
+        last_status: TaskStatusResponse | None,
+    ) -> ChunkDocumentResponse:
+        response = await self._fetch_result_response(
+            task_id=task_id,
+            last_status=last_status,
+            error_message=f"Fetching chunk result for task {task_id} failed.",
+        )
+        return ChunkDocumentResponse.model_validate_json(response.text)
+
+    async def _source_to_upload_files(
+        self,
+        source: Path | DocumentStream,
+    ) -> dict[str, tuple[str, IO[bytes] | bytes, str]]:
+        """Build multipart files dict for an async upload.
+        Path sources are read in a thread to avoid blocking the event loop.
+        DocumentStream data is already in memory — passed directly.
+        """
+        if isinstance(source, Path):
+            filename = source.name
+            content: IO[bytes] | bytes = await asyncio.to_thread(source.read_bytes)
+        else:
+            filename = source.name
+            source.stream.seek(0)
+            content = source.stream
+        mime = mimetypes.guess_type(filename)[0] or "application/octet-stream"
+        return {"files": (filename, content, mime)}
+
+    async def _request_with_retry(
+        self,
+        method: str,
+        path: str,
+        json: Any | None = None,
+        data: Any | None = None,
+        files: Any | None = None,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        retries: int | None = None,
+    ) -> httpx.Response:
+        url = self._url(path)
+        max_retries = self._http_retries if retries is None else retries
+        for attempt in range(max_retries + 1):
+            try:
+                response = await self._http_client.request(
+                    method=method,
+                    url=url,
+                    json=json,
+                    data=data,
+                    files=files,
+                    params=params,
+                    headers=headers,
+                )
+            except httpx.HTTPError as exc:
+                raise ServiceUnavailableError(
+                    "Service transport request failed.",
+                    detail=str(exc),
+                ) from exc
+            result, delay = self._check_retry(response, attempt, max_retries)
+            if result is not None:
+                return result
+            if delay > 0:
+                await asyncio.sleep(delay)
+
+        raise ServiceUnavailableError("Service request failed after retry loop.")
+
+    async def _wait_for_terminal_status_for_batch(
+        self,
+        task_id: str,
+        timeout: float,
+    ) -> TaskStatusResponse:
+        """Wait policy for batch operations.
+
+        Uses the configured status watcher (websocket or polling) so batch
+        callers see the same wait semantics as single-job calls.
+        """
+        watcher = self._status_watcher()
+        return await watcher.wait_for_terminal(task_id=task_id, timeout=timeout)
+
+    async def _convert_all_impl(
+        self,
+        sources: Iterable[SourceType],
+        headers: dict[str, str] | None,
+        resolved: _ResolvedOptions,
+        submit_options: ConvertDocumentsRequestOptions,
+        in_flight: int,
+    ) -> AsyncIterator[ConversionResult]:
+        results: dict[int, ConversionResult] = {}
+        descriptors: dict[int, _SourceDescriptor] = {}
+        errors: dict[int, Exception] = {}
+        total = 0
+
+        def result_for_index(idx: int) -> ConversionResult:
+            if idx in results:
+                return results[idx]
+
+            exc = errors.get(idx)
+            error_message = str(exc) if exc is not None else "Unknown conversion error."
+            result = self._build_failed_conversion_result(
+                descriptor=descriptors[idx],
+                limits=resolved.limits,
+                error_message=error_message,
+                status=ConversionStatus.FAILURE,
+            )
+            results[idx] = result
+            return result
+
+        def make_items() -> Iterable[ConversionItem]:
+            nonlocal total
+            for idx, source in enumerate(sources):
+                total = idx + 1
+                try:
+                    descriptor = self._describe_source(source)
+                except Exception as exc:
+                    errors[idx] = self._normalize_exception(exc)
+                    name = str(source) if isinstance(source, str) else source.name
+                    descriptors[idx] = _SourceDescriptor(
+                        source_name=name,
+                        input_format=self._guess_input_format(name),
+                        file_size=None,
+                    )
+                    continue
+                descriptors[idx] = descriptor
+                preflight = self._preflight_limits(
+                    descriptor=descriptor, limits=resolved.limits
+                )
+                if preflight is not None:
+                    results[idx] = preflight
+                    continue
+                yield ConversionItem(
+                    source=source,
+                    options=submit_options,
+                    source_headers=headers,
+                    metadata=_ConvertAllItemMetadata(
+                        source_index=idx,
+                        descriptor=descriptor,
+                    ),
+                )
+
+        next_output_index = 0
+        async for item, outcome in self._submit_and_retrieve_many_impl(
+            item_list=make_items(),
+            max_in_flight=in_flight,
+            ordered=True,
+        ):
+            metadata = cast(_ConvertAllItemMetadata, item.metadata)
+            while next_output_index < metadata.source_index:
+                yield result_for_index(next_output_index)
+                next_output_index += 1
+
+            if isinstance(outcome, BaseException):
+                errors[metadata.source_index] = self._normalize_exception(outcome)
+                yield result_for_index(metadata.source_index)
+            else:
+                result = self._build_conversion_result(
+                    payload=outcome,
+                    descriptor=metadata.descriptor,
+                    limits=resolved.limits,
+                )
+                results[metadata.source_index] = result
+                yield result
+            next_output_index += 1
+
+        for idx in range(next_output_index, total):
+            yield result_for_index(idx)
+
+    async def _submit_and_retrieve_many_impl(
+        self,
+        item_list: Iterable[ConversionItem],
+        max_in_flight: int,
+        ordered: bool,
+    ) -> AsyncIterator[tuple[ConversionItem, ConvertDocumentResponse | Exception]]:
+        async def process_one(
+            _idx: int,
+            item: ConversionItem,
+            _client: httpx.AsyncClient,
+        ) -> ConvertDocumentResponse:
+            resolved = self._resolve_options(
+                options=item.options,
+                max_num_pages=None,
+                max_file_size=None,
+                page_range=None,
+            )
+            submit_options, _raw_result = self._options_for_target_format(
+                resolved.options, OutputFormat.JSON
+            )
+            initial_status = await self._submit_convert_task(
+                source=item.source,
+                source_headers=item.source_headers,
+                options=submit_options,
+                raw_result=False,
+                request_headers=item.headers,
+            )
+            terminal_status = await self._wait_for_terminal_status_for_batch(
+                task_id=initial_status.task_id,
+                timeout=self._job_timeout,
+            )
+            return await self._fetch_convert_result_payload(
+                task_id=initial_status.task_id,
+                last_status=terminal_status,
+            )
+
+        buffered_results: dict[
+            int, tuple[ConversionItem, ConvertDocumentResponse | Exception]
+        ] = {}
+        next_ordered_index = 0
+        async for idx, item, outcome in _run_bounded(
+            items=item_list,
+            process_one=process_one,
+            async_client=self._http_client,
+            max_in_flight=max_in_flight,
+        ):
+            normalized: ConvertDocumentResponse | Exception
+            if isinstance(outcome, BaseException):
+                normalized = self._normalize_exception(outcome)
+            else:
+                normalized = outcome
+
+            if ordered:
+                buffered_results[idx] = (item, normalized)
+                while next_ordered_index in buffered_results:
+                    yield buffered_results.pop(next_ordered_index)
+                    next_ordered_index += 1
+                continue
+
+            yield item, normalized

--- a/docling/service_client/client.py
+++ b/docling/service_client/client.py
@@ -5,35 +5,22 @@ from __future__ import annotations
 import asyncio
 import logging
 import mimetypes
-import re
-import sys
 import time
 import warnings
 from collections.abc import AsyncGenerator, Iterable, Iterator
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from email.utils import parsedate_to_datetime
-from enum import Enum
-from io import BytesIO
-from pathlib import Path, PurePath
-from typing import IO, Any, Literal, TypeAlias, TypeVar, cast, overload
-from urllib.parse import urlencode, urlparse
+from pathlib import Path
+from typing import IO, Any, Literal, TypeVar, cast, overload
 
 import httpx
-from docling_core.types.doc import DoclingDocument
 from docling_core.types.io import DocumentStream
-from pydantic import ValidationError
 
-from docling.backend.noop_backend import NoOpBackend
 from docling.datamodel.base_models import (
     ConversionStatus,
-    DoclingComponentType,
-    ErrorItem,
-    FormatToExtensions,
-    InputFormat,
     OutputFormat,
 )
-from docling.datamodel.document import AssembledUnit, ConversionResult, InputDocument
+from docling.datamodel.document import ConversionResult
 from docling.datamodel.service.chunking import (
     HierarchicalChunkerOptions,
     HybridChunkerOptions,
@@ -50,20 +37,31 @@ from docling.datamodel.service.responses import (
     ConvertDocumentResponse,
     HealthCheckResponse,
     TaskStatusResponse,
-    UsageLimitExceededResponse,
 )
 from docling.datamodel.service.targets import InBodyTarget, ZipTarget
 from docling.datamodel.settings import DocumentLimits, PageRange
+from docling.service_client._base import (
+    DEFAULT_MAX_CONCURRENCY,
+    HTTP_RETRY_BACKOFF_BASE_SECONDS,
+    MAX_CONCURRENCY_LIMIT,
+    SUBMIT_AND_RETRIEVE_MANY_MAX_IN_FLIGHT_WEBSOCKETS,
+    SUCCESS_CONVERSION_STATUSES,
+    ChunkerKind,
+    ConversionItem,
+    ExperimentalWarning,
+    RawServiceResult,
+    SourceType,
+    StatusWatcherKind,
+    _BaseClient,
+    _ResolvedOptions,
+    _SourceDescriptor,
+)
 from docling.service_client._scheduler import _run_bounded
 from docling.service_client.exceptions import (
     ConversionError,
-    ResultExpiredError,
-    ResultNotReadyError,
-    ServiceError,
     ServiceUnavailableError,
     TaskNotFoundError,
     TaskTimeoutError,
-    UsageLimitExceededError,
 )
 from docling.service_client.job import ConversionJob, _JobHandlers
 from docling.service_client.watchers import (
@@ -74,47 +72,24 @@ from docling.service_client.watchers import (
     is_terminal_task_status,
 )
 
-SourceType: TypeAlias = Path | str | DocumentStream
 logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
 
-class ExperimentalWarning(UserWarning):
-    """Warning emitted by experimental features."""
-
-
-SUCCESS_CONVERSION_STATUSES: set[ConversionStatus] = {
-    ConversionStatus.SUCCESS,
-    ConversionStatus.PARTIAL_SUCCESS,
-}
-DEFAULT_MAX_CONCURRENCY = 8
-MAX_CONCURRENCY_LIMIT = 512
-SUBMIT_AND_RETRIEVE_MANY_MAX_IN_FLIGHT_WEBSOCKETS = 64
-HTTP_RETRY_BACKOFF_BASE_SECONDS = 1.0
-
-
-@dataclass(frozen=True, slots=True)
-class RawServiceResult:
-    """Typed wrapper for non-JSON result payloads."""
-
-    content: bytes
-    content_type: str
-    filename: str | None = None
-
-
-@dataclass(slots=True)
-class ConversionItem:
-    source: SourceType
-    options: ConvertDocumentsRequestOptions | None = None
-    headers: dict[str, str] | None = None
-    source_headers: dict[str, str] | None = None
-    metadata: Any = None
-
-
-@dataclass(slots=True)
-class _ResolvedOptions:
-    options: ConvertDocumentsRequestOptions
-    limits: DocumentLimits
+__all__ = [
+    "DEFAULT_MAX_CONCURRENCY",
+    "HTTP_RETRY_BACKOFF_BASE_SECONDS",
+    "MAX_CONCURRENCY_LIMIT",
+    "SUBMIT_AND_RETRIEVE_MANY_MAX_IN_FLIGHT_WEBSOCKETS",
+    "SUCCESS_CONVERSION_STATUSES",
+    "ChunkerKind",
+    "ConversionItem",
+    "DoclingServiceClient",
+    "ExperimentalWarning",
+    "RawServiceResult",
+    "SourceType",
+    "StatusWatcherKind",
+]
 
 
 @dataclass(slots=True)
@@ -123,24 +98,7 @@ class _ConvertAllItemMetadata:
     descriptor: _SourceDescriptor
 
 
-@dataclass(slots=True)
-class _SourceDescriptor:
-    source_name: str
-    input_format: InputFormat
-    file_size: int | None
-
-
-class StatusWatcherKind(str, Enum):
-    WEBSOCKET = "websocket"
-    POLLING = "polling"
-
-
-class ChunkerKind(str, Enum):
-    HYBRID = "hybrid"
-    HIERARCHICAL = "hierarchical"
-
-
-class DoclingServiceClient:
+class DoclingServiceClient(_BaseClient):
     """Client for docling-serve compatibility and task APIs."""
 
     def __init__(
@@ -158,27 +116,20 @@ class DoclingServiceClient:
         http_connect_timeout: float = 10.0,
         http_read_timeout: float = 60.0,
     ) -> None:
-        self._base_url = self._normalize_base_url(url)
-        self._api_key = api_key
-        self._extension_to_format = self._build_extension_to_format_map()
-        self._default_options = (
-            options.model_copy(deep=True)
-            if options is not None
-            else ConvertDocumentsRequestOptions()
+        super().__init__(
+            url=url,
+            api_key=api_key,
+            options=options,
+            status_watcher=status_watcher,
+            ws_fallback_to_poll=ws_fallback_to_poll,
+            poll_server_wait=poll_server_wait,
+            poll_client_interval=poll_client_interval,
+            job_timeout=job_timeout,
+            max_concurrency=max_concurrency,
+            http_retries=http_retries,
+            http_connect_timeout=http_connect_timeout,
+            http_read_timeout=http_read_timeout,
         )
-        self._status_watcher_kind = status_watcher
-        self._ws_fallback_to_poll = ws_fallback_to_poll
-        self._poll_server_wait = poll_server_wait
-        self._poll_client_interval = (
-            poll_server_wait if poll_client_interval is None else poll_client_interval
-        )
-        self._job_timeout = job_timeout
-        self._max_concurrency = self._validate_concurrency(
-            max_concurrency, name="max_concurrency"
-        )
-        self._http_retries = http_retries
-        self._http_connect_timeout = http_connect_timeout
-        self._http_read_timeout = http_read_timeout
 
         warnings.warn(
             "DoclingServiceClient is experimental and may change in future releases.",
@@ -685,203 +636,6 @@ class DoclingServiceClient:
         )
         return ChunkDocumentResponse.model_validate_json(response.text)
 
-    def _resolve_options(
-        self,
-        options: ConvertDocumentsRequestOptions | None,
-        max_num_pages: int | None,
-        max_file_size: int | None,
-        page_range: PageRange | None,
-    ) -> _ResolvedOptions:
-        merged = self._default_options.model_copy(deep=True)
-        if options is not None and options.model_fields_set:
-            # Only override fields explicitly set by the caller, preserving client defaults
-            # for everything else. Using model_fields_set (vs exclude_none) means callers
-            # can explicitly set a field to None to clear a client default.
-            explicit = {
-                field: getattr(options, field) for field in options.model_fields_set
-            }
-            merged = merged.model_copy(update=explicit, deep=True)
-
-        effective_range = merged.page_range if page_range is None else page_range
-        if max_num_pages is not None:
-            effective_range = (
-                effective_range[0],
-                min(effective_range[1], max_num_pages),
-            )
-        merged.page_range = effective_range
-
-        limits = DocumentLimits(
-            max_num_pages=sys.maxsize if max_num_pages is None else max_num_pages,
-            max_file_size=sys.maxsize if max_file_size is None else max_file_size,
-            page_range=effective_range,
-        )
-        return _ResolvedOptions(options=merged, limits=limits)
-
-    def _options_for_target_format(
-        self,
-        options: ConvertDocumentsRequestOptions,
-        target_format: OutputFormat | None,
-    ) -> tuple[ConvertDocumentsRequestOptions, bool]:
-        if target_format is None or target_format == OutputFormat.JSON:
-            formats = list(options.to_formats)
-            if OutputFormat.JSON not in formats:
-                formats.append(OutputFormat.JSON)
-            return options.model_copy(update={"to_formats": formats}, deep=True), False
-        return options.model_copy(
-            update={"to_formats": [target_format]}, deep=True
-        ), True
-
-    def _preflight_limits(
-        self,
-        descriptor: _SourceDescriptor,
-        limits: DocumentLimits,
-    ) -> ConversionResult | None:
-        if limits.max_file_size >= sys.maxsize:
-            return None
-
-        size = descriptor.file_size
-        if size is None or size <= limits.max_file_size:
-            return None
-
-        message = f"Input size {size} exceeds max_file_size limit {limits.max_file_size} bytes."
-        return self._build_failed_conversion_result(
-            descriptor=descriptor,
-            limits=limits,
-            error_message=message,
-            status=ConversionStatus.SKIPPED,
-        )
-
-    def _build_conversion_result(
-        self,
-        payload: ConvertDocumentResponse,
-        descriptor: _SourceDescriptor,
-        limits: DocumentLimits,
-    ) -> ConversionResult:
-        source_name = payload.document.filename or descriptor.source_name
-        input_doc = self._build_input_document(
-            source_name=source_name,
-            input_format=descriptor.input_format,
-            file_size=descriptor.file_size,
-            limits=limits,
-        )
-        document = payload.document.json_content
-        if document is None:
-            document = DoclingDocument(name=Path(source_name).stem)
-
-        return ConversionResult(
-            input=input_doc,
-            assembled=AssembledUnit(),
-            status=payload.status,
-            errors=payload.errors,
-            timings=payload.timings,
-            document=document,
-        )
-
-    def _build_failed_conversion_result(
-        self,
-        descriptor: _SourceDescriptor,
-        limits: DocumentLimits,
-        error_message: str,
-        status: ConversionStatus,
-    ) -> ConversionResult:
-        input_doc = self._build_input_document(
-            source_name=descriptor.source_name,
-            input_format=descriptor.input_format,
-            file_size=descriptor.file_size,
-            limits=limits,
-        )
-        error = ErrorItem(
-            component_type=DoclingComponentType.USER_INPUT,
-            module_name="docling.service_client",
-            error_message=error_message,
-        )
-        return ConversionResult(
-            input=input_doc,
-            assembled=AssembledUnit(),
-            status=status,
-            errors=[error],
-            document=DoclingDocument(name=Path(descriptor.source_name).stem),
-        )
-
-    def _build_input_document(
-        self,
-        source_name: str,
-        input_format: InputFormat,
-        file_size: int | None,
-        limits: DocumentLimits,
-    ) -> InputDocument:
-        # Build a lightweight InputDocument for compatibility results without
-        # invoking expensive parsing backends.
-        input_doc = InputDocument(
-            path_or_stream=BytesIO(b"x"),
-            format=input_format,
-            backend=NoOpBackend,
-            filename=source_name,
-            limits=limits,
-        )
-        input_doc.file = PurePath(source_name)
-        input_doc.document_hash = source_name
-        input_doc.filesize = file_size
-        input_doc.page_count = 0
-        return input_doc
-
-    def _decode_raw_result(self, response: httpx.Response) -> RawServiceResult:
-        content_type = response.headers.get("content-type", "application/octet-stream")
-        filename = self._filename_from_headers(response.headers)
-        return RawServiceResult(
-            content=response.content,
-            content_type=content_type,
-            filename=filename,
-        )
-
-    def _filename_from_headers(self, headers: httpx.Headers) -> str | None:
-        disposition = headers.get("content-disposition")
-        if disposition is None:
-            return None
-        match = re.search(r'filename="?(?P<name>[^";]+)"?', disposition)
-        if match is None:
-            return None
-        return match.group("name")
-
-    def _describe_source(self, source: SourceType) -> _SourceDescriptor:
-        if isinstance(source, Path):
-            return _SourceDescriptor(
-                source_name=source.name,
-                input_format=self._guess_input_format(source.name),
-                file_size=source.stat().st_size,
-            )
-        if isinstance(source, DocumentStream):
-            return _SourceDescriptor(
-                source_name=source.name,
-                input_format=self._guess_input_format(source.name),
-                file_size=len(source.stream.getbuffer()),
-            )
-
-        parsed = urlparse(source)
-        filename = Path(parsed.path).name if parsed.path else "document"
-        return _SourceDescriptor(
-            source_name=filename,
-            input_format=self._guess_input_format(filename),
-            file_size=None,
-        )
-
-    def _source_name(self, source: SourceType) -> str:
-        return self._describe_source(source).source_name
-
-    def _guess_input_format(self, name: str) -> InputFormat:
-        lowered = name.lower()
-        extension = (
-            "tar.gz" if lowered.endswith(".tar.gz") else Path(name).suffix[1:].lower()
-        )
-        if extension in self._extension_to_format:
-            return self._extension_to_format[extension]
-        return InputFormat.PDF
-
-    def _validate_http_source(self, source: str) -> None:
-        parsed = urlparse(source)
-        if parsed.scheme not in {"http", "https"}:
-            raise ValueError("String sources must be HTTP or HTTPS URLs.")
-
     def _source_to_upload_files(
         self,
         source: Path | DocumentStream,
@@ -994,25 +748,6 @@ class DoclingServiceClient:
                     loop.close()
 
         return iterator()
-
-    @staticmethod
-    def _validate_concurrency(value: int, *, name: str) -> int:
-        if value < 1 or value > MAX_CONCURRENCY_LIMIT:
-            raise ValueError(
-                f"{name} must be between 1 and {MAX_CONCURRENCY_LIMIT}, got {value}."
-            )
-        return value
-
-    def _effective_concurrency(self, override: int | None) -> int:
-        if override is None:
-            return self._max_concurrency
-        return self._validate_concurrency(override, name="max_concurrency")
-
-    @staticmethod
-    def _normalize_exception(exc: BaseException) -> Exception:
-        if isinstance(exc, Exception):
-            return exc
-        return RuntimeError(str(exc))
 
     async def _convert_all_async(
         self,
@@ -1380,81 +1115,6 @@ class DoclingServiceClient:
             self._raise_for_generic_http_error(response, error_message)
         return response
 
-    def _check_retry(
-        self,
-        response: httpx.Response,
-        attempt: int,
-        max_retries: int,
-    ) -> tuple[httpx.Response | None, float]:
-        """Return (response, 0.0) to yield, (None, delay) to retry after delay, or raise."""
-        if response.status_code == 500:
-            return self._retry_with_exponential_backoff(
-                response=response,
-                attempt=attempt,
-                max_retries=max_retries,
-                error_message="Service returned HTTP 500 after retries.",
-            )
-        if response.status_code in {429, 503}:
-            return self._retry_with_retry_after_header(
-                response=response,
-                attempt=attempt,
-                max_retries=max_retries,
-            )
-        return response, 0.0
-
-    def _retry_with_exponential_backoff(
-        self,
-        response: httpx.Response,
-        attempt: int,
-        max_retries: int,
-        error_message: str,
-    ) -> tuple[httpx.Response | None, float]:
-        if attempt < max_retries:
-            return None, self._exponential_backoff_delay(attempt)
-        raise ServiceUnavailableError(
-            error_message,
-            status_code=response.status_code,
-            detail=self._http_error_detail(response),
-        )
-
-    def _retry_with_retry_after_header(
-        self,
-        response: httpx.Response,
-        attempt: int,
-        max_retries: int,
-    ) -> tuple[httpx.Response | None, float]:
-        retry_after_delay = self._retry_after_delay_seconds(response)
-        if retry_after_delay is None:
-            return response, 0.0
-        if attempt < max_retries:
-            return None, retry_after_delay
-        raise ServiceUnavailableError(
-            f"Service returned HTTP {response.status_code} after retries.",
-            status_code=response.status_code,
-            detail=self._http_error_detail(response),
-        )
-
-    def _exponential_backoff_delay(self, attempt: int) -> float:
-        return HTTP_RETRY_BACKOFF_BASE_SECONDS * (2**attempt)
-
-    def _retry_after_delay_seconds(self, response: httpx.Response) -> float | None:
-        retry_after_header = response.headers.get("Retry-After")
-        if retry_after_header is None:
-            return None
-
-        try:
-            return max(0.0, float(retry_after_header))
-        except ValueError:
-            pass
-
-        try:
-            retry_at = parsedate_to_datetime(retry_after_header)
-        except (TypeError, ValueError, IndexError, OverflowError):
-            return None
-
-        now = datetime.now(tz=retry_at.tzinfo or timezone.utc)
-        return max(0.0, (retry_at - now).total_seconds())
-
     def _request_with_retry(
         self,
         method: str,
@@ -1529,111 +1189,3 @@ class DoclingServiceClient:
                 await asyncio.sleep(delay)
 
         raise ServiceUnavailableError("Service request failed after retry loop.")
-
-    def _raise_for_result_404(
-        self,
-        task_id: str,
-        response: httpx.Response,
-        last_status: TaskStatusResponse | None,
-    ) -> None:
-        detail = self._http_error_detail(response)
-        if detail == "Task not found.":
-            raise TaskNotFoundError(f"Task {task_id} was not found.")
-        if detail is not None and detail.startswith("Task result not found"):
-            if last_status is not None and is_terminal_task_status(last_status):
-                if last_status.task_status == "failure":
-                    message = last_status.error_message or f"Task {task_id} failed."
-                    raise ConversionError(message)
-                raise ResultExpiredError(f"Result for task {task_id} has expired.")
-            raise ResultNotReadyError(f"Result for task {task_id} is not ready.")
-        raise ServiceError(
-            "Unexpected result lookup error.",
-            status_code=response.status_code,
-            detail=detail,
-        )
-
-    def _raise_for_generic_http_error(
-        self,
-        response: httpx.Response,
-        message: str,
-    ) -> None:
-        if response.status_code == 402:
-            usage_limit = self._parse_usage_limit_exceeded_response(response)
-            raise UsageLimitExceededError(
-                message,
-                status_code=response.status_code,
-                detail=None if usage_limit is None else usage_limit.message,
-                current_usage=(
-                    None if usage_limit is None else usage_limit.details.currentUsage
-                ),
-                limit=None if usage_limit is None else usage_limit.details.limit,
-            )
-
-        detail = self._http_error_detail(response)
-        if 400 <= response.status_code < 500:
-            raise ServiceError(message, status_code=response.status_code, detail=detail)
-        raise ServiceUnavailableError(
-            message,
-            status_code=response.status_code,
-            detail=detail,
-        )
-
-    def _parse_usage_limit_exceeded_response(
-        self,
-        response: httpx.Response,
-    ) -> UsageLimitExceededResponse | None:
-        try:
-            return UsageLimitExceededResponse.model_validate_json(response.text)
-        except (ValidationError, ValueError):
-            return None
-
-    def _http_error_detail(self, response: httpx.Response) -> str | None:
-        try:
-            detail = response.json().get("detail")
-        except Exception:
-            return None
-        return detail if isinstance(detail, str) else None
-
-    def _failure_message(self, result: ConversionResult) -> str:
-        if result.errors:
-            messages = "; ".join(item.error_message for item in result.errors)
-            return (
-                f"Conversion failed for {result.input.file} with status "
-                f"{result.status.value}. Errors: {messages}"
-            )
-        return f"Conversion failed for {result.input.file} with status {result.status.value}."
-
-    def _url(self, path: str) -> str:
-        if path.startswith("/"):
-            return f"{self._base_url}{path}"
-        return f"{self._base_url}/{path}"
-
-    def _build_ws_status_url(self, task_id: str) -> str:
-        parsed = urlparse(self._base_url)
-        ws_scheme = "wss" if parsed.scheme == "https" else "ws"
-        ws_url = f"{ws_scheme}://{parsed.netloc}{parsed.path}/v1/status/ws/{task_id}"
-        if not self._api_key:
-            return ws_url
-        return f"{ws_url}?{urlencode({'api_key': self._api_key})}"
-
-    def _normalize_base_url(self, url: str) -> str:
-        parsed = urlparse(url)
-        if parsed.scheme not in {"http", "https"} or not parsed.netloc:
-            raise ValueError("Client URL must be an absolute http(s) base URL.")
-        if parsed.query or parsed.fragment:
-            raise ValueError(
-                "Client URL must not include query or fragment components."
-            )
-        path = parsed.path.rstrip("/")
-        if path.endswith("/v1"):
-            raise ValueError(
-                "Client URL must be the service base URL, not include /v1."
-            )
-        return f"{parsed.scheme}://{parsed.netloc}{path}"
-
-    def _build_extension_to_format_map(self) -> dict[str, InputFormat]:
-        extension_to_format: dict[str, InputFormat] = {}
-        for input_format, extensions in FormatToExtensions.items():
-            for extension in extensions:
-                extension_to_format.setdefault(extension.lower(), input_format)
-        return extension_to_format

--- a/docling/service_client/job.py
+++ b/docling/service_client/job.py
@@ -1,8 +1,8 @@
-"""Conversion job handle for asynchronous docling-serve tasks."""
+"""Conversion job handles for docling-serve tasks (sync and async)."""
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Generic, TypeVar
@@ -19,6 +19,14 @@ class _JobHandlers(Generic[T_Result]):
     watch: Callable[[str, float | None], Iterator[TaskStatusResponse]]
     wait: Callable[[str, float | None], TaskStatusResponse]
     fetch_result: Callable[[str, TaskStatusResponse | None], T_Result]
+
+
+@dataclass(slots=True)
+class _AsyncJobHandlers(Generic[T_Result]):
+    poll: Callable[[str, float], Awaitable[TaskStatusResponse]]
+    watch: Callable[[str, float | None], AsyncIterator[TaskStatusResponse]]
+    wait: Callable[[str, float | None], Awaitable[TaskStatusResponse]]
+    fetch_result: Callable[[str, TaskStatusResponse | None], Awaitable[T_Result]]
 
 
 class ConversionJob(Generic[T_Result]):
@@ -68,3 +76,54 @@ class ConversionJob(Generic[T_Result]):
         if not self.done:
             self._last_status = self._handlers.wait(self.task_id, timeout)
         return self._handlers.fetch_result(self.task_id, self._last_status)
+
+
+class AsyncConversionJob(Generic[T_Result]):
+    """Async handle for a submitted docling-serve task."""
+
+    def __init__(
+        self,
+        task_id: str,
+        submitted_at: datetime,
+        handlers: _AsyncJobHandlers[T_Result],
+        initial_status: TaskStatusResponse | None = None,
+    ) -> None:
+        self.task_id = task_id
+        self.submitted_at = submitted_at
+        self._handlers = handlers
+        self._last_status = initial_status
+
+    @property
+    def status(self) -> str:
+        if self._last_status is None:
+            return "pending"
+        return self._last_status.task_status
+
+    @property
+    def queue_position(self) -> int | None:
+        if self._last_status is None:
+            return None
+        return self._last_status.task_position
+
+    @property
+    def done(self) -> bool:
+        return self._last_status is not None and is_terminal_task_status(
+            self._last_status
+        )
+
+    async def poll(self, wait: float = 0.0) -> TaskStatusResponse:
+        update = await self._handlers.poll(self.task_id, wait)
+        self._last_status = update
+        return update
+
+    async def watch(
+        self, timeout: float | None = None
+    ) -> AsyncIterator[TaskStatusResponse]:
+        async for update in self._handlers.watch(self.task_id, timeout):
+            self._last_status = update
+            yield update
+
+    async def result(self, timeout: float | None = None) -> T_Result:
+        if not self.done:
+            self._last_status = await self._handlers.wait(self.task_id, timeout)
+        return await self._handlers.fetch_result(self.task_id, self._last_status)

--- a/docling/service_client/watchers.py
+++ b/docling/service_client/watchers.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterator
 from typing import Protocol
 
+from websockets.asyncio.client import connect as async_connect
 from websockets.exceptions import ConnectionClosedOK
 from websockets.sync.client import connect
 
@@ -209,6 +211,190 @@ class WebSocketWatcher:
                             # Once the server websocket contract is simplified to
                             # a pure push stream, remove the "next" handshake
                             # entirely instead of keeping this special case.
+                            return
+
+        except TaskTimeoutError:
+            raise
+        except TaskNotFoundError:
+            raise
+        except Exception as exc:
+            raise ServiceUnavailableError(
+                "WebSocket status stream is unavailable.", detail=str(exc)
+            ) from exc
+
+
+class AsyncStatusWatcher(Protocol):
+    """Protocol for async job status watchers."""
+
+    def iter_updates(
+        self, task_id: str, timeout: float | None
+    ) -> AsyncIterator[TaskStatusResponse]: ...
+
+    async def wait_for_terminal(
+        self, task_id: str, timeout: float | None
+    ) -> TaskStatusResponse: ...
+
+
+class AsyncPollingWatcher:
+    """Async status watcher using `GET /v1/status/poll/{task_id}` with server-side wait."""
+
+    def __init__(
+        self,
+        poll_status: Callable[[str, float], Awaitable[TaskStatusResponse]],
+        poll_server_wait: float,
+        poll_client_interval: float | None,
+        default_timeout: float,
+    ) -> None:
+        self._poll_status = poll_status
+        self._poll_server_wait = poll_server_wait
+        self._poll_client_interval = (
+            poll_server_wait if poll_client_interval is None else poll_client_interval
+        )
+        self._default_timeout = default_timeout
+
+    async def iter_updates(
+        self, task_id: str, timeout: float | None = None
+    ) -> AsyncIterator[TaskStatusResponse]:
+        wait_timeout = self._default_timeout if timeout is None else timeout
+        deadline = time.monotonic() + wait_timeout
+        while True:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                raise TaskTimeoutError(
+                    f"Timed out waiting for task {task_id} after {wait_timeout:.2f}s."
+                )
+
+            poll_wait = min(self._poll_server_wait, remaining)
+            poll_started = time.monotonic()
+            update = await self._poll_status(task_id, poll_wait)
+            yield update
+            if is_terminal_task_status(update):
+                return
+
+            # Keep a minimum client-side poll cadence when server-side wait is ignored.
+            sleep_for = _poll_sleep_duration(
+                poll_started=poll_started,
+                poll_interval=self._poll_client_interval,
+                deadline=deadline,
+            )
+            if sleep_for > 0:
+                await asyncio.sleep(sleep_for)
+
+    async def wait_for_terminal(
+        self, task_id: str, timeout: float | None = None
+    ) -> TaskStatusResponse:
+        final_status: TaskStatusResponse | None = None
+        async for update in self.iter_updates(task_id=task_id, timeout=timeout):
+            final_status = update
+
+        if final_status is None:
+            raise TaskTimeoutError(
+                f"Timed out waiting for task {task_id} to emit status updates."
+            )
+        return final_status
+
+
+class AsyncWebSocketWatcher:
+    """Async status watcher using `WS /v1/status/ws/{task_id}` with poll fallback."""
+
+    def __init__(
+        self,
+        ws_url_for_task: Callable[[str], str],
+        poll_fallback: AsyncPollingWatcher | None,
+        fallback_to_poll: bool,
+        connect_timeout: float,
+        default_timeout: float,
+        additional_headers: dict[str, str] | None = None,
+    ) -> None:
+        self._ws_url_for_task = ws_url_for_task
+        self._poll_fallback = poll_fallback
+        self._fallback_to_poll = fallback_to_poll
+        self._connect_timeout = connect_timeout
+        self._default_timeout = default_timeout
+        self._additional_headers = additional_headers or {}
+
+    async def iter_updates(
+        self, task_id: str, timeout: float | None = None
+    ) -> AsyncIterator[TaskStatusResponse]:
+        wait_timeout = self._default_timeout if timeout is None else timeout
+        try:
+            async for update in self._iter_ws_updates(
+                task_id=task_id, timeout=wait_timeout
+            ):
+                yield update
+        except ServiceUnavailableError:
+            if self._fallback_to_poll and self._poll_fallback is not None:
+                async for update in self._poll_fallback.iter_updates(
+                    task_id=task_id, timeout=wait_timeout
+                ):
+                    yield update
+                return
+            raise
+
+    async def wait_for_terminal(
+        self, task_id: str, timeout: float | None = None
+    ) -> TaskStatusResponse:
+        final_status: TaskStatusResponse | None = None
+        async for update in self.iter_updates(task_id=task_id, timeout=timeout):
+            final_status = update
+
+        if final_status is None:
+            raise TaskTimeoutError(
+                f"Timed out waiting for task {task_id} to emit status updates."
+            )
+        return final_status
+
+    async def _iter_ws_updates(
+        self, task_id: str, timeout: float
+    ) -> AsyncIterator[TaskStatusResponse]:
+        ws_url = self._ws_url_for_task(task_id)
+        deadline = time.monotonic() + timeout
+        try:
+            async with async_connect(
+                ws_url,
+                open_timeout=self._connect_timeout,
+                close_timeout=self._connect_timeout,
+                additional_headers=self._additional_headers,
+            ) as websocket:
+                while True:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise TaskTimeoutError(
+                            f"Timed out waiting for task {task_id} after {timeout:.2f}s."
+                        )
+
+                    try:
+                        raw_message = await asyncio.wait_for(
+                            websocket.recv(), timeout=remaining
+                        )
+                    except asyncio.TimeoutError as exc:
+                        raise TaskTimeoutError(
+                            f"Timed out waiting for task {task_id} after {timeout:.2f}s."
+                        ) from exc
+                    envelope = WebsocketMessage.model_validate_json(raw_message)
+
+                    if envelope.error:
+                        if envelope.error == "Task not found.":
+                            raise TaskNotFoundError(f"Task {task_id} was not found.")
+                        raise ServiceUnavailableError(
+                            "WebSocket status stream failed.",
+                            detail=envelope.error,
+                        )
+
+                    if envelope.task is None:
+                        continue
+
+                    yield envelope.task
+                    if is_terminal_task_status(envelope.task):
+                        return
+
+                    # Only send "next" for UPDATE messages. Mirrors the sync
+                    # watcher's protocol handshake — see WebSocketWatcher
+                    # `_iter_ws_updates` for the full rationale.
+                    if envelope.message == MessageKind.UPDATE:
+                        try:
+                            await websocket.send("next")
+                        except ConnectionClosedOK:
                             return
 
         except TaskTimeoutError:

--- a/docs/examples/service_client/README.md
+++ b/docs/examples/service_client/README.md
@@ -20,4 +20,7 @@ installed:
 python docs/examples/service_client/convert_compat.py
 python docs/examples/service_client/task_api.py
 python docs/examples/service_client/batch_and_chunk.py
+python docs/examples/service_client/convert_async.py
 ```
+
+`convert_async.py` shows the async client (`AsyncDoclingServiceClient`); the others use the synchronous client. Pick whichever matches your application's event-loop model.

--- a/docs/examples/service_client/convert_async.py
+++ b/docs/examples/service_client/convert_async.py
@@ -1,0 +1,156 @@
+# NOTE: docling.service_client is experimental and may change in future releases.
+"""Async client examples: convert / submit / chunk against a running docling-serve."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from docling.datamodel.base_models import ConversionStatus, OutputFormat
+from docling.datamodel.document import ConversionResult
+from docling.datamodel.service.options import (
+    ConvertDocumentsOptions as ConvertDocumentsRequestOptions,
+)
+from docling.service_client import (
+    AsyncConversionJob,
+    AsyncDoclingServiceClient,
+    ChunkerKind,
+    RawServiceResult,
+)
+
+SERVICE_URL_ENV = "DOCLING_SERVICE_URL"
+SERVICE_API_KEY_ENV = "DOCLING_SERVICE_API_KEY"
+SAMPLE_SOURCES = [
+    "https://arxiv.org/pdf/2206.01062",
+    "https://arxiv.org/pdf/2305.03393",
+]
+
+
+def _service_url() -> str:
+    service_url = os.environ.get(SERVICE_URL_ENV)
+    if not service_url:
+        raise SystemExit(f"Set {SERVICE_URL_ENV} to a running docling-serve URL.")
+    return service_url
+
+
+def create_conversion_options() -> ConvertDocumentsRequestOptions:
+    return ConvertDocumentsRequestOptions(
+        do_ocr=False,
+        do_table_structure=False,
+        include_images=False,
+        to_formats=[OutputFormat.JSON],
+        abort_on_error=False,
+    )
+
+
+async def run_convert_single(client: AsyncDoclingServiceClient) -> None:
+    print("\n=== await client.convert(source) ===")
+    result = await client.convert(
+        source=SAMPLE_SOURCES[0],
+        options=create_conversion_options(),
+    )
+    print("status:", result.status.value)
+    print("document name:", result.document.name)
+    print("num pages in output:", len(result.document.pages))
+
+
+async def run_convert_all(client: AsyncDoclingServiceClient) -> None:
+    print("\n=== async for r in client.convert_all(sources) ===")
+    idx = 0
+    async for result in client.convert_all(
+        sources=SAMPLE_SOURCES,
+        options=create_conversion_options(),
+        max_concurrency=2,
+    ):
+        idx += 1
+        print(
+            f"{idx}.",
+            "input=",
+            result.input.file.name,
+            "status=",
+            result.status.value,
+        )
+
+
+async def run_task_api_json(client: AsyncDoclingServiceClient) -> None:
+    print("\n=== submit -> watch -> result (JSON target) ===")
+    job: AsyncConversionJob[ConversionResult] = await client.submit(
+        source=SAMPLE_SOURCES[0],
+        options=create_conversion_options(),
+        target_format=OutputFormat.JSON,
+    )
+    print("submitted task id:", job.task_id)
+    async for update in job.watch(timeout=300.0):
+        print(
+            "status update:",
+            update.task_status,
+            "queue_position=",
+            update.task_position,
+        )
+    # After a terminal watch, result(...) returns immediately.
+    result = await job.result(timeout=300.0)
+    print("final status:", result.status.value)
+    print("document name:", result.document.name)
+
+
+async def run_task_api_markdown(client: AsyncDoclingServiceClient) -> None:
+    print("\n=== submit(...).result() (MARKDOWN target) ===")
+    job: AsyncConversionJob[RawServiceResult] = await client.submit(
+        source=SAMPLE_SOURCES[0],
+        options=create_conversion_options(),
+        target_format=OutputFormat.MARKDOWN,
+    )
+    raw_result = await job.result(timeout=300.0)
+    print("raw content-type:", raw_result.content_type)
+    print("raw payload bytes:", len(raw_result.content))
+
+
+async def run_batch_and_chunk(client: AsyncDoclingServiceClient) -> None:
+    print("\n=== convert_all() + chunk() (async) ===")
+    options = create_conversion_options()
+    chunked_count = 0
+    sources_iter = iter(SAMPLE_SOURCES)
+    async for result in client.convert_all(
+        sources=SAMPLE_SOURCES,
+        options=options,
+        max_concurrency=2,
+    ):
+        source = next(sources_iter)
+        print(
+            "input=",
+            result.input.file.name,
+            "status=",
+            result.status.value,
+        )
+        if result.status not in {
+            ConversionStatus.SUCCESS,
+            ConversionStatus.PARTIAL_SUCCESS,
+        }:
+            continue
+        chunk_response = await client.chunk(
+            source=source,
+            chunker=ChunkerKind.HIERARCHICAL,
+            options=options,
+        )
+        chunked_count += 1
+        print("num chunks:", len(chunk_response.chunks))
+    print("sources chunked:", chunked_count)
+
+
+async def main() -> None:
+    async with AsyncDoclingServiceClient(
+        url=_service_url(),
+        api_key=os.environ.get(SERVICE_API_KEY_ENV, ""),
+    ) as client:
+        health = await client.health()
+        print("health:", health.status)
+
+        await run_convert_single(client)
+        await run_convert_all(client)
+        await run_task_api_json(client)
+        await run_task_api_markdown(client)
+        await run_batch_and_chunk(client)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_service_client_async_sdk_unit.py
+++ b/tests/test_service_client_async_sdk_unit.py
@@ -1,0 +1,378 @@
+"""Unit tests for the asynchronous docling-serve client SDK."""
+
+import json
+import warnings
+from datetime import datetime, timezone
+from pathlib import PurePath
+from types import MethodType, SimpleNamespace
+
+import httpx
+import pytest
+from docling_core.types.doc import DoclingDocument
+
+from docling.datamodel.base_models import ConversionStatus, OutputFormat
+from docling.datamodel.service.responses import (
+    TaskStatusResponse,
+)
+from docling.datamodel.service.tasks import TaskType
+from docling.service_client import (
+    AsyncConversionJob,
+    AsyncDoclingServiceClient,
+    ConversionItem,
+    StatusWatcherKind,
+)
+from docling.service_client._base import ExperimentalWarning
+from docling.service_client.exceptions import ConversionError
+
+TEST_BASE_URL = "http://docling-service.invalid"
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+def _status_payload(task_id: str, status: str) -> str:
+    return TaskStatusResponse(
+        task_id=task_id,
+        task_type=TaskType.CONVERT,
+        task_status=status,
+        task_position=0,
+        task_meta=None,
+        error_message=None,
+    ).model_dump_json()
+
+
+def _convert_result_payload(source_name: str) -> str:
+    return json.dumps(
+        {
+            "status": ConversionStatus.SUCCESS.value,
+            "errors": [],
+            "processing_time": 0.0,
+            "timings": {},
+            "document": {
+                "filename": source_name,
+                "json_content": DoclingDocument(
+                    name=PurePath(source_name).stem
+                ).model_dump(mode="json"),
+            },
+        }
+    )
+
+
+def _client_with_transport(
+    handler,
+    *,
+    status_watcher: StatusWatcherKind = StatusWatcherKind.POLLING,
+) -> AsyncDoclingServiceClient:
+    """Build an async client whose HTTP layer is backed by a MockTransport.
+
+    Polling is used by default so tests never need to mock websockets.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ExperimentalWarning)
+        client = AsyncDoclingServiceClient(
+            url=TEST_BASE_URL,
+            status_watcher=status_watcher,
+            poll_server_wait=0.0,
+            poll_client_interval=0.0,
+            job_timeout=5.0,
+        )
+    transport = httpx.MockTransport(handler)
+    client._http_client = httpx.AsyncClient(transport=transport)
+    return client
+
+
+def test_async_client_emits_experimental_warning() -> None:
+    with pytest.warns(ExperimentalWarning):
+        AsyncDoclingServiceClient(url=TEST_BASE_URL)
+
+
+def test_async_client_rejects_invalid_max_concurrency() -> None:
+    with (
+        warnings.catch_warnings(),
+        pytest.raises(ValueError, match="max_concurrency must be between"),
+    ):
+        warnings.simplefilter("ignore", ExperimentalWarning)
+        AsyncDoclingServiceClient(url=TEST_BASE_URL, max_concurrency=0)
+
+
+def test_async_client_normalizes_base_url() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ExperimentalWarning)
+        client = AsyncDoclingServiceClient(url=f"{TEST_BASE_URL}/")
+        assert client._base_url == TEST_BASE_URL
+
+
+@pytest.mark.anyio
+async def test_async_client_context_manager_closes_http() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ExperimentalWarning)
+        async with AsyncDoclingServiceClient(url=TEST_BASE_URL) as client:
+            assert isinstance(client, AsyncDoclingServiceClient)
+            http_client = client._http_client
+        assert http_client.is_closed
+
+
+@pytest.mark.anyio
+async def test_async_health_returns_parsed_response() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/health"
+        return httpx.Response(200, json={"status": "ok"})
+
+    async with _client_with_transport(handler) as client:
+        health = await client.health()
+        assert health.status == "ok"
+
+
+@pytest.mark.anyio
+async def test_async_version_returns_dict() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.url.path == "/version"
+        return httpx.Response(200, json={"version": "1.2.3", "build": "abc"})
+
+    async with _client_with_transport(handler) as client:
+        version = await client.version()
+        assert version == {"version": "1.2.3", "build": "abc"}
+
+
+@pytest.mark.anyio
+async def test_async_convert_full_flow_via_polling() -> None:
+    """End-to-end: submit task, poll until terminal, fetch JSON result."""
+    poll_calls = 0
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal poll_calls
+        path = request.url.path
+        if path == "/v1/convert/source/async":
+            return httpx.Response(200, text=_status_payload("task-1", "pending"))
+        if path == "/v1/status/poll/task-1":
+            poll_calls += 1
+            status = "pending" if poll_calls == 1 else "success"
+            return httpx.Response(200, text=_status_payload("task-1", status))
+        if path == "/v1/result/task-1":
+            return httpx.Response(200, text=_convert_result_payload("paper.pdf"))
+        raise AssertionError(f"unexpected path {path}")
+
+    async with _client_with_transport(handler) as client:
+        result = await client.convert(source="https://example.invalid/paper.pdf")
+        assert result.status == ConversionStatus.SUCCESS
+        assert poll_calls >= 2  # at least one "pending" then one "success"
+
+
+@pytest.mark.anyio
+async def test_async_convert_raises_on_failure_when_raises_on_error_true() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/v1/convert/source/async":
+            return httpx.Response(200, text=_status_payload("task-1", "pending"))
+        if path == "/v1/status/poll/task-1":
+            return httpx.Response(200, text=_status_payload("task-1", "success"))
+        if path == "/v1/result/task-1":
+            payload = json.dumps(
+                {
+                    "status": ConversionStatus.FAILURE.value,
+                    "errors": [],
+                    "processing_time": 0.0,
+                    "timings": {},
+                    "document": {"filename": "paper.pdf", "json_content": None},
+                }
+            )
+            return httpx.Response(200, text=payload)
+        raise AssertionError(f"unexpected path {path}")
+
+    async with _client_with_transport(handler) as client:
+        with pytest.raises(ConversionError):
+            await client.convert(source="https://example.invalid/paper.pdf")
+
+
+@pytest.mark.anyio
+async def test_async_convert_all_yields_results_in_order() -> None:
+    sources = [f"https://example.invalid/doc-{i}.pdf" for i in range(3)]
+    submitted: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/v1/convert/source/async":
+            body = json.loads(request.content)
+            url = body["sources"][0]["url"]
+            task_id = f"task-{len(submitted)}"
+            submitted.append(url)
+            return httpx.Response(200, text=_status_payload(task_id, "pending"))
+        if path.startswith("/v1/status/poll/"):
+            task_id = path.rsplit("/", 1)[-1]
+            return httpx.Response(200, text=_status_payload(task_id, "success"))
+        if path.startswith("/v1/result/"):
+            task_id = path.rsplit("/", 1)[-1]
+            return httpx.Response(200, text=_convert_result_payload(f"{task_id}.pdf"))
+        raise AssertionError(f"unexpected path {path}")
+
+    async with _client_with_transport(handler) as client:
+        results = []
+        async for result in client.convert_all(sources=sources, max_concurrency=4):
+            results.append(result)
+
+    assert len(results) == 3
+    assert all(r.status == ConversionStatus.SUCCESS for r in results)
+
+
+@pytest.mark.anyio
+async def test_async_convert_all_callable_inside_running_loop() -> None:
+    """Regression guard: this is the case the sync client refused with RuntimeError.
+
+    See client.py `_ensure_sync_bridge_allowed` — calling convert_all from inside
+    an event loop used to raise. The async client must work here.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/v1/convert/source/async":
+            body = json.loads(request.content)
+            url = body["sources"][0]["url"]
+            task_id = f"task-{url[-5]}"
+            return httpx.Response(200, text=_status_payload(task_id, "pending"))
+        if path.startswith("/v1/status/poll/"):
+            task_id = path.rsplit("/", 1)[-1]
+            return httpx.Response(200, text=_status_payload(task_id, "success"))
+        if path.startswith("/v1/result/"):
+            task_id = path.rsplit("/", 1)[-1]
+            return httpx.Response(200, text=_convert_result_payload(f"{task_id}.pdf"))
+        raise AssertionError(f"unexpected path {path}")
+
+    sources = ["https://example.invalid/0.pdf", "https://example.invalid/1.pdf"]
+    async with _client_with_transport(handler) as client:
+        # If this method blocked on a sync bridge, we'd be deadlocked here.
+        agen = client.convert_all(sources=sources)
+        collected = [r async for r in agen]
+        assert len(collected) == 2
+
+
+@pytest.mark.anyio
+async def test_async_submit_returns_async_conversion_job() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/v1/convert/source/async":
+            return httpx.Response(200, text=_status_payload("task-9", "pending"))
+        raise AssertionError(f"unexpected path {request.url.path}")
+
+    async with _client_with_transport(handler) as client:
+        job = await client.submit(source="https://example.invalid/paper.pdf")
+        assert isinstance(job, AsyncConversionJob)
+        assert job.task_id == "task-9"
+        assert job.status == "pending"
+
+
+@pytest.mark.anyio
+async def test_async_conversion_job_result_waits_and_fetches() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/v1/convert/source/async":
+            return httpx.Response(200, text=_status_payload("task-7", "pending"))
+        if path == "/v1/status/poll/task-7":
+            return httpx.Response(200, text=_status_payload("task-7", "success"))
+        if path == "/v1/result/task-7":
+            return httpx.Response(200, text=_convert_result_payload("doc.pdf"))
+        raise AssertionError(f"unexpected path {path}")
+
+    async with _client_with_transport(handler) as client:
+        job = await client.submit(source="https://example.invalid/doc.pdf")
+        result = await job.result()
+        assert result.status == ConversionStatus.SUCCESS
+        assert job.done
+
+
+@pytest.mark.anyio
+async def test_async_submit_and_retrieve_many_yields_per_item() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path == "/v1/convert/source/async":
+            body = json.loads(request.content)
+            url = body["sources"][0]["url"]
+            task_id = f"task-{url[-5]}"
+            return httpx.Response(200, text=_status_payload(task_id, "pending"))
+        if path.startswith("/v1/status/poll/"):
+            task_id = path.rsplit("/", 1)[-1]
+            return httpx.Response(200, text=_status_payload(task_id, "success"))
+        if path.startswith("/v1/result/"):
+            task_id = path.rsplit("/", 1)[-1]
+            return httpx.Response(200, text=_convert_result_payload(f"{task_id}.pdf"))
+        raise AssertionError(f"unexpected path {path}")
+
+    items = [
+        ConversionItem(source="https://example.invalid/0.pdf"),
+        ConversionItem(source="https://example.invalid/1.pdf"),
+    ]
+    async with _client_with_transport(handler) as client:
+        outcomes = [
+            outcome
+            async for outcome in client.submit_and_retrieve_many(
+                items=items, max_in_flight=2, ordered=True
+            )
+        ]
+
+    assert len(outcomes) == 2
+    for item, response in outcomes:
+        assert isinstance(item, ConversionItem)
+        assert not isinstance(response, Exception)
+
+
+@pytest.mark.anyio
+async def test_async_client_uses_polling_watcher_when_configured() -> None:
+    from docling.service_client.watchers import AsyncPollingWatcher
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", ExperimentalWarning)
+        client = AsyncDoclingServiceClient(
+            url=TEST_BASE_URL,
+            status_watcher=StatusWatcherKind.POLLING,
+        )
+        watcher = client._status_watcher()
+        assert isinstance(watcher, AsyncPollingWatcher)
+        await client.aclose()
+
+
+@pytest.mark.anyio
+async def test_async_conversion_job_watch_yields_until_terminal() -> None:
+    statuses = iter(["pending", "running", "success"])
+
+    async def fake_watch(task_id: str, timeout):
+        for status in statuses:
+            yield _status_response(task_id, status)
+            if status == "success":
+                return
+
+    async def fake_wait(task_id: str, timeout):
+        return _status_response(task_id, "success")
+
+    async def fake_poll(task_id: str, wait: float):
+        return _status_response(task_id, "pending")
+
+    async def fake_fetch_result(task_id: str, last_status):
+        return SimpleNamespace(task_id=task_id, status="success")
+
+    from docling.service_client.job import _AsyncJobHandlers
+
+    handlers = _AsyncJobHandlers(
+        poll=fake_poll,
+        watch=fake_watch,
+        wait=fake_wait,
+        fetch_result=fake_fetch_result,
+    )
+    job = AsyncConversionJob(
+        task_id="task-watch",
+        submitted_at=datetime.now(tz=timezone.utc),
+        handlers=handlers,
+    )
+    updates = [u async for u in job.watch()]
+    assert [u.task_status for u in updates] == ["pending", "running", "success"]
+    assert job.done
+
+
+def _status_response(task_id: str, status: str) -> TaskStatusResponse:
+    return TaskStatusResponse(
+        task_id=task_id,
+        task_type=TaskType.CONVERT,
+        task_status=status,
+        task_position=0,
+        task_meta=None,
+        error_message=None,
+    )


### PR DESCRIPTION
## Summary

The synchronous `DoclingServiceClient` blocks the event loop on every HTTP call, and `convert_all` / `submit_and_retrieve_many` raise `RuntimeError` when invoked from inside a running asyncio loop (the `_ensure_sync_bridge_allowed` guard). This makes the SDK unusable from FastAPI handlers, async workers, and any code already running inside an event loop without dispatching to a thread.

This PR adds a native async client that mirrors the sync surface, with no new dependencies (`httpx>=0.28` and `websockets>=14.0` are already required by the `service-client` extra).

- New `AsyncDoclingServiceClient` — `convert` / `convert_all` / `submit` / `submit_chunk` / `chunk` / `submit_and_retrieve_many` / `health` / `version`, plus `aclose()` and async context manager.
- New `AsyncConversionJob` — async `poll` / `watch` (returns `AsyncIterator`) / `result`.
- New `AsyncPollingWatcher` / `AsyncWebSocketWatcher` using `websockets.asyncio` for native async WS connectivity.
- Refactor: `_BaseClient` holds shared pure helpers and config (URL building, source description, options resolution, retry policy, error mapping, result assembly). The existing `DoclingServiceClient` now inherits from it. No behavior change for the sync class — verified by the existing `tests/test_service_client_sdk_unit.py` (55/55 still pass).

The SDK remains marked experimental (`ExperimentalWarning`).

## Test plan

- `pytest tests/test_service_client_sdk_unit.py` — 55/55 pass (no regressions in the sync client).
- `pytest tests/test_service_client_async_sdk_unit.py` — 15/15 pass (new async-surface coverage).
- Regression guard: `test_async_convert_all_callable_inside_running_loop` asserts the original bug is fixed.
- `ruff format` / `ruff check` clean on touched files.
- `ty check` produces only pre-existing warning patterns (no new diagnostics).

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
