### PR TITLE
feat: add image_placeholder and use_markdown_images as fields in the BaseChunkerOptions

### DIFF
--- a/docling/datamodel/service/chunking.py
+++ b/docling/datamodel/service/chunking.py
@@ -49,7 +49,7 @@ class BaseChunkerOptions(BaseModel):
             ),
         ),
     ] = "![IMAGE]"
-    
+
     include_raw_text: Annotated[
         bool,
         Field(

--- a/docling/datamodel/service/chunking.py
+++ b/docling/datamodel/service/chunking.py
@@ -29,6 +29,27 @@ class BaseChunkerOptions(BaseModel):
         ),
     ] = False
 
+    use_markdown_images: Annotated[
+        bool,
+        Field(
+            description=(
+                "Enable image serialization and image references inside chunks. "
+                "Also adds a `has_image` field to chunk metadata to make image-containing "
+                "chunks easier to identify."
+            ),
+        ),
+    ] = False
+
+    image_placeholder: Annotated[
+        str,
+        Field(
+            description=(
+                "Placeholder text used inside chunks to reference an image when "
+                "markdown image serialization is disabled."
+            ),
+        ),
+    ] = "![IMAGE]"
+    
     include_raw_text: Annotated[
         bool,
         Field(


### PR DESCRIPTION
### Add image control options for chunking

This PR introduces new configuration options to improve flexibility in how images are represented inside chunked outputs.

### Changes

* Added `use_markdown_images: bool` to `BaseChunkerOptions`

  * Enables markdown-based image references inside chunks
  * When enabled, images are serialized as markdown instead of plain placeholders
  * Adds a `has_image: bool` field in chunk metadata to indicate whether a chunk contains images

* Added `image_placeholder: str` to `BaseChunkerOptions`

  * Defines the placeholder used inside chunks when markdown image serialization is disabled
  * Default value is `"![IMAGE]"`

### Motivation

Currently, image representation inside chunks is tightly coupled with `ConvertDocumentsOptions.image_export_mode`, which reduces flexibility and mixes export concerns with chunking logic.

This change decouples chunk-level image representation from document export configuration, allowing:

* Independent control of chunk formatting versus export formatting
* Easier detection of image-containing chunks via metadata
* More flexibility for downstream use cases such as retrieval pipelines and indexing

### Behavior

* When `use_markdown_images` is `True`, images are inserted as markdown image references in chunks
* When `False`, the `image_placeholder` value is used instead
* The `has_image` metadata field is added to chunks that contain at least one image reference

### Notes

This change is backward compatible. Default behavior preserves existing chunk output semantics.
