### PR TITLE
fix(service): Improve transport-level connection error handing in client SDK

### DIFF
--- a/docling/service_client/client.py
+++ b/docling/service_client/client.py
@@ -1387,12 +1387,14 @@ class DoclingServiceClient:
         max_retries: int,
     ) -> tuple[httpx.Response | None, float]:
         """Return (response, 0.0) to yield, (None, delay) to retry after delay, or raise."""
-        if response.status_code == 500:
+        if response.status_code in {500, 502}:
             return self._retry_with_exponential_backoff(
                 response=response,
                 attempt=attempt,
                 max_retries=max_retries,
-                error_message="Service returned HTTP 500 after retries.",
+                error_message=(
+                    f"Service returned HTTP {response.status_code} after retries."
+                ),
             )
         if response.status_code in {429, 503}:
             return self._retry_with_retry_after_header(

--- a/docling/service_client/client.py
+++ b/docling/service_client/client.py
@@ -91,6 +91,7 @@ DEFAULT_MAX_CONCURRENCY = 8
 MAX_CONCURRENCY_LIMIT = 512
 SUBMIT_AND_RETRIEVE_MANY_MAX_IN_FLIGHT_WEBSOCKETS = 64
 HTTP_RETRY_BACKOFF_BASE_SECONDS = 1.0
+TRANSPORT_RETRYABLE_HTTP_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -1439,6 +1440,27 @@ class DoclingServiceClient:
     def _exponential_backoff_delay(self, attempt: int) -> float:
         return HTTP_RETRY_BACKOFF_BASE_SECONDS * (2**attempt)
 
+    def _transport_retry_delay(
+        self,
+        *,
+        method: str,
+        exc: httpx.HTTPError,
+        attempt: int,
+        max_retries: int,
+    ) -> float | None:
+        method_name = method.upper()
+        if (
+            not isinstance(exc, httpx.TransportError)
+            or method_name not in TRANSPORT_RETRYABLE_HTTP_METHODS
+        ):
+            return None
+        if attempt < max_retries:
+            return self._exponential_backoff_delay(attempt)
+        raise ServiceUnavailableError(
+            "Service transport request failed after retries.",
+            detail=str(exc),
+        ) from exc
+
     def _retry_after_delay_seconds(self, response: httpx.Response) -> float | None:
         retry_after_header = response.headers.get("Retry-After")
         if retry_after_header is None:
@@ -1469,11 +1491,12 @@ class DoclingServiceClient:
         retries: int | None = None,
     ) -> httpx.Response:
         url = self._url(path)
+        method_name = method.upper()
         max_retries = self._http_retries if retries is None else retries
         for attempt in range(max_retries + 1):
             try:
                 response = self._http_client.request(
-                    method=method,
+                    method=method_name,
                     url=url,
                     json=json,
                     data=data,
@@ -1482,6 +1505,15 @@ class DoclingServiceClient:
                     headers=headers,
                 )
             except httpx.HTTPError as exc:
+                delay = self._transport_retry_delay(
+                    method=method_name,
+                    exc=exc,
+                    attempt=attempt,
+                    max_retries=max_retries,
+                )
+                if delay is not None:
+                    time.sleep(delay)
+                    continue
                 raise ServiceUnavailableError(
                     "Service transport request failed.",
                     detail=str(exc),
@@ -1507,11 +1539,12 @@ class DoclingServiceClient:
         retries: int | None = None,
     ) -> httpx.Response:
         url = self._url(path)
+        method_name = method.upper()
         max_retries = self._http_retries if retries is None else retries
         for attempt in range(max_retries + 1):
             try:
                 response = await async_client.request(
-                    method=method,
+                    method=method_name,
                     url=url,
                     json=json,
                     data=data,
@@ -1520,6 +1553,15 @@ class DoclingServiceClient:
                     headers=headers,
                 )
             except httpx.HTTPError as exc:
+                delay = self._transport_retry_delay(
+                    method=method_name,
+                    exc=exc,
+                    attempt=attempt,
+                    max_retries=max_retries,
+                )
+                if delay is not None:
+                    await asyncio.sleep(delay)
+                    continue
                 raise ServiceUnavailableError(
                     "Service transport request failed.",
                     detail=str(exc),

--- a/docling/service_client/watchers.py
+++ b/docling/service_client/watchers.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import Callable, Iterator
 from typing import Protocol
 
-from websockets.exceptions import ConnectionClosedOK
+from websockets.exceptions import ConnectionClosedError, ConnectionClosedOK
 from websockets.sync.client import connect
 
 from docling.datamodel.service.responses import (
@@ -20,7 +21,11 @@ from docling.service_client.exceptions import (
     TaskTimeoutError,
 )
 
+_logger = logging.getLogger(__name__)
+
 TERMINAL_TASK_STATUSES: set[str] = {"success", "failure"}
+WS_MAX_RECONNECT_ATTEMPTS = 3
+WS_RECONNECT_BACKOFF_BASE_SECONDS = 1.0
 
 
 def is_terminal_task_status(status: TaskStatusResponse) -> bool:
@@ -159,63 +164,82 @@ class WebSocketWatcher:
     ) -> Iterator[TaskStatusResponse]:
         ws_url = self._ws_url_for_task(task_id)
         deadline = time.monotonic() + timeout
-        try:
-            with connect(
-                ws_url,
-                open_timeout=self._connect_timeout,
-                close_timeout=self._connect_timeout,
-                additional_headers=self._additional_headers,
-            ) as websocket:
-                while True:
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
-                        raise TaskTimeoutError(
-                            f"Timed out waiting for task {task_id} after {timeout:.2f}s."
-                        )
 
-                    raw_message = websocket.recv(timeout=remaining)
-                    envelope = WebsocketMessage.model_validate_json(raw_message)
+        for attempt in range(WS_MAX_RECONNECT_ATTEMPTS + 1):
+            try:
+                yield from self._iter_ws_connection(ws_url, task_id, deadline, timeout)
+                return
+            except (ConnectionClosedError, OSError) as exc:
+                remaining = deadline - time.monotonic()
+                if attempt >= WS_MAX_RECONNECT_ATTEMPTS or remaining <= 0:
+                    raise ServiceUnavailableError(
+                        "WebSocket status stream is unavailable.", detail=str(exc)
+                    ) from exc
+                delay = min(WS_RECONNECT_BACKOFF_BASE_SECONDS * (2**attempt), remaining)
+                _logger.warning(
+                    "WebSocket connection dropped for task %s: %s — reconnecting in %.1fs",
+                    task_id,
+                    exc,
+                    delay,
+                )
+                time.sleep(delay)
+            except (TaskTimeoutError, TaskNotFoundError, ServiceUnavailableError):
+                raise
+            except Exception as exc:
+                raise ServiceUnavailableError(
+                    "WebSocket status stream is unavailable.", detail=str(exc)
+                ) from exc
 
-                    if envelope.error:
-                        if envelope.error == "Task not found.":
-                            raise TaskNotFoundError(f"Task {task_id} was not found.")
-                        raise ServiceUnavailableError(
-                            "WebSocket status stream failed.",
-                            detail=envelope.error,
-                        )
+    def _iter_ws_connection(
+        self, ws_url: str, task_id: str, deadline: float, timeout: float
+    ) -> Iterator[TaskStatusResponse]:
+        with connect(
+            ws_url,
+            open_timeout=self._connect_timeout,
+            close_timeout=self._connect_timeout,
+            additional_headers=self._additional_headers,
+        ) as websocket:
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise TaskTimeoutError(
+                        f"Timed out waiting for task {task_id} after {timeout:.2f}s."
+                    )
 
-                    if envelope.task is None:
-                        continue
+                raw_message = websocket.recv(timeout=remaining)
+                envelope = WebsocketMessage.model_validate_json(raw_message)
 
-                    yield envelope.task
-                    if is_terminal_task_status(envelope.task):
+                if envelope.error:
+                    if envelope.error == "Task not found.":
+                        raise TaskNotFoundError(f"Task {task_id} was not found.")
+                    raise ServiceUnavailableError(
+                        "WebSocket status stream failed.",
+                        detail=envelope.error,
+                    )
+
+                if envelope.task is None:
+                    continue
+
+                yield envelope.task
+                if is_terminal_task_status(envelope.task):
+                    return
+
+                # Only send "next" for UPDATE messages.  The server sends
+                # CONNECTION once before the update loop begins; sending
+                # "next" in response to it would queue an extra token that
+                # the server later consumes as a request for a post-terminal
+                # UPDATE, causing a send-after-close RuntimeError.
+                if envelope.message == MessageKind.UPDATE:
+                    try:
+                        websocket.send("next")
+                    except ConnectionClosedOK:
+                        # The current server contract mixes request/response
+                        # "next" handshakes with async notifier-driven closes.
+                        # Under that contract, the socket may close cleanly
+                        # after an UPDATE but before the client can ask for
+                        # the next one. Treat that as normal end-of-stream.
+                        #
+                        # Once the server websocket contract is simplified to
+                        # a pure push stream, remove the "next" handshake
+                        # entirely instead of keeping this special case.
                         return
-
-                    # Only send "next" for UPDATE messages.  The server sends
-                    # CONNECTION once before the update loop begins; sending
-                    # "next" in response to it would queue an extra token that
-                    # the server later consumes as a request for a post-terminal
-                    # UPDATE, causing a send-after-close RuntimeError.
-                    if envelope.message == MessageKind.UPDATE:
-                        try:
-                            websocket.send("next")
-                        except ConnectionClosedOK:
-                            # The current server contract mixes request/response
-                            # "next" handshakes with async notifier-driven closes.
-                            # Under that contract, the socket may close cleanly
-                            # after an UPDATE but before the client can ask for
-                            # the next one. Treat that as normal end-of-stream.
-                            #
-                            # Once the server websocket contract is simplified to
-                            # a pure push stream, remove the "next" handshake
-                            # entirely instead of keeping this special case.
-                            return
-
-        except TaskTimeoutError:
-            raise
-        except TaskNotFoundError:
-            raise
-        except Exception as exc:
-            raise ServiceUnavailableError(
-                "WebSocket status stream is unavailable.", detail=str(exc)
-            ) from exc

--- a/tests/test_service_client_sdk_unit.py
+++ b/tests/test_service_client_sdk_unit.py
@@ -1538,6 +1538,77 @@ def test_503_after_all_retries_raises_service_unavailable_error(
             )
 
 
+def test_get_transport_error_retries_with_exponential_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(client_module.time, "sleep", lambda s: sleep_calls.append(s))
+
+    call_count = 0
+
+    def fake_request(**kw: object) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise httpx.ConnectTimeout("connect timed out")
+        return httpx.Response(200, json={})
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        client._http_client.request = fake_request  # type: ignore[method-assign]
+        response = client._request_with_retry(method="GET", path="/v1/result/task-123")
+
+    assert response.status_code == 200
+    assert sleep_calls == [1.0, 2.0]
+
+
+def test_post_transport_error_does_not_retry() -> None:
+    call_count = 0
+
+    def fake_request(**kw: object) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        raise httpx.ConnectTimeout("connect timed out")
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        client._http_client.request = fake_request  # type: ignore[method-assign]
+        with pytest.raises(
+            ServiceUnavailableError,
+            match="Service transport request failed",
+        ):
+            client._request_with_retry(
+                method="POST", path="/v1/convert/source/async", retries=3
+            )
+
+    assert call_count == 1
+
+
+def test_get_transport_error_after_all_retries_raises_service_unavailable_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(client_module.time, "sleep", lambda s: sleep_calls.append(s))
+
+    call_count = 0
+
+    def fake_request(**kw: object) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        raise httpx.ConnectTimeout("connect timed out")
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        client._http_client.request = fake_request  # type: ignore[method-assign]
+        with pytest.raises(
+            ServiceUnavailableError,
+            match="Service transport request failed after retries",
+        ):
+            client._request_with_retry(
+                method="GET", path="/v1/result/task-123", retries=2
+            )
+
+    assert call_count == 3
+    assert sleep_calls == [1.0, 2.0]
+
+
 @pytest.mark.anyio
 async def test_503_with_retry_after_header_retries_async(
     monkeypatch: pytest.MonkeyPatch,
@@ -1639,6 +1710,63 @@ async def test_502_retries_with_exponential_backoff_async(
 
     assert response.status_code == 200
     assert sleep_calls == [1.0, 2.0, 4.0]
+
+
+@pytest.mark.anyio
+async def test_get_transport_error_retries_async(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(s: float) -> None:
+        sleep_calls.append(s)
+
+    monkeypatch.setattr(client_module.asyncio, "sleep", fake_sleep)
+
+    call_count = 0
+
+    class FakeAsyncClient:
+        async def request(self, **kw: object) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise httpx.ConnectTimeout("connect timed out")
+            return httpx.Response(200, json={})
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        response = await client._request_with_retry_async(
+            async_client=FakeAsyncClient(),  # type: ignore[arg-type]
+            method="GET",
+            path="/v1/result/task-123",
+        )
+
+    assert response.status_code == 200
+    assert sleep_calls == [1.0, 2.0]
+
+
+@pytest.mark.anyio
+async def test_post_transport_error_does_not_retry_async() -> None:
+    call_count = 0
+
+    class FakeAsyncClient:
+        async def request(self, **kw: object) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            raise httpx.ConnectTimeout("connect timed out")
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        with pytest.raises(
+            ServiceUnavailableError,
+            match="Service transport request failed",
+        ):
+            await client._request_with_retry_async(
+                async_client=FakeAsyncClient(),  # type: ignore[arg-type]
+                method="POST",
+                path="/v1/convert/source/async",
+                retries=3,
+            )
+
+    assert call_count == 1
 
 
 # --- Path-prefix URL tests ---

--- a/tests/test_service_client_sdk_unit.py
+++ b/tests/test_service_client_sdk_unit.py
@@ -1498,6 +1498,31 @@ def test_500_retries_with_exponential_backoff(
     assert sleep_calls == [1.0, 2.0, 4.0]
 
 
+def test_502_retries_with_exponential_backoff(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleep_calls: list[float] = []
+    monkeypatch.setattr(client_module.time, "sleep", lambda s: sleep_calls.append(s))
+
+    call_count = 0
+
+    def fake_request(**kw: object) -> httpx.Response:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 4:
+            return httpx.Response(502, json={"detail": "bad gateway"})
+        return httpx.Response(200, json={})
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        client._http_client.request = fake_request  # type: ignore[method-assign]
+        response = client._request_with_retry(
+            method="POST", path="/v1/convert/source/async", retries=3
+        )
+
+    assert response.status_code == 200
+    assert sleep_calls == [1.0, 2.0, 4.0]
+
+
 def test_503_after_all_retries_raises_service_unavailable_error(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1581,6 +1606,39 @@ async def test_429_with_retry_after_header_retries_async(
 
     assert response.status_code == 200
     assert sleep_calls == [5.0]
+
+
+@pytest.mark.anyio
+async def test_502_retries_with_exponential_backoff_async(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(s: float) -> None:
+        sleep_calls.append(s)
+
+    monkeypatch.setattr(client_module.asyncio, "sleep", fake_sleep)
+
+    call_count = 0
+
+    class FakeAsyncClient:
+        async def request(self, **kw: object) -> httpx.Response:
+            nonlocal call_count
+            call_count += 1
+            if call_count < 4:
+                return httpx.Response(502, json={"detail": "bad gateway"})
+            return httpx.Response(200, json={})
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        response = await client._request_with_retry_async(
+            async_client=FakeAsyncClient(),  # type: ignore[arg-type]
+            method="POST",
+            path="/v1/convert/source/async",
+            retries=3,
+        )
+
+    assert response.status_code == 200
+    assert sleep_calls == [1.0, 2.0, 4.0]
 
 
 # --- Path-prefix URL tests ---

--- a/tests/test_service_client_sdk_unit.py
+++ b/tests/test_service_client_sdk_unit.py
@@ -315,6 +315,142 @@ def test_websocket_watcher_treats_clean_close_on_next_as_end_of_stream(
     assert [update.task_status for update in updates] == ["pending", "pending"]
 
 
+def test_websocket_watcher_reconnects_after_connection_drop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeConnectionClosedError(Exception):
+        pass
+
+    class FakeConnectionClosedOK(Exception):
+        pass
+
+    connection_calls: list[int] = []
+
+    class FirstConnection:
+        def __init__(self) -> None:
+            self._consumed = False
+
+        def __enter__(self) -> "FirstConnection":
+            return self
+
+        def recv(self, timeout: float | None = None) -> str:
+            if self._consumed:
+                raise FakeConnectionClosedError("connection reset")
+            self._consumed = True
+            return WebsocketMessage(
+                message=MessageKind.CONNECTION,
+                task=_status_response("task-1", "pending"),
+            ).model_dump_json()
+
+        def send(self, message: str) -> None:
+            pass
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    class SecondConnection:
+        def __init__(self) -> None:
+            self._messages = iter(
+                [
+                    WebsocketMessage(
+                        message=MessageKind.CONNECTION,
+                        task=_status_response("task-1", "pending"),
+                    ).model_dump_json(),
+                    WebsocketMessage(
+                        message=MessageKind.UPDATE,
+                        task=_status_response("task-1", "success"),
+                    ).model_dump_json(),
+                ]
+            )
+
+        def recv(self, timeout: float | None = None) -> str:
+            return next(self._messages)
+
+        def send(self, message: str) -> None:
+            pass
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def __enter__(self) -> "SecondConnection":
+            return self
+
+    connections = iter([FirstConnection(), SecondConnection()])
+
+    def fake_connect(*args, **kwargs):
+        connection_calls.append(1)
+        return next(connections)
+
+    monkeypatch.setattr(
+        watchers_module, "ConnectionClosedError", FakeConnectionClosedError
+    )
+    monkeypatch.setattr(watchers_module, "ConnectionClosedOK", FakeConnectionClosedOK)
+    monkeypatch.setattr(watchers_module, "connect", fake_connect)
+    monkeypatch.setattr(watchers_module.time, "sleep", lambda _: None)
+
+    watcher = watchers_module.WebSocketWatcher(
+        ws_url_for_task=lambda task_id: f"ws://example.invalid/{task_id}",
+        poll_fallback=None,
+        fallback_to_poll=False,
+        connect_timeout=1.0,
+        default_timeout=10.0,
+    )
+
+    updates = list(watcher.iter_updates(task_id="task-1"))
+
+    assert len(connection_calls) == 2
+    assert [u.task_status for u in updates] == ["pending", "pending", "success"]
+
+
+def test_websocket_watcher_raises_after_max_reconnect_attempts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeConnectionClosedError(Exception):
+        pass
+
+    class FakeConnectionClosedOK(Exception):
+        pass
+
+    connection_calls: list[int] = []
+
+    class DroppingConnection:
+        def __enter__(self) -> "DroppingConnection":
+            return self
+
+        def recv(self, timeout: float | None = None) -> str:
+            raise FakeConnectionClosedError("connection reset")
+
+        def send(self, message: str) -> None:
+            pass
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    def fake_connect(*args, **kwargs):
+        connection_calls.append(1)
+        return DroppingConnection()
+
+    monkeypatch.setattr(
+        watchers_module, "ConnectionClosedError", FakeConnectionClosedError
+    )
+    monkeypatch.setattr(watchers_module, "ConnectionClosedOK", FakeConnectionClosedOK)
+    monkeypatch.setattr(watchers_module, "connect", fake_connect)
+    monkeypatch.setattr(watchers_module.time, "sleep", lambda _: None)
+
+    watcher = watchers_module.WebSocketWatcher(
+        ws_url_for_task=lambda task_id: f"ws://example.invalid/{task_id}",
+        poll_fallback=None,
+        fallback_to_poll=False,
+        connect_timeout=1.0,
+        default_timeout=10.0,
+    )
+
+    with pytest.raises(watchers_module.ServiceUnavailableError):
+        list(watcher.iter_updates(task_id="task-1"))
+
+    assert len(connection_calls) == watchers_module.WS_MAX_RECONNECT_ATTEMPTS + 1
+
+
 @pytest.mark.anyio
 async def test_async_wait_for_terminal_enforces_minimum_client_cadence(
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
The client now retries automatically when it hits connectivity problems, covering three classes of failures observed in load testing:
- 502 Bad Gateway is added to the set of error codes retried with exponential backoff alongside 500. This handles load balancer hiccups during pod restarts.
- TransportError exceptions (connection refused, reset, etc.) on idempotent methods (GET, HEAD, OPTIONS) are now retried with exponential backoff rather than failing immediately. Non-idempotent methods (POST, PUT, …) still fail fast since retrying them risks duplicate side effects.
- WebSocket reconnection: The WS status watcher now attempts to reconnect up to 3 times (backoff: 1s → 2s → 4s) when a connection drops unexpectedly (ConnectionClosedError, OSError). The overall job timeout budget is shared across all reconnect attempts, so retries don't extend the deadline. Semantic errors from the server (task not found, server-sent error payload) are not retried. A WARNING log is emitted on each reconnect attempt for observability.

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
