### PR TITLE
docs: fix copy-paste docstring error in PaginatedDocumentBackend

### DIFF
--- a/docling/backend/abstract_backend.py
+++ b/docling/backend/abstract_backend.py
@@ -52,10 +52,10 @@ class AbstractDocumentBackend(ABC):
 
 
 class PaginatedDocumentBackend(AbstractDocumentBackend):
-    """DeclarativeDocumentBackend.
+    """PaginatedDocumentBackend.
 
-    A declarative document backend is a backend that can transform to DoclingDocument
-    straight without a recognition pipeline.
+    A backend designed for handling multi-page documents (like PDFs or TIFFs)
+    that require page-count awareness and page-by-page processing.
     """
 
     @abstractmethod


### PR DESCRIPTION
## Description
This PR fixes a copy-paste error in the docstring of `PaginatedDocumentBackend`. Currently, it has the exact same docstring as `DeclarativeDocumentBackend`, which describes a declarative document transformation rather than paginated document behavior.

## Changes
- Updated the docstring for `PaginatedDocumentBackend` to correctly reflect its purpose (handling multi-page documents that require page-count awareness).

## Checklist
- [x] Conforms to the project's coding standards.
- [x] Docstring reflects the actual purpose of the class.