### PR TITLE
fix: guard against None _log in CodeFormulaVlmModel.__del__ during interpreter shutdown

### DIFF
--- a/docling/models/stages/code_formula/code_formula_vlm_model.py
+++ b/docling/models/stages/code_formula/code_formula_vlm_model.py
@@ -294,4 +294,6 @@ class CodeFormulaVlmModel(BaseItemAndImageEnrichmentModel):
             try:
                 self.engine.cleanup()
             except Exception as e:
-                _log.warning(f"Error cleaning up engine: {e}")
+                # _log may be None during interpreter shutdown
+                if _log is not None:
+                    _log.warning(f"Error cleaning up engine: {e}")


### PR DESCRIPTION
## Summary

During Python interpreter shutdown, module-level globals (including `_log`) can be set to `None` before `__del__` methods are called. In `CodeFormulaVlmModel.__del__`, if `engine.cleanup()` raises an exception at that point, the `except` block crashes with:

```
AttributeError: 'NoneType' object has no attribute 'warning'
```

instead of logging the warning — producing noise in the user's output with no actionable information.

**Fix:** add a `if _log is not None` guard before calling `_log.warning(...)` in `__del__`.

## Reproduction

Enable formula enrichment and convert a PDF:

```python
pipeline_options = PdfPipelineOptions()
pipeline_options.do_formula_enrichment = True
converter = DocumentConverter(format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)})
result = converter.convert("document.pdf")
```

On interpreter exit you may see:

```
Exception ignored in: <function CodeFormulaVlmModel.__del__ at 0x...>
AttributeError: 'NoneType' object has no attribute 'warning'
```

## Related issue

Closes #3525