### PR TITLE
docs: fix README configuration link target

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ result = converter.convert(source)
 print(result.document.export_to_markdown())  # output: "## Docling Technical Report[...]"
 ```
 
-More advanced [usage](https://docling-project.github.io/docling/usage/) and [configuration](https://docling-project.github.io/docling/installation/) options.
+More advanced [usage](https://docling-project.github.io/docling/usage/) and [configuration](https://docling-project.github.io/docling/usage/) options.
 
 ## Documentation
 


### PR DESCRIPTION
Fixes the README navigation so the configuration link no longer points back to the installation page.