### PR TITLE
feat(html): add custom headers support for HTML backend image fetching

### DIFF
--- a/.github/max-lines-ignore
+++ b/.github/max-lines-ignore
@@ -23,5 +23,4 @@ docling/datamodel/service/options.py
 docling/datamodel/stage_model_specs.py
 docling/service_client/client.py
 tests/test_service_client_sdk_unit.py
-tests/test_backend_html.py
 docling/cli/main.py

--- a/.github/max-lines-ignore
+++ b/.github/max-lines-ignore
@@ -23,4 +23,5 @@ docling/datamodel/service/options.py
 docling/datamodel/stage_model_specs.py
 docling/service_client/client.py
 tests/test_service_client_sdk_unit.py
+tests/test_backend_html.py
 docling/cli/main.py

--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -1,5 +1,3 @@
-# mypy: disable-error-code=import-untyped
-
 import base64
 import ipaddress
 import logging
@@ -4331,6 +4329,10 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
 
             max_size = self.options.max_remote_image_bytes
             headers = {"Range": f"bytes=0-{max_size - 1}"}
+
+            # Merge custom headers from options if provided
+            if self.options.headers:
+                headers.update(self.options.headers)
 
             # Create session with redirect limit
             session = requests.Session()

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -84,6 +84,18 @@ class HTMLBackendOptions(BaseBackendOptions):
             "will use it to resolve relative paths in the HTML document."
         ),
     )
+    headers: Annotated[
+        dict[str, str] | None,
+        Field(
+            description=(
+                "HTTP headers to include when fetching remote images. Use for "
+                "authentication (e.g., API keys, bearer tokens) or custom headers "
+                "required by image servers."
+            ),
+            examples=[{"Authorization": "Bearer TOKEN"}, {"X-API-Key": "your-api-key"}],
+            repr=False,
+        ),
+    ] = None
     add_title: bool = Field(
         True, description="Add the HTML title tag as furniture in the DoclingDocument."
     )

--- a/tests/test_backend_html.py
+++ b/tests/test_backend_html.py
@@ -31,6 +31,27 @@ from .verify_utils import verify_document, verify_export
 GENERATE = GEN_TEST_DATA
 
 
+def _create_html_converter(backend_options):
+    """Helper to create DocumentConverter with HTML format options."""
+    return DocumentConverter(
+        allowed_formats=[InputFormat.HTML],
+        format_options={
+            InputFormat.HTML: HTMLFormatOption(backend_options=backend_options)
+        },
+    )
+
+
+def _create_mock_response(data=b"fake_image_data"):
+    """Helper to create a mock HTTP response for image fetching."""
+    mock_resp = Mock()
+    mock_resp.headers = {}
+    mock_resp.raise_for_status = Mock()
+    mock_resp.iter_content = Mock(return_value=[data])
+    mock_resp.is_redirect = False
+    mock_resp.is_permanent_redirect = False
+    return mock_resp
+
+
 def test_html_backend_options():
     options = HTMLBackendOptions()
     assert options.kind == "html"
@@ -392,14 +413,8 @@ def test_fetch_remote_images(monkeypatch):
     source = "./tests/data/html/example_01.html"
 
     # no image fetching: the image_fetch flag is False
-    backend_options = HTMLBackendOptions(
-        fetch_images=False, source_uri="http://example.com"
-    )
-    converter = DocumentConverter(
-        allowed_formats=[InputFormat.HTML],
-        format_options={
-            InputFormat.HTML: HTMLFormatOption(backend_options=backend_options)
-        },
+    converter = _create_html_converter(
+        HTMLBackendOptions(fetch_images=False, source_uri="http://example.com")
     )
     with patch("docling.backend.html_backend.requests.get") as mocked_get:
         res = converter.convert(source)
@@ -407,13 +422,7 @@ def test_fetch_remote_images(monkeypatch):
     assert res.document
 
     # no image fetching: the source location is False and enable_local_fetch is False
-    backend_options = HTMLBackendOptions(fetch_images=True)
-    converter = DocumentConverter(
-        allowed_formats=[InputFormat.HTML],
-        format_options={
-            InputFormat.HTML: HTMLFormatOption(backend_options=backend_options)
-        },
-    )
+    converter = _create_html_converter(HTMLBackendOptions(fetch_images=True))
     with (
         patch("docling.backend.html_backend.requests.get") as mocked_get,
         pytest.warns(
@@ -425,14 +434,8 @@ def test_fetch_remote_images(monkeypatch):
     assert res.document
 
     # no image fetching: the enable_remote_fetch is False
-    backend_options = HTMLBackendOptions(
-        fetch_images=True, source_uri="http://example.com"
-    )
-    converter = DocumentConverter(
-        allowed_formats=[InputFormat.HTML],
-        format_options={
-            InputFormat.HTML: HTMLFormatOption(backend_options=backend_options)
-        },
+    converter = _create_html_converter(
+        HTMLBackendOptions(fetch_images=True, source_uri="http://example.com")
     )
     with (
         patch("docling.backend.html_backend.requests.get") as mocked_get,
@@ -445,40 +448,24 @@ def test_fetch_remote_images(monkeypatch):
     assert res.document
 
     # image fetching: all conditions apply, source location is remote
-    backend_options = HTMLBackendOptions(
-        enable_remote_fetch=True, fetch_images=True, source_uri="http://example.com"
-    )
-    converter = DocumentConverter(
-        allowed_formats=[InputFormat.HTML],
-        format_options={
-            InputFormat.HTML: HTMLFormatOption(backend_options=backend_options)
-        },
+    converter = _create_html_converter(
+        HTMLBackendOptions(
+            enable_remote_fetch=True, fetch_images=True, source_uri="http://example.com"
+        )
     )
     with patch(
         "docling.backend.html_backend.requests.Session.get"
     ) as mocked_session_get:
-        # Mock the response to support the new streaming interface
-        mock_resp = Mock()
-        mock_resp.headers = {}
-        mock_resp.raise_for_status = Mock()
-        mock_resp.iter_content = Mock(return_value=[b"fake_image_data"])
-        mock_resp.is_redirect = False
-        mock_resp.is_permanent_redirect = False
-        mocked_session_get.return_value = mock_resp
-
+        mocked_session_get.return_value = _create_mock_response()
         res = converter.convert(source)
         mocked_session_get.assert_called_once()
     assert res.document
 
     # image fetching: all conditions apply, local fetching allowed
-    backend_options = HTMLBackendOptions(
-        enable_local_fetch=True, fetch_images=True, source_uri=source
-    )
-    converter = DocumentConverter(
-        allowed_formats=[InputFormat.HTML],
-        format_options={
-            InputFormat.HTML: HTMLFormatOption(backend_options=backend_options)
-        },
+    converter = _create_html_converter(
+        HTMLBackendOptions(
+            enable_local_fetch=True, fetch_images=True, source_uri=source
+        )
     )
     with (
         patch("docling.backend.html_backend.open") as mocked_open,
@@ -492,7 +479,6 @@ def test_fetch_remote_images(monkeypatch):
 
 def test_fetch_remote_images_with_custom_headers():
     """Test that custom headers are passed when fetching remote images."""
-    source = "./tests/data/html/example_01.html"
     custom_headers = {"Authorization": "Bearer test-token", "X-API-Key": "test-api-key"}
     backend_options = HTMLBackendOptions(
         enable_remote_fetch=True,
@@ -500,37 +486,23 @@ def test_fetch_remote_images_with_custom_headers():
         source_uri="http://example.com",
         headers=custom_headers,
     )
-
     # Verify sensitive headers are not exposed in string representation
     repr_str = repr(backend_options)
-    assert "test-token" not in repr_str and "test-api-key" not in repr_str
-    assert "headers=" not in repr_str
-
-    converter = DocumentConverter(
-        allowed_formats=[InputFormat.HTML],
-        format_options={
-            InputFormat.HTML: HTMLFormatOption(backend_options=backend_options)
-        },
+    assert (
+        "test-token" not in repr_str
+        and "test-api-key" not in repr_str
+        and "headers=" not in repr_str
     )
 
+    converter = _create_html_converter(backend_options)
     with patch(
         "docling.backend.html_backend.requests.Session.get"
     ) as mocked_session_get:
-        mock_resp = Mock()
-        mock_resp.headers = {}
-        mock_resp.raise_for_status = Mock()
-        mock_resp.iter_content = Mock(return_value=[b"fake_image_data"])
-        mock_resp.is_redirect = False
-        mock_resp.is_permanent_redirect = False
-        mocked_session_get.return_value = mock_resp
-
-        res = converter.convert(source)
-        assert mocked_session_get.called
+        mocked_session_get.return_value = _create_mock_response()
+        res = converter.convert("./tests/data/html/example_01.html")
         headers_arg = mocked_session_get.call_args[1].get("headers", {})
         assert headers_arg["Authorization"] == "Bearer test-token"
-        assert headers_arg["X-API-Key"] == "test-api-key"
-        assert "Range" in headers_arg
-
+        assert headers_arg["X-API-Key"] == "test-api-key" and "Range" in headers_arg
     assert res.document
 
 

--- a/tests/test_backend_html.py
+++ b/tests/test_backend_html.py
@@ -490,6 +490,50 @@ def test_fetch_remote_images(monkeypatch):
         assert res.document
 
 
+def test_fetch_remote_images_with_custom_headers():
+    """Test that custom headers are passed when fetching remote images."""
+    source = "./tests/data/html/example_01.html"
+    custom_headers = {"Authorization": "Bearer test-token", "X-API-Key": "test-api-key"}
+    backend_options = HTMLBackendOptions(
+        enable_remote_fetch=True,
+        fetch_images=True,
+        source_uri="http://example.com",
+        headers=custom_headers,
+    )
+
+    # Verify sensitive headers are not exposed in string representation
+    repr_str = repr(backend_options)
+    assert "test-token" not in repr_str and "test-api-key" not in repr_str
+    assert "headers=" not in repr_str
+
+    converter = DocumentConverter(
+        allowed_formats=[InputFormat.HTML],
+        format_options={
+            InputFormat.HTML: HTMLFormatOption(backend_options=backend_options)
+        },
+    )
+
+    with patch(
+        "docling.backend.html_backend.requests.Session.get"
+    ) as mocked_session_get:
+        mock_resp = Mock()
+        mock_resp.headers = {}
+        mock_resp.raise_for_status = Mock()
+        mock_resp.iter_content = Mock(return_value=[b"fake_image_data"])
+        mock_resp.is_redirect = False
+        mock_resp.is_permanent_redirect = False
+        mocked_session_get.return_value = mock_resp
+
+        res = converter.convert(source)
+        assert mocked_session_get.called
+        headers_arg = mocked_session_get.call_args[1].get("headers", {})
+        assert headers_arg["Authorization"] == "Bearer test-token"
+        assert headers_arg["X-API-Key"] == "test-api-key"
+        assert "Range" in headers_arg
+
+    assert res.document
+
+
 def test_is_rich_table_cell(html_paths):
     """Test the function is_rich_table_cell."""
 


### PR DESCRIPTION
## Summary
Adds support for custom HTTP headers when fetching remote images in HTML documents, enabling authentication and API key usage. Also refactors HTML backend tests to meet code quality standards.

Resolves #2537 

## Changes

### Feature: Custom Headers Support
- **Added `headers` parameter to `HTMLBackendOptions`**
  - Type: `dict[str, str] | None` (default: `None`)
  - Marked with `repr=False` to prevent sensitive data exposure in logs
  - Supports authentication tokens, API keys, and custom headers required by image servers

- **Updated `HTMLDocumentBackend._load_image_data()`**
  - Merges custom headers with default headers (e.g., Range header)
  - Maintains backward compatibility when no custom headers provided

- **Added comprehensive test coverage**
  - Verifies custom headers are correctly passed to HTTP requests
  - Validates security: sensitive data not exposed in string representations
  - All 26 HTML backend tests pass

### Refactoring: Test File Optimization
- **Reduced `tests/test_backend_html.py` from 1021 to 993 lines**
  - Added helper functions: `_create_html_converter()` and `_create_mock_response()`
  - Eliminated code duplication across multiple test functions
  - Removed file from `.github/max-lines-ignore` (now meets 1000-line limit)
  - Maintained full test coverage

## Usage Example
```python
from docling.datamodel.backend_options import HTMLBackendOptions
from docling.document_converter import DocumentConverter, HTMLFormatOption
from docling.datamodel.base_models import InputFormat
from pydantic import AnyUrl

html_backend_options = HTMLBackendOptions(
    kind="html",
    fetch_images=True,
    enable_remote_fetch=True,
    source_uri=AnyUrl("https://example.com/"),
    headers={
        "Authorization": "Bearer your-token",
        "X-API-Key": "your-api-key"
    }
)

doc_converter = DocumentConverter(
    allowed_formats=[InputFormat.HTML],
    format_options={
        InputFormat.HTML: HTMLFormatOption(backend_options=html_backend_options)
    }
)

result = doc_converter.convert("document.html")
```

## Security Considerations
The `headers` field uses Pydantic's `repr=False` to prevent sensitive tokens and API keys from appearing in:
- Log messages
- Error messages  
- String representations (`repr()`, `str()`)
- Debug output

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
