### PR TITLE
refactor: use ConversionStatus type for task_status field

### DIFF
--- a/docling/datamodel/service/responses.py
+++ b/docling/datamodel/service/responses.py
@@ -167,7 +167,7 @@ class ChunkDocumentResponse(BaseModel):
 class TaskStatusResponse(BaseModel):
     task_id: str
     task_type: TaskType
-    task_status: str
+    task_status: ConversionStatus
     task_position: Optional[int] = None
     task_meta: Optional[TaskProcessingMeta] = None
     error_message: Optional[str] = None


### PR DESCRIPTION
It looks as though the `task_status` of a `TaskStatusResponse` should be the same as the `status` of a `ConversionResuilt` at least for when the task is a conversion. The other type of task is a chunking task, would that have different statuses?

If this `task_status` field can be narrowed from str to an enum, the Docling-Serve API docs will be more useful.