### PR TITLE
fix: fix OSTL ucel merged incorrectly

### DIFF
--- a/docling/models/stages/table_structure/table_structure_model_granite_vision.py
+++ b/docling/models/stages/table_structure/table_structure_model_granite_vision.py
@@ -23,8 +23,6 @@ _log = logging.getLogger(__name__)
 
 # OTSL tokens that represent content-bearing cells (produce a TableCell)
 _CONTENT_TOKENS = {"fcel", "ecel", "ched", "rhed", "srow"}
-# OTSL tokens that are span-extensions (no separate TableCell, affect span of predecessor)
-_SPAN_TOKENS = {"lcel", "ucel", "xcel"}
 
 # Regex to extract (tag_name, inner_text) from VLM OTSL output.
 # Handles two OTSL serialisation styles:
@@ -108,7 +106,7 @@ def _parse_otsl_output(
             # Detect colspan: count consecutive span-extension tokens to the right
             colspan = 1
             for c in range(col_idx + 1, num_cols):
-                if grid[row_idx][c][0] in _SPAN_TOKENS:
+                if grid[row_idx][c][0] in {"lcel", "xcel"}:
                     colspan += 1
                 else:
                     break
@@ -116,7 +114,7 @@ def _parse_otsl_output(
             # Detect rowspan: count consecutive span-extension tokens below
             rowspan = 1
             for r in range(row_idx + 1, num_rows):
-                if grid[r][col_idx][0] in _SPAN_TOKENS:
+                if grid[r][col_idx][0] in {"ucel", "xcel"}:
                     rowspan += 1
                 else:
                     break

--- a/tests/test_table_structure_granite_vision.py
+++ b/tests/test_table_structure_granite_vision.py
@@ -80,6 +80,61 @@ def test_parse_rowspan():
     assert tall[0].end_row_offset_idx == 2
 
 
+def test_parse_multiple_rowspan():
+    """Multiple ucel produces rowspan=2 on the corresponding fcel above it."""
+    text = (
+        "<fcel>Regular</fcel><fcel>Merged</fcel><fcel>Merged</fcel><nl>"
+        "<fcel>Regular</fcel><ucel><ucel><nl>"
+    )
+    _otsl_seq, cells, num_rows, num_cols = _parse_otsl_output(text)
+
+    assert num_cols == 3
+    assert num_rows == 2
+    assert len(cells) == 4
+    for cell in cells:
+        if cell.text == "Merged":
+            assert cell.row_span == 2
+            assert cell.col_span == 1
+            assert cell.start_row_offset_idx == 0
+            assert cell.end_row_offset_idx == 2
+            assert cell.start_col_offset_idx + 1 == cell.end_col_offset_idx
+        else:
+            assert cell.text == "Regular"
+            assert cell.row_span == 1
+            assert cell.col_span == 1
+            assert cell.start_row_offset_idx + 1 == cell.end_row_offset_idx
+            assert cell.start_col_offset_idx + 1 == cell.end_col_offset_idx
+
+
+def test_parse_xcel():
+    """xcel is merged with adjacent ucel and lcel."""
+    text = (
+        "<fcel>Regular</fcel><fcel>Regular</fcel><fcel>Regular</fcel><fcel>Regular</fcel><nl>"
+        "<fcel>Regular</fcel><fcel>Merged</fcel><lcel><fcel>Regular</fcel><nl>"
+        "<fcel>Regular</fcel><ucel><xcel><fcel>Regular</fcel><nl>"
+        "<fcel>Regular</fcel><fcel>Regular</fcel><fcel>Regular</fcel><fcel>Regular</fcel><nl>"
+    )
+    _otsl_seq, cells, num_rows, num_cols = _parse_otsl_output(text)
+
+    assert num_cols == 4
+    assert num_rows == 4
+    assert len(cells) == 13
+    for cell in cells:
+        if cell.text == "Merged":
+            assert cell.row_span == 2
+            assert cell.col_span == 2
+            assert cell.start_col_offset_idx == 1
+            assert cell.end_col_offset_idx == 3
+            assert cell.start_row_offset_idx == 1
+            assert cell.end_row_offset_idx == 3
+        else:
+            assert cell.text == "Regular"
+            assert cell.row_span == 1
+            assert cell.col_span == 1
+            assert cell.start_row_offset_idx + 1 == cell.end_row_offset_idx
+            assert cell.start_col_offset_idx + 1 == cell.end_col_offset_idx
+
+
 def test_parse_row_header():
     """rhed token produces row_header=True."""
     text = "<rhed>Section</rhed><fcel>Data</fcel><nl>"


### PR DESCRIPTION
The `_parse_otsl_output` function used to translate VLM OSTL output into structured table data incorrectly merges ucel to the left if they are not in the first column. This causes column spanning cells to be incorrectly reported as row spanning.

**Issue resolved by this Pull Request:**
Resolves #3452 

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
