### PR TITLE
fix: guard _log against None in __del__ methods during interpreter shutdown

### DIFF
--- a/docling/models/stages/code_formula/code_formula_vlm_model.py
+++ b/docling/models/stages/code_formula/code_formula_vlm_model.py
@@ -294,4 +294,5 @@ class CodeFormulaVlmModel(BaseItemAndImageEnrichmentModel):
             try:
                 self.engine.cleanup()
             except Exception as e:
-                _log.warning(f"Error cleaning up engine: {e}")
+                if _log is not None:
+                    _log.warning(f"Error cleaning up engine: {e}")

--- a/docling/models/stages/picture_description/picture_description_vlm_engine_model.py
+++ b/docling/models/stages/picture_description/picture_description_vlm_engine_model.py
@@ -159,4 +159,5 @@ class PictureDescriptionVlmEngineModel(PictureDescriptionBaseModel):
             try:
                 self.engine.cleanup()
             except Exception as e:
-                _log.warning(f"Error cleaning up engine: {e}")
+                if _log is not None:
+                    _log.warning(f"Error cleaning up engine: {e}")

--- a/docling/models/stages/vlm_convert/vlm_convert_model.py
+++ b/docling/models/stages/vlm_convert/vlm_convert_model.py
@@ -260,4 +260,5 @@ class VlmConvertModel(BasePageModel):
             try:
                 self.engine.cleanup()
             except Exception as e:
-                _log.warning(f"Error cleaning up engine: {e}")
+                if _log is not None:
+                    _log.warning(f"Error cleaning up engine: {e}")


### PR DESCRIPTION
## Description

Fix `AttributeError: 'NoneType' object has no attribute 'warning'` in `__del__` methods during Python interpreter shutdown.

During Python interpreter shutdown, module-level variables (like `_log`) can be set to `None` before `__del__` methods are called on remaining objects. Three files have `__del__` methods that reference the module-level `_log` without guarding against this:

```python
# Before (broken during shutdown):
_log.warning(f"Error cleaning up engine: {e}")

# After (safe):
if _log is not None:
    _log.warning(f"Error cleaning up engine: {e}")
```

### Files changed
- `docling/models/stages/code_formula/code_formula_vlm_model.py`
- `docling/models/stages/picture_description/picture_description_vlm_engine_model.py`
- `docling/models/stages/vlm_convert/vlm_convert_model.py`

The error is non-fatal (Python just reports it as "Exception ignored in: ...") but produces noisy tracebacks on every exit when formula enrichment or VLM conversion is used.

Fixes #3525
