### PR TITLE
feat: skip OCR on text-layer pages

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -195,6 +195,13 @@ class OcrOptions(BaseOptions):
             examples=[0.05, 0.1],
         ),
     ] = 0.05
+    skip_text_layer_pages: Annotated[
+        bool,
+        Field(
+            description="If enabled, skip OCR on pages with enough native text cells.",
+            examples=[False],
+        ),
+    ] = False
 
 
 class OcrAutoOptions(OcrOptions):

--- a/docling/datamodel/service/options.py
+++ b/docling/datamodel/service/options.py
@@ -358,6 +358,16 @@ class ConvertDocumentsOptions(BaseModel):
         ),
     ] = False
 
+    ocr_skip_text_layer_pages: Annotated[
+        bool,
+        Field(
+            description=(
+                "If enabled, skip OCR on pages with enough native text cells. "
+                "Boolean. Optional, defaults to false."
+            ),
+        ),
+    ] = False
+
     ocr_engine: Annotated[
         str,
         Field(

--- a/docling/models/base_ocr_model.py
+++ b/docling/models/base_ocr_model.py
@@ -20,6 +20,9 @@ from docling.models.base_model import BaseModelWithOptions, BasePageModel
 
 _log = logging.getLogger(__name__)
 
+_TEXT_LAYER_MIN_CELLS = 3
+_TEXT_LAYER_MIN_CHARS = 80
+
 
 class BaseOcrModel(BasePageModel, BaseModelWithOptions):
     def __init__(
@@ -35,6 +38,18 @@ class BaseOcrModel(BasePageModel, BaseModelWithOptions):
 
         self.enabled = enabled
         self.options = options
+
+    @staticmethod
+    def _has_sufficient_text_layer(page: Page) -> bool:
+        text_cells = [
+            cell for cell in page.cells if cell.text.strip() and not cell.from_ocr
+        ]
+        text_chars = sum(len(cell.text.strip()) for cell in text_cells)
+
+        return (
+            len(text_cells) >= _TEXT_LAYER_MIN_CELLS
+            and text_chars >= _TEXT_LAYER_MIN_CHARS
+        )
 
     # Computes the optimum amount and coordinates of rectangles to OCR on a given page
     def get_ocr_rects(self, page: Page) -> List[BoundingBox]:
@@ -90,6 +105,13 @@ class BaseOcrModel(BasePageModel, BaseModelWithOptions):
             bitmap_rects = page._backend.get_bitmap_rects()
         else:
             bitmap_rects = []
+
+        if (
+            self.options.skip_text_layer_pages
+            and not self.options.force_full_page_ocr
+            and self._has_sufficient_text_layer(page)
+        ):
+            return []
 
         coverage, ocr_rects = find_ocr_rects(page.size, bitmap_rects)
 

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -93,6 +93,9 @@ doc_converter = DocumentConverter(
 )
 ```
 
+To avoid OCR on PDF pages that already contain a usable text layer, set
+`pipeline_options.ocr_options.skip_text_layer_pages = True`.
+
 ??? "Tesseract installation"
 
     [Tesseract](https://github.com/tesseract-ocr/tesseract) is a popular OCR engine which is available

--- a/tests/test_base_ocr_model.py
+++ b/tests/test_base_ocr_model.py
@@ -1,0 +1,152 @@
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, cast
+
+from docling_core.types.doc import BoundingBox, CoordOrigin, Size
+from docling_core.types.doc.page import (
+    BoundingRectangle,
+    PdfPageBoundaryType,
+    PdfPageGeometry,
+    SegmentedPdfPage,
+    TextCell,
+)
+
+from docling.datamodel.accelerator_options import AcceleratorOptions
+from docling.datamodel.base_models import Page
+from docling.datamodel.document import ConversionResult
+from docling.datamodel.pipeline_options import OcrOptions
+from docling.models.base_ocr_model import BaseOcrModel
+
+if TYPE_CHECKING:
+    from docling.backend.pdf_backend import PdfPageBackend
+
+
+class _BitmapBackend:
+    def __init__(self, bitmap_rects: list[BoundingBox]):
+        self.bitmap_rects = bitmap_rects
+
+    def get_bitmap_rects(self) -> list[BoundingBox]:
+        return self.bitmap_rects
+
+
+class _OcrModel(BaseOcrModel):
+    @classmethod
+    def get_options_type(cls) -> type[OcrOptions]:
+        return OcrOptions
+
+    def __call__(
+        self, conv_res: ConversionResult, page_batch: Iterable[Page]
+    ) -> Iterable[Page]:
+        return page_batch
+
+
+def _cell(text: str, *, index: int) -> TextCell:
+    return TextCell(
+        index=index,
+        rect=BoundingRectangle(
+            r_x0=0,
+            r_y0=index * 10,
+            r_x1=100,
+            r_y1=index * 10,
+            r_x2=100,
+            r_y2=index * 10 + 5,
+            r_x3=0,
+            r_y3=index * 10 + 5,
+        ),
+        text=text,
+        orig=text,
+        from_ocr=False,
+    )
+
+
+def _page_geometry() -> PdfPageGeometry:
+    bbox = BoundingBox(l=0, t=0, r=100, b=100, coord_origin=CoordOrigin.TOPLEFT)
+    return PdfPageGeometry(
+        angle=0,
+        rect=BoundingRectangle(
+            r_x0=0,
+            r_y0=0,
+            r_x1=100,
+            r_y1=0,
+            r_x2=100,
+            r_y2=100,
+            r_x3=0,
+            r_y3=100,
+        ),
+        boundary_type=PdfPageBoundaryType.CROP_BOX,
+        art_bbox=bbox,
+        bleed_bbox=bbox,
+        crop_bbox=bbox,
+        media_bbox=bbox,
+        trim_bbox=bbox,
+    )
+
+
+def _page(texts: list[str]) -> Page:
+    page = Page(page_no=1, size=Size(width=100, height=100))
+    page.parsed_page = SegmentedPdfPage(
+        dimension=_page_geometry(),
+        char_cells=[],
+        word_cells=[],
+        textline_cells=[_cell(text, index=i) for i, text in enumerate(texts)],
+    )
+    page._backend = cast(
+        "PdfPageBackend",
+        _BitmapBackend(
+            [BoundingBox(l=0, t=0, r=100, b=100, coord_origin=CoordOrigin.TOPLEFT)]
+        ),
+    )
+    return page
+
+
+def _model(*, skip_text_layer_pages: bool, force_full_page_ocr: bool = False):
+    return _OcrModel(
+        enabled=True,
+        artifacts_path=None,
+        options=OcrOptions(
+            lang=[],
+            force_full_page_ocr=force_full_page_ocr,
+            skip_text_layer_pages=skip_text_layer_pages,
+        ),
+        accelerator_options=AcceleratorOptions(),
+    )
+
+
+def test_text_layer_skip_is_opt_in():
+    page = _page(
+        ["This page has enough native text.", "More text.", "Still more text."]
+    )
+
+    assert _model(skip_text_layer_pages=False).get_ocr_rects(page) != []
+
+
+def test_text_layer_skip_drops_ocr_rects_for_text_rich_page():
+    page = _page(
+        [
+            "This page has a usable text layer with enough text to avoid OCR.",
+            "Docling should keep the programmatic text instead of OCRing it.",
+            "The bitmap resources on this page do not require OCR.",
+        ]
+    )
+
+    assert _model(skip_text_layer_pages=True).get_ocr_rects(page) == []
+
+
+def test_text_layer_skip_keeps_ocr_rects_for_sparse_text_page():
+    page = _page(["Footer"])
+
+    assert _model(skip_text_layer_pages=True).get_ocr_rects(page) != []
+
+
+def test_force_full_page_ocr_overrides_text_layer_skip():
+    page = _page(
+        [
+            "This page has a usable text layer with enough text to avoid OCR.",
+            "Docling should keep the programmatic text instead of OCRing it.",
+            "The bitmap resources on this page do not require OCR.",
+        ]
+    )
+
+    assert (
+        _model(skip_text_layer_pages=True, force_full_page_ocr=True).get_ocr_rects(page)
+        != []
+    )

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -190,6 +190,14 @@ def test_ocr_coverage_threshold(test_doc_path):
     assert len(doc_result.document.texts) == 0
 
 
+def test_convert_options_support_ocr_text_layer_skip():
+    from docling.datamodel.service.options import ConvertDocumentsOptions
+
+    options = ConvertDocumentsOptions(ocr_skip_text_layer_pages=True)
+
+    assert options.ocr_skip_text_layer_pages is True
+
+
 def test_parser_backends(test_doc_path):
     pipeline_options = PdfPipelineOptions()
     pipeline_options.do_ocr = False


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #3464

## Summary

This adds an opt-in OCR option for PDFs with a usable native text layer:

```python
OcrOptions(skip_text_layer_pages=True)
```

It also exposes the same behavior to service requests:

```python
ConvertDocumentsOptions(ocr_skip_text_layer_pages=True)
```

When enabled, the OCR rectangle selection step skips pages that already have enough native text cells. Sparse text still falls through to the existing bitmap-coverage OCR logic, and `force_full_page_ocr=True` still takes precedence.

Default behavior is unchanged.

Related context: #2029 and #2036.

## Validation

- `uv run --extra standard ruff check docling/datamodel/pipeline_options.py docling/datamodel/service/options.py docling/models/base_ocr_model.py tests/test_base_ocr_model.py tests/test_options.py docs/getting_started/installation.md`
- `uv run --extra standard ty check docling/datamodel/pipeline_options.py docling/datamodel/service/options.py docling/models/base_ocr_model.py tests/test_base_ocr_model.py tests/test_options.py` completed with existing warnings in broader checked files
- `uv run --extra standard pytest tests/test_base_ocr_model.py tests/test_options.py::test_ocr_coverage_threshold tests/test_options.py::test_convert_options_support_ocr_text_layer_skip`
- `git diff --check`

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.