### PR TITLE
chore: add shared Python agent skills

### DIFF
--- a/.agents/skills/building-pydantic-ai-agents/SKILL.md
+++ b/.agents/skills/building-pydantic-ai-agents/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: building-pydantic-ai-agents
+description: Build AI agents with Pydantic AI — tools, capabilities, structured output, streaming, testing, and multi-agent patterns. Use when the user mentions Pydantic AI, imports pydantic_ai, or asks to build an AI agent, add tools/capabilities, stream output, define agents from YAML, or test agent behavior.
+license: MIT
+compatibility: Requires Python 3.10+
+metadata:
+  version: "1.1.0"
+  author: pydantic
+---
+
+# Building AI Agents with Pydantic AI
+
+Pydantic AI is a Python agent framework for building production-grade Generative AI applications.
+This skill provides patterns, architecture guidance, and tested code examples for building applications with Pydantic AI.
+
+## When to Use This Skill
+
+Invoke this skill when:
+- User asks to build an AI agent, create an LLM-powered app, or mentions Pydantic AI
+- User wants to add tools, capabilities (thinking, web search), or structured output to an agent
+- User asks to define agents from YAML/JSON specs or use template strings
+- User wants to stream agent events, delegate between agents, or test agent behavior
+- Code imports `pydantic_ai` or references Pydantic AI classes (`Agent`, `RunContext`, `Tool`)
+- User asks about hooks, lifecycle interception, or agent observability with Logfire
+
+Do **not** use this skill for:
+- The Pydantic validation library alone (`pydantic`/`BaseModel` without agents)
+- Other AI frameworks (LangChain, LlamaIndex, CrewAI, AutoGen)
+- General Python development unrelated to AI agents
+
+## Quick-Start Patterns
+
+### Create a Basic Agent
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    instructions='Be concise, reply with one sentence.',
+)
+
+result = agent.run_sync('Where does "hello world" come from?')
+print(result.output)
+"""
+The first known use of "hello, world" was in a 1974 textbook about the C programming language.
+"""
+```
+
+### Add Tools to an Agent
+
+```python
+import random
+
+from pydantic_ai import Agent, RunContext
+
+agent = Agent(
+    'google-gla:gemini-3-flash-preview',
+    deps_type=str,
+    instructions=(
+        "You're a dice game, you should roll the die and see if the number "
+        "you get back matches the user's guess. If so, tell them they're a winner. "
+        "Use the player's name in the response."
+    ),
+)
+
+
+@agent.tool_plain
+def roll_dice() -> str:
+    """Roll a six-sided die and return the result."""
+    return str(random.randint(1, 6))
+
+
+@agent.tool
+def get_player_name(ctx: RunContext[str]) -> str:
+    """Get the player's name."""
+    return ctx.deps
+
+
+dice_result = agent.run_sync('My guess is 4', deps='Anne')
+print(dice_result.output)
+#> Congratulations Anne, you guessed correctly! You're a winner!
+```
+
+### Structured Output with Pydantic Models
+
+```python
+from pydantic import BaseModel
+
+from pydantic_ai import Agent
+
+
+class CityLocation(BaseModel):
+    city: str
+    country: str
+
+
+agent = Agent('google-gla:gemini-3-flash-preview', output_type=CityLocation)
+result = agent.run_sync('Where were the olympics held in 2012?')
+print(result.output)
+#> city='London' country='United Kingdom'
+print(result.usage())
+#> RunUsage(input_tokens=57, output_tokens=8, requests=1)
+```
+
+### Dependency Injection
+
+```python
+from datetime import date
+
+from pydantic_ai import Agent, RunContext
+
+agent = Agent(
+    'openai:gpt-5.2',
+    deps_type=str,
+    instructions="Use the customer's name while replying to them.",
+)
+
+
+@agent.instructions
+def add_the_users_name(ctx: RunContext[str]) -> str:
+    return f"The user's name is {ctx.deps}."
+
+
+@agent.instructions
+def add_the_date() -> str:
+    return f'The date is {date.today()}.'
+
+
+result = agent.run_sync('What is the date?', deps='Frank')
+print(result.output)
+#> Hello Frank, the date today is 2032-01-02.
+```
+
+### Testing with TestModel
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+my_agent = Agent('openai:gpt-5.2', instructions='...')
+
+
+async def test_my_agent():
+    """Unit test for my_agent, to be run by pytest."""
+    m = TestModel()
+    with my_agent.override(model=m):
+        result = await my_agent.run('Testing my agent...')
+        assert result.output == 'success (no tool calls)'
+    assert m.last_model_request_parameters.function_tools == []
+```
+
+### Use Capabilities
+
+Capabilities are reusable, composable units of agent behavior — bundling tools, hooks, instructions, and model settings.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import Thinking, WebSearch
+
+agent = Agent(
+    'anthropic:claude-opus-4-6',
+    instructions='You are a research assistant. Be thorough and cite sources.',
+    capabilities=[
+        Thinking(effort='high'),
+        WebSearch(),
+    ],
+)
+```
+
+### Add Lifecycle Hooks
+
+Use `Hooks` to intercept model requests, tool calls, and runs with decorators — no subclassing needed.
+
+```python
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.capabilities.hooks import Hooks
+from pydantic_ai.models import ModelRequestContext
+
+hooks = Hooks()
+
+
+@hooks.on.before_model_request
+async def log_request(ctx: RunContext[None], request_context: ModelRequestContext) -> ModelRequestContext:
+    print(f'Sending {len(request_context.messages)} messages')
+    return request_context
+
+
+agent = Agent('openai:gpt-5.2', capabilities=[hooks])
+```
+
+### Define Agent from YAML Spec
+
+Use `Agent.from_file` to load agents from YAML or JSON — no Python agent construction code needed.
+
+```python
+from pydantic_ai import Agent
+
+# agent.yaml:
+# model: anthropic:claude-opus-4-6
+# instructions: You are a helpful research assistant.
+# capabilities:
+#   - WebSearch
+#   - Thinking:
+#       effort: high
+
+agent = Agent.from_file('agent.yaml')
+```
+
+## Task Routing Table
+
+Load only the most relevant reference first. Read additional references only if the task spans multiple areas.
+
+| I want to... | Reference |
+|---|---|
+| Create/configure agents, choose output types, use deps, define specs, or pick run methods | [Agents Core](./references/AGENTS-CORE.md) |
+| Bundle reusable behavior or intercept lifecycle events | [Capabilities and Hooks](./references/CAPABILITIES-AND-HOOKS.md) |
+| Add function tools, toolsets, MCP servers, or explicit search tools | [Tools Core](./references/TOOLS-CORE.md) |
+| Use provider-native web search, web fetch, or code execution | [Built-in Tools](./references/BUILTIN-TOOLS.md) |
+| Use advanced tool features such as approval, retries, `ToolReturn`, validators, timeouts, or tool search | [Tools Advanced](./references/TOOLS-ADVANCED.md) |
+| Work with multimodal input, message history, or context trimming | [Input and History](./references/INPUT-AND-HISTORY.md) |
+| Test or debug agent behavior | [Testing and Debugging](./references/TESTING-AND-DEBUGGING.md) |
+| Coordinate multiple agents or build graph workflows | [Orchestration and Integrations](./references/ORCHESTRATION-AND-INTEGRATIONS.md#coordinate-multiple-agents) |
+| Call the model directly, expose A2A, use durable execution, embeddings, evals, or third-party integrations | [Orchestration and Integrations](./references/ORCHESTRATION-AND-INTEGRATIONS.md) |
+| Compare abstractions, output modes, decorators, or model-string patterns | [Architecture and Decision Guide](./references/ARCHITECTURE.md) |
+| Follow an older link into `COMMON-TASKS.md` | [Task Reference Map](./references/COMMON-TASKS.md) |
+
+## Architecture and Decisions
+
+Load [Architecture and Decision Guide](./references/ARCHITECTURE.md) only when the user is choosing between abstractions or wants comparison tables and decision trees:
+
+| Topic | What it covers |
+|---|---|
+| Decision Trees | Tool registration, output modes, multi-agent patterns, capabilities, testing approaches, extensibility |
+| Comparison Tables | Output modes, model provider prefixes, tool decorators, built-in capabilities, agent methods |
+| Architecture Overview | Execution flow, generic types, construction patterns, lifecycle hooks, model string format |
+
+**Quick reference — model string format:** `"provider:model-name"` (e.g., `"openai:gpt-5.2"`, `"anthropic:claude-sonnet-4-6"`, `"google-gla:gemini-3-pro-preview"`)
+
+**Quick reference — key agent methods:** `run()`, `run_sync()`, `run_stream()`, `run_stream_sync()`, `run_stream_events()`, `iter()`
+
+## Key Practices
+
+- **Python 3.10+** compatibility required
+- **Observability**: Pydantic AI has first-class integration with Logfire for tracing agent runs, tool calls, and model requests. Add it with `logfire.instrument_pydantic_ai()`. For deeper HTTP-level visibility, `logfire.instrument_httpx(capture_all=True)` captures the exact payloads sent to model providers.
+- **Testing**: Use `TestModel` for deterministic tests, `FunctionModel` for custom logic
+
+## Common Gotchas
+
+These are mistakes agents commonly make with Pydantic AI. Getting these wrong produces silent failures or confusing errors.
+
+- **`@agent.tool` requires `RunContext` as first param**; `@agent.tool_plain` must **not** have it. Mixing these up causes runtime errors. Use `tool_plain` when you don't need deps, usage, or messages.
+- **Model strings need the provider prefix**: `'openai:gpt-5.2'` not `'gpt-5.2'`. Without the prefix, Pydantic AI can't resolve the provider.
+- **`TestModel` requires `agent.override()`**: Don't set `agent.model` directly. Always use the context manager: `with agent.override(model=TestModel()):`.
+- **`str` in output_type allows plain text to end the run**: If your union includes `str` (or no `output_type` is set), the model can return plain text instead of structured output. Omit `str` from the union to force tool-based output.
+- **Hook decorator names on `.on` don't repeat `on_`**: Use `hooks.on.run_error` and `hooks.on.model_request_error` — not `hooks.on.on_run_error`.
+- **`history_processors` is plural**: The Agent parameter is `history_processors=[...]`, not `history_processor=`.
+
+## Task-Family References
+
+Load exactly one of these unless the task clearly spans multiple families:
+
+| Task family | Reference |
+|---|---|
+| Core agent setup, output, deps, specs, models, run methods | [Agents Core](./references/AGENTS-CORE.md) |
+| Capabilities, hooks, and reusable behavior | [Capabilities and Hooks](./references/CAPABILITIES-AND-HOOKS.md) |
+| Function tools, toolsets, MCP, explicit search tools | [Tools Core](./references/TOOLS-CORE.md) |
+| Provider-native builtin tools | [Built-in Tools](./references/BUILTIN-TOOLS.md) |
+| Approval, retries, validators, timeouts, rich tool returns, deferred loading | [Tools Advanced](./references/TOOLS-ADVANCED.md) |
+| Multimodal input, message history, history processors | [Input and History](./references/INPUT-AND-HISTORY.md) |
+| Testing, request inspection, and Logfire debugging | [Testing and Debugging](./references/TESTING-AND-DEBUGGING.md) |
+| Multi-agent patterns, graphs, direct API, A2A, durable execution, embeddings, evals, third-party integrations | [Orchestration and Integrations](./references/ORCHESTRATION-AND-INTEGRATIONS.md) |
+
+Use [Task Reference Map](./references/COMMON-TASKS.md) only for compatibility with older links or when you need a pointer from an old section name to the new file.

--- a/.agents/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
+++ b/.agents/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
@@ -1,0 +1,158 @@
+# Agents Core
+
+Read this file when the user needs the core `Agent` workflow: creating agents, choosing output types, using dependencies, defining specs, selecting models, or choosing how to run/stream an agent.
+
+## Create a Basic Agent
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    instructions='Be concise, reply with one sentence.',
+)
+
+result = agent.run_sync('Where does "hello world" come from?')
+print(result.output)
+```
+
+## Structured Output with Pydantic Models
+
+Use `output_type=MyModel` when the model should return validated structured data.
+
+```python
+from pydantic import BaseModel
+
+from pydantic_ai import Agent
+
+
+class CityLocation(BaseModel):
+    city: str
+    country: str
+
+
+agent = Agent('google-gla:gemini-3-flash-preview', output_type=CityLocation)
+result = agent.run_sync('Where were the olympics held in 2012?')
+print(result.output)
+```
+
+If the user is choosing between output modes:
+
+- `output_type=str` for plain text
+- `output_type=MyModel` for structured output
+- `TextOutput` for custom text parsing
+- `NativeOutput` or `ToolOutput` when they need explicit output-mode control
+
+## Dependency Injection
+
+Use `deps_type=...` plus `RunContext[...]` when tools or instructions need app state.
+
+```python
+from pydantic_ai import Agent, RunContext
+
+agent = Agent('openai:gpt-5.2', deps_type=str)
+
+
+@agent.instructions
+def add_user_name(ctx: RunContext[str]) -> str:
+    return f"The user's name is {ctx.deps}."
+```
+
+Use `@agent.tool` when the tool needs `RunContext`. Use `@agent.tool_plain` when it does not.
+
+## Define Agents Declaratively with Specs
+
+Use YAML or JSON specs when configuration should live outside Python code.
+
+```yaml
+model: anthropic:claude-opus-4-6
+instructions: "You are helping {{user_name}} with research."
+capabilities:
+  - WebSearch
+  - Thinking:
+      effort: high
+```
+
+```python
+from dataclasses import dataclass
+
+from pydantic_ai import Agent
+
+
+@dataclass
+class UserContext:
+    user_name: str
+
+
+agent = Agent.from_file('agent.yaml', deps_type=UserContext)
+result = agent.run_sync('Find recent papers on AI safety', deps=UserContext(user_name='Alice'))
+```
+
+Template strings are part of the spec flow, so route template-string questions here too.
+
+## Choose or Configure Models
+
+Model strings use the `"provider:model-name"` format.
+
+Examples:
+
+- `openai:gpt-5.2`
+- `anthropic:claude-sonnet-4-6`
+- `google-gla:gemini-3-pro-preview`
+
+Use a model instance instead of a string when the user needs provider-specific constructor arguments.
+
+## Run Methods and Streaming
+
+Pick a run method based on the interaction pattern:
+
+- `run()` for async runs that complete normally
+- `run_sync()` for synchronous scripts and notebooks
+- `run_stream()` for streaming final output
+- `run_stream_sync()` for sync streaming
+- `run_stream_events()` when the caller needs the typed event stream directly
+- `iter()` when the caller needs step-by-step control over the agent loop
+
+Use `event_stream_handler=` with `run()` or `run_stream()` when the user wants progress updates without manually consuming the event stream:
+
+```python
+from collections.abc import AsyncIterable
+
+from pydantic_ai import Agent, AgentStreamEvent, FunctionToolCallEvent, RunContext
+
+agent = Agent('openai:gpt-5.2')
+
+
+async def stream_handler(ctx: RunContext[None], events: AsyncIterable[AgentStreamEvent]):
+    async for event in events:
+        if isinstance(event, FunctionToolCallEvent):
+            print(f'Calling {event.part.tool_name}...')
+
+
+async def main():
+    await agent.run('Do the task', event_stream_handler=stream_handler)
+```
+
+## Handle Provider Failures
+
+Use `FallbackModel` when the user wants automatic provider or model failover.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.models.fallback import FallbackModel
+from pydantic_ai.models.openai import OpenAIChatModel
+
+fallback = FallbackModel(
+    OpenAIChatModel('gpt-5.2'),
+    AnthropicModel('claude-sonnet-4-6'),
+)
+
+agent = Agent(fallback)
+```
+
+Good defaults:
+
+- primary expensive/strong model, cheaper fallback for resilience
+- same prompt/output contract across both models
+- per-model settings only when the user actually needs them

--- a/.agents/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
+++ b/.agents/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
@@ -1,0 +1,230 @@
+# Architecture and Decision Guide
+
+Detailed decision trees, comparison tables, and architecture overview for Pydantic AI.
+
+## Contents
+
+- [Task-Family References](#task-family-references)
+- [Decision Trees](#decision-trees)
+  - [Choosing a Tool Registration Method](#choosing-a-tool-registration-method)
+  - [Choosing an Output Mode](#choosing-an-output-mode)
+  - [Choosing a Multi-Agent Pattern](#choosing-a-multi-agent-pattern)
+  - [Choosing How to Extend Agent Behavior](#choosing-how-to-extend-agent-behavior)
+  - [Choosing a Capability](#choosing-a-capability)
+  - [Choosing a Testing Approach](#choosing-a-testing-approach)
+- [Comparison Tables](#comparison-tables)
+  - [Output Mode Comparison](#output-mode-comparison)
+  - [Model Provider Prefixes](#model-provider-prefixes)
+  - [Tool Decorator Comparison](#tool-decorator-comparison)
+  - [Built-in Capabilities](#built-in-capabilities)
+  - [When to Use Each Agent Method](#when-to-use-each-agent-method)
+- [Architecture Overview](#architecture-overview)
+
+## Task-Family References
+
+Use this file for comparisons and abstraction choices.
+
+If the user already knows what they want to do, load the narrower task guide instead:
+
+- [AGENTS-CORE.md](./AGENTS-CORE.md)
+- [CAPABILITIES-AND-HOOKS.md](./CAPABILITIES-AND-HOOKS.md)
+- [TOOLS-CORE.md](./TOOLS-CORE.md)
+- [BUILTIN-TOOLS.md](./BUILTIN-TOOLS.md)
+- [TOOLS-ADVANCED.md](./TOOLS-ADVANCED.md)
+- [INPUT-AND-HISTORY.md](./INPUT-AND-HISTORY.md)
+- [TESTING-AND-DEBUGGING.md](./TESTING-AND-DEBUGGING.md)
+- [ORCHESTRATION-AND-INTEGRATIONS.md](./ORCHESTRATION-AND-INTEGRATIONS.md)
+
+## Decision Trees
+
+### Choosing a Tool Registration Method
+
+```
+Need RunContext (deps, usage, messages)?
+├── Yes → Use @agent.tool
+└── No → Pure function, no context needed?
+    ├── Yes → Use @agent.tool_plain
+    └── Tools defined outside agent file?
+        ├── Yes → Use tools=[Tool(...)] in constructor
+        └── Dynamic tools based on context?
+            ├── Yes → Use ToolPrepareFunc
+            └── Multiple related tools as a group?
+                └── Yes → Use FunctionToolset
+```
+
+### Choosing an Output Mode
+
+```
+Need structured data with Pydantic validation?
+├── Yes → Does provider support native JSON mode?
+│   ├── Yes, and you want it → Use NativeOutput(MyModel)
+│   └── No, or prefer consistency → Use ToolOutput(MyModel) [default]
+└── No → Need custom parsing logic?
+    ├── Yes → Use TextOutput(parser_fn)
+    └── No → Just plain text?
+        └── Yes → Use output_type=str [default]
+
+Dynamic schema at runtime?
+└── Yes → Use StructuredDict(json_schema)
+```
+
+### Choosing a Multi-Agent Pattern
+
+```
+Child agent returns result to parent?
+├── Yes → Use agent delegation via tools
+└── No → Permanent hand-off to specialist?
+    ├── Yes → Use output functions
+    └── Application code between agents?
+        ├── Yes → Use programmatic hand-off
+        └── Complex state machine?
+            └── Yes → Use Graph-based control
+```
+
+### Choosing How to Extend Agent Behavior
+
+```
+Need reusable behavior across agents (tools + hooks + instructions)?
+├── Yes → Build a custom capability (subclass AbstractCapability)
+└── No → Just intercepting lifecycle events?
+    ├── Yes → Complex interception needing tools/instructions too?
+    │   ├── Yes → Subclass AbstractCapability
+    │   └── No → Use Hooks capability with decorators
+    └── No → Defining agents from config files?
+        ├── Yes → Use Agent.from_file() with YAML/JSON specs
+        └── No → Just adding tools?
+            ├── Yes → Use @agent.tool or Toolset
+            └── Pass args directly to Agent constructor
+```
+
+### Choosing a Capability
+
+```
+Need model thinking/reasoning?
+├── Yes → Use Thinking(effort='high')
+└── Need web search?
+    ├── Yes → Use WebSearch() (auto-fallback to local)
+    └── Need URL fetching?
+        ├── Yes → Use WebFetch()
+        └── Need MCP servers?
+            ├── Yes → Use MCP()
+            └── Need lifecycle hooks only?
+                ├── Yes → Use Hooks()
+                └── Need to filter/modify tool defs per step?
+                    └── Yes → Use PrepareTools()
+```
+
+### Choosing a Testing Approach
+
+```
+Need deterministic, fast tests?
+├── Yes → Use TestModel with agent.override()
+└── Need specific tool call behavior?
+    ├── Yes → Use FunctionModel
+    └── Testing against real API (integration)?
+        └── Yes → Use pytest-recording with VCR cassettes
+```
+
+## Comparison Tables
+
+### Output Mode Comparison
+
+| Scenario | Mode |
+|----------|------|
+| Need structured data and want maximum provider compatibility | `ToolOutput` (default) — works with all providers, supports streaming |
+| Want the provider to natively enforce JSON schema compliance | `NativeOutput` — OpenAI, Anthropic, Google only; limited streaming |
+| Provider doesn't support tools or JSON mode | `PromptedOutput` — works everywhere as a fallback |
+| LLM returns non-JSON structured text (markdown, YAML, domain-specific) | `TextOutput` — custom parsing function |
+
+### Model Provider Prefixes
+
+| Provider | Prefix | Example |
+|----------|--------|---------|
+| OpenAI | `openai:` | `openai:gpt-5.2` |
+| Anthropic | `anthropic:` | `anthropic:claude-sonnet-4-6` |
+| Google (AI Studio) | `google-gla:` | `google-gla:gemini-3-pro-preview` |
+| Google (Vertex) | `google-vertex:` | `google-vertex:gemini-3-pro-preview` |
+| Groq | `groq:` | `groq:llama-3.3-70b-versatile` |
+| Mistral | `mistral:` | `mistral:mistral-large-latest` |
+| Cohere | `cohere:` | `cohere:command-r-plus-08-2024` |
+| AWS Bedrock | `bedrock:` | `bedrock:anthropic.claude-sonnet-4-6` |
+| Azure | `azure:` | `azure:gpt-5.2` |
+| OpenRouter | `openrouter:` | `openrouter:anthropic/claude-sonnet-4-6` |
+| xAI | `xai:` | `xai:grok-3` |
+| DeepSeek | `deepseek:` | `deepseek:deepseek-chat` |
+| Fireworks | `fireworks:` | `fireworks:accounts/fireworks/models/llama-v3p3-70b-instruct` |
+| Together | `together:` | `together:meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo` |
+| Ollama (local) | `ollama:` | `ollama:llama3.2` |
+| GitHub Models | `github:` | `github:openai/gpt-5.2` |
+| Hugging Face | `huggingface:` | `huggingface:meta-llama/Llama-3.3-70B-Instruct` |
+| Cerebras | `cerebras:` | `cerebras:llama-4-scout-17b-16e-instruct` |
+| Heroku | `heroku:` | `heroku:claude-sonnet-4-6` |
+
+**Additional prefixes:** `litellm:`, `nebius:`, `ovhcloud:`, `alibaba:`, `sambanova:`, `vercel:`, `outlines:`, `moonshotai:`. For truly custom providers, subclass `Model` or use `OpenAIChatModel` with a custom `base_url`.
+
+### Tool Decorator Comparison
+
+| Scenario | Decorator |
+|----------|-----------|
+| Tool needs access to deps, usage stats, messages, or retry info | `@agent.tool` — `RunContext` as required first param |
+| Pure function, no agent context needed | `@agent.tool_plain` |
+| Tools defined in a separate module or shared across agents | `Tool(fn)` — pass to agent constructor via `tools=[...]` |
+
+### Built-in Capabilities
+
+| Capability | What it provides | Usable in YAML Specs |
+|---|---|:---:|
+| `Thinking` | Model thinking/reasoning at configurable effort | Yes |
+| `Hooks` | Decorator-based lifecycle hook registration | No |
+| `WebSearch` | Web search — builtin when supported, local fallback | Yes |
+| `WebFetch` | URL fetching — builtin when supported, custom fallback | Yes |
+| `ImageGeneration` | Image generation — builtin when supported, custom fallback | Yes |
+| `MCP` | MCP server — builtin when supported, direct connection | Yes |
+| `PrepareTools` | Filters or modifies tool definitions per step | No |
+| `PrefixTools` | Wraps a capability and prefixes its tool names | Yes |
+| `BuiltinTool` | Registers a builtin tool with the agent | Yes |
+| `Toolset` | Wraps an `AbstractToolset` | No |
+| `HistoryProcessor` | Wraps a history processor function | No |
+
+### When to Use Each Agent Method
+
+| Scenario | Method |
+|----------|--------|
+| Building a chatbot or assistant that shows tool calls, progress, and output in real-time | `agent.run(event_stream_handler=...)` — streams all events while running to completion |
+| Running an autonomous agent, batch job, or background task | `agent.run()` |
+| Writing a CLI tool, script, or Jupyter notebook (no async) | `agent.run_sync()` |
+| Streaming final text word-by-word to a UI | `agent.run_stream()` |
+| Synchronous streaming for CLI tools or scripts (no async) | `agent.run_stream_sync()` |
+| Receiving an async iterable of typed events (tool calls, results, final output) | `agent.run_stream_events()` |
+| Inspecting or modifying state between agent steps, human-in-the-loop approval | `agent.iter()` |
+
+See [Run Methods and Streaming](./AGENTS-CORE.md#run-methods-and-streaming) for `event_stream_handler` details.
+
+## Architecture Overview
+
+**Agent execution flow:**
+`Agent.run()` → `UserPromptNode` → `ModelRequestNode` → `CallToolsNode` → (loop or end)
+
+**Key generic types:**
+
+- `Agent[AgentDepsT, OutputDataT]` — dependency type + output type
+- `RunContext[AgentDepsT]` — available in tools and system prompts
+- `AbstractCapability[AgentDepsT]` — base class for reusable behavior bundles
+
+**Agent construction:**
+
+- **Python:** `Agent(model, instructions=..., tools=..., capabilities=...)`
+- **Declarative:** `Agent.from_file('agent.yaml')` or `Agent.from_spec({...})`
+
+**Capabilities** are the primary extension point — they bundle tools, lifecycle hooks, instructions, and model settings into reusable units. Built-in capabilities include `Thinking`, `WebSearch`, `WebFetch`, `Hooks`, `MCP`, and more.
+
+**Lifecycle hooks** (via `Hooks` or `AbstractCapability`) intercept every stage: `before_run` → `before_model_request` → `before_tool_execute` → `after_tool_execute` → `after_model_request` → `after_run`
+
+**Model string format:** `"provider:model-name"` (e.g., `"openai:gpt-5.2"`, `"anthropic:claude-sonnet-4-6"`, `"google-gla:gemini-3-pro-preview"`)
+
+**Output modes:**
+
+- `ToolOutput` — structured data via tool calls (default for Pydantic models)
+- `NativeOutput` — provider-specific structured output
+- `PromptedOutput` — prompt-based structured extraction
+- `TextOutput` — plain text responses

--- a/.agents/skills/building-pydantic-ai-agents/references/BUILTIN-TOOLS.md
+++ b/.agents/skills/building-pydantic-ai-agents/references/BUILTIN-TOOLS.md
@@ -1,0 +1,66 @@
+# Built-in Tools
+
+Read this file when the user wants provider-native tools such as web search, web fetch, code execution, memory, or file search.
+
+Prefer capabilities like `WebSearch()` or `WebFetch()` when the user wants a provider-agnostic solution. Use built-in tools directly when they explicitly want provider-native behavior or provider-specific configuration.
+
+## Give My Agent Web Search or Code Execution
+
+Builtin tools are passed via `builtin_tools=[...]`.
+
+```python
+from pydantic_ai import Agent, WebSearchTool
+
+agent = Agent('openai-responses:gpt-5.2', builtin_tools=[WebSearchTool()])
+result = agent.run_sync('Give me a sentence with the biggest news in AI this week.')
+print(result.output)
+```
+
+For OpenAI web search, use the Responses API model prefix (`openai-responses:`), not `openai:`.
+
+## Built-in Tool Defaults
+
+Reach for these when the provider supports them:
+
+- `WebSearchTool`
+- `WebFetchTool`
+- `CodeExecutionTool`
+- `ImageGenerationTool`
+- `MemoryTool`
+- `MCPServerTool`
+- `FileSearchTool`
+
+## Dynamic Built-in Tool Configuration
+
+Prepare built-in tools from `RunContext` when configuration depends on the current user or request.
+
+```python
+from pydantic_ai import Agent, RunContext, WebSearchTool
+
+
+async def prepared_web_search(ctx: RunContext[dict]) -> WebSearchTool | None:
+    if not ctx.deps.get('location'):
+        return None
+    return WebSearchTool(user_location={'city': ctx.deps['location']})
+
+
+agent = Agent(
+    'openai-responses:gpt-5.2',
+    builtin_tools=[prepared_web_search],
+    deps_type=dict,
+)
+```
+
+## When to Use Built-in Tools vs Capabilities
+
+Use built-in tools when:
+
+- the user explicitly wants provider-native behavior
+- the provider-specific configuration matters
+- the user already picked a provider that supports the tool
+
+Use capabilities when:
+
+- the code should work across providers
+- you want local fallback when builtin support is missing
+- the user has not committed to a provider yet

--- a/.agents/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
+++ b/.agents/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
@@ -1,0 +1,102 @@
+# Capabilities and Hooks
+
+Read this file when the user wants reusable agent behavior, provider-adaptive tools, or lifecycle interception.
+
+## Add Capabilities to an Agent
+
+Capabilities bundle reusable behavior and compose automatically.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import Thinking, WebSearch
+
+agent = Agent(
+    'anthropic:claude-opus-4-6',
+    capabilities=[
+        Thinking(effort='high'),
+        WebSearch(),
+    ],
+)
+```
+
+Provider-adaptive capabilities to reach for first:
+
+- `Thinking`
+- `WebSearch`
+- `WebFetch`
+- `ImageGeneration`
+- `MCP`
+
+Use capabilities when the user wants behavior that should survive model/provider changes.
+
+## Enable Thinking Across Providers
+
+Use the unified `Thinking` capability or the `thinking` model setting.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import Thinking
+
+agent = Agent('anthropic:claude-opus-4-6', capabilities=[Thinking(effort='high')])
+agent = Agent('anthropic:claude-opus-4-6', model_settings={'thinking': 'high'})
+```
+
+Supported effort values:
+
+- `True`
+- `False`
+- `'minimal'`
+- `'low'`
+- `'medium'`
+- `'high'`
+- `'xhigh'`
+
+## Intercept Agent Lifecycle with Hooks
+
+Use `Hooks` for decorator-based lifecycle interception.
+
+```python
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.capabilities.hooks import Hooks
+from pydantic_ai.models import ModelRequestContext
+
+hooks = Hooks()
+
+
+@hooks.on.before_model_request
+async def log_request(ctx: RunContext[None], request_context: ModelRequestContext) -> ModelRequestContext:
+    print(f'Sending {len(request_context.messages)} messages')
+    return request_context
+
+
+@hooks.on.before_tool_execute(tools=['send_email'])
+async def audit_tool(ctx, *, call, tool_def, args):
+    print(f'Executing {call.tool_name}')
+    return args
+
+
+agent = Agent('openai:gpt-5.2', capabilities=[hooks])
+```
+
+Important hook families:
+
+- run-level hooks
+- node-level hooks
+- model-request hooks
+- tool-validation hooks
+- tool-execution hooks
+- event-stream hooks
+
+Use hooks when the user wants observability, auditing, or light interception without adding a new abstraction.
+
+## Build a Custom Capability
+
+Subclass `AbstractCapability` when the user wants reusable behavior that combines tools, hooks, instructions, or model settings into one package.
+
+Reach for a custom capability when:
+
+- the same bundle should be reused across multiple agents
+- `Hooks` alone is not enough
+- the behavior should be installable or declarative
+
+Keep custom capabilities focused. If the user only needs one tool or one hook, do not introduce a capability.

--- a/.agents/skills/building-pydantic-ai-agents/references/COMMON-TASKS.md
+++ b/.agents/skills/building-pydantic-ai-agents/references/COMMON-TASKS.md
@@ -1,0 +1,108 @@
+# Task Reference Map
+
+This file exists as a compatibility index for older links into `COMMON-TASKS.md`.
+
+Prefer the narrower task-family guides below so the agent loads only the material it needs:
+
+- [AGENTS-CORE.md](./AGENTS-CORE.md) — agent creation, output, deps, specs, models, run methods
+- [CAPABILITIES-AND-HOOKS.md](./CAPABILITIES-AND-HOOKS.md) — `Thinking`, `WebSearch`, `Hooks`, custom capabilities
+- [TOOLS-CORE.md](./TOOLS-CORE.md) — `@agent.tool`, `Tool`, toolsets, MCP, common search tools
+- [BUILTIN-TOOLS.md](./BUILTIN-TOOLS.md) — provider-native tools like `WebSearchTool` and `CodeExecutionTool`
+- [TOOLS-ADVANCED.md](./TOOLS-ADVANCED.md) — approval, retries, `ToolReturn`, timeouts, validators, deferred loading
+- [INPUT-AND-HISTORY.md](./INPUT-AND-HISTORY.md) — multimodal input, message history, history processors
+- [TESTING-AND-DEBUGGING.md](./TESTING-AND-DEBUGGING.md) — `TestModel`, `FunctionModel`, `capture_run_messages`, Logfire
+- [ORCHESTRATION-AND-INTEGRATIONS.md](./ORCHESTRATION-AND-INTEGRATIONS.md) — multi-agent patterns, graphs, A2A, direct API, durable execution, embeddings, evals, third-party tools
+
+## Add Capabilities to an Agent
+
+Read [Add Capabilities](./CAPABILITIES-AND-HOOKS.md#add-capabilities-to-an-agent).
+
+## Intercept Agent Lifecycle with Hooks
+
+Read [Intercept Agent Lifecycle with Hooks](./CAPABILITIES-AND-HOOKS.md#intercept-agent-lifecycle-with-hooks).
+
+## Define Agents Declaratively with Specs
+
+Read [Define Agents Declaratively with Specs](./AGENTS-CORE.md#define-agents-declaratively-with-specs).
+
+## Enable Thinking Across Providers
+
+Read [Enable Thinking Across Providers](./CAPABILITIES-AND-HOOKS.md#enable-thinking-across-providers).
+
+## Use MCP Servers
+
+Read [Use MCP Servers](./TOOLS-CORE.md#use-mcp-servers).
+
+## Search with DuckDuckGo, Tavily, or Exa
+
+Read [Search with DuckDuckGo, Tavily, or Exa](./TOOLS-CORE.md#search-with-duckduckgo-tavily-or-exa).
+
+## Require Tool Approval (Human in the Loop)
+
+Read [Require Tool Approval](./TOOLS-ADVANCED.md#require-tool-approval-human-in-the-loop).
+
+## Send Images, Audio, Video, or Documents to the Model
+
+Read [Send Images, Audio, Video, or Documents to the Model](./INPUT-AND-HISTORY.md#send-images-audio-video-or-documents-to-the-model).
+
+## Manage Context Size
+
+Read [Manage Context Size](./INPUT-AND-HISTORY.md#manage-context-size).
+
+## Work with Message History
+
+Read [Work with Message History](./INPUT-AND-HISTORY.md#work-with-message-history).
+
+## Show Real-Time Progress
+
+Read [Run Methods and Streaming](./AGENTS-CORE.md#run-methods-and-streaming).
+
+## Handle Provider Failures
+
+Read [Handle Provider Failures](./AGENTS-CORE.md#handle-provider-failures).
+
+## Make an Agent Resilient with Retries
+
+Read [Make an Agent Resilient with Retries](./TOOLS-ADVANCED.md#make-an-agent-resilient-with-retries).
+
+## Debug a Failed Agent Run
+
+Read [Debug a Failed Agent Run](./TESTING-AND-DEBUGGING.md#debug-a-failed-agent-run).
+
+## Test Agent Behavior
+
+Read [Test Agent Behavior](./TESTING-AND-DEBUGGING.md#test-agent-behavior).
+
+## Coordinate Multiple Agents
+
+Read [Coordinate Multiple Agents](./ORCHESTRATION-AND-INTEGRATIONS.md#coordinate-multiple-agents).
+
+## Build Multi-Step Workflows with Graphs
+
+Read [Build Multi-Step Workflows with Graphs](./ORCHESTRATION-AND-INTEGRATIONS.md#build-multi-step-workflows-with-graphs).
+
+## Debug and Validate Agent Behavior
+
+Read [Debug and Validate Agent Behavior](./TESTING-AND-DEBUGGING.md#debug-and-validate-agent-behavior).
+
+## Advanced and Less Common Features
+
+Read only the relevant section in [ORCHESTRATION-AND-INTEGRATIONS.md](./ORCHESTRATION-AND-INTEGRATIONS.md):
+
+- [Direct API](./ORCHESTRATION-AND-INTEGRATIONS.md#call-the-model-without-using-an-agent)
+- [A2A](./ORCHESTRATION-AND-INTEGRATIONS.md#expose-agents-as-http-servers-a2a)
+- [Durable Execution](./ORCHESTRATION-AND-INTEGRATIONS.md#use-durable-execution)
+- [Embeddings](./ORCHESTRATION-AND-INTEGRATIONS.md#use-embeddings-for-rag)
+- [Third-Party Tools](./ORCHESTRATION-AND-INTEGRATIONS.md#use-langchain-or-acidev-tools)
+- [Custom Extensibility](./ORCHESTRATION-AND-INTEGRATIONS.md#build-custom-toolsets-models-or-agents)
+- [Evals](./ORCHESTRATION-AND-INTEGRATIONS.md#systematically-verify-agent-behavior-with-evals)
+
+## Working with the Installed Pydantic AI Package
+
+Prefer the checked-out repository or these bundled references first.
+
+Inspect local package source only as a last resort when:
+
+- the user asks about a symbol that is not covered in this skill
+- the local environment already includes `pydantic_ai` and you need exact module layout
+- you have no narrower offline reference available

--- a/.agents/skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md
+++ b/.agents/skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md
@@ -1,0 +1,66 @@
+# Input and History
+
+Read this file when the user wants multimodal input, message history, or context trimming.
+
+## Send Images, Audio, Video, or Documents to the Model
+
+Pass multimodal content as a list mixing text with `ImageUrl`, `AudioUrl`, `VideoUrl`, `DocumentUrl`, or `BinaryContent`.
+
+```python
+from pydantic_ai import Agent, ImageUrl
+
+agent = Agent(model='openai:gpt-5.2')
+result = agent.run_sync(
+    [
+        'What company is this logo from?',
+        ImageUrl(url='https://example.com/logo.png'),
+    ]
+)
+print(result.output)
+```
+
+Use `BinaryContent(...)` when the asset is already in memory instead of at a URL.
+
+Not every model supports every input type. Keep provider expectations in mind when the user chooses a specific model.
+
+## Work with Message History
+
+Use `message_history=` to continue a conversation across runs.
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2', instructions='Be a helpful assistant.')
+
+result1 = agent.run_sync('Tell me a joke.')
+result2 = agent.run_sync('Explain?', message_history=result1.new_messages())
+print(result2.output)
+```
+
+Important distinctions:
+
+- `new_messages()` returns only the current run
+- `all_messages()` returns the full history accumulated so far
+- when `message_history` is non-empty, Pydantic AI assumes the history already carries the system prompt
+
+## Manage Context Size
+
+Use `history_processors=[...]` to trim or rewrite message history before each model request.
+
+```python
+from pydantic_ai import Agent, ModelMessage
+
+
+async def keep_recent(messages: list[ModelMessage]) -> list[ModelMessage]:
+    return messages[-10:] if len(messages) > 10 else messages
+
+
+agent = Agent('openai:gpt-5.2', history_processors=[keep_recent])
+```
+
+Good uses:
+
+- trimming long conversations
+- removing PII before provider calls
+- summarizing old messages
+- applying app-specific history policies

--- a/.agents/skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md
+++ b/.agents/skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md
@@ -1,0 +1,138 @@
+# Orchestration and Integrations
+
+Read this file when the user wants multi-agent coordination, graphs, direct model calls, A2A, durable execution, embeddings, evals, or third-party integrations.
+
+## Coordinate Multiple Agents
+
+Use agent delegation when one agent should call another and return the result.
+
+```python
+from pydantic_ai import Agent, RunContext
+
+parent = Agent('openai:gpt-5.2')
+researcher = Agent('openai:gpt-5.2', output_type=str)
+
+
+@parent.tool
+async def research(ctx: RunContext[None], topic: str) -> str:
+    result = await researcher.run(f'Research: {topic}', usage=ctx.usage)
+    return result.output
+```
+
+Good split:
+
+- delegation via tools when the parent keeps control
+- output functions or programmatic hand-off when control should move elsewhere
+
+## Build Multi-Step Workflows with Graphs
+
+Use `pydantic_graph` when the workflow is a state machine rather than a single agent loop.
+
+```python
+from dataclasses import dataclass
+
+from pydantic_graph import BaseNode, End, Graph, GraphRunContext
+
+
+@dataclass
+class FirstNode(BaseNode[None, None, int]):
+    value: int
+
+    async def run(self, ctx: GraphRunContext) -> 'SecondNode | End[int]':
+        if self.value >= 5:
+            return End(self.value)
+        return SecondNode(self.value + 1)
+
+
+@dataclass
+class SecondNode(BaseNode):
+    value: int
+
+    async def run(self, ctx: GraphRunContext) -> FirstNode:
+        return FirstNode(self.value)
+
+
+graph = Graph(nodes=[FirstNode, SecondNode])
+result = graph.run_sync(FirstNode(0))
+```
+
+## Call the Model Without Using an Agent
+
+Use the direct API when the user wants a single model request without agent orchestration.
+
+```python
+from pydantic_ai import ModelRequest
+from pydantic_ai.direct import model_request_sync
+
+response = model_request_sync(
+    'openai:gpt-5.2',
+    [ModelRequest.user_text_prompt('Summarize this in one sentence.')],
+)
+```
+
+Reach for this when there is no need for tools, retries, or agent loop state.
+
+## Expose Agents as HTTP Servers (A2A)
+
+Use `agent.to_a2a()` when the agent should be exposed as an ASGI app that speaks the A2A protocol.
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2')
+app = agent.to_a2a()
+```
+
+## Use Durable Execution
+
+Use the durable execution integrations when the run must survive crashes, retries, or long-lived workflows.
+
+Temporal entry points:
+
+- `TemporalAgent`
+- `PydanticAIWorkflow`
+- `PydanticAIPlugin`
+
+There are parallel integrations for DBOS and Prefect.
+
+## Use Embeddings for RAG
+
+Use `Embedder(...)` for query/document embeddings when the user is building retrieval or semantic search.
+
+```python
+from pydantic_ai import Embedder
+
+embedder = Embedder('openai:text-embedding-3-small')
+```
+
+## Use LangChain or ACI.dev Tools
+
+Third-party integrations to reach for:
+
+- `tool_from_langchain`
+- `LangChainToolset`
+- `tool_from_aci`
+- `ACIToolset`
+
+Use these when the user explicitly wants those ecosystems instead of native Pydantic AI tools.
+
+## Systematically Verify Agent Behavior with Evals
+
+Use `pydantic_evals` when the user wants repeatable evaluation datasets and evaluators rather than ad hoc tests.
+
+Common entry points:
+
+- `Case`
+- `Dataset`
+- evaluator classes from `pydantic_evals.evaluators`
+
+## Build Custom Toolsets, Models, or Agents
+
+Extensibility entry points:
+
+- `AbstractToolset` / `WrapperToolset`
+- `Model` / `WrapperModel`
+- `AbstractAgent` / `WrapperAgent`
+- `AbstractCapability`
+
+Reach for these only when the built-in primitives are genuinely insufficient.

--- a/.agents/skills/building-pydantic-ai-agents/references/TESTING-AND-DEBUGGING.md
+++ b/.agents/skills/building-pydantic-ai-agents/references/TESTING-AND-DEBUGGING.md
@@ -1,0 +1,75 @@
+# Testing and Debugging
+
+Read this file when the user wants deterministic tests, custom test models, request inspection, or runtime debugging.
+
+## Test Agent Behavior
+
+Use `TestModel` for fast deterministic tests and `FunctionModel` for custom response logic.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+agent = Agent('openai:gpt-5.2')
+
+with agent.override(model=TestModel()):
+    result = agent.run_sync('test prompt')
+    assert result.output == 'success (no tool calls)'
+```
+
+```python
+from pydantic_ai import Agent, ModelResponse, TextPart
+from pydantic_ai.models.function import FunctionModel
+
+agent = Agent('openai:gpt-5.2')
+
+
+def custom_model(messages, info):
+    return ModelResponse(parts=[TextPart(content='mocked response')])
+
+
+with agent.override(model=FunctionModel(custom_model)):
+    result = agent.run_sync('test prompt')
+```
+
+Default split:
+
+- `TestModel` when you want automatic valid outputs
+- `FunctionModel` when you need exact behavior for assertions, failures, or retries
+
+## Debug a Failed Agent Run
+
+Use `capture_run_messages()` when the user needs the exact request/response history that led to a failure.
+
+```python
+from pydantic_ai import Agent, UnexpectedModelBehavior, capture_run_messages
+
+agent = Agent('openai:gpt-5.2')
+
+with capture_run_messages() as messages:
+    try:
+        agent.run_sync('Please get me the volume of a box with size 6.')
+    except UnexpectedModelBehavior:
+        print(messages)
+```
+
+Use this for in-process debugging. It is a better fit than broad logging when the user wants to inspect one failing run.
+
+## Debug and Validate Agent Behavior
+
+Use Logfire when the user wants observability across agent runs, tools, and model requests.
+
+```python
+import logfire
+
+logfire.configure()
+logfire.instrument_pydantic_ai()
+logfire.instrument_httpx(capture_all=True)
+```
+
+Good uses:
+
+- tracing tool calls
+- validating what was sent to the provider
+- understanding structured-output failures
+- production observability

--- a/.agents/skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md
+++ b/.agents/skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md
@@ -1,0 +1,133 @@
+# Tools Advanced
+
+Read this file when the user wants advanced tool behavior: approval, retries, validation, timeouts, rich tool returns, or tool search/deferred loading.
+
+## Require Tool Approval (Human in the Loop)
+
+Use deferred tools when the run should pause for approval.
+
+```python
+from pydantic_ai import (
+    Agent,
+    DeferredToolRequests,
+    DeferredToolResults,
+    ToolDenied,
+)
+
+agent = Agent('openai:gpt-5.2', output_type=[str, DeferredToolRequests])
+
+
+@agent.tool_plain(requires_approval=True)
+def delete_file(path: str) -> str:
+    return f'File {path!r} deleted'
+
+
+result = agent.run_sync('Delete __init__.py')
+messages = result.all_messages()
+
+assert isinstance(result.output, DeferredToolRequests)
+results = DeferredToolResults()
+for call in result.output.approvals:
+    results.approvals[call.tool_call_id] = ToolDenied('Deleting files is not allowed')
+
+result = agent.run_sync('Continue', message_history=messages, deferred_tool_results=results)
+print(result.output)
+```
+
+Two key rules:
+
+- `DeferredToolRequests` must be in the output type
+- for conditional approval, raise `ApprovalRequired(...)` instead of marking the whole tool `requires_approval=True`
+
+## Make an Agent Resilient with Retries
+
+Raise `ModelRetry` from inside the tool when the model should correct and try again.
+
+```python
+from pydantic_ai import Agent, ModelRetry, RunContext
+
+agent = Agent('openai:gpt-5.2', deps_type=dict[str, int])
+
+
+@agent.tool(retries=2)
+def get_user_by_name(ctx: RunContext[dict[str, int]], name: str) -> int:
+    user_id = ctx.deps.get(name)
+    if user_id is None:
+        raise ModelRetry(f'No user found with name {name!r}')
+    return user_id
+```
+
+Use retries for recoverable model mistakes, not application crashes.
+
+## Validate or Require Approval Before Tool Execution
+
+Use `args_validator=` when arguments are structurally valid but still need business-rule validation before execution or approval.
+
+```python
+from pydantic_ai import Agent, DeferredToolRequests, ModelRetry, RunContext
+
+agent = Agent('openai:gpt-5.2', deps_type=int, output_type=[str, DeferredToolRequests])
+
+
+def validate_sum_limit(ctx: RunContext[int], x: int, y: int) -> None:
+    if x + y > ctx.deps:
+        raise ModelRetry(f'Sum of x and y must not exceed {ctx.deps}')
+
+
+@agent.tool(requires_approval=True, args_validator=validate_sum_limit)
+def add_numbers(ctx: RunContext[int], x: int, y: int) -> int:
+    return x + y
+```
+
+## Use Advanced Tool Features
+
+Reach for these features when the user needs more than a simple function tool:
+
+- `ToolReturn` for rich return values plus separate content/metadata
+- `prepare=` for dynamic tool definitions
+- `timeout=` for tool execution limits
+- `sequential=True` when tool calls must not run concurrently
+
+Example with `ToolReturn`:
+
+```python
+from pydantic_ai import Agent, BinaryContent, ToolReturn
+
+agent = Agent('openai:gpt-5.2')
+
+
+@agent.tool_plain
+def click_and_capture(x: int, y: int) -> ToolReturn:
+    return ToolReturn(
+        return_value=f'Successfully clicked at ({x}, {y})',
+        content=['After:', BinaryContent(data=b'png-data', media_type='image/png')],
+        metadata={'coordinates': {'x': x, 'y': y}},
+    )
+```
+
+## Handle Network Errors and Rate Limiting Automatically
+
+For tool-call retries, use `ModelRetry` and tool `retries=...`.
+
+For HTTP request retries at the transport layer, use the library's retry configuration separately. Do not assume `ModelRetry` alone solves provider transport failures.
+
+## Tool Search and Deferred Loading
+
+Use deferred loading when the agent has many tools and the model should discover them on demand via `search_tools`.
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2')
+
+
+@agent.tool_plain(defer_loading=True)
+def lookup_internal_policy(policy_name: str) -> str:
+    return f'policy details for {policy_name}'
+```
+
+Good fit:
+
+- large MCP servers
+- big tool catalogs
+- situations where loading all tool schemas would bloat context

--- a/.agents/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
+++ b/.agents/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
@@ -1,0 +1,102 @@
+# Tools Core
+
+Read this file when the user wants to add function tools, organize toolsets, connect MCP servers, or use explicit common search tools.
+
+## Add Tools to an Agent
+
+Use `@agent.tool_plain` for pure functions and `@agent.tool` for tools that need `RunContext`.
+
+```python
+import random
+
+from pydantic_ai import Agent, RunContext
+
+agent = Agent('google-gla:gemini-3-flash-preview', deps_type=str)
+
+
+@agent.tool_plain
+def roll_dice() -> str:
+    return str(random.randint(1, 6))
+
+
+@agent.tool
+def get_player_name(ctx: RunContext[str]) -> str:
+    return ctx.deps
+```
+
+Use `Tool(fn)` when tools are defined outside the agent file or shared between agents.
+
+## Choosing a Tool Registration Method
+
+Default choices:
+
+- `@agent.tool` when the tool needs deps, usage, retry count, or message history
+- `@agent.tool_plain` when the tool is a plain function
+- `Tool(...)` in `tools=[...]` when the tool should be reusable across agents
+- `FunctionToolset` when multiple related tools should be managed as a group
+
+## Organize or Restrict Which Tools an Agent Can Use
+
+Use toolsets when the user has multiple related tools or wants cross-cutting behavior applied to a group.
+
+Examples:
+
+- `FunctionToolset` for a bundle of Python tools
+- MCP servers, which are themselves toolsets
+- wrapper toolsets for approval, deferred loading, or other cross-cutting behavior
+
+## Access Usage Stats, Message History, or Retry Count in Tools
+
+Route this to `@agent.tool` with `RunContext`.
+
+Useful `RunContext` fields include:
+
+- `ctx.deps`
+- `ctx.usage`
+- `ctx.messages`
+- `ctx.retry`
+
+## Use MCP Servers
+
+Attach an MCP server as a toolset on the agent.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPServerStdio
+
+server = MCPServerStdio('python', args=['mcp_server.py'], timeout=10)
+agent = Agent('openai:gpt-5.2', toolsets=[server])
+
+
+async def main():
+    async with agent:
+        result = await agent.run('What is the weather in Paris?')
+        print(result.output)
+```
+
+Default transport choices:
+
+- `MCPServerStdio` for local subprocess servers
+- `MCPServerStreamableHTTP` for HTTP servers
+
+`MCPServerSSE` still exists, but Streamable HTTP is the better default.
+
+## Search with DuckDuckGo, Tavily, or Exa
+
+Use common tools when the user wants explicit search tools rather than provider-adaptive capabilities.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.common_tools.duckduckgo import duckduckgo_search_tool
+
+agent = Agent(
+    'openai:gpt-5.2',
+    tools=[duckduckgo_search_tool()],
+    instructions='Search DuckDuckGo for the given query and return the results.',
+)
+```
+
+Good default split:
+
+- use `WebSearch()` capability when the user wants model-agnostic search with builtin fallback
+- use `duckduckgo_search_tool()` / Tavily / Exa when the user explicitly wants those engines as tools

--- a/.agents/skills/dignified-python/LICENSE
+++ b/.agents/skills/dignified-python/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2025 Dagster Labs, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.agents/skills/dignified-python/SKILL.md
+++ b/.agents/skills/dignified-python/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: dignified-python
+description:
+  Opinionated production Python standards with automatic version detection (3.10-3.13). Use when
+  writing, reviewing, or refactoring Python in repos that want modern type syntax, explicit
+  condition checks where practical, pathlib operations, interface guidance, and pragmatic
+  production patterns.
+references:
+  - dignified-python-core
+  - cli-patterns
+  - versions/python-3.10
+  - versions/python-3.11
+  - versions/python-3.12
+  - versions/python-3.13
+  - references/advanced/api-design
+  - references/advanced/exception-handling
+  - references/advanced/interfaces
+  - references/advanced/typing-advanced
+---
+
+# Dignified Python
+
+Opinionated Python guidance for writing clean, maintainable, modern Python code (versions
+3.10-3.13).
+
+## When to Use This Skill
+
+Auto-invoke when users ask about:
+
+- "make this pythonic" / "is this good python"
+- "type hints" / "type annotations" / "typing"
+- "LBYL vs EAFP" / "exception handling"
+- "pathlib vs os.path" / "path operations"
+- "CLI patterns" / "click usage"
+- "code review" / "improve this code"
+- Any Python code quality or standards question
+
+**Note**: This skill is **general-purpose Python style guidance**, not Dagster-specific. It
+captures one explicit, LBYL-leaning set of conventions; project conventions can override it when needed.
+
+## When to Use This Skill vs. Others
+
+| User Need                    | Use This Skill              | Alternative Skill         |
+| ---------------------------- | --------------------------- | ------------------------- |
+| "make this pythonic"         | ✅ Yes - Python standards   |                           |
+| "is this good python"        | ✅ Yes - code quality       |                           |
+| "type hints"                 | ✅ Yes - typing guidance    |                           |
+| "LBYL vs EAFP"               | ✅ Yes - exception patterns |                           |
+| "pathlib vs os.path"         | ✅ Yes - path handling      |                           |
+| "best practices for dagster" | ❌ No                       | `/dagster-best-practices` |
+| "implement X pipeline"       | ❌ No                       | `/dg` for implementation  |
+| "which integration to use"   | ❌ No                       | `/dagster-expert`         |
+| "CLI argument parsing"       | ✅ Yes - CLI patterns       |                           |
+
+## Core Knowledge (ALWAYS Loaded)
+
+@dignified-python-core.md
+
+## Version Detection
+
+**Identify the project's minimum Python version** by checking (in order):
+
+1. `pyproject.toml` - Look for `requires-python` field (e.g., `requires-python = ">=3.12"`)
+2. `setup.py` or `setup.cfg` - Look for `python_requires`
+3. `.python-version` file - Contains version like `3.12` or `3.12.0`
+4. Default to Python 3.12 if no version specifier found
+
+**Once identified, load the appropriate version-specific file:**
+
+- Python 3.10: Load `versions/python-3.10.md`
+- Python 3.11: Load `versions/python-3.11.md`
+- Python 3.12: Load `versions/python-3.12.md`
+- Python 3.13: Load `versions/python-3.13.md`
+
+## Conditional Loading (Load Based on Task Patterns)
+
+Core files above cover 80%+ of Python code patterns. Only load these additional files when you
+detect specific patterns:
+
+Pattern detection examples:
+
+- If task mentions "click" or "CLI" -> Load `cli-patterns.md`
+- If task mentions "subprocess" -> Load `subprocess.md`
+
+## Reference Documentation Structure
+
+This skill's reference material is organized by topic:
+
+### Core References
+
+- **`dignified-python-core.md`** - Essential standards (always loaded)
+- **`cli-patterns.md`** - Command-line interface patterns (click, argparse)
+
+### Version-Specific References (`versions/`)
+
+- **`python-3.10.md`** - Features available in Python 3.10+
+- **`python-3.11.md`** - Features available in Python 3.11+
+- **`python-3.12.md`** - Features available in Python 3.12+
+- **`python-3.13.md`** - Features available in Python 3.13+
+
+### Advanced Topics (`references/advanced/`)
+
+- **`exception-handling.md`** - LBYL patterns, error boundaries
+- **`interfaces.md`** - ABC and Protocol patterns
+- **`typing-advanced.md`** - Advanced typing patterns
+- **`api-design.md`** - API design principles
+
+## When to Read Each Reference Document
+
+### `references/advanced/exception-handling.md`
+
+**Read when**:
+
+- Writing try/except blocks
+- Wrapping third-party APIs that may raise
+- Seeing or writing `from e` or `from None`
+- Unsure if LBYL alternative exists
+
+### `references/advanced/interfaces.md`
+
+**Read when**:
+
+- Creating ABC or Protocol classes
+- Writing @abstractmethod decorators
+- Designing gateway layer interfaces
+- Choosing between ABC and Protocol
+
+### `references/advanced/typing-advanced.md`
+
+**Read when**:
+
+- Using typing.cast()
+- Creating Literal type aliases
+- Narrowing types in conditional blocks
+
+### `references/module-design.md`
+
+**Read when**:
+
+- Creating new Python modules
+- Adding module-level code (beyond simple constants)
+- Using @cache decorator at module level
+- Seeing Path() or computation at module level
+- Considering inline imports
+
+### `references/advanced/api-design.md`
+
+**Read when**:
+
+- Adding default parameter values to functions
+- Defining functions with 5 or more parameters
+- Using ThreadPoolExecutor.submit()
+- Reviewing function signatures
+
+### `references/checklists.md`
+
+**Read when**:
+
+- Final review before committing Python code
+- Unsure if you've followed all rules
+- Need a quick lookup of requirements
+
+## How to Use This Skill
+
+1. **Core knowledge** is loaded automatically (defaults, pathlib, imports,
+   anti-patterns)
+2. **Version detection** happens once - identify the minimum Python version and load the appropriate
+   version file
+3. **Reference documents** are loaded on-demand based on the triggers above
+4. **Additional patterns** may require extra loading (CLI patterns, subprocess)
+5. **Each file is self-contained** with complete guidance for its domain

--- a/.agents/skills/dignified-python/cli-patterns.md
+++ b/.agents/skills/dignified-python/cli-patterns.md
@@ -1,0 +1,156 @@
+---
+---
+
+# CLI Patterns - Click Best Practices
+
+## Core Rules
+
+1. **Use `click.echo()` for output, NEVER `print()`**
+2. **Exit with `raise SystemExit(1)` for CLI errors**
+3. **Error boundaries at command level**
+4. **Use `err=True` for error output**
+5. **Flush stderr before `click.confirm()`** (prevents buffering hangs)
+
+## Basic Click Patterns
+
+```python
+import click
+from pathlib import Path
+
+# ✅ CORRECT: Use click.echo for output
+@click.command()
+@click.argument("name")
+def greet(name: str) -> None:
+    """Greet the user."""
+    click.echo(f"Hello, {name}!")
+
+# ❌ WRONG: Using print()
+@click.command()
+def greet(name: str) -> None:
+    print(f"Hello, {name}!")  # NEVER use print in CLI
+```
+
+## Error Handling in CLI
+
+```python
+# ✅ CORRECT: CLI command error boundary
+@click.command("create")
+@click.argument("name")
+def create(name: str) -> None:
+    """Create a resource."""
+    try:
+        create_resource(name)
+    except subprocess.CalledProcessError as e:
+        click.echo(f"Error: Command failed: {e.stderr}", err=True)
+        raise SystemExit(1)
+    except ValueError as e:
+        click.echo(f"Error: {e}", err=True)
+        raise SystemExit(1)
+```
+
+## Output Patterns
+
+```python
+# Regular output to stdout
+click.echo("Processing complete")
+
+# Error output to stderr
+click.echo("Error: Operation failed", err=True)
+
+# Colored output
+click.echo(click.style("Success!", fg="green"))
+click.echo(click.style("Warning!", fg="yellow", bold=True))
+
+# Progress indication
+with click.progressbar(items) as bar:
+    for item in bar:
+        process(item)
+```
+
+## Command Structure
+
+```python
+@click.group()
+@click.pass_context
+def cli(ctx: click.Context) -> None:
+    """Main CLI entry point."""
+    ctx.ensure_object(dict)
+    ctx.obj["config"] = load_config()
+
+@cli.command()
+@click.option("--dry-run", is_flag=True, help="Perform dry run")
+@click.argument("path", type=click.Path(exists=True))
+@click.pass_obj
+def sync(obj: dict, path: str, dry_run: bool) -> None:
+    """Sync the repository."""
+    config = obj["config"]
+
+    if dry_run:
+        click.echo("DRY RUN: Would sync...")
+    else:
+        perform_sync(Path(path), config)
+        click.echo("✓ Sync complete")
+```
+
+## User Interaction
+
+```python
+import sys
+
+# ✅ CORRECT: Flush stderr before confirmation prompts
+# This prevents buffering hangs when mixing stderr output with stdin prompts
+click.echo("Warning: This operation is destructive!", err=True)
+sys.stderr.flush()  # Flush before prompting
+if click.confirm("Are you sure?"):
+    perform_dangerous_operation()
+
+# ❌ WRONG: click.confirm() after stderr output without flush
+# This can hang because stderr isn't flushed before the prompt
+click.echo("Warning: This operation is destructive!", err=True)
+if click.confirm("Are you sure?"):  # BAD: potential buffering hang
+    perform_dangerous_operation()
+
+# User input
+name = click.prompt("Enter your name", default="User")
+
+# Password input
+password = click.prompt("Password", hide_input=True)
+
+# Choice selection
+choice = click.prompt(
+    "Select option",
+    type=click.Choice(["option1", "option2"]),
+    default="option1"
+)
+```
+
+## Path Handling
+
+```python
+@click.command()
+@click.argument(
+    "input_file",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False)
+)
+@click.argument(
+    "output_dir",
+    type=click.Path(exists=False, file_okay=False, dir_okay=True)
+)
+def process(input_file: str, output_dir: str) -> None:
+    """Process input file to output directory."""
+    input_path = Path(input_file)
+    output_path = Path(output_dir)
+
+    if not output_path.exists():
+        output_path.mkdir(parents=True)
+
+    click.echo(f"Processing {input_path} → {output_path}")
+```
+
+## Key Takeaways
+
+1. **Always click.echo()**: Never use print() in CLI code
+2. **Error to stderr**: Use `err=True` for error messages
+3. **Exit cleanly**: Use `raise SystemExit(1)` for errors
+4. **User-friendly**: Provide clear messages and confirmations
+5. **Type paths**: Use `click.Path()` for path arguments

--- a/.agents/skills/dignified-python/dignified-python-core.md
+++ b/.agents/skills/dignified-python/dignified-python-core.md
@@ -1,0 +1,373 @@
+---
+---
+
+# Dignified Python - Core Standards
+
+This document contains the core Python coding standards that apply to 80%+ of Python code. These
+principles are loaded with every skill invocation.
+
+For conditional loading of specialized patterns:
+
+- CLI development -> Load `cli-patterns.md`
+- Subprocess operations -> Load `subprocess.md`
+
+For detailed reference material, see the "When to Read Each Reference" section in SKILL.md.
+
+---
+
+## Default Stance: Prefer Explicit Preconditions
+
+This skill leans LBYL when a cheap, precise precondition keeps intent clearer than a `try/except`.
+
+```python
+# CORRECT: Check first
+if key in mapping:
+    value = mapping[key]
+    process(value)
+
+# WRONG: Exception as control flow
+try:
+    value = mapping[key]
+    process(value)
+except KeyError:
+    pass
+```
+
+---
+
+## Exception Handling Basics
+
+### Core Principle
+
+**Prefer LBYL for routine branching when the precondition is cheap and precise.**
+
+LBYL means checking conditions before acting. EAFP (Easier to Ask for Forgiveness than Permission)
+means trying operations and catching exceptions. In this skill, default to LBYL for ordinary
+branching, but use EAFP when the operation itself is the authoritative test or when you're
+translating failures at a boundary.
+
+### Dictionary Access Patterns
+
+```python
+# CORRECT: Membership testing
+if key in mapping:
+    value = mapping[key]
+    process(value)
+else:
+    handle_missing()
+
+# ALSO CORRECT: .get() with default
+value = mapping.get(key, default_value)
+process(value)
+
+# CORRECT: Check before nested access
+if "config" in data and "timeout" in data["config"]:
+    timeout = data["config"]["timeout"]
+
+# WRONG: KeyError as control flow
+try:
+    value = mapping[key]
+except KeyError:
+    handle_missing()
+```
+
+### When Exceptions ARE Acceptable
+
+Exceptions are a good fit at:
+
+1. **Error boundaries** (CLI/API level)
+2. **Operations where the action itself is the authoritative test**
+3. **Adding context before re-raising**
+
+**Default: Let exceptions bubble up**
+
+For detailed exception handling patterns including B904 chaining, third-party API examples, and
+anti-patterns, see `references/advanced/exception-handling.md`.
+
+---
+
+## Path Operations
+
+### The Golden Rule
+
+Use `.exists()` when filesystem presence is part of your requirement, not as a blanket precondition
+for `.resolve()` or `.is_relative_to()`.
+
+### Why This Matters
+
+- `Path.resolve()` on Python 3.11 resolves non-existent paths unless you pass `strict=True`
+- `Path.is_relative_to()` returns `bool`; it does not raise `ValueError` when a path is not under
+  another path
+- Broad exception wrappers around these APIs usually hide intent instead of clarifying it
+
+### Correct Patterns
+
+```python
+from pathlib import Path
+
+# CORRECT: Check existence only when you need a real filesystem entry
+for wt_path in worktree_paths:
+    wt_path_resolved = wt_path.resolve()
+    if not wt_path_resolved.exists():
+        continue
+    if current_dir.is_relative_to(wt_path_resolved):
+        current_worktree = wt_path_resolved
+        break
+
+# ALSO CORRECT: Ask resolve() to fail when absence is an error
+config_dir = config_path.resolve(strict=True)
+
+# WRONG: Broad exception handling around APIs that already communicate the result directly
+for wt_path in worktree_paths:
+    try:
+        wt_path_resolved = wt_path.resolve()
+        if current_dir.is_relative_to(wt_path_resolved):
+            current_worktree = wt_path_resolved
+            break
+    except OSError:
+        continue
+```
+
+### Pathlib Best Practices
+
+**Always Use Pathlib (Never os.path)**
+
+```python
+# CORRECT: Use pathlib.Path
+from pathlib import Path
+
+config_file = Path.home() / ".config" / "app.yml"
+if config_file.exists():
+    content = config_file.read_text(encoding="utf-8")
+
+# WRONG: Use os.path
+import os.path
+config_file = os.path.join(os.path.expanduser("~"), ".config", "app.yml")
+```
+
+**Always Specify Encoding**
+
+```python
+# CORRECT: Always specify encoding
+content = path.read_text(encoding="utf-8")
+path.write_text(data, encoding="utf-8")
+
+# WRONG: Default encoding
+content = path.read_text()  # Platform-dependent!
+```
+
+---
+
+## Import Organization
+
+### Core Rules
+
+1. **Default: ALWAYS place imports at module level**
+2. **Use absolute imports only** (no relative imports)
+3. **Inline imports only for specific exceptions** (circular deps, TYPE_CHECKING, conditional
+   features)
+
+```python
+# CORRECT: Module-level imports
+import json
+import click
+from pathlib import Path
+from myapp.config import load_config
+
+def my_function() -> None:
+    data = json.loads(content)
+
+# CORRECT: Absolute import
+from myapp.config import load_config
+
+# WRONG: Relative import
+from .config import load_config
+
+# WRONG: Inline imports without justification
+def my_function() -> None:
+    import json  # NEVER do this
+```
+
+For detailed inline import patterns and when they're legitimate, see `references/module-design.md`.
+
+---
+
+## Performance Guidelines
+
+### Properties Must Be O(1)
+
+```python
+# WRONG: Property doing I/O
+@property
+def size(self) -> int:
+    return self._fetch_from_db()
+
+# CORRECT: Explicit method name
+def fetch_size_from_db(self) -> int:
+    return self._fetch_from_db()
+
+# CORRECT: O(1) property
+@property
+def size(self) -> int:
+    return self._cached_size
+```
+
+### Magic Methods Must Be O(1)
+
+```python
+# WRONG: __len__ doing iteration
+def __len__(self) -> int:
+    return sum(1 for _ in self._items)
+
+# CORRECT: O(1) __len__
+def __len__(self) -> int:
+    return self._count
+```
+
+---
+
+## Anti-Patterns
+
+### No Backwards Compatibility Preservation (Default)
+
+```python
+# WRONG: Keeping old API unnecessarily
+def process_data(data: dict, legacy_format: bool = False) -> Result:
+    if legacy_format:
+        return legacy_process(data)
+    return new_process(data)
+
+# CORRECT: Break and migrate immediately
+def process_data(data: dict) -> Result:
+    return new_process(data)
+```
+
+### No Re-Exports: One Canonical Import Path
+
+**Core Principle:** Every symbol has exactly one import path. Never re-export.
+
+```python
+# WRONG: __all__ exports create duplicate import paths
+# myapp/__init__.py
+from myapp.core import Process
+__all__ = ["Process"]
+
+# CORRECT: Empty __init__.py, import from canonical location
+# from myapp.core import Process
+```
+
+**When re-exports ARE required** (plugin entry points): Use explicit `import X as X` syntax:
+
+```python
+# CORRECT: Explicit re-export syntax for required entry points
+from myapp.core.feature import my_function as my_function
+```
+
+### Declare Variables Close to Use
+
+```python
+# WRONG: Variable declared far from use
+def process_data(ctx, items):
+    result_path = compute_result_path(ctx)  # Declared here...
+    # 20+ lines of other logic...
+    save_to_path(transformed, result_path)  # ...used here
+
+# CORRECT: Inline at use site
+def process_data(ctx, items):
+    validate_items(items)
+    transformed = transform_items(items)
+    save_to_path(transformed, compute_result_path(ctx))
+```
+
+### Don't Destructure Objects Into Single-Use Locals
+
+```python
+# WRONG: Unnecessary field extraction
+result = fetch_user(user_id)
+name = result.name      # only used once below
+email = result.email    # only used once below
+send_notification(name, email, role)
+
+# CORRECT: Access fields directly
+user = fetch_user(user_id)
+send_notification(user.name, user.email, user.role)
+```
+
+### Indentation Depth Limit
+
+**Maximum indentation: 4 levels**
+
+```python
+# WRONG: Too deeply nested (5 levels)
+def process_items(items):
+    for item in items:
+        if item.valid:
+            for child in item.children:
+                if child.enabled:
+                    for grandchild in child.descendants:
+                        pass  # 5 levels deep!
+
+# CORRECT: Extract helper functions
+def process_items(items):
+    for item in items:
+        if item.valid:
+            process_children(item.children)
+
+def process_children(children):
+    for child in children:
+        if child.enabled:
+            process_descendants(child.descendants)
+```
+
+### Keep Context Managers Inline in `with` Statements
+
+```python
+# CORRECT: Context manager stays in with statement
+with (cm_a if condition else nullcontext()):
+    do_work()
+
+# CORRECT: Multiple conditional context managers
+with (lock if thread_safe else nullcontext()):
+    process(data)
+
+# WRONG: Extracting to intermediate variable obscures lifecycle
+cm = cm_a if condition else nullcontext()
+with cm:
+    do_work()
+```
+
+Context managers belong in `with` statements where the `__enter__`/`__exit__` lifecycle is explicit.
+Do not extract them to intermediate variables. If the inline expression is genuinely overwhelming,
+extract the logic into a helper function that returns the context manager.
+
+---
+
+## Backwards Compatibility Philosophy
+
+**Default stance: NO backwards compatibility preservation**
+
+Only preserve backwards compatibility when:
+
+- Code is clearly part of public API
+- User explicitly requests it
+- Migration cost is prohibitively high (rare)
+
+Benefits:
+
+- Cleaner, maintainable codebase
+- Faster iteration
+- No legacy code accumulation
+- Simpler mental models
+
+---
+
+## See Also
+
+For detailed guidance on specialized topics:
+
+- **Exception chaining (B904)**: `references/advanced/exception-handling.md`
+- **ABC vs Protocol**: `references/advanced/interfaces.md`
+- **typing.cast() assertions**: `references/advanced/typing-advanced.md`
+- **Import-time side effects, @cache**: `references/module-design.md`
+- **Default parameters, keyword-only args**: `references/advanced/api-design.md`
+- **All decision checklists**: `references/checklists.md`

--- a/.agents/skills/dignified-python/references/README.md
+++ b/.agents/skills/dignified-python/references/README.md
@@ -1,0 +1,323 @@
+# Dignified Python Reference Documentation
+
+Opinionated Python standards for writing clean, maintainable, modern Python code.
+
+## Table of Contents
+
+### Core Standards
+
+- **[dignified-python-core.md](../dignified-python-core.md)** - Essential Python standards (always
+  apply)
+  - Modern type syntax (list[str], str | None)
+  - LBYL exception handling patterns
+  - Pathlib operations
+  - Absolute imports
+  - Error boundaries
+
+- **[cli-patterns.md](../cli-patterns.md)** - Command-line interface patterns
+  - Click usage patterns
+  - Argparse best practices
+  - CLI error handling
+  - Configuration management
+
+### Version-Specific Features (`versions/`)
+
+- **[python-3.10.md](../versions/python-3.10.md)** - Python 3.10+ features
+  - Structural pattern matching (match/case)
+  - Parenthesized context managers
+  - Better error messages
+  - Type union operator (X | Y)
+
+- **[python-3.11.md](../versions/python-3.11.md)** - Python 3.11+ features
+  - Exception groups (ExceptionGroup)
+  - except\* syntax
+  - Self type
+  - Variadic generics
+
+- **[python-3.12.md](../versions/python-3.12.md)** - Python 3.12+ features
+  - Type parameter syntax (Generic[T])
+  - Override decorator
+  - Per-interpreter GIL
+  - f-string improvements
+
+- **[python-3.13.md](../versions/python-3.13.md)** - Python 3.13+ features
+  - Experimental free-threading
+  - JIT compilation
+  - Improved error messages
+  - Performance improvements
+
+### Advanced Topics (`advanced/`)
+
+- **[exception-handling.md](./advanced/exception-handling.md)** - Exception patterns
+  - LBYL (Look Before You Leap) patterns
+  - Error boundaries
+  - Exception chaining
+  - Custom exceptions
+
+- **[interfaces.md](./advanced/interfaces.md)** - Interface design
+  - ABC (Abstract Base Class) patterns
+  - Protocol types
+  - Gateway layer interfaces
+  - Type narrowing
+
+- **[typing-advanced.md](./advanced/typing-advanced.md)** - Advanced typing
+  - Generic types
+  - Type narrowing
+  - Literal types
+  - TypedDict and dataclasses
+
+- **[api-design.md](./advanced/api-design.md)** - API design principles
+  - Function signatures
+  - Parameter complexity
+  - Code organization
+  - Production application code examples
+
+## Philosophy
+
+### Core Principles
+
+**Modern Type Syntax**: Use Python 3.10+ type syntax everywhere
+
+```python
+# Good (modern)
+def process(items: list[str]) -> str | None:
+    pass
+
+# Avoid (legacy)
+from typing import List, Optional
+def process(items: List[str]) -> Optional[str]:
+    pass
+```
+
+**Prefer LBYL When It Is Cheap and Precise**: This skill leans toward explicit precondition
+checks for routine branching, while still using targeted `try/except` blocks when parsing or API
+calls are the authoritative test.
+
+```python
+# Good (LBYL)
+if path.exists():
+    content = path.read_text()
+
+# Avoid (EAFP)
+try:
+    content = path.read_text()
+except FileNotFoundError:
+    pass
+```
+
+**Pathlib Over os.path**: Use pathlib for all file operations
+
+```python
+# Good
+from pathlib import Path
+config_path = Path("config.yaml")
+if config_path.exists():
+    content = config_path.read_text()
+
+# Avoid
+import os
+if os.path.exists("config.yaml"):
+    with open("config.yaml") as f:
+        content = f.read()
+```
+
+**Absolute Imports**: Never use relative imports
+
+```python
+# Good
+from myproject.utils import helper
+
+# Avoid
+from .utils import helper
+from ..shared import helper
+```
+
+**Error Boundaries at CLI Level**: Handle errors at the CLI entry point, not deep in the stack
+
+## Quick Reference
+
+### Type Annotations
+
+```python
+# Basic types
+def greet(name: str) -> str:
+    return f"Hello, {name}"
+
+# Collections (modern syntax)
+def process(items: list[str], mapping: dict[str, int]) -> tuple[str, int]:
+    pass
+
+# Optional/Union (modern syntax)
+def find(query: str) -> str | None:
+    pass
+
+# Multiple types
+def parse(value: str | int | float) -> float:
+    pass
+```
+
+### LBYL Patterns
+
+```python
+# File operations
+if path.exists():
+    content = path.read_text()
+
+# Dictionary access
+if "key" in data:
+    value = data["key"]
+
+# Attribute access
+if hasattr(obj, "method"):
+    obj.method()
+
+# Type checking
+if isinstance(value, str):
+    result = value.upper()
+```
+
+### Pathlib Operations
+
+```python
+from pathlib import Path
+
+# Create path
+config = Path("config.yaml")
+data_dir = Path("/data")
+
+# Check existence
+if config.exists():
+    pass
+
+# Read/write
+content = config.read_text()
+config.write_text("data")
+
+# Directory operations
+for file in data_dir.glob("*.txt"):
+    print(file.name)
+
+# Path manipulation
+full_path = data_dir / "subdir" / "file.txt"
+parent = full_path.parent
+name = full_path.name
+```
+
+### CLI Patterns (Click)
+
+```python
+import click
+
+@click.command()
+@click.option("--name", required=True, help="User name")
+@click.option("--count", default=1, help="Number of times")
+def greet(name: str, count: int) -> None:
+    """Greet a user multiple times."""
+    for _ in range(count):
+        click.echo(f"Hello, {name}!")
+
+if __name__ == "__main__":
+    greet()
+```
+
+## Version Detection
+
+**Automatic version detection** determines which Python version features are available:
+
+1. Check `pyproject.toml` for `requires-python` field
+2. Check `setup.py`/`setup.cfg` for `python_requires`
+3. Check `.python-version` file
+4. Default to Python 3.12 if not specified
+
+Based on detected version, appropriate version-specific features are recommended.
+
+## Navigation Tips
+
+- **Start with dignified-python-core.md** for essential patterns that apply to all code
+- **Check version-specific docs** based on your project's Python version
+- **Reference advanced topics** when dealing with specialized patterns
+- **Use cli-patterns.md** when building command-line tools
+
+## When to Read Each Reference
+
+| Situation                  | Reference                      |
+| -------------------------- | ------------------------------ |
+| Writing any Python code    | dignified-python-core.md       |
+| Building a CLI tool        | cli-patterns.md                |
+| Using Python 3.10 features | versions/python-3.10.md        |
+| Using Python 3.11 features | versions/python-3.11.md        |
+| Using Python 3.12 features | versions/python-3.12.md        |
+| Using Python 3.13 features | versions/python-3.13.md        |
+| Handling exceptions        | advanced/exception-handling.md |
+| Designing interfaces       | advanced/interfaces.md         |
+| Complex type hints         | advanced/typing-advanced.md    |
+| API design decisions       | advanced/api-design.md         |
+
+## Related Skills
+
+- **`/dagster-best-practices`** - Dagster-specific patterns (not general Python)
+- **`/dg`** - Dagster CLI operations
+- **`/dagster-expert`** - Dagster expertise including integrations
+
+**Important**: `/dignified-python` is for **general-purpose Python style guidance**, not
+Dagster-specific patterns. It is intentionally opinionated rather than universal. For Dagster
+patterns, use `/dagster-best-practices`.
+
+## Cross-Skill Usage
+
+Users invoke `/dignified-python` when they need Python code quality guidance, regardless of whether
+it's for a Dagster project or any other Python project.
+
+**Workflow:**
+
+```
+User: "Is this good Python code?"
+→ /dignified-python (check dignified-python-core.md)
+→ Apply modern type syntax, LBYL, pathlib patterns
+→ Check version-specific features based on project
+
+User: "How should I structure my Dagster assets?"
+→ /dagster-best-practices (NOT dignified-python)
+→ Learn asset patterns, dependencies, partitions
+```
+
+## Production Patterns
+
+These standards reflect production-tested conventions:
+
+- ✅ **Modern type syntax** - Improves IDE support and type checking
+- ✅ **LBYL patterns** - More explicit and easier to debug than EAFP
+- ✅ **Pathlib** - More readable and cross-platform than os.path
+- ✅ **Absolute imports** - Avoid import confusion and relative import issues
+- ✅ **Error boundaries at CLI** - Clean error messages for end users
+
+## Documentation Structure
+
+Each reference document follows a consistent structure:
+
+1. **Overview** - High-level concepts
+2. **Patterns** - Common code patterns with examples
+3. **Best Practices** - Recommended approaches
+4. **Anti-Patterns** - What to avoid
+5. **Real-World Examples** - Production code samples
+6. **Related Topics** - Cross-references
+
+## Self-Selecting Usage
+
+Users only invoke `/dignified-python` when they want Python standards guidance. The skill
+description makes it clear it's for general Python quality, not Dagster-specific patterns, so users
+naturally select it when appropriate.
+
+**Users will invoke this when they want:**
+
+- Code review and quality improvements
+- Modern Python patterns
+- Type annotation guidance
+- Exception handling best practices
+- CLI implementation patterns
+
+**Users will NOT invoke this when they want:**
+
+- Dagster-specific patterns (they'll use `/dagster-best-practices`)
+- Creating Dagster projects (they'll use `/dg`)
+- Finding integrations (they'll use `/dagster-expert`)

--- a/.agents/skills/dignified-python/references/advanced/api-design.md
+++ b/.agents/skills/dignified-python/references/advanced/api-design.md
@@ -1,0 +1,229 @@
+---
+description:
+  Default parameter dangers, keyword-only arguments, ThreadPoolExecutor patterns, speculative test
+  infrastructure.
+---
+
+# API Design Reference
+
+**Read when**: Adding default parameters, functions with 5+ params, using ThreadPoolExecutor
+
+---
+
+## Default Parameter Values Are Dangerous
+
+> **Scope:** This rule applies to **function definitions** (`def foo(bar: bool = False)`), NOT to
+> **function calls** where you pass an argument named `default` (e.g.,
+> `click.confirm(default=True)`). Passing `default=True` to a function that accepts a `default`
+> parameter is perfectly valid—you're not creating a default parameter value, you're explicitly
+> providing a value.
+
+**Avoid default parameter values unless absolutely necessary.** They are a significant source of
+bugs.
+
+**Why defaults are dangerous:**
+
+1. **Silent incorrect behavior** - Callers forget to pass a parameter and get unexpected results
+2. **Hidden coupling** - The default encodes an assumption that may not hold for all callers
+3. **Audit difficulty** - Hard to verify all call sites are using the right value
+4. **Refactoring hazard** - Adding a new parameter with a default doesn't trigger errors at existing
+   call sites
+
+```python
+# DANGEROUS: Default that might be wrong for some callers
+def process_file(path: Path, encoding: str = "utf-8") -> str:
+    return path.read_text(encoding=encoding)
+
+# Caller forgets encoding, silently gets wrong behavior for legacy file
+content = process_file(legacy_latin1_file)  # Bug: should be encoding="latin-1"
+
+# SAFER: Require explicit choice
+def process_file(path: Path, encoding: str) -> str:
+    return path.read_text(encoding=encoding)
+
+# Caller must think about encoding
+content = process_file(legacy_latin1_file, encoding="latin-1")
+```
+
+**When you discover a default is never overridden, eliminate it:**
+
+```python
+# If every call site uses the default...
+activate_worktree(ctx, repo, path, script, "up", preserve_relative_path=True)  # Always True
+activate_worktree(ctx, repo, path, script, "down", preserve_relative_path=True)  # Always True
+
+# CORRECT: Remove the parameter entirely
+def activate_worktree(ctx, repo, path, script, command_name) -> None:
+    # Always preserve relative path - it's just the behavior
+    ...
+```
+
+**Acceptable uses of defaults:**
+
+1. **Truly optional behavior** - Where the default is correct for 95%+ of callers
+2. **Backwards compatibility** - When adding a parameter to existing API (temporary)
+3. **Test helper functions** - Functions in `tests/test_utils/` that exist to reduce test
+   boilerplate are explicitly exempt. These helpers often wrap complex constructors (like
+   `format_plan_header_body`) with sensible defaults, and having many default parameters is their
+   intended purpose—not a code smell
+
+**When reviewing code with defaults, ask:**
+
+- Do all call sites actually want this default?
+- Would a caller forgetting this parameter cause a bug?
+- Is there a safer design that makes the choice explicit?
+
+---
+
+## Keyword-Only Arguments for Complex Functions
+
+**Functions with 5 or more parameters MUST use keyword-only arguments.**
+
+Use the `*` separator after the first positional parameter to enforce keyword-only at the language
+level. This improves call-site readability by forcing explicit parameter names.
+
+```python
+# CORRECT: Keyword-only after first param
+def fetch_data(
+    url,
+    *,
+    timeout: float,
+    retries: int,
+    headers: dict[str, str],
+    auth_token: str,
+) -> Response:
+    ...
+
+# Call site is self-documenting
+response = fetch_data(
+    api_url,
+    timeout=30.0,
+    retries=3,
+    headers={"Accept": "application/json"},
+    auth_token=token,
+)
+
+# WRONG: All positional parameters
+def fetch_data(
+    url,
+    timeout: float,
+    retries: int,
+    headers: dict[str, str],
+    auth_token: str,
+) -> Response:
+    ...
+
+# Call site is unreadable - what do these values mean?
+response = fetch_data(api_url, 30.0, 3, {"Accept": "application/json"}, token)
+```
+
+**Exceptions:**
+
+1. **`self`** - Always positional (Python requirement)
+2. **`ctx` / context objects** - Can remain positional as the first parameter (convention)
+3. **ABC/Protocol methods** - Exempt to avoid forcing all implementations to change signatures
+4. **Click callbacks** - Click injects parameters; follow Click conventions
+
+```python
+# CORRECT: ctx stays positional, rest are keyword-only
+def build_report(
+    ctx: AppContext,
+    *,
+    project_id: str,
+    output_path: Path,
+    include_drafts: bool,
+) -> Report:
+    ...
+```
+
+---
+
+## ThreadPoolExecutor.submit() Pattern
+
+`ThreadPoolExecutor.submit()` passes arguments positionally to the callable. For functions with
+keyword-only parameters, wrap the call in a lambda:
+
+```python
+# WRONG: submit() passes args positionally - fails with keyword-only functions
+future = executor.submit(fetch_data, url, timeout, retries, headers, token)
+
+# CORRECT: Lambda enables keyword arguments
+future = executor.submit(
+    lambda: fetch_data(
+        url,
+        timeout=timeout,
+        retries=retries,
+        headers=headers,
+        auth_token=token,
+    )
+)
+```
+
+---
+
+## Speculative Test Infrastructure
+
+**Don't add parameters to fakes "just in case" they might be useful for testing.**
+
+Fakes should mirror production interfaces. Adding test-only configuration knobs that never get used
+creates dead code and false complexity.
+
+```python
+# WRONG: Test-only parameter that's never used in production
+class FakeGitHub:
+    def __init__(
+        self,
+        prs: dict[str, PullRequestInfo] | None = None,
+        rate_limited: bool = False,  # "Might test this later"
+    ) -> None:
+        self._rate_limited = rate_limited  # Never set to True anywhere
+
+# CORRECT: Only add infrastructure when you need it
+class FakeGitHub:
+    def __init__(
+        self,
+        prs: dict[str, PullRequestInfo] | None = None,
+    ) -> None:
+        ...
+```
+
+**The test for this:** If grep shows a parameter is only ever passed in test files, and those tests
+are testing hypothetical scenarios rather than actual production behavior, delete both the parameter
+and the tests.
+
+---
+
+## Speculative Tests
+
+```python
+# FORBIDDEN: Tests for future features
+# def test_feature_we_might_add():
+#     pass
+
+# CORRECT: TDD for current implementation
+def test_feature_being_built_now():
+    result = new_feature()
+    assert result == expected
+```
+
+---
+
+## Decision Checklist
+
+Before adding a default parameter value:
+
+- [ ] Do 95%+ of callers actually want this default?
+- [ ] Would forgetting to pass this parameter cause a subtle bug?
+- [ ] Is there a safer design that makes the choice explicit?
+- [ ] If the default is never overridden anywhere, should this parameter exist at all?
+
+**Default: Require explicit values; eliminate unused defaults**
+
+Before adding a function with 5+ parameters:
+
+- [ ] Have I added `*` after the first (or ctx) parameter?
+- [ ] Is only `self`/`ctx` positional?
+- [ ] Is this an ABC/Protocol method? (exempt from rule)
+- [ ] If using ThreadPoolExecutor.submit(), am I using a lambda wrapper?
+
+**Default: All parameters after the first should be keyword-only**

--- a/.agents/skills/dignified-python/references/advanced/exception-handling.md
+++ b/.agents/skills/dignified-python/references/advanced/exception-handling.md
@@ -1,0 +1,184 @@
+---
+description:
+  Detailed exception handling patterns including B904 chaining, third-party API compatibility, and
+  anti-patterns.
+---
+
+# Exception Handling Reference
+
+**Read when**: Writing try/except blocks, wrapping third-party APIs, seeing `from e` or `from None`
+
+---
+
+## When Exceptions Are a Good Fit
+
+This skill prefers explicit condition checks when they are cheap and precise, but exceptions are
+the right tool in a few common situations:
+
+1. **Error boundaries** (CLI/API level)
+2. **Operations where the call itself is the authoritative test**
+3. **Adding context before re-raising**
+
+### 1. Error Boundaries
+
+```python
+# ACCEPTABLE: CLI command error boundary
+@click.command("create")
+@click.pass_obj
+def create(ctx: AppContext, name: str) -> None:
+    """Create a resource."""
+    try:
+        create_resource(ctx, name)
+    except subprocess.CalledProcessError as e:
+        click.echo(f"Error: Git command failed: {e.stderr}", err=True)
+        raise SystemExit(1) from e
+```
+
+### 2. Third-Party API Compatibility
+
+```python
+# ACCEPTABLE: Third-party API forces exception handling
+def _get_bigquery_sample(sql_client, table_name):
+    """
+    BigQuery's TABLESAMPLE doesn't work on views.
+    There's no reliable way to determine a priori whether
+    a table supports TABLESAMPLE.
+    """
+    try:
+        return sql_client.run_query(f"SELECT * FROM {table_name} TABLESAMPLE...")
+    except Exception:
+        return sql_client.run_query(f"SELECT * FROM {table_name} ORDER BY RAND()...")
+```
+
+> **The test for "use LBYL first"**: Can you validate the condition with a cheap, precise check
+> before calling the API? If yes, prefer that. If the operation itself is the authoritative
+> validator, a small `try/except` is often clearer.
+
+### Prefer Real Parsers Over Brittle Pre-Checks
+
+Do not replace parser calls with incomplete string-shape checks such as `str.isdigit()` or
+hand-rolled ISO date heuristics. Those checks often reject valid inputs and accept invalid ones.
+
+When the same try/parse/default pattern recurs, extract a generic helper:
+
+```python
+from typing import TypeVar, Callable
+
+T = TypeVar("T")
+
+def try_parse(parse: Callable[[str], T], value: str, default: T) -> T:
+    """Parse *value* with *parse*, returning *default* on ValueError."""
+    try:
+        return parse(value)
+    except ValueError:
+        return default
+```
+
+Usage:
+
+```python
+from datetime import datetime
+
+port = try_parse(int, user_input, 80)
+ts = try_parse(datetime.fromisoformat, timestamp_str, None)
+```
+
+Use a separate pre-check only when you intentionally accept a narrower format than the parser and
+can state that rule precisely.
+
+### 3. Adding Context Before Re-raising
+
+```python
+# ACCEPTABLE: Adding context before re-raising
+try:
+    process_file(config_file)
+except yaml.YAMLError as e:
+    raise ValueError(f"Failed to parse config file {config_file}: {e}") from e
+```
+
+---
+
+## Exception Chaining (B904 Lint Compliance)
+
+**Ruff rule B904** requires explicit exception chaining when raising inside an `except` block. This
+prevents losing the original traceback.
+
+```python
+# CORRECT: Chain to preserve context
+try:
+    parse_config(path)
+except ValueError as e:
+    click.echo(json.dumps({"success": False, "error": str(e)}))
+    raise SystemExit(1) from e  # Preserves traceback
+
+# CORRECT: Explicitly break chain when intentional
+try:
+    fetch_from_cache(key)
+except KeyError:
+    # Original exception is not relevant to caller
+    raise ValueError(f"Unknown key: {key}") from None
+
+# WRONG: Missing exception chain (B904 violation)
+try:
+    parse_config(path)
+except ValueError:
+    raise SystemExit(1)  # Lint error: missing 'from e' or 'from None'
+
+# CORRECT: CLI error boundary with JSON output
+try:
+    result = some_operation()
+except RuntimeError as e:
+    click.echo(json.dumps({"success": False, "error": str(e)}))
+    raise SystemExit(0) from None  # Exception is in JSON, traceback irrelevant to CLI user
+```
+
+**When to use each:**
+
+- `from e` - Preserve original exception for debugging
+- `from None` - Intentionally suppress original (e.g., transforming exception type, CLI JSON output)
+
+---
+
+## Exception Anti-Patterns
+
+**Never swallow exceptions silently**
+
+Even at error boundaries, you must at least log/warn so issues can be diagnosed:
+
+```python
+# WRONG: Silent exception swallowing
+try:
+    risky_operation()
+except:
+    pass
+
+# WRONG: Silent swallowing even at error boundary
+try:
+    optional_feature()
+except Exception:
+    pass  # Silent - impossible to diagnose issues
+
+# CORRECT: Let exceptions bubble up (default)
+risky_operation()
+
+# CORRECT: At error boundaries, log the exception
+try:
+    optional_feature()
+except Exception as e:
+    logging.warning("Optional feature failed: %s", e)  # Diagnosable
+```
+
+**Never use silent fallback behavior**
+
+```python
+# WRONG: Silent fallback masks failure
+def process_text(text: str) -> dict:
+    try:
+        return llm_client.process(text)
+    except Exception:
+        return regex_parse_fallback(text)
+
+# CORRECT: Let error bubble to boundary
+def process_text(text: str) -> dict:
+    return llm_client.process(text)
+```

--- a/.agents/skills/dignified-python/references/advanced/interfaces.md
+++ b/.agents/skills/dignified-python/references/advanced/interfaces.md
@@ -1,0 +1,185 @@
+---
+description: ABC vs Protocol decision guide, dependency injection patterns, and complete DI examples.
+---
+
+# Interface Design Reference
+
+**Read when**: Creating ABC/Protocol classes, writing @abstractmethod, designing gateway interfaces
+
+---
+
+## ABC vs Protocol: Choosing the Right Interface
+
+**ABCs (nominal typing)** and **Protocols (structural typing)** serve different purposes. Choose
+based on ownership and coupling needs.
+
+| Use Case                                  | Recommended | Why                                                  |
+| ----------------------------------------- | ----------- | ---------------------------------------------------- |
+| Internal interfaces you control           | ABC         | Explicit enforcement, runtime validation, code reuse |
+| Third-party library boundaries            | Protocol    | No inheritance required, loose coupling              |
+| Plugin systems with isinstance checks     | ABC         | Reliable runtime type validation                     |
+| Minimal interface contracts (1-2 methods) | Protocol    | Less boilerplate, focused contracts                  |
+
+**Default for internal application code you own: ABC. Default for external library facades:
+Protocol.**
+
+---
+
+## ABC Interface Pattern
+
+```python
+# CORRECT: Use ABC for interfaces
+from abc import ABC, abstractmethod
+
+class Repository(ABC):
+    @abstractmethod
+    def save(self, entity: Entity) -> None:
+        """Save entity to storage."""
+        ...
+
+    @abstractmethod
+    def load(self, id: str) -> Entity:
+        """Load entity by ID."""
+        ...
+
+class PostgresRepository(Repository):
+    def save(self, entity: Entity) -> None:
+        # Implementation
+        pass
+
+    def load(self, id: str) -> Entity:
+        # Implementation
+        pass
+```
+
+---
+
+## Benefits of ABC (Internal Interfaces)
+
+1. **Explicit inheritance** - Clear class hierarchy, explicit opt-in
+2. **Runtime validation** - Errors at instantiation if abstract methods missing
+3. **Code reuse** - Can include concrete methods and shared logic
+4. **Reliable isinstance()** - Full signature checking at runtime
+
+---
+
+## Benefits of Protocol (External Boundaries)
+
+1. **No inheritance required** - Works with code you don't control
+2. **Loose coupling** - Implementations don't know about the protocol
+3. **Minimal contracts** - Define only the methods you need
+4. **Duck typing** - Aligns with Python's philosophy
+
+---
+
+## Complete DI Example
+
+```python
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+
+# Define the interface
+class DataStore(ABC):
+    @abstractmethod
+    def get(self, key: str) -> str | None:
+        """Retrieve value by key."""
+        ...
+
+    @abstractmethod
+    def set(self, key: str, value: str) -> None:
+        """Store value with key."""
+        ...
+
+# Real implementation
+class RedisStore(DataStore):
+    def get(self, key: str) -> str | None:
+        return self.client.get(key)
+
+    def set(self, key: str, value: str) -> None:
+        self.client.set(key, value)
+
+# Fake for testing
+class FakeStore(DataStore):
+    def __init__(self) -> None:
+        self._data: dict[str, str] = {}
+
+    def get(self, key: str) -> str | None:
+        if key not in self._data:
+            return None
+        return self._data[key]
+
+    def set(self, key: str, value: str) -> None:
+        self._data[key] = value
+
+# Business logic accepts interface
+@dataclass
+class Service:
+    store: DataStore  # Depends on abstraction
+
+    def process(self, item: str) -> None:
+        cached = self.store.get(item)
+        if cached is None:
+            result = expensive_computation(item)
+            self.store.set(item, result)
+        else:
+            result = cached
+        use_result(result)
+```
+
+---
+
+## When to Use Protocol
+
+**Protocols excel at defining interfaces for code you don't control:**
+
+```python
+# CORRECT: Protocol for third-party library facade
+from typing import Protocol
+
+class HttpClient(Protocol):
+    """Interface for HTTP operations - decouples from requests/httpx/aiohttp."""
+    def get(self, url: str) -> Response: ...
+    def post(self, url: str, data: dict) -> Response: ...
+
+# Any HTTP library that has these methods works - no inheritance needed
+def fetch_data(client: HttpClient, endpoint: str) -> dict:
+    response = client.get(endpoint)
+    return response.json()
+```
+
+**Protocols are also appropriate for minimal, focused interfaces:**
+
+```python
+# CORRECT: Protocol for structural typing with minimal interface
+from typing import Protocol
+
+class Closeable(Protocol):
+    def close(self) -> None: ...
+
+def cleanup_resources(resources: list[Closeable]) -> None:
+    for r in resources:
+        r.close()
+```
+
+---
+
+## Protocol Limitations
+
+1. **No runtime validation** - `@runtime_checkable` only checks method existence, not signatures
+2. **No code reuse** - Protocols shouldn't have method implementations
+3. **Weaker isinstance() checks** - ABCs provide more reliable runtime type checking
+
+---
+
+## Decision Checklist
+
+Before defining an interface (ABC or Protocol):
+
+- [ ] Do I own all implementations? -> Prefer ABC
+- [ ] Am I wrapping a third-party library? -> Prefer Protocol
+- [ ] Do I need runtime isinstance() validation? -> Use ABC
+- [ ] Is this a minimal interface (1-2 methods)? -> Protocol may be simpler
+- [ ] Do I need shared method implementations? -> Use ABC
+
+**Default for internal application code you own: ABC. Default for external library facades:
+Protocol.**

--- a/.agents/skills/dignified-python/references/advanced/typing-advanced.md
+++ b/.agents/skills/dignified-python/references/advanced/typing-advanced.md
@@ -1,0 +1,158 @@
+---
+description: Advanced typing patterns including cast() with assertions, Literal types for programmatic strings.
+---
+
+# Advanced Typing Reference
+
+**Read when**: Using typing.cast(), creating Literal type aliases, narrowing types
+
+---
+
+## Using `typing.cast()`
+
+### Core Rule
+
+**ALWAYS verify `cast()` with a runtime assertion, unless there's a documented reason not to.**
+
+`typing.cast()` is a compile-time only construct—it tells the type checker to trust you but performs
+no runtime verification. If your assumption is wrong, you'll get silent misbehavior instead of a
+clear error.
+
+### Required Pattern
+
+```python
+from collections.abc import MutableMapping
+from typing import Any, cast
+
+# CORRECT: Runtime assertion before cast
+assert isinstance(doc, MutableMapping), f"Expected MutableMapping, got {type(doc)}"
+cast(dict[str, Any], doc)["key"] = value
+
+# CORRECT: Alternative with hasattr for duck typing
+assert hasattr(obj, '__setitem__'), f"Expected subscriptable, got {type(obj)}"
+cast(dict[str, Any], obj)["key"] = value
+```
+
+### Anti-Pattern
+
+```python
+# WRONG: Cast without runtime verification
+cast(dict[str, Any], doc)["key"] = value  # If doc isn't a dict-like, silent failure
+```
+
+### When to Skip Runtime Verification
+
+**Default: Always add the assertion when cost is trivial (O(1) checks like `in`, `isinstance`).**
+
+Skip the assertion only in these narrow cases:
+
+1. **Immediately after a type guard**: The check was just performed and would be redundant
+
+   ```python
+   if isinstance(value, str):
+       # No assertion needed - we just checked
+       result = cast(str, value).upper()
+   ```
+
+2. **Performance-critical hot path**: Add a comment explaining the measured overhead
+   ```python
+   # Skip assertion: called 10M times/sec, isinstance adds 15% overhead
+   # Type invariant maintained by _validate_input() at entry point
+   cast(int, cached_value)
+   ```
+
+**What is NOT a valid reason to skip:**
+
+- "Click validates the choice set" - Add assertion anyway; cost is trivial
+- "The library guarantees the type" - Add assertion anyway; defense in depth
+- "It's obvious from context" - Add assertion anyway; future readers benefit
+
+### Why This Matters
+
+- **Silent bugs are worse than loud bugs**: An assertion failure gives you a stack trace and clear
+  error message
+- **Documentation**: The assertion documents your assumption for future readers
+- **Defense in depth**: Third-party libraries can change behavior between versions
+
+---
+
+## Programmatically Significant Strings
+
+**Use `Literal` types for strings that have programmatic meaning.**
+
+When strings represent a fixed set of valid values (error codes, status values, command types),
+model them in the type system using `Literal`.
+
+### Why This Matters
+
+1. **Type safety** - Typos caught at type-check time, not runtime
+2. **IDE support** - Autocomplete shows valid options
+3. **Documentation** - Valid values are explicit in the code
+4. **Refactoring** - Rename operations work correctly
+
+### Naming Convention
+
+**Use kebab-case for all internal Literal string values:**
+
+```python
+# CORRECT: kebab-case for internal values
+IssueCode = Literal["orphan-state", "orphan-dir", "missing-branch"]
+ErrorType = Literal["not-found", "invalid-format", "timeout-exceeded"]
+```
+
+**Exception: When modeling external systems, match the external API's convention:**
+
+```python
+# CORRECT: Match GitHub API's UPPER_CASE
+PRState = Literal["OPEN", "MERGED", "CLOSED"]
+
+# CORRECT: Match GitHub Actions API's lowercase
+WorkflowStatus = Literal["completed", "in_progress", "queued"]
+```
+
+The rule is: kebab-case by default, external convention when modeling external APIs.
+
+### Pattern
+
+```python
+from dataclasses import dataclass
+from typing import Literal
+
+# CORRECT: Define a type alias for the valid values
+IssueCode = Literal["orphan-state", "orphan-dir", "missing-branch"]
+
+@dataclass(frozen=True)
+class Issue:
+    code: IssueCode
+    message: str
+
+def check_state() -> list[Issue]:
+    issues: list[Issue] = []
+    if problem_detected:
+        issues.append(Issue(code="orphan-state", message="description"))  # Type-checked!
+    return issues
+
+# WRONG: Bare strings without type constraint
+def check_state() -> list[tuple[str, str]]:
+    issues: list[tuple[str, str]] = []
+    issues.append(("orphen-state", "desc"))  # Typo goes unnoticed!
+    return issues
+```
+
+### When to Use Literal
+
+- Error/issue codes
+- Status values (pending, complete, failed)
+- Command types or action names
+- Configuration keys with fixed valid values
+- Any string that is compared programmatically
+
+### Decision Checklist
+
+Before using a bare `str` type, ask:
+
+- Is this string compared with `==` or `in` anywhere?
+- Is there a fixed set of valid values?
+- Would a typo in this string cause a bug?
+
+If any answer is "yes", use `Literal` instead.

--- a/.agents/skills/dignified-python/references/checklists.md
+++ b/.agents/skills/dignified-python/references/checklists.md
@@ -1,0 +1,136 @@
+---
+description: All decision checklists consolidated for final review before committing Python changes.
+---
+
+# Decision Checklists Reference
+
+**Read when**: Final review before committing Python code, need quick lookup of requirements
+
+---
+
+## Before Writing `try/except`
+
+- [ ] Is this at an error boundary? (CLI/API level)
+- [ ] Can I check the condition proactively with a cheap, precise test?
+- [ ] If not, is a small `try/except` around the authoritative operation clearer?
+- [ ] Am I adding meaningful context, or just hiding?
+- [ ] Is a third-party API forcing me to use exceptions because no precise pre-check exists?
+- [ ] Have I encapsulated the violation?
+- [ ] Am I catching specific exceptions, not broad?
+- [ ] If catching at error boundary, am I logging/warning? (Never silently swallow)
+
+**Default: Let exceptions bubble up**
+
+---
+
+## Before Path Operations
+
+- [ ] Am I checking `.exists()` because filesystem presence matters for this operation?
+- [ ] If missing paths should fail during `.resolve()`, did I pass `strict=True`?
+- [ ] Am I treating `.is_relative_to()` as a boolean check instead of wrapping it for `ValueError`?
+- [ ] Am I using `pathlib.Path`, not `os.path`?
+- [ ] Did I specify `encoding="utf-8"`?
+
+---
+
+## Before Using `typing.cast()`
+
+- [ ] Have I added a runtime assertion to verify the cast?
+- [ ] Is the assertion cost trivial (O(1))? If yes, always add it.
+- [ ] If skipping, is it because I just performed an isinstance check (redundant)?
+- [ ] If skipping for performance, have I documented the measured overhead?
+
+**Default: Always add runtime assertion before cast when cost is trivial**
+
+---
+
+## Before Defining an Interface (ABC or Protocol)
+
+- [ ] Do I own all implementations? -> Prefer ABC
+- [ ] Am I wrapping a third-party library? -> Prefer Protocol
+- [ ] Do I need runtime isinstance() validation? -> Use ABC
+- [ ] Is this a minimal interface (1-2 methods)? -> Protocol may be simpler
+- [ ] Do I need shared method implementations? -> Use ABC
+
+**Default for internal application code you own: ABC. Default for external library facades:
+Protocol.**
+
+---
+
+## Before Preserving Backwards Compatibility
+
+- [ ] Did the user explicitly request it?
+- [ ] Is this a public API with external consumers?
+- [ ] Have I documented why it's needed?
+- [ ] Is migration cost prohibitively high?
+
+**Default: Break the API and migrate callsites immediately**
+
+---
+
+## Before Inline Imports
+
+- [ ] Is this to break a circular dependency?
+- [ ] Is this for TYPE_CHECKING?
+- [ ] Is this for conditional features?
+- [ ] If for startup time: Have I MEASURED the import cost?
+- [ ] If for startup time: Is the cost significant (>100ms)?
+- [ ] If for startup time: Have I documented the measured cost in a comment?
+- [ ] Have I documented why the inline import is needed?
+
+**Default: Module-level imports**
+
+---
+
+## Before Importing/Re-Exporting Symbols
+
+- [ ] Is there already a canonical location for this symbol?
+- [ ] Am I creating a second import path for the same symbol?
+- [ ] If this is a shim module, am I importing only what's needed for this module's purpose?
+- [ ] Have I avoided `__all__` exports?
+
+**Default: Import from canonical location, never re-export**
+
+---
+
+## Before Declaring a Local Variable
+
+- [ ] Is this variable used more than once?
+- [ ] Is this variable used close to where it's declared?
+- [ ] Would inlining the computation hurt readability?
+- [ ] Am I extracting object fields into locals that are only used once?
+
+**Default: Inline single-use computations at the call site; access object attributes directly**
+
+---
+
+## Before Adding a Default Parameter Value
+
+- [ ] Do 95%+ of callers actually want this default?
+- [ ] Would forgetting to pass this parameter cause a subtle bug?
+- [ ] Is there a safer design that makes the choice explicit?
+- [ ] If the default is never overridden anywhere, should this parameter exist at all?
+
+**Default: Require explicit values; eliminate unused defaults**
+
+---
+
+## Before Adding a Function with 5+ Parameters
+
+- [ ] Have I added `*` after the first (or ctx) parameter?
+- [ ] Is only `self`/`ctx` positional?
+- [ ] Is this an ABC/Protocol method? (exempt from rule)
+- [ ] If using ThreadPoolExecutor.submit(), am I using a lambda wrapper?
+
+**Default: All parameters after the first should be keyword-only**
+
+---
+
+## Before Writing Module-Level Code
+
+- [ ] Does this involve any computation (even `Path()` construction)?
+- [ ] Does this involve I/O (file, network, environment)?
+- [ ] Could this fail or raise exceptions?
+- [ ] Would tests need to mock this value?
+
+If any answer is "yes", wrap in a `@cache`-decorated function instead.

--- a/.agents/skills/dignified-python/references/module-design.md
+++ b/.agents/skills/dignified-python/references/module-design.md
@@ -1,0 +1,214 @@
+---
+description: Import-time side effects, @cache for deferred computation, module-level code patterns.
+---
+
+# Module Design Reference
+
+**Read when**: Creating new modules, adding module-level code, using @cache decorator
+
+---
+
+## Import-Time Side Effects
+
+### Core Rule
+
+**Avoid computation and side effects at import time. Defer to function calls.**
+
+Module-level code runs when the module is imported. Side effects at import time cause:
+
+1. **Slower startup** - Every import triggers computation
+2. **Test brittleness** - Hard to mock/control behavior
+3. **Circular import issues** - Dependencies evaluated too early
+4. **Unpredictable order** - Import order affects behavior
+
+---
+
+## Common Anti-Patterns
+
+```python
+# WRONG: Path computed at import time
+SESSION_ID_FILE = Path(".app/scratch/current-session-id")
+
+def get_session_id() -> str | None:
+    if SESSION_ID_FILE.exists():
+        return SESSION_ID_FILE.read_text(encoding="utf-8")
+    return None
+
+# WRONG: Config loaded at import time
+CONFIG = load_config()  # I/O at import!
+
+# WRONG: Connection established at import time
+DB_CLIENT = DatabaseClient(os.environ["DB_URL"])  # Side effect at import!
+```
+
+---
+
+## Correct Patterns
+
+**Use `@cache` for deferred computation:**
+
+```python
+from functools import cache
+
+# CORRECT: Defer computation until first call
+@cache
+def _session_id_file_path() -> Path:
+    """Return path to session ID file (cached after first call)."""
+    return Path(".app/scratch/current-session-id")
+
+def get_session_id() -> str | None:
+    session_file = _session_id_file_path()
+    if session_file.exists():
+        return session_file.read_text(encoding="utf-8")
+    return None
+```
+
+**Use functions for resources:**
+
+```python
+# CORRECT: Defer resource creation to function call
+@cache
+def get_config() -> Config:
+    """Load config on first call, cache result."""
+    return load_config()
+
+@cache
+def get_db_client() -> DatabaseClient:
+    """Create database client on first call."""
+    return DatabaseClient(os.environ["DB_URL"])
+```
+
+---
+
+## When Module-Level Constants ARE Acceptable
+
+Simple, static values that don't involve computation or I/O:
+
+```python
+# ACCEPTABLE: Static constants
+DEFAULT_TIMEOUT = 30
+MAX_RETRIES = 3
+SUPPORTED_FORMATS = frozenset({"json", "yaml", "toml"})
+```
+
+---
+
+## Inline Import Patterns
+
+### Core Rules
+
+1. **Default: ALWAYS place imports at module level**
+2. **Use absolute imports only** (no relative imports)
+3. **Inline imports only for specific exceptions** (see below)
+
+### Legitimate Inline Import Patterns
+
+#### 1. Circular Import Prevention
+
+```python
+# commands/sync.py
+def register_commands(cli_group):
+    """Register commands with CLI group (avoids circular import)."""
+    from myapp.cli import sync_command  # Breaks circular dependency
+    cli_group.add_command(sync_command)
+```
+
+**When to use:**
+
+- CLI command registration
+- Plugin systems with bidirectional dependencies
+- Lazy loading to break import cycles
+
+#### 2. Conditional Feature Imports
+
+```python
+def process_data(data: dict, dry_run: bool = False) -> None:
+    if dry_run:
+        # Inline import: Only needed for dry-run mode
+        from myapp.dry_run import NoopProcessor
+        processor = NoopProcessor()
+    else:
+        processor = RealProcessor()
+    processor.execute(data)
+```
+
+**When to use:**
+
+- Debug/verbose mode utilities
+- Dry-run mode wrappers
+- Optional feature modules
+- Platform-specific implementations
+
+#### 3. TYPE_CHECKING Imports
+
+```python
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from myapp.models import User  # Only for type hints
+
+def process_user(user: "User") -> None:
+    ...
+```
+
+**When to use:**
+
+- Avoiding circular dependencies in type hints
+- Forward declarations
+
+#### 4. Startup Time Optimization (Rare)
+
+Some packages have genuinely heavy import costs (pyspark, jupyter ecosystem, large ML frameworks).
+Deferring these imports can improve CLI startup time.
+
+**However, apply "innocent until proven guilty":**
+
+- Default to module-level imports
+- Only defer imports when you have MEASURED evidence of startup impact
+- Document the measured cost in a comment
+
+```python
+# ACCEPTABLE: Measured heavy import (adds 800ms to startup)
+def run_spark_job(config: SparkConfig) -> None:
+    from pyspark.sql import SparkSession  # Heavy: 800ms import time
+    session = SparkSession.builder.getOrCreate()
+    ...
+
+# WRONG: Speculative deferral without measurement
+def check_staleness(project_dir: Path) -> None:
+    # Inline imports to avoid import-time side effects  <- WRONG: no evidence
+    from myapp.staleness import get_version
+    ...
+```
+
+**When NOT to defer:**
+
+- Standard library modules
+- Lightweight internal modules
+- Modules you haven't measured
+- "Just in case" optimization
+
+---
+
+## Decision Checklist
+
+Before writing module-level code:
+
+- [ ] Does this involve any computation (even `Path()` construction)?
+- [ ] Does this involve I/O (file, network, environment)?
+- [ ] Could this fail or raise exceptions?
+- [ ] Would tests need to mock this value?
+
+If any answer is "yes", wrap in a `@cache`-decorated function instead.
+
+Before inline imports:
+
+- [ ] Is this to break a circular dependency?
+- [ ] Is this for TYPE_CHECKING?
+- [ ] Is this for conditional features?
+- [ ] If for startup time: Have I MEASURED the import cost?
+- [ ] If for startup time: Is the cost significant (>100ms)?
+- [ ] If for startup time: Have I documented the measured cost in a comment?
+- [ ] Have I documented why the inline import is needed?
+
+**Default: Module-level imports**

--- a/.agents/skills/dignified-python/subprocess.md
+++ b/.agents/skills/dignified-python/subprocess.md
@@ -1,0 +1,104 @@
+---
+---
+
+# Subprocess Handling - Safe Execution
+
+## Core Rule
+
+**ALWAYS set `check` explicitly on `subprocess.run()`** — either `check=True` (raise on non-zero exit) or `check=False` (handle the return code yourself). Never rely on the default.
+
+## Basic Subprocess Pattern
+
+```python
+import subprocess
+from pathlib import Path
+
+# ✅ CORRECT: check=True to raise on error
+result = subprocess.run(
+    ["git", "status"],
+    check=True,
+    capture_output=True,
+    text=True
+)
+print(result.stdout)
+
+# ✅ ALSO CORRECT: check=False when you intend to inspect returncode yourself
+result = subprocess.run(["git", "status"], check=False, capture_output=True, text=True)
+if result.returncode != 0:
+    ...
+
+# ❌ WRONG: check unset - intent is ambiguous
+result = subprocess.run(["git", "status"])
+```
+
+## Complete Subprocess Example
+
+```python
+def run_git_command(args: list[str], cwd: Path | None = None) -> str:
+    """Run a git command and return output."""
+    try:
+        result = subprocess.run(
+            ["git"] + args,
+            check=True,          # Raise on non-zero exit
+            capture_output=True, # Capture stdout/stderr
+            text=True,          # Return strings, not bytes
+            cwd=cwd            # Working directory
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        # Error boundary - add context
+        raise RuntimeError(f"Git command failed: {e.stderr}") from e
+```
+
+## Error Handling
+
+```python
+try:
+    result = subprocess.run(
+        ["make", "test"],
+        check=True,
+        capture_output=True,
+        text=True
+    )
+except subprocess.CalledProcessError as e:
+    # Access error details
+    print(f"Command: {e.cmd}")
+    print(f"Exit code: {e.returncode}")
+    print(f"Stdout: {e.stdout}")
+    print(f"Stderr: {e.stderr}")
+    raise
+```
+
+## Common Patterns
+
+```python
+# Silent execution (no output)
+subprocess.run(["git", "fetch"], check=True, capture_output=True)
+
+# Stream output in real-time
+process = subprocess.Popen(
+    ["pytest", "-v"],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.STDOUT,
+    text=True
+)
+for line in process.stdout:
+    print(line, end="")
+process.wait()
+if process.returncode != 0:
+    raise subprocess.CalledProcessError(process.returncode, process.args)
+
+# With timeout
+try:
+    subprocess.run(["long-command"], check=True, timeout=30)
+except subprocess.TimeoutExpired:
+    print("Command timed out")
+```
+
+## Key Takeaways
+
+1. **Always set `check` explicitly**: Use `check=True` to raise, or `check=False` when you'll handle `returncode` yourself — never leave it unset
+2. **Capture output**: Use `capture_output=True` for stdout/stderr
+3. **Text mode**: Use `text=True` for string output
+4. **Error context**: Wrap in try/except at boundaries
+5. **Timeout safety**: Set timeout for long-running commands

--- a/.agents/skills/dignified-python/versions/python-3.10.md
+++ b/.agents/skills/dignified-python/versions/python-3.10.md
@@ -1,0 +1,520 @@
+---
+---
+
+# Type Annotations - Python 3.10
+
+This document captures type annotation guidance for Python 3.10.
+This is the baseline for modern Python type syntax.
+
+## Overview
+
+Python 3.10 introduced major improvements to type annotation syntax through PEP 604 (union types via
+`|`) and PEP 585 (generic types in standard collections). These features eliminated the need for
+most `typing` module imports and made type annotations more concise and readable.
+
+**What's new in 3.10:**
+
+- Union types with `|` operator (PEP 604)
+- Built-in generic types: `list[T]`, `dict[K, V]`, etc. (PEP 585)
+- No more need for `List`, `Dict`, `Union`, `Optional` from typing
+
+**What you need from typing module:**
+
+- `TypeVar` for generic functions/classes
+- `Protocol` for structural typing (rare - prefer ABC)
+- `TYPE_CHECKING` for conditional imports
+- `Any` (use sparingly)
+
+## Complete Type Annotation Syntax for Python 3.10
+
+### Basic Collection Types
+
+✅ **PREFERRED** - Use built-in generic types:
+
+```python
+names: list[str] = []
+mapping: dict[str, int] = {}
+unique_ids: set[str] = set()
+coordinates: tuple[int, int] = (0, 0)
+```
+
+❌ **WRONG** - Don't use typing module equivalents:
+
+```python
+from typing import List, Dict, Set, Tuple  # Don't do this
+names: List[str] = []
+mapping: Dict[str, int] = {}
+```
+
+**Why**: Built-in types are more concise, don't require imports, and are the modern Python standard.
+
+### Union Types
+
+✅ **PREFERRED** - Use `|` operator:
+
+```python
+def process(value: str | int) -> str:
+    return str(value)
+
+def find_config(name: str) -> dict[str, str] | dict[str, int]:
+    ...
+
+# Multiple unions
+def parse(input: str | int | float) -> str:
+    return str(input)
+```
+
+❌ **WRONG** - Don't use `typing.Union`:
+
+```python
+from typing import Union
+def process(value: Union[str, int]) -> str:  # Don't do this
+    ...
+```
+
+### Optional Types
+
+✅ **PREFERRED** - Use `X | None`:
+
+```python
+def find_user(id: str) -> User | None:
+    """Returns user or None if not found."""
+    if id in users:
+        return users[id]
+    return None
+
+def get_config(key: str) -> str | None:
+    return config.get(key)
+```
+
+❌ **WRONG** - Don't use `typing.Optional`:
+
+```python
+from typing import Optional
+def find_user(id: str) -> Optional[User]:  # Don't do this
+    ...
+```
+
+### Generic Functions with TypeVar
+
+✅ **PREFERRED** - Use TypeVar for generic functions:
+
+```python
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def first(items: list[T]) -> T | None:
+    """Return first item or None if empty."""
+    if not items:
+        return None
+    return items[0]
+
+def identity(value: T) -> T:
+    """Return the value unchanged."""
+    return value
+```
+
+**Note**: This is the standard way in Python 3.10. Python 3.12 introduces better syntax (PEP 695).
+
+### Generic Classes
+
+✅ **PREFERRED** - Use Generic with TypeVar:
+
+```python
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Stack(Generic[T]):
+    """A generic stack data structure."""
+
+    def __init__(self) -> None:
+        self._items: list[T] = []
+
+    def push(self, item: T) -> None:
+        self._items.append(item)
+
+    def pop(self) -> T | None:
+        if not self._items:
+            return None
+        return self._items.pop()
+
+# Usage
+int_stack = Stack[int]()
+int_stack.push(42)
+```
+
+**Note**: Python 3.12 introduces cleaner syntax for this pattern.
+
+### Constrained and Bounded TypeVars
+
+✅ **Use TypeVar constraints when needed**:
+
+```python
+from typing import TypeVar
+
+# Constrained to specific types
+Numeric = TypeVar("Numeric", int, float)
+
+def add(a: Numeric, b: Numeric) -> Numeric:
+    return a + b
+
+# Bounded to base class
+T = TypeVar("T", bound=BaseClass)
+
+def process(obj: T) -> T:
+    return obj
+```
+
+### Callable Types
+
+✅ **PREFERRED** - Use `collections.abc.Callable`:
+
+```python
+from collections.abc import Callable
+
+# Function that takes int, returns str
+processor: Callable[[int], str] = str
+
+# Function with no args, returns None
+callback: Callable[[], None] = lambda: None
+
+# Function with multiple args
+validator: Callable[[str, int], bool] = lambda s, i: len(s) > i
+```
+
+### Type Aliases
+
+✅ **Use simple assignment for type aliases**:
+
+```python
+# Simple alias
+UserId = str
+Config = dict[str, str | int | bool]
+
+# Complex nested type
+JsonValue = dict[str, "JsonValue"] | list["JsonValue"] | str | int | float | bool | None
+
+def load_config() -> Config:
+    return {"host": "localhost", "port": 8080}
+```
+
+**Note**: Python 3.12 introduces `type` statement for better alias support.
+
+### when from **future** import annotations is Needed
+
+Use `from __future__ import annotations` when you encounter:
+
+**Forward references** (class referencing itself):
+
+```python
+from __future__ import annotations
+
+class Node:
+    def __init__(self, value: int, parent: Node | None = None):
+        self.value = value
+        self.parent = parent
+```
+
+**Circular type imports**:
+
+```python
+# a.py
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from b import B
+
+class A:
+    def method(self) -> B:
+        ...
+```
+
+**Complex recursive types**:
+
+```python
+from __future__ import annotations
+
+JsonValue = dict[str, JsonValue] | list[JsonValue] | str | int | float | bool | None
+```
+
+### Interfaces: ABC vs Protocol
+
+✅ **PREFERRED** - Use ABC for interfaces:
+
+```python
+from abc import ABC, abstractmethod
+
+class Repository(ABC):
+    @abstractmethod
+    def get(self, id: str) -> User | None:
+        """Get user by ID."""
+
+    @abstractmethod
+    def save(self, user: User) -> None:
+        """Save user."""
+```
+
+🟡 **VALID** - Use Protocol only for structural typing:
+
+```python
+from typing import Protocol
+
+class Drawable(Protocol):
+    def draw(self) -> None: ...
+
+# Any object with draw() method matches
+def render(obj: Drawable) -> None:
+    obj.draw()
+```
+
+**Dignified Python prefers ABC** because it makes inheritance and intent explicit.
+
+## Complete Examples
+
+### Repository Pattern
+
+```python
+from abc import ABC, abstractmethod
+
+class Repository(ABC):
+    """Abstract base class for data repositories."""
+
+    @abstractmethod
+    def get(self, id: str) -> dict[str, str] | None:
+        """Get entity by ID."""
+
+    @abstractmethod
+    def save(self, entity: dict[str, str]) -> None:
+        """Save entity."""
+
+    @abstractmethod
+    def delete(self, id: str) -> bool:
+        """Delete entity, return success."""
+
+class UserRepository(Repository):
+    def __init__(self) -> None:
+        self._users: dict[str, dict[str, str]] = {}
+
+    def get(self, id: str) -> dict[str, str] | None:
+        return self._users.get(id)
+
+    def save(self, entity: dict[str, str]) -> None:
+        if "id" not in entity:
+            raise ValueError("Entity must have id")
+        self._users[entity["id"]] = entity
+
+    def delete(self, id: str) -> bool:
+        if id in self._users:
+            del self._users[id]
+            return True
+        return False
+```
+
+### Generic Data Structures
+
+```python
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Node(Generic[T]):
+    """A node in a tree structure."""
+
+    def __init__(self, value: T, children: list[Node[T]] | None = None) -> None:
+        self.value = value
+        self.children = children or []
+
+    def add_child(self, child: Node[T]) -> None:
+        self.children.append(child)
+
+    def find(self, predicate: Callable[[T], bool]) -> Node[T] | None:
+        """Find first node matching predicate."""
+        if predicate(self.value):
+            return self
+        for child in self.children:
+            result = child.find(predicate)
+            if result:
+                return result
+        return None
+
+# Usage
+from collections.abc import Callable
+
+root = Node[int](1)
+root.add_child(Node[int](2))
+root.add_child(Node[int](3))
+```
+
+### Configuration Management
+
+```python
+from dataclasses import dataclass
+
+@dataclass(frozen=True)
+class DatabaseConfig:
+    host: str
+    port: int
+    username: str
+    password: str | None = None
+    ssl_enabled: bool = False
+
+@dataclass(frozen=True)
+class AppConfig:
+    app_name: str
+    debug_mode: bool
+    database: DatabaseConfig
+    feature_flags: dict[str, bool]
+
+def load_config(path: str) -> AppConfig:
+    """Load application configuration from file."""
+    import json
+    from pathlib import Path
+
+    config_path = Path(path)
+    if not config_path.exists():
+        raise FileNotFoundError(f"Config not found: {path}")
+
+    data: dict[str, str | int | bool | dict[str, str | int | bool]] = json.loads(
+        config_path.read_text(encoding="utf-8")
+    )
+
+    # Parse and validate...
+    return AppConfig(...)
+```
+
+### API Client with Error Handling
+
+```python
+from collections.abc import Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+class ApiResponse(Generic[T]):
+    """Container for API response with data or error."""
+
+    def __init__(self, data: T | None = None, error: str | None = None) -> None:
+        self.data = data
+        self.error = error
+
+    def is_success(self) -> bool:
+        return self.error is None
+
+    def map(self, func: Callable[[T], U]) -> ApiResponse[U]:
+        """Transform successful response data."""
+        if self.is_success() and self.data is not None:
+            return ApiResponse(data=func(self.data))
+        return ApiResponse(error=self.error)
+
+U = TypeVar("U")
+
+def fetch_user(id: str) -> ApiResponse[dict[str, str]]:
+    """Fetch user from API."""
+    # Implementation...
+    return ApiResponse(data={"id": id, "name": "Alice"})
+```
+
+## Type Checking Rules
+
+### What to Type
+
+✅ **MUST type**:
+
+- All public function parameters (except `self`, `cls`)
+- All public function return values
+- All class attributes (public and private)
+- Module-level constants
+
+🟡 **SHOULD type**:
+
+- Internal function signatures
+- Complex local variables
+
+🟢 **MAY skip**:
+
+- Simple local variables where type is obvious (`count = 0`)
+- Lambda parameters in short inline lambdas
+- Loop variables in short comprehensions
+
+### Running Type Checker
+
+```bash
+uv run ty check
+```
+
+All code should pass type checking without errors.
+
+### Type Checking Configuration
+
+Configure ty in `pyproject.toml`:
+
+```toml
+[tool.ty.environment]
+python-version = "3.10"
+```
+
+## Common Patterns
+
+### Checking for None
+
+✅ **CORRECT** - Check before use:
+
+```python
+def process_user(user: User | None) -> str:
+    if user is None:
+        return "No user"
+    return user.name
+```
+
+### Dict.get() with Type Safety
+
+✅ **CORRECT** - Handle None case:
+
+```python
+def get_port(config: dict[str, int]) -> int:
+    port = config.get("port")
+    if port is None:
+        return 8080
+    return port
+```
+
+### List Operations
+
+✅ **CORRECT** - Check before accessing:
+
+```python
+def first_or_default(items: list[str], default: str) -> str:
+    if not items:
+        return default
+    return items[0]
+```
+
+## Migration from Python 3.9
+
+If upgrading from Python 3.9, apply these changes:
+
+1. **Replace typing module types**:
+   - `List[X]` → `list[X]`
+   - `Dict[K, V]` → `dict[K, V]`
+   - `Set[X]` → `set[X]`
+   - `Tuple[X, Y]` → `tuple[X, Y]`
+   - `Union[X, Y]` → `X | Y`
+   - `Optional[X]` → `X | None`
+
+2. **Add future annotations if needed**:
+   - Add `from __future__ import annotations` for forward references
+   - Add for circular imports with `TYPE_CHECKING`
+
+3. **Remove unnecessary imports**:
+   - Remove `from typing import List, Dict, Optional, Union`
+   - Keep only `TypeVar`, `Generic`, `Protocol`, `TYPE_CHECKING`, `Any`
+
+## References
+
+- [PEP 604: Union Types](https://peps.python.org/pep-0604/)
+- [PEP 585: Type Hinting Generics In Standard Collections](https://peps.python.org/pep-0585/)
+- [PEP 563: Postponed Evaluation of Annotations](https://peps.python.org/pep-0563/)
+- [Python 3.10 What's New - Type Hints](https://docs.python.org/3.10/whatsnew/3.10.html)

--- a/.agents/skills/dignified-python/versions/python-3.11.md
+++ b/.agents/skills/dignified-python/versions/python-3.11.md
@@ -1,0 +1,538 @@
+---
+---
+
+# Type Annotations - Python 3.11
+
+This document captures type annotation guidance for Python 3.11.
+
+## Overview
+
+Python 3.11 builds on 3.10's type syntax with the addition of the `Self` type (PEP 673), making
+method chaining and builder patterns significantly cleaner. All modern syntax from 3.10 continues to
+work.
+
+**What's new in 3.11:**
+
+- `Self` type for self-returning methods (PEP 673)
+- Variadic generics with TypeVarTuple (PEP 646)
+- Significantly improved error messages
+
+**Available from 3.10:**
+
+- Built-in generic types: `list[T]`, `dict[K, V]`, etc. (PEP 585)
+- Union types with `|` operator (PEP 604)
+- Optional with `X | None`
+
+**What you need from typing module:**
+
+- `Self` for self-returning methods (NEW)
+- `TypeVar` for generic functions/classes
+- `Generic` for generic classes
+- `Protocol` for structural typing (rare - prefer ABC)
+- `TYPE_CHECKING` for conditional imports
+- `Any` (use sparingly)
+
+## Complete Type Annotation Syntax for Python 3.11
+
+### Basic Collection Types
+
+✅ **PREFERRED** - Use built-in generic types:
+
+```python
+names: list[str] = []
+mapping: dict[str, int] = {}
+unique_ids: set[str] = set()
+coordinates: tuple[int, int] = (0, 0)
+```
+
+❌ **WRONG** - Don't use typing module equivalents:
+
+```python
+from typing import List, Dict, Set, Tuple  # Don't do this
+names: List[str] = []
+```
+
+### Union Types
+
+✅ **PREFERRED** - Use `|` operator:
+
+```python
+def process(value: str | int) -> str:
+    return str(value)
+
+def find_config(name: str) -> dict[str, str] | dict[str, int]:
+    ...
+
+# Multiple unions
+def parse(input: str | int | float) -> str:
+    return str(input)
+```
+
+❌ **WRONG** - Don't use `typing.Union`:
+
+```python
+from typing import Union
+def process(value: Union[str, int]) -> str:  # Don't do this
+    ...
+```
+
+### Optional Types
+
+✅ **PREFERRED** - Use `X | None`:
+
+```python
+def find_user(id: str) -> User | None:
+    """Returns user or None if not found."""
+    if id in users:
+        return users[id]
+    return None
+```
+
+❌ **WRONG** - Don't use `typing.Optional`:
+
+```python
+from typing import Optional
+def find_user(id: str) -> Optional[User]:  # Don't do this
+    ...
+```
+
+### Self Type for Self-Returning Methods (NEW in 3.11)
+
+✅ **PREFERRED** - Use Self for methods that return the instance:
+
+```python
+from typing import Self
+
+class Builder:
+    def set_name(self, name: str) -> Self:
+        self.name = name
+        return self
+
+    def set_value(self, value: int) -> Self:
+        self.value = value
+        return self
+
+# Usage with type safety
+builder = Builder().set_name("app").set_value(42)
+```
+
+❌ **WRONG** - Don't use bound TypeVar anymore:
+
+```python
+from typing import TypeVar
+
+T = TypeVar("T", bound="Builder")
+
+class Builder:
+    def set_name(self: T, name: str) -> T:  # Don't do this
+        ...
+```
+
+**When to use Self:**
+
+- Methods that return `self`
+- Builder pattern methods
+- Fluent interfaces with method chaining
+- Factory classmethods
+
+**Self in classmethod:**
+
+```python
+from typing import Self
+
+class Config:
+    def __init__(self, data: dict[str, str]) -> None:
+        self.data = data
+
+    @classmethod
+    def from_file(cls, path: str) -> Self:
+        """Load config from file."""
+        import json
+        with open(path, encoding="utf-8") as f:
+            data = json.load(f)
+        return cls(data)
+```
+
+### Generic Functions with TypeVar
+
+✅ **PREFERRED** - Use TypeVar for generic functions:
+
+```python
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def first(items: list[T]) -> T | None:
+    """Return first item or None if empty."""
+    if not items:
+        return None
+    return items[0]
+
+def identity(value: T) -> T:
+    return value
+```
+
+**Note**: Python 3.12 introduces better syntax (PEP 695) for this pattern.
+
+### Generic Classes
+
+✅ **PREFERRED** - Use Generic with TypeVar:
+
+```python
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Stack(Generic[T]):
+    """A generic stack data structure."""
+
+    def __init__(self) -> None:
+        self._items: list[T] = []
+
+    def push(self, item: T) -> Self:  # Can combine with Self!
+        self._items.append(item)
+        return self
+
+    def pop(self) -> T | None:
+        if not self._items:
+            return None
+        return self._items.pop()
+
+# Usage
+int_stack = Stack[int]()
+int_stack.push(42).push(43)  # Method chaining works!
+```
+
+**Note**: Python 3.12 introduces cleaner syntax for generic classes.
+
+### Constrained and Bounded TypeVars
+
+✅ **Use TypeVar constraints when needed**:
+
+```python
+from typing import TypeVar
+
+# Constrained to specific types
+Numeric = TypeVar("Numeric", int, float)
+
+def add(a: Numeric, b: Numeric) -> Numeric:
+    return a + b
+
+# Bounded to base class
+T = TypeVar("T", bound=BaseClass)
+
+def process(obj: T) -> T:
+    return obj
+```
+
+### Callable Types
+
+✅ **PREFERRED** - Use `collections.abc.Callable`:
+
+```python
+from collections.abc import Callable
+
+# Function that takes int, returns str
+processor: Callable[[int], str] = str
+
+# Function with no args, returns None
+callback: Callable[[], None] = lambda: None
+
+# Function with multiple args
+validator: Callable[[str, int], bool] = lambda s, i: len(s) > i
+```
+
+### Type Aliases
+
+✅ **Use simple assignment for type aliases**:
+
+```python
+# Simple alias
+UserId = str
+Config = dict[str, str | int | bool]
+
+# Complex nested type
+JsonValue = dict[str, "JsonValue"] | list["JsonValue"] | str | int | float | bool | None
+
+def load_config() -> Config:
+    return {"host": "localhost", "port": 8080}
+```
+
+**Note**: Python 3.12 introduces `type` statement for better alias support.
+
+### When from **future** import annotations is Needed
+
+Use `from __future__ import annotations` when you encounter:
+
+**Forward references** (class referencing itself):
+
+```python
+from __future__ import annotations
+
+class Node:
+    def __init__(self, value: int, parent: Node | None = None):
+        self.value = value
+        self.parent = parent
+```
+
+**Circular type imports**:
+
+```python
+# a.py
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from b import B
+
+class A:
+    def method(self) -> B:
+        ...
+```
+
+**Complex recursive types**:
+
+```python
+from __future__ import annotations
+
+JsonValue = dict[str, JsonValue] | list[JsonValue] | str | int | float | bool | None
+```
+
+### Interfaces: ABC vs Protocol
+
+✅ **PREFERRED** - Use ABC for interfaces:
+
+```python
+from abc import ABC, abstractmethod
+
+class Repository(ABC):
+    @abstractmethod
+    def get(self, id: str) -> User | None:
+        """Get user by ID."""
+
+    @abstractmethod
+    def save(self, user: User) -> None:
+        """Save user."""
+```
+
+🟡 **VALID** - Use Protocol only for structural typing:
+
+```python
+from typing import Protocol
+
+class Drawable(Protocol):
+    def draw(self) -> None: ...
+
+# Any object with draw() method matches
+def render(obj: Drawable) -> None:
+    obj.draw()
+```
+
+**Dignified Python prefers ABC** because it makes inheritance and intent explicit.
+
+## Complete Examples
+
+### Builder Pattern with Self
+
+```python
+from typing import Self
+
+class QueryBuilder:
+    """SQL query builder with fluent interface."""
+
+    def __init__(self) -> None:
+        self._select: list[str] = ["*"]
+        self._from: str | None = None
+        self._where: list[str] = []
+        self._limit: int | None = None
+
+    def select(self, *columns: str) -> Self:
+        """Specify columns to select."""
+        self._select = list(columns)
+        return self
+
+    def from_table(self, table: str) -> Self:
+        """Specify table to query."""
+        self._from = table
+        return self
+
+    def where(self, condition: str) -> Self:
+        """Add WHERE condition."""
+        self._where.append(condition)
+        return self
+
+    def limit(self, n: int) -> Self:
+        """Set LIMIT."""
+        self._limit = n
+        return self
+
+    def build(self) -> str:
+        """Build final SQL query."""
+        if not self._from:
+            raise ValueError("FROM table not specified")
+
+        parts = [f"SELECT {', '.join(self._select)}"]
+        parts.append(f"FROM {self._from}")
+
+        if self._where:
+            parts.append(f"WHERE {' AND '.join(self._where)}")
+
+        if self._limit:
+            parts.append(f"LIMIT {self._limit}")
+
+        return " ".join(parts)
+
+# Usage with type-safe method chaining
+query = (
+    QueryBuilder()
+    .select("id", "name", "email")
+    .from_table("users")
+    .where("active = true")
+    .where("age > 18")
+    .limit(10)
+    .build()
+)
+```
+
+### Factory Methods with Self
+
+```python
+from typing import Self
+from pathlib import Path
+import json
+
+class Config:
+    """Application configuration with multiple factory methods."""
+
+    def __init__(self, data: dict[str, str | int]) -> None:
+        self.data = data
+
+    @classmethod
+    def from_json(cls, path: Path) -> Self:
+        """Load configuration from JSON file."""
+        if not path.exists():
+            raise FileNotFoundError(f"Config not found: {path}")
+
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+        return cls(data)
+
+    @classmethod
+    def from_env(cls) -> Self:
+        """Load configuration from environment variables."""
+        import os
+        data = {
+            k.lower(): v
+            for k, v in os.environ.items()
+            if k.startswith("APP_")
+        }
+        return cls(data)
+
+    @classmethod
+    def default(cls) -> Self:
+        """Create default configuration."""
+        return cls({"host": "localhost", "port": 8080})
+
+    def with_override(self, key: str, value: str | int) -> Self:
+        """Return new config with overridden value."""
+        new_data = self.data.copy()
+        new_data[key] = value
+        return type(self)(new_data)
+
+# All factory methods return correct type
+config = Config.from_json(Path("config.json"))
+dev_config = config.with_override("debug", True)
+```
+
+## Type Checking Rules
+
+### What to Type
+
+✅ **MUST type**:
+
+- All public function parameters (except `self`, `cls`)
+- All public function return values
+- All class attributes (public and private)
+- Module-level constants
+
+🟡 **SHOULD type**:
+
+- Internal function signatures
+- Complex local variables
+
+🟢 **MAY skip**:
+
+- Simple local variables where type is obvious (`count = 0`)
+- Lambda parameters in short inline lambdas
+- Loop variables in short comprehensions
+
+### Running Type Checker
+
+```bash
+uv run ty check
+```
+
+All code should pass type checking without errors.
+
+### Type Checking Configuration
+
+Configure ty in `pyproject.toml`:
+
+```toml
+[tool.ty.environment]
+python-version = "3.11"
+```
+
+## Common Patterns
+
+### Checking for None
+
+✅ **CORRECT** - Check before use:
+
+```python
+def process_user(user: User | None) -> str:
+    if user is None:
+        return "No user"
+    return user.name
+```
+
+### Dict.get() with Type Safety
+
+✅ **CORRECT** - Handle None case:
+
+```python
+def get_port(config: dict[str, int]) -> int:
+    port = config.get("port")
+    if port is None:
+        return 8080
+    return port
+```
+
+### List Operations
+
+✅ **CORRECT** - Check before accessing:
+
+```python
+def first_or_default(items: list[str], default: str) -> str:
+    if not items:
+        return default
+    return items[0]
+```
+
+## Migration from Python 3.10
+
+If upgrading from Python 3.10:
+
+1. **Replace bound TypeVar with Self** for self-returning methods:
+   - Old: `T = TypeVar("T", bound="ClassName")`
+   - New: `from typing import Self` and use `-> Self`
+
+2. **Enjoy improved error messages** (no code changes needed)
+
+3. **All existing 3.10 syntax continues to work**
+
+## References
+
+- [PEP 673: Self Type](https://peps.python.org/pep-0673/)
+- [PEP 646: Variadic Generics](https://peps.python.org/pep-0646/)
+- [Python 3.11 What's New](https://docs.python.org/3.11/whatsnew/3.11.html)

--- a/.agents/skills/dignified-python/versions/python-3.12.md
+++ b/.agents/skills/dignified-python/versions/python-3.12.md
@@ -1,0 +1,664 @@
+---
+---
+
+# Type Annotations - Python 3.12
+
+This document captures type annotation guidance for Python 3.12.
+
+## Overview
+
+Python 3.12 introduces PEP 695, a major syntactic improvement for generic types. The new type
+parameter syntax makes generic functions and classes significantly more readable. All syntax from
+3.10 and 3.11 continues to work.
+
+**What's new in 3.12:**
+
+- PEP 695 type parameter syntax: `def func[T](x: T) -> T`
+- `type` statement for better type aliases
+- Cleaner generic class syntax
+
+**Available from 3.11:**
+
+- `Self` type for self-returning methods
+
+**Available from 3.10:**
+
+- Built-in generic types: `list[T]`, `dict[K, V]`, etc.
+- Union types with `|` operator
+- Optional with `X | None`
+
+**What you need from typing module:**
+
+- `Self` for self-returning methods
+- `TypeVar` only for constrained/bounded generics
+- `Protocol` for structural typing (rare - prefer ABC)
+- `TYPE_CHECKING` for conditional imports
+- `Any` (use sparingly)
+
+## Complete Type Annotation Syntax for Python 3.12
+
+### Basic Collection Types
+
+✅ **PREFERRED** - Use built-in generic types:
+
+```python
+names: list[str] = []
+mapping: dict[str, int] = {}
+unique_ids: set[str] = set()
+coordinates: tuple[int, int] = (0, 0)
+```
+
+❌ **WRONG** - Don't use typing module equivalents:
+
+```python
+from typing import List, Dict, Set, Tuple  # Don't do this
+names: List[str] = []
+```
+
+### Union Types
+
+✅ **PREFERRED** - Use `|` operator:
+
+```python
+def process(value: str | int) -> str:
+    return str(value)
+
+def find_config(name: str) -> dict[str, str] | dict[str, int]:
+    ...
+
+# Multiple unions
+def parse(input: str | int | float) -> str:
+    return str(input)
+```
+
+❌ **WRONG** - Don't use `typing.Union`:
+
+```python
+from typing import Union
+def process(value: Union[str, int]) -> str:  # Don't do this
+    ...
+```
+
+### Optional Types
+
+✅ **PREFERRED** - Use `X | None`:
+
+```python
+def find_user(id: str) -> User | None:
+    """Returns user or None if not found."""
+    if id in users:
+        return users[id]
+    return None
+```
+
+❌ **WRONG** - Don't use `typing.Optional`:
+
+```python
+from typing import Optional
+def find_user(id: str) -> Optional[User]:  # Don't do this
+    ...
+```
+
+### Self Type for Self-Returning Methods
+
+✅ **PREFERRED** - Use Self for methods that return the instance:
+
+```python
+from typing import Self
+
+class Builder:
+    def set_name(self, name: str) -> Self:
+        self.name = name
+        return self
+
+    def set_value(self, value: int) -> Self:
+        self.value = value
+        return self
+```
+
+### Generic Functions with PEP 695 (NEW in 3.12)
+
+✅ **PREFERRED** - Use PEP 695 type parameter syntax:
+
+```python
+def first[T](items: list[T]) -> T | None:
+    """Return first item or None if empty."""
+    if not items:
+        return None
+    return items[0]
+
+def identity[T](value: T) -> T:
+    """Return value unchanged."""
+    return value
+
+# Multiple type parameters
+def zip_dicts[K, V](keys: list[K], values: list[V]) -> dict[K, V]:
+    """Create dict from separate key and value lists."""
+    return dict(zip(keys, values))
+```
+
+🟡 **VALID** - TypeVar still works:
+
+```python
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def first(items: list[T]) -> T | None:
+    if not items:
+        return None
+    return items[0]
+```
+
+**Note**: Prefer PEP 695 syntax for simple generics. TypeVar is still needed for constraints/bounds.
+
+### Generic Classes with PEP 695 (NEW in 3.12)
+
+✅ **PREFERRED** - Use PEP 695 class syntax:
+
+```python
+class Stack[T]:
+    """A generic stack data structure."""
+
+    def __init__(self) -> None:
+        self._items: list[T] = []
+
+    def push(self, item: T) -> Self:
+        self._items.append(item)
+        return self
+
+    def pop(self) -> T | None:
+        if not self._items:
+            return None
+        return self._items.pop()
+
+# Usage
+int_stack = Stack[int]()
+int_stack.push(42).push(43)
+```
+
+🟡 **VALID** - Generic with TypeVar still works:
+
+```python
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Stack(Generic[T]):
+    def __init__(self) -> None:
+        self._items: list[T] = []
+    # ... rest of implementation
+```
+
+**Note**: PEP 695 is cleaner - no imports needed, type parameter scope is local to class.
+
+### Type Parameter Bounds
+
+✅ **Use bounds with PEP 695**:
+
+```python
+class Comparable:
+    def compare(self, other: object) -> int:
+        ...
+
+def max_value[T: Comparable](items: list[T]) -> T:
+    """Get maximum value from comparable items."""
+    return max(items, key=lambda x: x)
+```
+
+### Constrained TypeVars (Still Use TypeVar)
+
+✅ **Use TypeVar for specific type constraints**:
+
+```python
+from typing import TypeVar
+
+# Constrained to specific types - must use TypeVar
+Numeric = TypeVar("Numeric", int, float)
+
+def add(a: Numeric, b: Numeric) -> Numeric:
+    return a + b
+```
+
+❌ **WRONG** - PEP 695 doesn't support constraints:
+
+```python
+# This doesn't constrain to int|float
+def add[Numeric](a: Numeric, b: Numeric) -> Numeric:
+    return a + b
+```
+
+### Type Aliases with type Statement (NEW in 3.12)
+
+✅ **PREFERRED** - Use `type` statement:
+
+```python
+# Simple alias
+type UserId = str
+type Config = dict[str, str | int | bool]
+
+# Generic type alias
+type Result[T] = tuple[T, str | None]
+
+def process(value: str) -> Result[int]:
+    try:
+        return (int(value), None)
+    except ValueError as e:
+        return (0, str(e))
+```
+
+🟡 **VALID** - Simple assignment still works:
+
+```python
+UserId = str  # Still valid
+Config = dict[str, str | int | bool]  # Still valid
+```
+
+**Note**: `type` statement is more explicit and works better with generics.
+
+### Callable Types
+
+✅ **PREFERRED** - Use `collections.abc.Callable`:
+
+```python
+from collections.abc import Callable
+
+# Function that takes int, returns str
+processor: Callable[[int], str] = str
+
+# Function with no args, returns None
+callback: Callable[[], None] = lambda: None
+
+# Function with multiple args
+validator: Callable[[str, int], bool] = lambda s, i: len(s) > i
+```
+
+### When from **future** import annotations is Needed
+
+Use `from __future__ import annotations` when you encounter:
+
+**Forward references** (class referencing itself):
+
+```python
+from __future__ import annotations
+
+class Node:
+    def __init__(self, value: int, parent: Node | None = None):
+        self.value = value
+        self.parent = parent
+```
+
+**Circular type imports**:
+
+```python
+# a.py
+from __future__ import annotations
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from b import B
+
+class A:
+    def method(self) -> B:
+        ...
+```
+
+**Complex recursive types**:
+
+```python
+from __future__ import annotations
+
+type JsonValue = dict[str, JsonValue] | list[JsonValue] | str | int | float | bool | None
+```
+
+### Interfaces: ABC vs Protocol
+
+✅ **PREFERRED** - Use ABC for interfaces:
+
+```python
+from abc import ABC, abstractmethod
+
+class Repository(ABC):
+    @abstractmethod
+    def get(self, id: str) -> User | None:
+        """Get user by ID."""
+
+    @abstractmethod
+    def save(self, user: User) -> None:
+        """Save user."""
+```
+
+🟡 **VALID** - Use Protocol only for structural typing:
+
+```python
+from typing import Protocol
+
+class Drawable(Protocol):
+    def draw(self) -> None: ...
+
+def render(obj: Drawable) -> None:
+    obj.draw()
+```
+
+**Dignified Python prefers ABC** because it makes inheritance and intent explicit.
+
+## Complete Examples
+
+### Generic Stack with PEP 695
+
+```python
+from typing import Self
+
+class Stack[T]:
+    """Type-safe stack with PEP 695 syntax."""
+
+    def __init__(self) -> None:
+        self._items: list[T] = []
+
+    def push(self, item: T) -> Self:
+        """Push item and return self for chaining."""
+        self._items.append(item)
+        return self
+
+    def pop(self) -> T | None:
+        """Pop item or return None if empty."""
+        if not self._items:
+            return None
+        return self._items.pop()
+
+    def peek(self) -> T | None:
+        """Peek at top item without removing."""
+        if not self._items:
+            return None
+        return self._items[-1]
+
+    def is_empty(self) -> bool:
+        """Check if stack is empty."""
+        return len(self._items) == 0
+
+# Usage
+numbers = Stack[int]()
+numbers.push(1).push(2).push(3)
+top = numbers.pop()  # Type checker knows this is int | None
+```
+
+### Generic Repository with PEP 695
+
+```python
+from abc import ABC, abstractmethod
+from typing import Self
+
+class Repository[T]:
+    """Abstract repository with generic type parameter."""
+
+    @abstractmethod
+    def get(self, id: str) -> T | None:
+        """Get entity by ID."""
+
+    @abstractmethod
+    def save(self, entity: T) -> Self:
+        """Save entity, return self for chaining."""
+
+    @abstractmethod
+    def delete(self, id: str) -> bool:
+        """Delete entity, return success."""
+
+    def get_or_fail(self, id: str) -> T:
+        """Get entity or raise error."""
+        entity = self.get(id)
+        if entity is None:
+            raise ValueError(f"Entity not found: {id}")
+        return entity
+
+class InMemoryRepository[T](Repository[T]):
+    """In-memory repository implementation."""
+
+    def __init__(self) -> None:
+        self._storage: dict[str, T] = {}
+
+    def get(self, id: str) -> T | None:
+        return self._storage.get(id)
+
+    def save(self, entity: T) -> Self:
+        # Assume entity has 'id' attribute
+        entity_id = str(getattr(entity, "id", id(entity)))
+        self._storage[entity_id] = entity
+        return self
+
+    def delete(self, id: str) -> bool:
+        if id in self._storage:
+            del self._storage[id]
+            return True
+        return False
+
+# Usage
+from dataclasses import dataclass
+
+@dataclass
+class User:
+    id: str
+    name: str
+
+repo = InMemoryRepository[User]()
+repo.save(User("1", "Alice")).save(User("2", "Bob"))
+user = repo.get("1")  # Type: User | None
+```
+
+### Type Aliases with type Statement
+
+```python
+# Simple aliases
+type UserId = str
+type ErrorMessage = str
+
+# Complex nested types
+type JsonValue = dict[str, JsonValue] | list[JsonValue] | str | int | float | bool | None
+
+# Generic type aliases
+type Result[T] = tuple[T, ErrorMessage | None]
+type AsyncResult[T] = tuple[T | None, ErrorMessage | None]
+
+def parse_int(value: str) -> Result[int]:
+    """Parse string to int, return result with optional error."""
+    try:
+        return (int(value), None)
+    except ValueError as e:
+        return (0, str(e))
+
+def fetch_user(id: UserId) -> AsyncResult[dict[str, str]]:
+    """Fetch user data asynchronously."""
+    # Implementation...
+    return ({"id": id, "name": "Alice"}, None)
+```
+
+### Builder Pattern with Self and PEP 695
+
+```python
+from typing import Self
+
+class QueryBuilder[T]:
+    """Generic query builder with fluent interface."""
+
+    def __init__(self, result_type: type[T]) -> None:
+        self._result_type = result_type
+        self._filters: list[str] = []
+        self._limit: int | None = None
+
+    def filter(self, condition: str) -> Self:
+        """Add filter condition."""
+        self._filters.append(condition)
+        return self
+
+    def limit(self, n: int) -> Self:
+        """Set result limit."""
+        self._limit = n
+        return self
+
+    def build(self) -> str:
+        """Build query string."""
+        query = " AND ".join(self._filters)
+        if self._limit:
+            query += f" LIMIT {self._limit}"
+        return query
+
+# Usage
+@dataclass
+class User:
+    name: str
+    age: int
+
+builder = QueryBuilder[User](User)
+query = (
+    builder
+    .filter("active = true")
+    .filter("age > 18")
+    .limit(10)
+    .build()
+)
+```
+
+### Generic Function Utilities
+
+```python
+def map_list[T, U](items: list[T], func: Callable[[T], U]) -> list[U]:
+    """Map function over list items."""
+    from collections.abc import Callable
+    return [func(item) for item in items]
+
+def filter_list[T](items: list[T], predicate: Callable[[T], bool]) -> list[T]:
+    """Filter list by predicate."""
+    from collections.abc import Callable
+    return [item for item in items if predicate(item)]
+
+def reduce_list[T, U](
+    items: list[T],
+    func: Callable[[U, T], U],
+    initial: U,
+) -> U:
+    """Reduce list to single value."""
+    from collections.abc import Callable
+    result = initial
+    for item in items:
+        result = func(result, item)
+    return result
+
+# Usage
+numbers = [1, 2, 3, 4, 5]
+doubled = map_list(numbers, lambda x: x * 2)  # list[int]
+evens = filter_list(numbers, lambda x: x % 2 == 0)  # list[int]
+sum_val = reduce_list(numbers, lambda acc, x: acc + x, 0)  # int
+```
+
+## Type Checking Rules
+
+### What to Type
+
+✅ **MUST type**:
+
+- All public function parameters (except `self`, `cls`)
+- All public function return values
+- All class attributes (public and private)
+- Module-level constants
+
+🟡 **SHOULD type**:
+
+- Internal function signatures
+- Complex local variables
+
+🟢 **MAY skip**:
+
+- Simple local variables where type is obvious (`count = 0`)
+- Lambda parameters in short inline lambdas
+- Loop variables in short comprehensions
+
+### Running Type Checker
+
+```bash
+uv run ty check
+```
+
+All code should pass type checking without errors.
+
+### Type Checking Configuration
+
+Configure ty in `pyproject.toml`:
+
+```toml
+[tool.ty.environment]
+python-version = "3.12"
+```
+
+## Common Patterns
+
+### Checking for None
+
+✅ **CORRECT** - Check before use:
+
+```python
+def process_user(user: User | None) -> str:
+    if user is None:
+        return "No user"
+    return user.name
+```
+
+### Dict.get() with Type Safety
+
+✅ **CORRECT** - Handle None case:
+
+```python
+def get_port(config: dict[str, int]) -> int:
+    port = config.get("port")
+    if port is None:
+        return 8080
+    return port
+```
+
+### List Operations
+
+✅ **CORRECT** - Check before accessing:
+
+```python
+def first_or_default[T](items: list[T], default: T) -> T:
+    if not items:
+        return default
+    return items[0]
+```
+
+## When to Use PEP 695 vs TypeVar
+
+**Use PEP 695 for**:
+
+- Simple generic functions (no constraints/bounds)
+- Simple generic classes
+- Most common generic use cases
+- New code
+
+**Still use TypeVar for**:
+
+- Constrained type variables: `TypeVar("T", str, bytes)`
+- Bound type variables with complex bounds
+- Covariant/contravariant type variables
+- Reusing same TypeVar across multiple functions
+
+## Migration from Python 3.11
+
+If upgrading from Python 3.11:
+
+1. **Consider migrating to PEP 695 syntax**:
+   - `TypeVar` + `def func(x: T) -> T` → `def func[T](x: T) -> T`
+   - `Generic[T]` + `class C(Generic[T])` → `class C[T]`
+
+2. **Consider using `type` statement for aliases**:
+   - `Config = dict[str, str]` → `type Config = dict[str, str]`
+
+3. **Keep TypeVar for constraints**:
+   - `TypeVar` with constraints still needed
+
+4. **All existing 3.11 syntax continues to work**:
+   - `Self` type still preferred
+   - Union with `|` still preferred
+
+## References
+
+- [PEP 695: Type Parameter Syntax](https://peps.python.org/pep-0695/)
+- [Python 3.12 What's New - Type Hints](https://docs.python.org/3.12/whatsnew/3.12.html)

--- a/.agents/skills/dignified-python/versions/python-3.13.md
+++ b/.agents/skills/dignified-python/versions/python-3.13.md
@@ -1,0 +1,657 @@
+---
+---
+
+# Type Annotations - Python 3.13
+
+This document captures type annotation guidance for Python 3.13.
+Python 3.13 implements PEP 649 (Deferred Evaluation of Annotations), fundamentally changing how
+annotations are evaluated.
+
+## Overview
+
+**The key change: forward references and circular imports work naturally without
+`from __future__ import annotations`.**
+
+All type features from previous versions (3.10-3.12) continue to work.
+
+**What's new in 3.13:**
+
+- PEP 649 deferred annotation evaluation
+- Forward references work naturally (no quotes, no `from __future__`)
+- Circular imports no longer cause annotation errors
+- **DO NOT use `from __future__ import annotations`**
+
+**Available from 3.12:**
+
+- PEP 695 type parameter syntax: `def func[T](x: T) -> T`
+- `type` statement for better type aliases
+
+**Available from 3.11:**
+
+- `Self` type for self-returning methods
+
+## Universal Philosophy
+
+**Code Clarity:**
+
+- Types serve as inline documentation
+- Make function contracts explicit
+- Reduce cognitive load when reading code
+- Help understand data flow without tracing through implementation
+
+**IDE Support:**
+
+- Enable autocomplete and intelligent suggestions
+- Catch typos and attribute errors before runtime
+- Support refactoring tools (rename, move, extract)
+- Provide jump-to-definition for typed objects
+
+**Bug Prevention:**
+
+- Catch type mismatches during static analysis
+- Prevent None-related errors with explicit optional types
+- Document expected input/output without running code
+- Enable early detection of API contract violations
+
+## Consistency Rules
+
+**All public APIs:**
+
+- 🔴 MUST: Type all function parameters (except `self` and `cls`)
+- 🔴 MUST: Type all function return values
+- 🔴 MUST: Type all class attributes
+- 🟡 SHOULD: Type module-level constants
+
+**Internal code:**
+
+- 🟡 SHOULD: Type function signatures where helpful for clarity
+- 🟢 MAY: Type complex local variables where type isn't obvious
+- 🟢 MAY: Omit types for obvious cases (e.g., `count = 0`)
+
+## Basic Collection Types
+
+✅ **PREFERRED** - Use built-in generic types:
+
+```python
+names: list[str] = []
+mapping: dict[str, int] = {}
+unique_ids: set[str] = set()
+coordinates: tuple[int, int] = (0, 0)
+```
+
+❌ **WRONG** - Don't use typing module equivalents:
+
+```python
+from typing import List, Dict, Set, Tuple  # Don't do this
+names: List[str] = []
+```
+
+**Why**: Built-in types are more concise, don't require imports, and are the modern Python standard
+(available since 3.10).
+
+## Union Types
+
+✅ **PREFERRED** - Use `|` operator:
+
+```python
+def process(value: str | int) -> str:
+    return str(value)
+
+def find_config(name: str) -> dict[str, str] | dict[str, int]:
+    ...
+
+# Multiple unions
+def parse(input: str | int | float) -> str:
+    return str(input)
+```
+
+❌ **WRONG** - Don't use `typing.Union`:
+
+```python
+from typing import Union
+def process(value: Union[str, int]) -> str:  # Don't do this
+    ...
+```
+
+## Optional Types
+
+✅ **PREFERRED** - Use `X | None`:
+
+```python
+def find_user(id: str) -> User | None:
+    """Returns user or None if not found."""
+    if id in users:
+        return users[id]
+    return None
+```
+
+❌ **WRONG** - Don't use `typing.Optional`:
+
+```python
+from typing import Optional
+def find_user(id: str) -> Optional[User]:  # Don't do this
+    ...
+```
+
+## Callable Types
+
+✅ **PREFERRED** - Use `collections.abc.Callable`:
+
+```python
+from collections.abc import Callable
+
+# Function that takes int, returns str
+processor: Callable[[int], str] = str
+
+# Function with no args, returns None
+callback: Callable[[], None] = lambda: None
+
+# Function with multiple args
+validator: Callable[[str, int], bool] = lambda s, i: len(s) > i
+```
+
+## Interfaces: ABC vs Protocol
+
+✅ **PREFERRED** - Use ABC for interfaces:
+
+```python
+from abc import ABC, abstractmethod
+
+class Repository(ABC):
+    @abstractmethod
+    def get(self, id: str) -> User | None:
+        """Get user by ID."""
+
+    @abstractmethod
+    def save(self, user: User) -> None:
+        """Save user."""
+```
+
+🟡 **VALID** - Use Protocol only for structural typing:
+
+```python
+from typing import Protocol
+
+class Drawable(Protocol):
+    def draw(self) -> None: ...
+
+def render(obj: Drawable) -> None:
+    obj.draw()
+```
+
+**Dignified Python prefers ABC** because it makes inheritance and intent explicit.
+
+## Self Type for Self-Returning Methods (3.11+)
+
+✅ **PREFERRED** - Use Self for methods that return the instance:
+
+```python
+from typing import Self
+
+class Builder:
+    def set_name(self, name: str) -> Self:
+        self.name = name
+        return self
+
+    def set_value(self, value: int) -> Self:
+        self.value = value
+        return self
+```
+
+## Generic Functions with PEP 695 (3.12+)
+
+✅ **PREFERRED** - Use PEP 695 type parameter syntax:
+
+```python
+def first[T](items: list[T]) -> T | None:
+    """Return first item or None if empty."""
+    if not items:
+        return None
+    return items[0]
+
+def identity[T](value: T) -> T:
+    """Return value unchanged."""
+    return value
+
+# Multiple type parameters
+def zip_dicts[K, V](keys: list[K], values: list[V]) -> dict[K, V]:
+    """Create dict from separate key and value lists."""
+    return dict(zip(keys, values))
+```
+
+🟡 **VALID** - TypeVar still works:
+
+```python
+from typing import TypeVar
+
+T = TypeVar("T")
+
+def first(items: list[T]) -> T | None:
+    if not items:
+        return None
+    return items[0]
+```
+
+**Note**: Prefer PEP 695 syntax for simple generics. TypeVar is still needed for constraints/bounds.
+
+## Generic Classes with PEP 695 (3.12+)
+
+✅ **PREFERRED** - Use PEP 695 class syntax:
+
+```python
+class Stack[T]:
+    """A generic stack data structure."""
+
+    def __init__(self) -> None:
+        self._items: list[T] = []
+
+    def push(self, item: T) -> Self:
+        self._items.append(item)
+        return self
+
+    def pop(self) -> T | None:
+        if not self._items:
+            return None
+        return self._items.pop()
+
+# Usage
+int_stack = Stack[int]()
+int_stack.push(42).push(43)
+```
+
+🟡 **VALID** - Generic with TypeVar still works:
+
+```python
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+class Stack(Generic[T]):
+    def __init__(self) -> None:
+        self._items: list[T] = []
+    # ... rest of implementation
+```
+
+**Note**: PEP 695 is cleaner - no imports needed, type parameter scope is local to class.
+
+## Type Parameter Bounds (3.12+)
+
+✅ **Use bounds with PEP 695**:
+
+```python
+class Comparable:
+    def compare(self, other: object) -> int:
+        ...
+
+def max_value[T: Comparable](items: list[T]) -> T:
+    """Get maximum value from comparable items."""
+    return max(items, key=lambda x: x)
+```
+
+## Constrained TypeVars (Still Use TypeVar)
+
+✅ **Use TypeVar for specific type constraints**:
+
+```python
+from typing import TypeVar
+
+# Constrained to specific types - must use TypeVar
+Numeric = TypeVar("Numeric", int, float)
+
+def add(a: Numeric, b: Numeric) -> Numeric:
+    return a + b
+```
+
+❌ **WRONG** - PEP 695 doesn't support constraints:
+
+```python
+# This doesn't constrain to int|float
+def add[Numeric](a: Numeric, b: Numeric) -> Numeric:
+    return a + b
+```
+
+## Type Aliases with type Statement (3.12+)
+
+✅ **PREFERRED** - Use `type` statement:
+
+```python
+# Simple alias
+type UserId = str
+type Config = dict[str, str | int | bool]
+
+# Generic type alias
+type Result[T] = tuple[T, str | None]
+
+def process(value: str) -> Result[int]:
+    try:
+        return (int(value), None)
+    except ValueError as e:
+        return (0, str(e))
+```
+
+🟡 **VALID** - Simple assignment still works:
+
+```python
+UserId = str  # Still valid
+Config = dict[str, str | int | bool]  # Still valid
+```
+
+**Note**: `type` statement is more explicit and works better with generics.
+
+## Forward References and Circular Imports (NEW in 3.13)
+
+✅ **CORRECT** - Just works naturally with PEP 649:
+
+```python
+# Forward reference - no quotes needed!
+class Node:
+    def __init__(self, value: int, parent: Node | None = None):
+        self.value = value
+        self.parent = parent
+
+# Circular imports - just works!
+# a.py
+from b import B
+
+class A:
+    def method(self) -> B:
+        ...
+
+# b.py
+from a import A
+
+class B:
+    def method(self) -> A:
+        ...
+
+# Recursive types - no future needed!
+type JsonValue = dict[str, JsonValue] | list[JsonValue] | str | int | float | bool | None
+```
+
+❌ **WRONG** - Don't use `from __future__ import annotations`:
+
+```python
+from __future__ import annotations  # DON'T DO THIS in Python 3.13
+
+class Node:
+    def __init__(self, value: int, parent: Node | None = None):
+        ...
+```
+
+**Why avoid `from __future__ import annotations` in 3.13:**
+
+- Unnecessary - PEP 649 provides better default behavior
+- Can cause confusion
+- Masks the native 3.13 deferred evaluation
+- Prevents you from leveraging improvements
+
+## Complete Examples
+
+### Tree Structure with Natural Forward References
+
+```python
+from typing import Self
+from collections.abc import Callable
+
+class Node[T]:
+    """Tree node - forward reference works naturally in 3.13!"""
+
+    def __init__(
+        self,
+        value: T,
+        parent: Node[T] | None = None,  # Forward ref, no quotes!
+        children: list[Node[T]] | None = None,  # Forward ref, no quotes!
+    ) -> None:
+        self.value = value
+        self.parent = parent
+        self.children = children or []
+
+    def add_child(self, child: Node[T]) -> Self:
+        """Add child and return self for chaining."""
+        self.children.append(child)
+        child.parent = self
+        return self
+
+    def find(self, predicate: Callable[[T], bool]) -> Node[T] | None:
+        """Find first node matching predicate."""
+        if predicate(self.value):
+            return self
+
+        for child in self.children:
+            result = child.find(predicate)
+            if result:
+                return result
+
+        return None
+
+# Usage - all type-safe with no __future__ import!
+root = Node[int](1)
+root.add_child(Node[int](2)).add_child(Node[int](3))
+```
+
+### Generic Repository with PEP 695
+
+```python
+from abc import ABC, abstractmethod
+from typing import Self
+
+class Entity[T]:
+    """Base class for entities."""
+
+    def __init__(self, id: T) -> None:
+        self.id = id
+
+class Repository[T](ABC):
+    """Generic repository interface."""
+
+    @abstractmethod
+    def get(self, id: str) -> T | None:
+        """Get entity by ID."""
+
+    @abstractmethod
+    def save(self, entity: T) -> None:
+        """Save entity."""
+
+    @abstractmethod
+    def delete(self, id: str) -> bool:
+        """Delete entity, return True if deleted."""
+
+class User(Entity[str]):
+    def __init__(self, id: str, name: str) -> None:
+        super().__init__(id)
+        self.name = name
+
+class UserRepository(Repository[User]):
+    def __init__(self) -> None:
+        self._users: dict[str, User] = {}
+
+    def get(self, id: str) -> User | None:
+        if id not in self._users:
+            return None
+        return self._users[id]
+
+    def save(self, entity: User) -> None:
+        self._users[entity.id] = entity
+
+    def delete(self, id: str) -> bool:
+        if id not in self._users:
+            return False
+        del self._users[id]
+        return True
+```
+
+## General Best Practices
+
+**Prefer specificity:**
+
+```python
+# ✅ GOOD - Specific
+def get_config() -> dict[str, str | int]:
+    ...
+
+# ❌ WRONG - Too vague
+def get_config() -> dict:
+    ...
+```
+
+**Use Union sparingly:**
+
+```python
+# ✅ GOOD - Union only when necessary
+def process(value: str | int) -> str:
+    ...
+
+# ❌ WRONG - Too permissive
+def process(value: str | int | list | dict) -> str | None | list:
+    ...
+```
+
+**Be explicit with None:**
+
+```python
+# ✅ GOOD - Explicit optional
+def find_user(id: str) -> User | None:
+    ...
+
+# ❌ WRONG - Implicit None return
+def find_user(id: str) -> User:
+    return None  # Type checker error!
+```
+
+**Avoid Any when possible:**
+
+```python
+# ✅ GOOD - Specific type
+def serialize(obj: User | Config) -> str:
+    ...
+
+# ❌ WRONG - Defeats purpose of types
+from typing import Any
+def serialize(obj: Any) -> str:
+    ...
+```
+
+## When to Use Types
+
+**Always type:**
+
+- Public function signatures (parameters + return)
+- Class attributes (including private ones)
+- Function parameters that cross module boundaries
+- Return values that aren't immediately obvious
+
+**Type when helpful:**
+
+- Complex local variables
+- Closures and nested functions
+- Lambda expressions used as callbacks
+
+**Can skip:**
+
+- Obvious cases: `count = 0`, `name = "example"`
+- Trivial private helpers
+- Test fixture setup code (if types add no clarity)
+
+## Type Checking with ty
+
+Dignified Python uses ty for static type checking:
+
+```bash
+# Check all files
+ty check
+
+# Check specific file
+ty check src/mymodule.py
+
+# Check with specific Python version
+ty check --python-version 3.13
+```
+
+**Configuration** (in `pyproject.toml`):
+
+```toml
+[tool.ty.environment]
+python-version = "3.13"
+```
+
+## Anti-Patterns
+
+**❌ Don't ignore type errors with `# type: ignore`**
+
+```python
+# ❌ WRONG - Hiding type error
+result = unsafe_function()  # type: ignore
+
+# ✅ CORRECT - Fix the type error
+result: Expected = cast(Expected, unsafe_function())
+```
+
+**❌ Don't use bare Exception in type hints**
+
+```python
+# ❌ WRONG - No value from typing exception
+def risky() -> str | Exception:
+    ...
+
+# ✅ CORRECT - Let exceptions bubble
+def risky() -> str:
+    ...  # Raises ValueError on error
+```
+
+**❌ Don't over-type simple cases**
+
+```python
+# ❌ WRONG - Obvious from context
+def add_numbers(a: int, b: int) -> int:
+    result: int = a + b  # Unnecessary type annotation
+    return result
+
+# ✅ CORRECT - Type only signature
+def add_numbers(a: int, b: int) -> int:
+    result = a + b  # Type is obvious
+    return result
+```
+
+## Migration from 3.10/3.11
+
+If migrating from Python 3.10/3.11:
+
+1. **Remove `from __future__ import annotations`** - No longer needed
+2. **Consider upgrading to PEP 695 syntax** - Cleaner generics
+3. **Use `type` statement for aliases** - More explicit than assignment
+4. **Remove quoted forward references** - They work naturally now
+
+```python
+# Python 3.10/3.11
+from __future__ import annotations
+from typing import TypeVar, Generic
+
+T = TypeVar("T")
+
+class Node(Generic[T]):
+    def __init__(self, value: T, parent: "Node[T] | None" = None):
+        ...
+
+# Python 3.13
+from typing import Self
+
+class Node[T]:
+    def __init__(self, value: T, parent: Node[T] | None = None):
+        ...
+```
+
+## What typing imports are still needed?
+
+**Very rare:**
+
+- `TypeVar` - Only for constrained/bounded type variables
+- `Any` - Use sparingly when type truly unknown
+- `Protocol` - Structural typing (prefer ABC)
+- `TYPE_CHECKING` - Conditional imports to avoid circular dependencies
+
+**Never needed:**
+
+- `List`, `Dict`, `Set`, `Tuple` - Use built-in types
+- `Union` - Use `|` operator
+- `Optional` - Use `X | None`
+- `Generic` - Use PEP 695 class syntax

--- a/.claude/skills/building-pydantic-ai-agents
+++ b/.claude/skills/building-pydantic-ai-agents
@@ -1,0 +1,1 @@
+../../.agents/skills/building-pydantic-ai-agents

--- a/.claude/skills/dignified-python
+++ b/.claude/skills/dignified-python
@@ -1,0 +1,1 @@
+../../.agents/skills/dignified-python

--- a/.codex/skills/building-pydantic-ai-agents
+++ b/.codex/skills/building-pydantic-ai-agents
@@ -1,0 +1,1 @@
+../../.agents/skills/building-pydantic-ai-agents

--- a/.codex/skills/dignified-python
+++ b/.codex/skills/dignified-python
@@ -1,0 +1,1 @@
+../../.agents/skills/dignified-python

--- a/.opencode/skills/building-pydantic-ai-agents
+++ b/.opencode/skills/building-pydantic-ai-agents
@@ -1,0 +1,1 @@
+../../.agents/skills/building-pydantic-ai-agents

--- a/.opencode/skills/dignified-python
+++ b/.opencode/skills/dignified-python
@@ -1,0 +1,1 @@
+../../.agents/skills/dignified-python


### PR DESCRIPTION
Resolves #3444.

## Summary
- add `.agents/skills` as the canonical in-repo skill tree
- vendor Dagster's `dignified-python` skill for production Python guidance
- vendor Pydantic's `building-pydantic-ai-agents` skill for Pydantic AI applications
- expose both skills to Claude, Codex, and OpenCode through symlinks

## Sources
- https://github.com/dagster-io/skills#dignified-python
- https://pydantic.dev/docs/ai/overview/coding-agent-skills/

## Validation
- `python3` skill metadata and symlink check
- `git diff --cached --check`
- `make validate`
