### PR TITLE
fix(layout): drop PICTURE cluster when substantially overlapping TABLE

### DIFF
--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -419,7 +419,24 @@ class LayoutPostprocessor:
             if cluster.id not in wrappers_to_remove
         ]
 
-        return special_clusters
+        # Drop PICTURE clusters that are substantially covered by a TABLE cluster.
+        # Both can appear in special_clusters when the layout model fires both labels
+        # on the same region (common with borderless/raster tables).
+        table_clusters = [c for c in special_clusters if c.label == DocItemLabel.TABLE]
+        pictures_to_remove: set[int] = set()
+        for picture in special_clusters:
+            if picture.label != DocItemLabel.PICTURE:
+                continue
+            for table in table_clusters:
+                if picture.bbox.intersection_over_self(table.bbox) > 0.5:
+                    pictures_to_remove.add(picture.id)
+                    break
+
+        return [
+            cluster
+            for cluster in special_clusters
+            if cluster.id not in pictures_to_remove
+        ]
 
     def _should_prefer_cluster(
         self, candidate: Cluster, other: Cluster, params: dict

--- a/tests/test_layout_postprocessor.py
+++ b/tests/test_layout_postprocessor.py
@@ -1,5 +1,8 @@
+from docling_core.types.doc import DocItemLabel, Size
 from docling_core.types.doc.page import BoundingRectangle, TextCell
 
+from docling.datamodel.base_models import BoundingBox, Cluster, Page
+from docling.datamodel.pipeline_options import LayoutOptions
 from docling.utils.layout_postprocessor import LayoutPostprocessor
 
 
@@ -22,6 +25,21 @@ def _text_cell(index: int) -> TextCell:
     )
 
 
+def _make_cluster(id: int, label: DocItemLabel, confidence: float) -> Cluster:
+    return Cluster(
+        id=id,
+        label=label,
+        confidence=confidence,
+        bbox=BoundingBox(l=10, t=10, r=200, b=150),
+    )
+
+
+def _make_postprocessor(clusters: list[Cluster]) -> LayoutPostprocessor:
+    page = Page(page_no=1)
+    page.size = Size(width=500, height=700)
+    return LayoutPostprocessor(page, clusters, LayoutOptions(skip_cell_assignment=True))
+
+
 def test_sort_cells_uses_native_cell_index_order() -> None:
     processor = object.__new__(LayoutPostprocessor)
     cells = [_text_cell(3), _text_cell(1), _text_cell(2)]
@@ -30,3 +48,32 @@ def test_sort_cells_uses_native_cell_index_order() -> None:
 
     assert [cell.index for cell in sorted_cells] == [1, 2, 3]
     assert [cell.index for cell in cells] == [3, 1, 2]
+
+
+def test_picture_overlapping_table_is_removed() -> None:
+    """A PICTURE cluster substantially overlapping a TABLE cluster must be dropped."""
+    table = _make_cluster(0, DocItemLabel.TABLE, confidence=0.85)
+    picture = _make_cluster(1, DocItemLabel.PICTURE, confidence=0.72)
+
+    final_clusters, _ = _make_postprocessor([table, picture]).postprocess()
+
+    labels = {c.label for c in final_clusters}
+    assert DocItemLabel.TABLE in labels
+    assert DocItemLabel.PICTURE not in labels
+
+
+def test_non_overlapping_picture_survives() -> None:
+    """A PICTURE cluster on a different region must not be removed."""
+    table = _make_cluster(0, DocItemLabel.TABLE, confidence=0.85)
+    picture = Cluster(
+        id=1,
+        label=DocItemLabel.PICTURE,
+        confidence=0.80,
+        bbox=BoundingBox(l=250, t=200, r=450, b=350),  # non-overlapping
+    )
+
+    final_clusters, _ = _make_postprocessor([table, picture]).postprocess()
+
+    labels = {c.label for c in final_clusters}
+    assert DocItemLabel.TABLE in labels
+    assert DocItemLabel.PICTURE in labels


### PR DESCRIPTION
When the layout model fires both TABLE and PICTURE labels on the same region (common with borderless/raster tables), _handle_cross_type_overlaps would leave both clusters alive — the guard checking regular_clusters for TABLE is unreachable because TABLE is in SPECIAL_TYPES, so it never lands in regular_clusters.

Fix: after the existing KEY_VALUE_REGION deduplication, compare every PICTURE cluster against every TABLE cluster within special_clusters. Drop the PICTURE when intersection_over_self > 0.5. TABLE is preferred because it triggers structured cell extraction via TableFormer; keeping the PICTURE would yield only an unstructured image crop of the same region.

Resolves #3495

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ X] Tests have been added, if necessary.
