### PR TITLE
docs: replace minimal, custom, and batch convert examples with doclin…

### DIFF
--- a/docs/examples/batch_convert.py
+++ b/docs/examples/batch_convert.py
@@ -1,20 +1,20 @@
 # %% [markdown]
-# Batch convert multiple PDF files and export results in several formats.
+# Batch convert multiple PDF files and export results in several formats with Docling Serve.
 
 # What this example does
 # - Loads a small set of sample PDFs.
-# - Runs the Docling PDF pipeline once per file.
+# - Runs the Docling Serve PDF pipeline once per file.
 # - Writes outputs to `scratch/` in multiple formats (JSON, HTML, Markdown, text, doctags, YAML).
 
 # Prerequisites
-# - Install Docling and dependencies as described in the repository README.
-# - Ensure you can import `docling` from your Python environment.
+# - Install Docling, Docling Serve and dependencies as described in the repository README.
+# - Ensure you can import `docling.service_client` from your Python environment.
 # <!-- YAML export requires `PyYAML` (`pip install pyyaml`). -->
 
 # Input documents
-# - By default, this example uses a few PDFs from `tests/data/pdf/` in the repo.
-# - If you cloned without test data, or want to use your own files, edit
-#   `input_doc_paths` below to point to PDFs on your machine.
+# - Default set of sample PDFs.
+# - Update `input_doc_paths` to a desired list of file URLs.
+# - All input sources must start with `http://` or `https://`.
 
 # Output formats (controlled by flags)
 # - `USE_V2 = True` enables the current Docling document exports (recommended).
@@ -35,13 +35,13 @@ from collections.abc import Iterable
 from pathlib import Path
 
 import yaml
-from docling_core.types.doc import ImageRefMode
+from docling_core.types.doc.base import ImageRefMode
 
-from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
-from docling.datamodel.base_models import ConversionStatus, InputFormat
+from docling.datamodel.base_models import ConversionStatus
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import PdfPipelineOptions
-from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.service_client import DoclingServiceClient
+from docling.datamodel.service.options import ConvertDocumentsOptions
 
 _log = logging.getLogger(__name__)
 
@@ -157,60 +157,59 @@ def export_documents(
 def main():
     logging.basicConfig(level=logging.INFO)
 
-    # Location of sample PDFs used by this example. If your checkout does not
-    # include test data, change `data_folder` or point `input_doc_paths` to
-    # your own files.
-    data_folder = Path(__file__).parent / "../../tests/data"
-    input_doc_paths = [
-        data_folder / "pdf/2206.01062.pdf",
-        data_folder / "pdf/2203.01017v2.pdf",
-        data_folder / "pdf/2305.03393v1.pdf",
-        data_folder / "pdf/redp5110_sampled.pdf",
+    # Add your HTTP or HTTPS URLs here
+    input_doc_urls = [
+        "https://arxiv.org/pdf/1706.03762",
+        "https://arxiv.org/pdf/1103.0398",
+        "https://arxiv.org/pdf/2501.17887",
+        "https://arxiv.org/pdf/2408.09869",
     ]
-
-    # buf = BytesIO((data_folder / "pdf/2206.01062.pdf").open("rb").read())
-    # docs = [DocumentStream(name="my_doc.pdf", stream=buf)]
-    # input = DocumentConversionInput.from_streams(docs)
-
-    # # Turn on inline debug visualizations:
-    # settings.debug.visualize_layout = True
-    # settings.debug.visualize_ocr = True
-    # settings.debug.visualize_tables = True
-    # settings.debug.visualize_cells = True
 
     # Configure the PDF pipeline. Enabling page image generation improves HTML
     # previews (embedded images) but adds processing time.
     pipeline_options = PdfPipelineOptions()
     pipeline_options.generate_page_images = True
 
-    doc_converter = DocumentConverter(
-        format_options={
-            InputFormat.PDF: PdfFormatOption(
-                pipeline_options=pipeline_options, backend=DoclingParseDocumentBackend
-            )
-        }
+    SERVE_URL = "http://localhost:5001"
+    
+    options = ConvertDocumentsOptions(
+        do_ocr=pipeline_options.do_ocr,
+        ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     )
 
     start_time = time.time()
 
     # Convert all inputs. Set `raises_on_error=False` to keep processing other
     # files even if one fails; errors are summarized after the run.
-    conv_results = doc_converter.convert_all(
-        input_doc_paths,
-        raises_on_error=False,  # to let conversion run through all and examine results at the end
-    )
+    conv_results = []
+    failure_count = 0
+    with DoclingServiceClient(url=SERVE_URL) as client:
+        for input_doc_url in input_doc_urls:
+            try:
+                conv_result = client.convert(
+                    source=input_doc_url,
+                    options=options
+                )
+                conv_results.append(conv_result)
+            except Exception as e:
+                _log.error(f"Failed to convert {input_doc_url}: {e}")
+                failure_count += 1
+    
     # Write outputs to ./scratch and log a summary.
-    _success_count, _partial_success_count, failure_count = export_documents(
+    _success_count, _partial_success_count, export_failure_count = export_documents(
         conv_results, output_dir=Path("scratch")
     )
+    
+    # Add conversion failures to the total failure count
+    total_failures = failure_count + export_failure_count
 
     end_time = time.time() - start_time
 
     _log.info(f"Document conversion complete in {end_time:.2f} seconds.")
 
-    if failure_count > 0:
+    if total_failures > 0:
         raise RuntimeError(
-            f"The example failed converting {failure_count} on {len(input_doc_paths)}."
+            f"The example failed converting {total_failures} on {len(input_doc_urls)}."
         )
 
 

--- a/docs/examples/batch_convert.py
+++ b/docs/examples/batch_convert.py
@@ -40,8 +40,8 @@ from docling_core.types.doc.base import ImageRefMode
 from docling.datamodel.base_models import ConversionStatus
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import PdfPipelineOptions
-from docling.service_client import DoclingServiceClient
 from docling.datamodel.service.options import ConvertDocumentsOptions
+from docling.service_client import DoclingServiceClient
 
 _log = logging.getLogger(__name__)
 
@@ -171,7 +171,7 @@ def main():
     pipeline_options.generate_page_images = True
 
     SERVE_URL = "http://localhost:5001"
-    
+
     options = ConvertDocumentsOptions(
         do_ocr=pipeline_options.do_ocr,
         ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
@@ -186,20 +186,17 @@ def main():
     with DoclingServiceClient(url=SERVE_URL) as client:
         for input_doc_url in input_doc_urls:
             try:
-                conv_result = client.convert(
-                    source=input_doc_url,
-                    options=options
-                )
+                conv_result = client.convert(source=input_doc_url, options=options)
                 conv_results.append(conv_result)
             except Exception as e:
                 _log.error(f"Failed to convert {input_doc_url}: {e}")
                 failure_count += 1
-    
+
     # Write outputs to ./scratch and log a summary.
     _success_count, _partial_success_count, export_failure_count = export_documents(
         conv_results, output_dir=Path("scratch")
     )
-    
+
     # Add conversion failures to the total failure count
     total_failures = failure_count + export_failure_count
 

--- a/docs/examples/custom_convert.py
+++ b/docs/examples/custom_convert.py
@@ -2,13 +2,13 @@
 # Customize PDF conversion by toggling OCR/backends and pipeline options.
 #
 # What this example does
-# - Shows several alternative configurations for the Docling PDF pipeline.
+# - Shows several alternative configurations for the Docling Serve PDF pipeline.
 # - Lets you try OCR engines (EasyOCR, Tesseract, system OCR) or no OCR.
 # - Converts a single sample PDF and exports results to `scratch/`.
 #
 # Prerequisites
-# - Install Docling and its optional OCR backends per the docs.
-# - Ensure you can import `docling` from your Python environment.
+# - Install Docling Serve and the docling optional OCR backends per the docs.
+# - Ensure you can import `docling.service_client` from your Python environment.
 #
 # How to run
 # - From the repository root, run: `python docs/examples/custom_convert.py`.
@@ -24,8 +24,10 @@
 #   - `from docling.datamodel.pipeline_options import TesseractOcrOptions, TesseractCliOcrOptions, OcrMacOptions`
 #
 # Input document
-# - Defaults to a single PDF from `tests/data/pdf/` in the repo.
-# - If you don't have the test data, update `input_doc_path` to a local PDF.
+# - Defaults to a sample PDF
+# - Update `input_doc_path` to a desired file URL
+# - All input sources must start with `http://` or `https://`.
+#
 #
 # Notes
 # - EasyOCR language: adjust `pipeline_options.ocr_options.lang` (e.g., ["en"], ["es"], ["en", "de"]).
@@ -40,12 +42,12 @@ import time
 from pathlib import Path
 
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
-from docling.datamodel.base_models import InputFormat
 from docling.datamodel.pipeline_options import (
     PdfPipelineOptions,
     TableStructureOptions,
 )
-from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.service_client import DoclingServiceClient
+from docling.datamodel.service.options import ConvertDocumentsOptions
 
 _log = logging.getLogger(__name__)
 
@@ -53,8 +55,8 @@ _log = logging.getLogger(__name__)
 def main():
     logging.basicConfig(level=logging.INFO)
 
-    data_folder = Path(__file__).parent / "../../tests/data"
-    input_doc_path = data_folder / "pdf/2206.01062.pdf"
+    input_doc_path = "https://arxiv.org/pdf/2408.09869"
+    SERVE_URL = "http://localhost:5001"
 
     ###########################################################################
 
@@ -68,12 +70,9 @@ def main():
     # pipeline_options.do_table_structure = True
     # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=False)
 
-    # doc_converter = DocumentConverter(
-    #     format_options={
-    #         InputFormat.PDF: PdfFormatOption(
-    #             pipeline_options=pipeline_options, backend=PyPdfiumDocumentBackend
-    #         )
-    #     }
+    # options = ConvertDocumentsOptions(
+    #     do_ocr=pipeline_options.do_ocr,
+    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     # )
 
     # PyPdfium with EasyOCR
@@ -83,12 +82,9 @@ def main():
     # pipeline_options.do_table_structure = True
     # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
 
-    # doc_converter = DocumentConverter(
-    #     format_options={
-    #         InputFormat.PDF: PdfFormatOption(
-    #             pipeline_options=pipeline_options, backend=PyPdfiumDocumentBackend
-    #         )
-    #     }
+    # options = ConvertDocumentsOptions(
+    #     do_ocr=pipeline_options.do_ocr,
+    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     # )
 
     # Docling Parse without EasyOCR
@@ -98,10 +94,9 @@ def main():
     # pipeline_options.do_table_structure = True
     # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
 
-    # doc_converter = DocumentConverter(
-    #     format_options={
-    #         InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
-    #     }
+    # options = ConvertDocumentsOptions(
+    #     do_ocr=pipeline_options.do_ocr,
+    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     # )
 
     # Docling Parse with EasyOCR (default)
@@ -119,10 +114,9 @@ def main():
         num_threads=4, device=AcceleratorDevice.AUTO
     )
 
-    doc_converter = DocumentConverter(
-        format_options={
-            InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
-        }
+    options = ConvertDocumentsOptions(
+        do_ocr=pipeline_options.do_ocr,
+        ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     )
 
     # Docling Parse with EasyOCR (CPU only)
@@ -133,10 +127,9 @@ def main():
     # pipeline_options.do_table_structure = True
     # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
 
-    # doc_converter = DocumentConverter(
-    #     format_options={
-    #         InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
-    #     }
+    # options = ConvertDocumentsOptions(
+    #     do_ocr=pipeline_options.do_ocr,
+    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     # )
 
     # Docling Parse with Tesseract
@@ -147,10 +140,9 @@ def main():
     # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
     # pipeline_options.ocr_options = TesseractOcrOptions()
 
-    # doc_converter = DocumentConverter(
-    #     format_options={
-    #         InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
-    #     }
+    # options = ConvertDocumentsOptions(
+    #     do_ocr=pipeline_options.do_ocr,
+    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     # )
 
     # Docling Parse with Tesseract CLI
@@ -161,10 +153,9 @@ def main():
     # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
     # pipeline_options.ocr_options = TesseractCliOcrOptions()
 
-    # doc_converter = DocumentConverter(
-    #     format_options={
-    #         InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
-    #     }
+    # options = ConvertDocumentsOptions(
+    #     do_ocr=pipeline_options.do_ocr,
+    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     # )
 
     # Docling Parse with ocrmac (macOS only)
@@ -175,16 +166,20 @@ def main():
     # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
     # pipeline_options.ocr_options = OcrMacOptions()
 
-    # doc_converter = DocumentConverter(
-    #     format_options={
-    #         InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
-    #     }
+    # options = ConvertDocumentsOptions(
+    #     do_ocr=pipeline_options.do_ocr,
+    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     # )
-
     ###########################################################################
 
     start_time = time.time()
-    conv_result = doc_converter.convert(input_doc_path)
+    
+    with DoclingServiceClient(url=SERVE_URL) as client:
+        conv_result = client.convert(
+            source=str(input_doc_path),
+            options=options
+        )
+    
     end_time = time.time() - start_time
 
     _log.info(f"Document converted in {end_time:.2f} seconds.")
@@ -192,7 +187,7 @@ def main():
     ## Export results
     output_dir = Path("scratch")
     output_dir.mkdir(parents=True, exist_ok=True)
-    doc_filename = conv_result.input.file.stem
+    doc_filename = Path(input_doc_path).stem
 
     # Export Docling document JSON format:
     with (output_dir / f"{doc_filename}.json").open("w", encoding="utf-8") as fp:
@@ -213,3 +208,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+# Made with Bob

--- a/docs/examples/custom_convert.py
+++ b/docs/examples/custom_convert.py
@@ -46,8 +46,8 @@ from docling.datamodel.pipeline_options import (
     PdfPipelineOptions,
     TableStructureOptions,
 )
-from docling.service_client import DoclingServiceClient
 from docling.datamodel.service.options import ConvertDocumentsOptions
+from docling.service_client import DoclingServiceClient
 
 _log = logging.getLogger(__name__)
 
@@ -173,13 +173,10 @@ def main():
     ###########################################################################
 
     start_time = time.time()
-    
+
     with DoclingServiceClient(url=SERVE_URL) as client:
-        conv_result = client.convert(
-            source=str(input_doc_path),
-            options=options
-        )
-    
+        conv_result = client.convert(source=str(input_doc_path), options=options)
+
     end_time = time.time() - start_time
 
     _log.info(f"Document converted in {end_time:.2f} seconds.")

--- a/docs/examples/minimal.py
+++ b/docs/examples/minimal.py
@@ -1,30 +1,30 @@
 # %% [markdown]
 # What this example does
 # - Converts a single source (URL or local file path) to a unified Docling
-#   document and prints Markdown to stdout.
+#   document with Docling Serve and prints Markdown to stdout.
 #
 # Requirements
-# - Python 3.9+
-# - Install Docling: `pip install docling`
+# - Python 3.10+
+# - Install Docling Serve: `pip install "docling-serve[ui]"`
+# - Run the Docling Serve Server: `docling-serve run --enable-ui`
+#
+# Notes
+# - The converter auto-detects supported formats (PDF, DOCX, HTML, PPTX, images, etc.).
+# - For batch processing or saving outputs to files, see `docs/examples/batch_convert.py`. 
 #
 # How to run
 # - Use the default sample URL: `python docs/examples/minimal.py`
 # - To use your own file or URL, edit the `source` variable below.
-#
-# Notes
-# - The converter auto-detects supported formats (PDF, DOCX, HTML, PPTX, images, etc.).
-# - For batch processing or saving outputs to files, see `docs/examples/batch_convert.py`.
 # %%
 
-from docling.document_converter import DocumentConverter
+from docling.service_client import DoclingServiceClient
 
-# Change this to a local path or another URL if desired.
-# Note: using the default URL requires network access; if offline, provide a
-# local file path (e.g., Path("/path/to/file.pdf")).
-source = "https://arxiv.org/pdf/2408.09869"
+# Replace SERVE_URL with your hosted URL if it's different
+SERVE_URL="http://localhost:5001"
 
-converter = DocumentConverter()
-result = converter.convert(source)
+with DoclingServiceClient(url=SERVE_URL) as client:
+    result = client.convert(
+        source="https://arxiv.org/pdf/2408.09869"
+    )
 
-# Print Markdown to stdout.
 print(result.document.export_to_markdown())

--- a/docs/examples/minimal.py
+++ b/docs/examples/minimal.py
@@ -10,7 +10,7 @@
 #
 # Notes
 # - The converter auto-detects supported formats (PDF, DOCX, HTML, PPTX, images, etc.).
-# - For batch processing or saving outputs to files, see `docs/examples/batch_convert.py`. 
+# - For batch processing or saving outputs to files, see `docs/examples/batch_convert.py`.
 #
 # How to run
 # - Use the default sample URL: `python docs/examples/minimal.py`
@@ -20,11 +20,9 @@
 from docling.service_client import DoclingServiceClient
 
 # Replace SERVE_URL with your hosted URL if it's different
-SERVE_URL="http://localhost:5001"
+SERVE_URL = "http://localhost:5001"
 
 with DoclingServiceClient(url=SERVE_URL) as client:
-    result = client.convert(
-        source="https://arxiv.org/pdf/2408.09869"
-    )
+    result = client.convert(source="https://arxiv.org/pdf/2408.09869")
 
 print(result.document.export_to_markdown())


### PR DESCRIPTION
# Updating docs examples to reflect Docling Serve + DoclingServiceClient

This is to update the examples for simple conversion, custom conversion, and batch conversion files to work with DoclingServiceClient instead of the original implementation. Also updated some of the language to reflect Docling Serve instead of just Docling.

To be reviewed by @mingxzhao first, please don't merge!