### PR TITLE
fix(html): add default_content_layer option to HTMLBackendOptions

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -543,11 +543,15 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         if len(clean_headers):
             header = clean_headers[0]
         # Set starting content layer
-        self.content_layer = (
-            ContentLayer.BODY
-            if (not self.options.infer_furniture) or (header is None)
-            else ContentLayer.FURNITURE
-        )
+        options = cast(HTMLBackendOptions, self.options)
+        if options.default_content_layer is not None:
+            self.content_layer = options.default_content_layer
+        else:
+            self.content_layer = (
+                ContentLayer.BODY
+                if (not self.options.infer_furniture) or (header is None)
+                else ContentLayer.FURNITURE
+            )
         # reset context
         self.ctx = _Context()
         self._render_visibility_cache.clear()

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -1,6 +1,7 @@
 from pathlib import Path, PurePath
 from typing import Annotated, Literal, Optional, Union
 
+from docling_core.types.doc.document import ContentLayer
 from pydantic import AnyUrl, BaseModel, Field, PositiveInt, SecretStr, conint
 
 
@@ -89,6 +90,15 @@ class HTMLBackendOptions(BaseBackendOptions):
     )
     infer_furniture: bool = Field(
         True, description="Infer all the content before the first header as furniture."
+    )
+    default_content_layer: Optional[ContentLayer] = Field(
+        None,
+        description=(
+            "Override the default content layer for all content. "
+            "When set, all content is assigned to this layer (e.g. BODY) "
+            "instead of using the 'infer_furniture' logic. "
+            "Set to ContentLayer.BODY to force all content into the body layer."
+        ),
     )
     max_image_data_base64_bytes: PositiveInt = Field(
         20 * 1024 * 1024,  # 20 MB


### PR DESCRIPTION
## Summary

This PR adds a `default_content_layer` option to `HTMLBackendOptions` that allows users to override the default content layer assignment for all content.

## Problem (from issue #2487)

When using Docling in RAG pipelines with HTML content retrieved from specific endpoints (which may not contain a heading at the beginning), the HTML backend's "infer_furniture" logic causes content before the first heading to be placed in the FURNITURE content layer instead of BODY. This means content is excluded from markdown export.

## Solution

Add `default_content_layer: Optional[ContentLayer]` field to `HTMLBackendOptions`:

- When `None` (default): existing behavior preserved
- When `ContentLayer.BODY`: all content forced into BODY layer, bypassing the furniture inference

## Changes

### `docling/datamodel/backend_options.py`
- Added `default_content_layer: Optional[ContentLayer]` field to `HTMLBackendOptions`

### `docling/backend/html_backend.py`
- Modified `_to_docling_document()` to check `default_content_layer` and use it as the starting content layer when set

## Usage Example

```python
from docling.datamodel.backend_options import HTMLBackendOptions
from docling_core.types.doc.document import ContentLayer

backend_options = HTMLBackendOptions(
    default_content_layer=ContentLayer.BODY,
    # existing options...
)
```

## Testing

Existing tests should pass. The change is backward-compatible as `default_content_layer` defaults to `None`.
