### PR TITLE
fix: retry transient remote VLM API failures

### DIFF
--- a/docling/utils/api_image_request.py
+++ b/docling/utils/api_image_request.py
@@ -7,6 +7,8 @@ from typing import Any
 import requests
 from PIL import Image
 from pydantic import AnyUrl
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 from docling.datamodel.base_models import (
     OpenAiApiResponse,
@@ -16,6 +18,30 @@ from docling.datamodel.base_models import (
 from docling.models.utils.generation_utils import GenerationStopper
 
 _log = logging.getLogger(__name__)
+
+_RETRY_TOTAL = 5
+_RETRY_BACKOFF_FACTOR = 0.1
+_RETRY_STATUS_FORCELIST = (429, 500, 502, 503, 504)
+
+
+def _make_retry_session() -> requests.Session:
+    retry_strategy = Retry(
+        total=_RETRY_TOTAL,
+        connect=_RETRY_TOTAL,
+        read=0,
+        status=_RETRY_TOTAL,
+        allowed_methods={"POST"},
+        backoff_factor=_RETRY_BACKOFF_FACTOR,
+        status_forcelist=_RETRY_STATUS_FORCELIST,
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry_strategy)
+
+    session = requests.Session()
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+    return session
 
 
 def _extract_text_from_tool_arguments(arguments: str | None) -> str:
@@ -119,12 +145,13 @@ def api_image_request(
 
             headers = headers or {}
 
-            r = requests.post(
-                str(url),
-                headers=headers,
-                json=payload,
-                timeout=timeout,
-            )
+            with _make_retry_session() as session:
+                r = session.post(
+                    str(url),
+                    headers=headers,
+                    json=payload,
+                    timeout=timeout,
+                )
             if not r.ok:
                 _log.error(f"Error calling the API. Response was {r.text}")
                 # image.show()
@@ -194,64 +221,67 @@ def api_image_request_streaming(
         hdrs["X-Temperature"] = str(params["temperature"])
 
     # Stream the HTTP response
-    with requests.post(
-        str(url), headers=hdrs, json=payload, timeout=timeout, stream=True
-    ) as r:
-        if not r.ok:
-            _log.error(
-                f"Error calling the API {url} in streaming mode. Response was {r.text}"
-            )
-        r.raise_for_status()
+    with _make_retry_session() as session:
+        with session.post(
+            str(url), headers=hdrs, json=payload, timeout=timeout, stream=True
+        ) as r:
+            if not r.ok:
+                _log.error(
+                    f"Error calling the API {url} in streaming mode. "
+                    f"Response was {r.text}"
+                )
+            r.raise_for_status()
 
-        full_text = []
-        for raw_line in r.iter_lines(decode_unicode=True):
-            if not raw_line:  # keep-alives / blank lines
-                continue
-            if not raw_line.startswith("data:"):
-                # Some proxies inject comments; ignore anything not starting with 'data:'
-                continue
+            full_text = []
+            for raw_line in r.iter_lines(decode_unicode=True):
+                if not raw_line:  # keep-alives / blank lines
+                    continue
+                if not raw_line.startswith("data:"):
+                    # Some proxies inject comments; ignore anything not starting with 'data:'
+                    continue
 
-            data = raw_line[len("data:") :].strip()
-            if data == "[DONE]":
-                break
+                data = raw_line[len("data:") :].strip()
+                if data == "[DONE]":
+                    break
 
-            try:
-                obj = json.loads(data)
-            except json.JSONDecodeError:
-                _log.debug("Skipping non-JSON SSE chunk: %r", data[:200])
-                continue
+                try:
+                    obj = json.loads(data)
+                except json.JSONDecodeError:
+                    _log.debug("Skipping non-JSON SSE chunk: %r", data[:200])
+                    continue
 
-            # OpenAI-compatible delta format
-            # obj["choices"][0]["delta"]["content"] may be None or missing (e.g., tool calls)
-            try:
-                delta = obj["choices"][0].get("delta") or {}
-                piece = delta.get("content") or ""
-            except (KeyError, IndexError) as e:
-                _log.debug("Unexpected SSE chunk shape: %s", e)
-                piece = ""
+                # OpenAI-compatible delta format
+                # obj["choices"][0]["delta"]["content"] may be None or missing
+                # (e.g., tool calls)
+                try:
+                    delta = obj["choices"][0].get("delta") or {}
+                    piece = delta.get("content") or ""
+                except (KeyError, IndexError) as e:
+                    _log.debug("Unexpected SSE chunk shape: %s", e)
+                    piece = ""
 
-            # Try to extract token count
-            num_tokens = None
-            try:
-                if "usage" in obj:
-                    usage = obj["usage"]
-                    num_tokens = usage.get("total_tokens")
-            except Exception as e:
+                # Try to extract token count
                 num_tokens = None
-                _log.debug("Usage key not included in response: %s", e)
+                try:
+                    if "usage" in obj:
+                        usage = obj["usage"]
+                        num_tokens = usage.get("total_tokens")
+                except Exception as e:
+                    num_tokens = None
+                    _log.debug("Usage key not included in response: %s", e)
 
-            if piece:
-                full_text.append(piece)
-                for stopper in generation_stoppers:
-                    # Respect stopper's lookback window. We use a simple string window which
-                    # works with the GenerationStopper interface.
-                    lookback = max(1, stopper.lookback_tokens())
-                    window = "".join(full_text)[-lookback:]
-                    if stopper.should_stop(window):
-                        # Break out of the loop cleanly. The context manager will handle
-                        # closing the connection when we exit the 'with' block.
-                        # vLLM/OpenAI-compatible servers will detect the client disconnect
-                        # and abort the request server-side.
-                        return "".join(full_text), num_tokens
+                if piece:
+                    full_text.append(piece)
+                    for stopper in generation_stoppers:
+                        # Respect stopper's lookback window. We use a simple string window
+                        # which works with the GenerationStopper interface.
+                        lookback = max(1, stopper.lookback_tokens())
+                        window = "".join(full_text)[-lookback:]
+                        if stopper.should_stop(window):
+                            # Break out of the loop cleanly. The context manager will handle
+                            # closing the connection when we exit the 'with' block.
+                            # vLLM/OpenAI-compatible servers will detect the client
+                            # disconnect and abort the request server-side.
+                            return "".join(full_text), num_tokens
 
-        return "".join(full_text), num_tokens
+            return "".join(full_text), num_tokens

--- a/tests/test_api_image_request.py
+++ b/tests/test_api_image_request.py
@@ -5,9 +5,10 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 from PIL import Image
+from requests.adapters import HTTPAdapter
 
 from docling.datamodel.base_models import VlmStopReason
-from docling.utils.api_image_request import api_image_request
+from docling.utils.api_image_request import _make_retry_session, api_image_request
 
 pytestmark = pytest.mark.cross_platform
 
@@ -56,13 +57,15 @@ class TestApiImageRequest:
 
         return _create_mock_response
 
-    @patch("docling.utils.api_image_request.requests.post")
+    @patch("docling.utils.api_image_request._make_retry_session")
     def test_content_filter_finish_reason(
-        self, mock_post, sample_image, mock_response_factory
+        self, mock_session_factory, sample_image, mock_response_factory
     ):
         """Test that content_filter finish reason returns CONTENT_FILTERED."""
-        mock_post.return_value = mock_response_factory(
-            content="Filtered content", finish_reason="content_filter"
+        mock_session_factory.return_value.__enter__.return_value.post.return_value = (
+            mock_response_factory(
+                content="Filtered content", finish_reason="content_filter"
+            )
         )
 
         result_text, _tokens, stop_reason = api_image_request(
@@ -74,11 +77,13 @@ class TestApiImageRequest:
         assert result_text == "Filtered content"
         assert stop_reason == VlmStopReason.CONTENT_FILTERED
 
-    @patch("docling.utils.api_image_request.requests.post")
-    def test_length_finish_reason(self, mock_post, sample_image, mock_response_factory):
+    @patch("docling.utils.api_image_request._make_retry_session")
+    def test_length_finish_reason(
+        self, mock_session_factory, sample_image, mock_response_factory
+    ):
         """Test that length finish reason returns LENGTH."""
-        mock_post.return_value = mock_response_factory(
-            content="Truncated content", finish_reason="length"
+        mock_session_factory.return_value.__enter__.return_value.post.return_value = (
+            mock_response_factory(content="Truncated content", finish_reason="length")
         )
 
         result_text, _tokens, stop_reason = api_image_request(
@@ -90,11 +95,13 @@ class TestApiImageRequest:
         assert result_text == "Truncated content"
         assert stop_reason == VlmStopReason.LENGTH
 
-    @patch("docling.utils.api_image_request.requests.post")
-    def test_stop_finish_reason(self, mock_post, sample_image, mock_response_factory):
+    @patch("docling.utils.api_image_request._make_retry_session")
+    def test_stop_finish_reason(
+        self, mock_session_factory, sample_image, mock_response_factory
+    ):
         """Test that stop finish reason returns END_OF_SEQUENCE."""
-        mock_post.return_value = mock_response_factory(
-            content="Normal completion", finish_reason="stop"
+        mock_session_factory.return_value.__enter__.return_value.post.return_value = (
+            mock_response_factory(content="Normal completion", finish_reason="stop")
         )
 
         result_text, _tokens, stop_reason = api_image_request(
@@ -106,26 +113,30 @@ class TestApiImageRequest:
         assert result_text == "Normal completion"
         assert stop_reason == VlmStopReason.END_OF_SEQUENCE
 
-    @patch("docling.utils.api_image_request.requests.post")
-    def test_tool_calls_response(self, mock_post, sample_image, mock_response_factory):
+    @patch("docling.utils.api_image_request._make_retry_session")
+    def test_tool_calls_response(
+        self, mock_session_factory, sample_image, mock_response_factory
+    ):
         """Test that tool calling responses are converted into generated text."""
-        mock_post.return_value = mock_response_factory(
-            message={
-                "role": "assistant",
-                "tool_calls": [
-                    {
-                        "function": {
-                            "name": "markdown_no_bbox",
-                            "arguments": json.dumps(
-                                [
-                                    {"text": "Extracted text"},
-                                    {"text": "Second block"},
-                                ]
-                            ),
+        mock_session_factory.return_value.__enter__.return_value.post.return_value = (
+            mock_response_factory(
+                message={
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "function": {
+                                "name": "markdown_no_bbox",
+                                "arguments": json.dumps(
+                                    [
+                                        {"text": "Extracted text"},
+                                        {"text": "Second block"},
+                                    ]
+                                ),
+                            }
                         }
-                    }
-                ],
-            }
+                    ],
+                }
+            )
         )
 
         result_text, tokens, stop_reason = api_image_request(
@@ -137,3 +148,20 @@ class TestApiImageRequest:
         assert result_text == "Extracted text\nSecond block"
         assert tokens == 100
         assert stop_reason == VlmStopReason.END_OF_SEQUENCE
+
+    def test_retry_session_retries_transient_api_errors(self):
+        """Test that remote API calls retry common transient failures."""
+        with _make_retry_session() as session:
+            adapter = session.get_adapter("https://")
+
+            assert isinstance(adapter, HTTPAdapter)
+
+            retry_config = adapter.max_retries
+            assert retry_config.total == 5
+            assert retry_config.connect == 5
+            assert retry_config.read == 0
+            assert retry_config.status == 5
+            assert retry_config.backoff_factor == 0.1
+            assert set(retry_config.status_forcelist) == {429, 500, 502, 503, 504}
+            assert retry_config.allowed_methods == {"POST"}
+            assert retry_config.respect_retry_after_header is True


### PR DESCRIPTION
## Summary
- add a retry-enabled requests session for remote VLM API calls
- retry transient 429/5xx responses while respecting Retry-After
- use the same retry session for streaming and non-streaming image requests
- cover the retry configuration in `test_api_image_request`

## Tests
- `python3 -m py_compile docling/utils/api_image_request.py tests/test_api_image_request.py`
- `pytest tests/test_api_image_request.py -q` with temporary import stubs for sparse-checkout-only dependencies: 5 passed

Fixes #2465