### PR TITLE
fix(layout): resolve dead code and TABLE/PICTURE dual-detection in _handle_cross_type_overlaps

### DIFF
--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -387,39 +387,41 @@ class LayoutPostprocessor:
         return picture_clusters + wrapper_clusters
 
     def _handle_cross_type_overlaps(self, special_clusters) -> list[Cluster]:
-        """Handle overlaps between regular and wrapper clusters before child assignment.
+        """Handle overlaps between clusters of different special types.
 
-        In particular, KEY_VALUE_REGION proposals that are almost identical to a TABLE
-        should be removed.
+        Removes:
+        - Non-TABLE wrapper proposals (e.g. KEY_VALUE_REGION) that heavily overlap
+          a TABLE cluster (TABLE is always preferred).
+        - PICTURE proposals that heavily overlap a TABLE cluster — borderless tables
+          can score above the confidence threshold for both TABLE and PICTURE
+          simultaneously; TABLE is the more specific label and takes priority.
         """
-        wrappers_to_remove = set()
+        clusters_to_remove: set[int] = set()
 
-        for wrapper in special_clusters:
-            if wrapper.label not in self.WRAPPER_TYPES:
-                continue  # only treat KEY_VALUE_REGION for now.
+        table_clusters = [c for c in special_clusters if c.label == DocItemLabel.TABLE]
 
-            for regular in self.regular_clusters:
-                if regular.label == DocItemLabel.TABLE:
-                    # Calculate overlap
-                    overlap_ratio = wrapper.bbox.intersection_over_self(regular.bbox)
+        for cluster in special_clusters:
+            if cluster.id in clusters_to_remove:
+                continue
 
-                    conf_diff = wrapper.confidence - regular.confidence
-
-                    # If wrapper is mostly overlapping with a TABLE, remove the wrapper
-                    if (
-                        overlap_ratio > 0.9 and conf_diff < 0.1
-                    ):  # self.OVERLAP_PARAMS["wrapper"]["conf_threshold"]):  # 80% overlap threshold
-                        wrappers_to_remove.add(wrapper.id)
+            # Non-TABLE wrapper (e.g. KEY_VALUE_REGION) vs TABLE
+            if cluster.label in self.WRAPPER_TYPES and cluster.label != DocItemLabel.TABLE:
+                for table in table_clusters:
+                    overlap_ratio = cluster.bbox.intersection_over_self(table.bbox)
+                    conf_diff = cluster.confidence - table.confidence
+                    if overlap_ratio > 0.9 and conf_diff < 0.1:
+                        clusters_to_remove.add(cluster.id)
                         break
 
-        # Filter out the identified wrappers
-        special_clusters = [
-            cluster
-            for cluster in special_clusters
-            if cluster.id not in wrappers_to_remove
-        ]
+            # PICTURE vs TABLE — prefer TABLE when they share the same region
+            elif cluster.label == DocItemLabel.PICTURE:
+                for table in table_clusters:
+                    overlap_ratio = cluster.bbox.intersection_over_self(table.bbox)
+                    if overlap_ratio > 0.9:
+                        clusters_to_remove.add(cluster.id)
+                        break
 
-        return special_clusters
+        return [c for c in special_clusters if c.id not in clusters_to_remove]
 
     def _should_prefer_cluster(
         self, candidate: Cluster, other: Cluster, params: dict

--- a/tests/test_layout_postprocessor.py
+++ b/tests/test_layout_postprocessor.py
@@ -1,5 +1,7 @@
+from docling_core.types.doc import BoundingBox, DocItemLabel
 from docling_core.types.doc.page import BoundingRectangle, TextCell
 
+from docling.datamodel.base_models import Cluster
 from docling.utils.layout_postprocessor import LayoutPostprocessor
 
 
@@ -20,6 +22,52 @@ def _text_cell(index: int) -> TextCell:
         orig=str(index),
         from_ocr=False,
     )
+
+
+def _cluster(id: int, label: DocItemLabel, confidence: float = 0.9) -> Cluster:
+    return Cluster(
+        id=id,
+        label=label,
+        bbox=BoundingBox(l=0, t=0, r=100, b=100),
+        confidence=confidence,
+    )
+
+
+def test_handle_cross_type_overlaps_removes_picture_overlapping_table() -> None:
+    """A PICTURE that shares the same region as a TABLE should be dropped (issue #3495)."""
+    processor = object.__new__(LayoutPostprocessor)
+    table = _cluster(1, DocItemLabel.TABLE, confidence=0.9)
+    picture = _cluster(2, DocItemLabel.PICTURE, confidence=0.8)
+
+    result = processor._handle_cross_type_overlaps([table, picture])
+
+    labels = {c.label for c in result}
+    assert DocItemLabel.TABLE in labels
+    assert DocItemLabel.PICTURE not in labels
+
+
+def test_handle_cross_type_overlaps_removes_kvregion_overlapping_table() -> None:
+    """A KEY_VALUE_REGION that heavily overlaps a TABLE should be dropped."""
+    processor = object.__new__(LayoutPostprocessor)
+    table = _cluster(1, DocItemLabel.TABLE, confidence=0.9)
+    kvr = _cluster(2, DocItemLabel.KEY_VALUE_REGION, confidence=0.85)
+
+    result = processor._handle_cross_type_overlaps([table, kvr])
+
+    labels = {c.label for c in result}
+    assert DocItemLabel.TABLE in labels
+    assert DocItemLabel.KEY_VALUE_REGION not in labels
+
+
+def test_handle_cross_type_overlaps_keeps_picture_without_table() -> None:
+    """A PICTURE with no overlapping TABLE should survive."""
+    processor = object.__new__(LayoutPostprocessor)
+    picture = _cluster(1, DocItemLabel.PICTURE, confidence=0.8)
+
+    result = processor._handle_cross_type_overlaps([picture])
+
+    assert len(result) == 1
+    assert result[0].label == DocItemLabel.PICTURE
 
 
 def test_sort_cells_uses_native_cell_index_order() -> None:


### PR DESCRIPTION
## Summary

`_handle_cross_type_overlaps` contained an unreachable condition that silently disabled the cross-type deduplication logic. Additionally, borderless tables were emitted as both a `TableItem` and a `PictureItem` — the same region chunked twice in downstream RAG pipelines.

### Root cause

```python
for wrapper in special_clusters:
    if wrapper.label not in self.WRAPPER_TYPES:
        continue

    for regular in self.regular_clusters:
        if regular.label == DocItemLabel.TABLE:  # ← never True
```

`TABLE` is a member of `WRAPPER_TYPES ⊂ SPECIAL_TYPES`, so TABLE clusters are always in `special_clusters`, never in `regular_clusters`. The inner `if` could never fire — the entire function was a no-op.

As a result:
1. **KEY_VALUE_REGION vs TABLE** deduplication never ran.
2. **TABLE vs PICTURE** deduplication never existed. When the layout model scores a borderless table above 0.5 for both TABLE and PICTURE, both clusters survive and the same region appears in `doc.tables` and `doc.pictures` with identical bounding boxes.

### Fix

- Look for TABLE in `special_clusters` instead of `regular_clusters` to fix the KEY_VALUE_REGION deduplication.
- Add an explicit TABLE-vs-PICTURE pass: when a PICTURE bbox is covered >90% by a TABLE bbox, the PICTURE is dropped (TABLE is the more specific label and takes priority).

### Tests

Three new unit tests cover:
- PICTURE overlapping TABLE → PICTURE removed
- KEY_VALUE_REGION overlapping TABLE → KEY_VALUE_REGION removed
- PICTURE with no TABLE → PICTURE kept

## Verification

```python
from docling.document_converter import DocumentConverter
doc = DocumentConverter().convert("borderless_table.png").document

for t in doc.tables:
    for p in doc.pictures:
        if t.prov[0].bbox == p.prov[0].bbox:
            print("dual detection — should not appear after fix")
```

## Related issue

Closes #3495