### PR TITLE
fix: Handle valid JATS contributor name variants

### DIFF
--- a/docling/backend/xml/jats_backend.py
+++ b/docling/backend/xml/jats_backend.py
@@ -214,6 +214,75 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
 
         return text
 
+    @staticmethod
+    def _normalize_whitespace(text: str | None) -> str:
+        return " ".join(text.split()) if text else ""
+
+    @staticmethod
+    def _get_node_text(node: etree._Element) -> str:
+        return JatsDocumentBackend._normalize_whitespace(" ".join(node.itertext()))
+
+    @staticmethod
+    def _parse_structured_name(name_node: etree._Element) -> str:
+        name_parts: list[str] = []
+        for tag_name in ["prefix", "given-names", "surname", "suffix"]:
+            for part_node in name_node.xpath(tag_name):
+                part_text = JatsDocumentBackend._get_node_text(part_node)
+                if part_text:
+                    name_parts.append(part_text)
+
+        if name_parts:
+            return JatsDocumentBackend._normalize_whitespace(" ".join(name_parts))
+
+        return JatsDocumentBackend._get_node_text(name_node)
+
+    @staticmethod
+    def _parse_name_alternatives(node: etree._Element) -> str:
+        for tag_name in ["name", "string-name", "collab-name", "collab"]:
+            for name_node in node.xpath(tag_name):
+                if tag_name == "name":
+                    name = JatsDocumentBackend._parse_structured_name(name_node)
+                else:
+                    name = JatsDocumentBackend._get_node_text(name_node)
+                if name:
+                    return name
+
+        return ""
+
+    @staticmethod
+    def _parse_contrib_name(author_node: etree._Element) -> str:
+        for name_node in author_node.xpath("name"):
+            name = JatsDocumentBackend._parse_structured_name(name_node)
+            if name:
+                return name
+
+        for name_node in author_node.xpath("string-name"):
+            name = JatsDocumentBackend._get_node_text(name_node)
+            if name:
+                return name
+
+        for alternatives_node in author_node.xpath("name-alternatives"):
+            name = JatsDocumentBackend._parse_name_alternatives(alternatives_node)
+            if name:
+                return name
+
+        for tag_name in ["collab-name", "collab"]:
+            for name_node in author_node.xpath(tag_name):
+                name = JatsDocumentBackend._get_node_text(name_node)
+                if name:
+                    return name
+
+        for tag_name in ["collab-name-alternatives", "collab-alternatives"]:
+            for alternatives_node in author_node.xpath(tag_name):
+                name = JatsDocumentBackend._parse_name_alternatives(alternatives_node)
+                if name:
+                    return name
+
+        if author_node.xpath("anonymous"):
+            return "Anonymous"
+
+        return ""
+
     def _find_metadata(self) -> etree._Element | None:
         meta_names: list[str] = ["article-meta", "book-part-meta"]
         meta: etree._Element | None = None
@@ -282,11 +351,9 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
                     author["affiliation_names"].append(affiliation_ids_names[id])
 
             # Name
-            author["name"] = (
-                author_node.xpath("name/given-names")[0].text
-                + " "
-                + author_node.xpath("name/surname")[0].text
-            )
+            author["name"] = JatsDocumentBackend._parse_contrib_name(author_node)
+            if not author["name"]:
+                continue
 
             authors.append(author)
 

--- a/tests/test_backend_jats.py
+++ b/tests/test_backend_jats.py
@@ -2,6 +2,7 @@ import os
 from io import BytesIO
 from pathlib import Path
 
+import pytest
 from docling_core.types.doc import DoclingDocument
 
 from docling.datamodel.base_models import DocumentStream, InputFormat
@@ -23,6 +24,88 @@ def get_jats_paths():
 def get_converter():
     converter = DocumentConverter(allowed_formats=[InputFormat.XML_JATS])
     return converter
+
+
+def convert_jats_contribs(contribs: str, affiliations: str = "") -> DoclingDocument:
+    xml = f"""<!DOCTYPE article
+PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN" "JATS-archivearticle1.dtd">
+<article article-type="research-article">
+  <front>
+    <article-meta>
+      <title-group><article-title>Author Variant Test</article-title></title-group>
+      <contrib-group>{contribs}</contrib-group>
+      {affiliations}
+    </article-meta>
+  </front>
+</article>
+"""
+    stream = DocumentStream(
+        name="author-variant-test.nxml", stream=BytesIO(xml.encode())
+    )
+    conv_result: ConversionResult = get_converter().convert(stream)
+    return conv_result.document
+
+
+@pytest.mark.parametrize(
+    ("contrib", "expected"),
+    [
+        (
+            """<contrib contrib-type="author"><name><given-names>Jane</given-names><surname>Doe</surname></name></contrib>""",
+            "Jane Doe",
+        ),
+        (
+            """<contrib contrib-type="author"><string-name>Jane Q. Doe</string-name></contrib>""",
+            "Jane Q. Doe",
+        ),
+        (
+            """<contrib contrib-type="author"><name-alternatives><name><given-names>Jane</given-names><surname>Doe</surname></name><string-name>J. Doe</string-name></name-alternatives></contrib>""",
+            "Jane Doe",
+        ),
+        (
+            """<contrib contrib-type="author"><collab-name>Example Working Group</collab-name></contrib>""",
+            "Example Working Group",
+        ),
+        (
+            """<contrib contrib-type="author"><collab>Deprecated Working Group</collab></contrib>""",
+            "Deprecated Working Group",
+        ),
+        (
+            """<contrib contrib-type="author"><collab-name-alternatives><collab-name>Primary Group</collab-name><collab>Legacy Group</collab></collab-name-alternatives></contrib>""",
+            "Primary Group",
+        ),
+        (
+            """<contrib contrib-type="author"><collab-alternatives><collab>Alternative Group</collab></collab-alternatives></contrib>""",
+            "Alternative Group",
+        ),
+        (
+            """<contrib contrib-type="author"><anonymous/></contrib>""",
+            "Anonymous",
+        ),
+        (
+            """<contrib contrib-type="author"><name><surname>Doe</surname></name></contrib>""",
+            "Doe",
+        ),
+        (
+            """<contrib contrib-type="author"><name><given-names>Jane</given-names></name></contrib>""",
+            "Jane",
+        ),
+    ],
+)
+def test_jats_author_name_variants(contrib: str, expected: str):
+    doc = convert_jats_contribs(contrib)
+
+    assert expected in doc.export_to_markdown()
+
+
+def test_jats_author_affiliations_still_map_from_xref():
+    doc = convert_jats_contribs(
+        """<contrib contrib-type="author"><name><given-names>Jane</given-names><surname>Doe</surname></name><xref ref-type="aff" rid="aff1">1</xref></contrib>""",
+        """<aff id="aff1"><label>1</label><addr-line>Example University</addr-line></aff>""",
+    )
+
+    md = doc.export_to_markdown()
+    assert "Jane Doe" in md
+    assert "Example University" in md
 
 
 def test_e2e_jats_conversions(use_stream=False):


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

## Context

The JATS XML backend previously assumed article-level authors always used this narrow structure:
```xml
<contrib contrib-type="author">
  <name>
    <given-names>...</given-names>
    <surname>...</surname>
  </name>
</contrib>
```
`JatsDocumentBackend._parse_authors()` indexed directly into:
```python
author_node.xpath("name/given-names")[0].text
author_node.xpath("name/surname")[0].text
```
That could raise `IndexError` for valid contributors missing either field, and it failed to represent other legal contributor naming forms such as `string-name`, `name-alternatives`, group authors, and anonymous contributors.
This is a schema-validity fix rather than a version-specific JATS migration.
## Summary
- Adds robust contributor-name parsing for JATS article authors.
- Preserves existing behavior for the simple structured `name` case.
- Supports `string-name`, `name-alternatives`, `collab`, `collab-name`, `collab-alternatives`, `collab-name-alternatives`, and `anonymous`.
- Handles structured personal names with partial fields, such as surname-only or given-name-only authors.
- Normalizes whitespace in parsed display names.
- Keeps existing affiliation extraction and `xref ref-type="aff"` mapping behavior unchanged.
## Behavior
Valid JATS contributor variants no longer crash conversion when `given-names` or `surname` are absent.
Parsed author names continue to appear in the generated Docling document metadata/header text.
Contributors without any displayable name are skipped rather than producing an empty author entry.
## Testing
- `uv run pytest tests/test_backend_jats.py -q`
- `make validate`
 - Smoke-tested conversion of two real-world JATS XML files:
   - `pubmedcentral_cloud-service_PMC10000194.1_PMC10000194.1.xml`
   - `aaas_signaling.2026.19.issue-934_scisignal.aea2753_scisignal.aea2753.xml`

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
