### PR TITLE
fix: accept JSON transformers model type

### DIFF
--- a/docling/models/inference_engines/vlm/transformers_engine.py
+++ b/docling/models/inference_engines/vlm/transformers_engine.py
@@ -50,6 +50,12 @@ if TYPE_CHECKING:
 _log = logging.getLogger(__name__)
 
 
+def _coerce_transformers_model_type(value: Any) -> TransformersModelType:
+    if isinstance(value, TransformersModelType):
+        return value
+    return TransformersModelType(value)
+
+
 class TransformersVlmEngine(BaseVlmEngine, HuggingFaceModelDownloadMixin):
     """HuggingFace Transformers engine for VLM inference.
 
@@ -116,6 +122,7 @@ class TransformersVlmEngine(BaseVlmEngine, HuggingFaceModelDownloadMixin):
                 "transformers_model_type",
                 TransformersModelType.AUTOMODEL,
             )
+            model_type = _coerce_transformers_model_type(model_type)
 
             _log.info(
                 f"Loading model {repo_id} (revision: {revision}, "

--- a/tests/test_vlm_presets_and_runtime_options.py
+++ b/tests/test_vlm_presets_and_runtime_options.py
@@ -11,12 +11,16 @@ This test suite validates:
 import pytest
 from pydantic import ValidationError
 
+from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
 from docling.datamodel.pipeline_options import (
     CodeFormulaVlmOptions,
     PictureDescriptionVlmEngineOptions,
     VlmConvertOptions,
 )
-from docling.datamodel.pipeline_options_vlm_model import ResponseFormat
+from docling.datamodel.pipeline_options_vlm_model import (
+    ResponseFormat,
+    TransformersModelType,
+)
 from docling.datamodel.stage_model_specs import (
     ApiModelConfig,
     EngineModelConfig,
@@ -31,6 +35,9 @@ from docling.datamodel.vlm_engine_options import (
     VllmVlmEngineOptions,
 )
 from docling.models.inference_engines.vlm import VlmEngineType
+from docling.models.inference_engines.vlm.transformers_engine import (
+    TransformersVlmEngine,
+)
 
 pytestmark = pytest.mark.ml_vlm
 
@@ -116,6 +123,45 @@ class TestRuntimeOptions:
 
         with pytest.raises(ValidationError):
             VllmVlmEngineOptions(model_impl=None)
+
+    def test_transformers_engine_accepts_json_model_type(self, monkeypatch):
+        """Custom JSON configs carry enum values as strings."""
+        calls = []
+
+        def fake_load_model_for_repo(
+            self,
+            repo_id,
+            revision="main",
+            model_type=TransformersModelType.AUTOMODEL,
+        ):
+            calls.append((repo_id, revision, model_type))
+
+        monkeypatch.setattr(
+            TransformersVlmEngine, "_load_model_for_repo", fake_load_model_for_repo
+        )
+
+        TransformersVlmEngine(
+            options=TransformersVlmEngineOptions(),
+            accelerator_options=AcceleratorOptions(device=AcceleratorDevice.CPU),
+            artifacts_path=None,
+            model_config=EngineModelConfig(
+                repo_id="test/model",
+                revision="v1",
+                extra_config={
+                    "transformers_model_type": (
+                        TransformersModelType.AUTOMODEL_IMAGETEXTTOTEXT.value
+                    )
+                },
+            ),
+        )
+
+        assert calls == [
+            (
+                "test/model",
+                "v1",
+                TransformersModelType.AUTOMODEL_IMAGETEXTTOTEXT,
+            )
+        ]
 
 
 # =============================================================================


### PR DESCRIPTION
Closes #3487.

## Summary

- coerce JSON string `transformers_model_type` values before loading Transformers VLM models
- preserve existing enum/native preset behavior
- add regression coverage for the custom model-spec path

## Rationale

Native presets store `transformers_model_type` as a `TransformersModelType`. Custom configs can arrive through JSON, so the same value is a string.

The engine already supports the enum values; this keeps the JSON path equivalent before the value is logged and passed into model loading.

## Tests

- `uv run --extra standard ruff check docling/models/inference_engines/vlm/transformers_engine.py tests/test_vlm_presets_and_runtime_options.py`
- `uv run --extra standard ruff format --check docling/models/inference_engines/vlm/transformers_engine.py tests/test_vlm_presets_and_runtime_options.py`
- `uv run --extra standard pytest tests/test_vlm_presets_and_runtime_options.py -q -k json_model_type`
- `uv run --extra standard pytest tests/test_vlm_presets_and_runtime_options.py -q`