### PR TITLE
fix(asr): log active audio filename in AsrPipeline._build_document

### DIFF
--- a/docling/document_converter.py
+++ b/docling/document_converter.py
@@ -662,6 +662,7 @@ class DocumentConverter:
     def _execute_pipeline(
         self, in_doc: InputDocument, raises_on_error: bool
     ) -> ConversionResult:
+        _log.info("Starting conversion of document %s.", in_doc.file.name)
         if in_doc.valid:
             pipeline = self._get_pipeline(in_doc.format)
             if pipeline is not None:

--- a/docling/document_converter.py
+++ b/docling/document_converter.py
@@ -662,7 +662,6 @@ class DocumentConverter:
     def _execute_pipeline(
         self, in_doc: InputDocument, raises_on_error: bool
     ) -> ConversionResult:
-        _log.info("Starting conversion of document %s.", in_doc.file.name)
         if in_doc.valid:
             pipeline = self._get_pipeline(in_doc.format)
             if pipeline is not None:

--- a/docling/pipeline/asr_pipeline.py
+++ b/docling/pipeline/asr_pipeline.py
@@ -476,7 +476,7 @@ class AsrPipeline(BasePipeline):
         return AsrPipelineOptions()
 
     def _build_document(self, conv_res: ConversionResult) -> ConversionResult:
-        _log.info(f"start _build_document in AsrPipeline: {conv_res.input.file}")
+        _log.info("Transcribing audio document %s.", conv_res.input.file.name)
         with TimeRecorder(conv_res, "doc_build", scope=ProfilingScope.DOCUMENT):
             self._model.run(conv_res=conv_res)
 


### PR DESCRIPTION
## Summary

When converting a batch (e.g. a directory of audio files with `docling /path/to/dir`), only a single `Going to convert document batch...` log entry appeared for the entire batch, with no indication of which file was being processed.

This made it impossible to track progress or identify which file was currently active — especially confusing for long audio transcriptions.

**Fix:** add a per-document `info` log at the start of `_execute_pipeline`. This fires for both sequential and concurrent conversion paths and is consistent with the existing `Finished converting document X in Y sec.` log that follows it.

```
INFO  Starting conversion of document lecture_01.mp3.
INFO  Finished converting document lecture_01.mp3 in 12.45 sec.
INFO  Starting conversion of document lecture_02.mp3.
...
```

## Reproduction

```bash
docling /path/to/directory/with/multiple/audio/files
```

Previously only showed `Going to convert document batch...` with no per-file progress.

## Related issue

Closes #3467