### PR TITLE
fix(cli): Fix for unknown docling version when docling meta-package is not present

### DIFF
--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -190,7 +190,11 @@ def logo_callback(value: bool):
 def version_callback(value: bool):
     if value:
         v = DoclingVersion()
-        docling_version = v.docling_version if v.docling_version != "unknown" else v.docling_slim_version
+        docling_version = (
+            v.docling_version
+            if v.docling_version != "unknown"
+            else v.docling_slim_version
+        )
         print(f"Docling version: {docling_version}")
         print(f"Docling Core version: {v.docling_core_version}")
         print(f"Docling IBM Models version: {v.docling_ibm_models_version}")

--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -190,7 +190,8 @@ def logo_callback(value: bool):
 def version_callback(value: bool):
     if value:
         v = DoclingVersion()
-        print(f"Docling version: {v.docling_version}")
+        docling_version = v.docling_version if v.docling_version != "unknown" else v.docling_slim_version
+        print(f"Docling version: {docling_version}")
         print(f"Docling Core version: {v.docling_core_version}")
         print(f"Docling IBM Models version: {v.docling_ibm_models_version}")
         print(f"Docling Parse version: {v.docling_parse_version}")


### PR DESCRIPTION
Description
This PR fixes issue https://github.com/docling-project/docling/issues/3459 where docling version was printed as unknown when docling meta-package is not present

The bug occurs when docling-slim is installed directly without the docling meta-package present in the environment

Made changes to print the docling-slim-version if docling version is returned as unknown

Before the fix:
```
(docling) rintureji@Rintus-MacBook-Pro docling % uv run docling --version
Docling version: unknown
Docling Core version: 2.73.0
Docling IBM Models version: 3.13.0
Docling Parse version: 5.6.2
Python: cpython-312 (3.12.10)
Platform: macOS-26.2-arm64-arm-64bit
```

After the fix:
```
(docling) rintureji@Rintus-MacBook-Pro docling % uv run docling --version
Docling version: 2.93.0
Docling Core version: 2.73.0
Docling IBM Models version: 3.13.0
Docling Parse version: 5.6.2
Python: cpython-312 (3.12.10)
Platform: macOS-26.2-arm64-arm-64bit
```

Issue resolved by this Pull Request:
Resolves https://github.com/docling-project/docling/issues/3459

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
