### PR TITLE
fix(cli): show per-file progress at default verbosity

### DIFF
--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -835,6 +835,11 @@ def convert(  # noqa: C901
 
     if verbose == 0:
         logging.basicConfig(level=logging.WARNING, format=log_format)
+        # Keep per-file progress visible at default verbosity so users running
+        # long-running conversions (e.g. directories of audio files) can see
+        # which input is currently in flight.
+        logging.getLogger("docling.pipeline.base_pipeline").setLevel(logging.INFO)
+        logging.getLogger("docling.document_converter").setLevel(logging.INFO)
     elif verbose == 1:
         logging.basicConfig(level=logging.INFO, format=log_format)
     else:

--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -288,6 +288,11 @@ class _DefaultCommandGroup(typer.core.TyperGroup):
 app = typer.Typer(
     name="Docling",
     cls=_DefaultCommandGroup,
+    help=(
+        "Convert documents with Docling. At default verbosity a per-file "
+        "progress line is logged; pass -q/--quiet for fully silent output "
+        "(useful when calling docling from an AI agent or script)."
+    ),
     no_args_is_help=True,
     add_completion=False,
     pretty_exceptions_enable=False,
@@ -728,6 +733,16 @@ def convert(  # noqa: C901
             help="Set the verbosity level. -v for info logging, -vv for debug logging.",
         ),
     ] = 0,
+    quiet: Annotated[
+        bool,
+        typer.Option(
+            "--quiet",
+            "-q",
+            help="Suppress the per-file progress log emitted at default verbosity, "
+            "restoring fully silent output (warnings and errors only). Has no "
+            "effect when -v/--verbose is given.",
+        ),
+    ] = False,
     debug_visualize_cells: Annotated[
         bool,
         typer.Option(..., help="Enable debug output which visualizes the PDF cells"),
@@ -835,11 +850,13 @@ def convert(  # noqa: C901
 
     if verbose == 0:
         logging.basicConfig(level=logging.WARNING, format=log_format)
-        # Keep per-file progress visible at default verbosity so users running
-        # long-running conversions (e.g. directories of audio files) can see
-        # which input is currently in flight.
-        logging.getLogger("docling.pipeline.base_pipeline").setLevel(logging.INFO)
-        logging.getLogger("docling.document_converter").setLevel(logging.INFO)
+        if not quiet:
+            # Keep per-file progress visible at default verbosity so users running
+            # long-running conversions (e.g. directories of audio files) can see
+            # which input is currently in flight. --quiet opts back out for callers
+            # (e.g. AI agents) that need fully silent output.
+            logging.getLogger("docling.pipeline.base_pipeline").setLevel(logging.INFO)
+            logging.getLogger("docling.document_converter").setLevel(logging.INFO)
     elif verbose == 1:
         logging.basicConfig(level=logging.INFO, format=log_format)
     else:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -317,6 +317,40 @@ def test_cli_html_image_headers_require_remote_fetch(tmp_path):
     )
 
 
+def test_cli_default_verbosity_logs_per_file_progress(tmp_path):
+    """At default verbosity (-v not given), the CLI must still surface
+    which input file is currently being converted. Regression for #3467
+    where multi-file batches (e.g. directories of audio) gave no per-file
+    feedback at default verbosity.
+    """
+    import logging
+
+    progress_logger = logging.getLogger("docling.pipeline.base_pipeline")
+    converter_logger = logging.getLogger("docling.document_converter")
+    saved_progress_level = progress_logger.level
+    saved_converter_level = converter_logger.level
+    progress_logger.setLevel(logging.WARNING)
+    converter_logger.setLevel(logging.WARNING)
+    try:
+        sources = [
+            "./tests/data/md/blocks.md",
+            "./tests/data/md/duck.md",
+        ]
+        output = tmp_path / "out"
+        output.mkdir()
+
+        result = runner.invoke(app, [*sources, "--output", str(output)])
+        assert result.exit_code == 0
+
+        # After default-verbosity invocation, per-file progress loggers must
+        # be enabled at INFO so the "Processing document <name>" line fires.
+        assert progress_logger.isEnabledFor(logging.INFO)
+        assert converter_logger.isEnabledFor(logging.INFO)
+    finally:
+        progress_logger.setLevel(saved_progress_level)
+        converter_logger.setLevel(saved_converter_level)
+
+
 def test_export_documents_marks_empty_markdown_as_failure(tmp_path):
     from docling.cli.main import export_documents
     from docling.datamodel.base_models import ConversionStatus, InputFormat

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -332,20 +332,66 @@ def test_cli_default_verbosity_logs_per_file_progress(tmp_path):
     progress_logger.setLevel(logging.WARNING)
     converter_logger.setLevel(logging.WARNING)
     try:
-        sources = [
-            "./tests/data/md/blocks.md",
-            "./tests/data/md/duck.md",
-        ]
+        first = tmp_path / "first.md"
+        first.write_text("# First\n\nHello.", encoding="utf-8")
+        second = tmp_path / "second.md"
+        second.write_text("# Second\n\nWorld.", encoding="utf-8")
         output = tmp_path / "out"
         output.mkdir()
 
-        result = runner.invoke(app, [*sources, "--output", str(output)])
+        result = runner.invoke(
+            app, [str(first), str(second), "--from", "md", "--output", str(output)]
+        )
         assert result.exit_code == 0
 
         # After default-verbosity invocation, per-file progress loggers must
         # be enabled at INFO so the "Processing document <name>" line fires.
         assert progress_logger.isEnabledFor(logging.INFO)
         assert converter_logger.isEnabledFor(logging.INFO)
+    finally:
+        progress_logger.setLevel(saved_progress_level)
+        converter_logger.setLevel(saved_converter_level)
+
+
+def test_cli_quiet_suppresses_per_file_progress(tmp_path):
+    """`--quiet` reinstates fully silent default output: the per-file progress
+    loggers stay at WARNING so callers (e.g. AI agents) that shell out to
+    docling don't get unexpected INFO lines bloating their context.
+    """
+    import logging
+
+    progress_logger = logging.getLogger("docling.pipeline.base_pipeline")
+    converter_logger = logging.getLogger("docling.document_converter")
+    saved_progress_level = progress_logger.level
+    saved_converter_level = converter_logger.level
+    progress_logger.setLevel(logging.WARNING)
+    converter_logger.setLevel(logging.WARNING)
+    try:
+        first = tmp_path / "first.md"
+        first.write_text("# First\n\nHello.", encoding="utf-8")
+        second = tmp_path / "second.md"
+        second.write_text("# Second\n\nWorld.", encoding="utf-8")
+        output = tmp_path / "out"
+        output.mkdir()
+
+        result = runner.invoke(
+            app,
+            [
+                str(first),
+                str(second),
+                "--from",
+                "md",
+                "--quiet",
+                "--output",
+                str(output),
+            ],
+        )
+        assert result.exit_code == 0
+
+        # With --quiet the progress loggers are left at WARNING, so INFO-level
+        # per-file lines are suppressed.
+        assert not progress_logger.isEnabledFor(logging.INFO)
+        assert not converter_logger.isEnabledFor(logging.INFO)
     finally:
         progress_logger.setLevel(saved_progress_level)
         converter_logger.setLevel(saved_converter_level)


### PR DESCRIPTION
## Description

Without `-v`, the CLI configures the root logger at `WARNING`, which silences the `_log.info("Processing document <name>")` line in `docling/pipeline/base_pipeline.py`. On multi-file inputs (a directory of audio files is the case in #3467) the user has no indication of which file is currently in flight.

This patch keeps the root logger at `WARNING` (so model-loading and library noise stay hidden) but bumps two specific loggers — `docling.pipeline.base_pipeline` and `docling.document_converter` — to `INFO` at default verbosity. The per-file `Processing document X` and `Finished converting document X` lines then fire, while the rest of the default-verbosity behavior is unchanged.

Before:

```
$ docling ./audio_dir --output ./out
(no per-file output until the first file completes)
```

After:

```
$ docling ./audio_dir --output ./out
INFO:docling.pipeline.base_pipeline:Processing document one.mp3
INFO:docling.document_converter:Finished converting document one.mp3 in 12.3 sec.
INFO:docling.pipeline.base_pipeline:Processing document two.mp3
...
```

A regression test in `tests/test_cli.py` resets both progress loggers to `WARNING`, invokes the CLI, and asserts both are enabled for `INFO` afterward.

**Issue resolved by this Pull Request:**
Resolves #3467

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.