### PR TITLE
docs: add docling client examples for minimal, custom and batch without replacing originals

### DIFF
--- a/docs/examples/batch_convert.py
+++ b/docs/examples/batch_convert.py
@@ -1,20 +1,20 @@
 # %% [markdown]
-# Batch convert multiple PDF files and export results in several formats.
+# Batch convert multiple PDF files and export results in several formats with Docling Serve.
 
 # What this example does
 # - Loads a small set of sample PDFs.
-# - Runs the Docling PDF pipeline once per file.
+# - Runs the Docling Serve PDF pipeline once per file.
 # - Writes outputs to `scratch/` in multiple formats (JSON, HTML, Markdown, text, doctags, YAML).
 
 # Prerequisites
-# - Install Docling and dependencies as described in the repository README.
-# - Ensure you can import `docling` from your Python environment.
+# - Install Docling, Docling Serve and dependencies as described in the repository README.
+# - Ensure you can import `docling.service_client` from your Python environment.
 # <!-- YAML export requires `PyYAML` (`pip install pyyaml`). -->
 
 # Input documents
-# - By default, this example uses a few PDFs from `tests/data/pdf/` in the repo.
-# - If you cloned without test data, or want to use your own files, edit
-#   `input_doc_paths` below to point to PDFs on your machine.
+# - Default set of sample PDFs.
+# - Update `input_doc_paths` to a desired list of file URLs.
+# - All input sources must start with `http://` or `https://`.
 
 # Output formats (controlled by flags)
 # - `USE_V2 = True` enables the current Docling document exports (recommended).
@@ -35,13 +35,13 @@ from collections.abc import Iterable
 from pathlib import Path
 
 import yaml
-from docling_core.types.doc import ImageRefMode
+from docling_core.types.doc.base import ImageRefMode
 
-from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
-from docling.datamodel.base_models import ConversionStatus, InputFormat
+from docling.datamodel.base_models import ConversionStatus
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import PdfPipelineOptions
-from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.service_client import DoclingServiceClient
+from docling.datamodel.service.options import ConvertDocumentsOptions
 
 _log = logging.getLogger(__name__)
 
@@ -157,60 +157,59 @@ def export_documents(
 def main():
     logging.basicConfig(level=logging.INFO)
 
-    # Location of sample PDFs used by this example. If your checkout does not
-    # include test data, change `data_folder` or point `input_doc_paths` to
-    # your own files.
-    data_folder = Path(__file__).parent / "../../tests/data"
-    input_doc_paths = [
-        data_folder / "pdf/2206.01062.pdf",
-        data_folder / "pdf/2203.01017v2.pdf",
-        data_folder / "pdf/2305.03393v1.pdf",
-        data_folder / "pdf/redp5110_sampled.pdf",
+    # Add your HTTP or HTTPS URLs here
+    input_doc_urls = [
+        "https://arxiv.org/pdf/1706.03762",
+        "https://arxiv.org/pdf/1103.0398",
+        "https://arxiv.org/pdf/2501.17887",
+        "https://arxiv.org/pdf/2408.09869",
     ]
-
-    # buf = BytesIO((data_folder / "pdf/2206.01062.pdf").open("rb").read())
-    # docs = [DocumentStream(name="my_doc.pdf", stream=buf)]
-    # input = DocumentConversionInput.from_streams(docs)
-
-    # # Turn on inline debug visualizations:
-    # settings.debug.visualize_layout = True
-    # settings.debug.visualize_ocr = True
-    # settings.debug.visualize_tables = True
-    # settings.debug.visualize_cells = True
 
     # Configure the PDF pipeline. Enabling page image generation improves HTML
     # previews (embedded images) but adds processing time.
     pipeline_options = PdfPipelineOptions()
     pipeline_options.generate_page_images = True
 
-    doc_converter = DocumentConverter(
-        format_options={
-            InputFormat.PDF: PdfFormatOption(
-                pipeline_options=pipeline_options, backend=DoclingParseDocumentBackend
-            )
-        }
+    SERVE_URL = "http://localhost:5001"
+    
+    options = ConvertDocumentsOptions(
+        do_ocr=pipeline_options.do_ocr,
+        ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     )
 
     start_time = time.time()
 
     # Convert all inputs. Set `raises_on_error=False` to keep processing other
     # files even if one fails; errors are summarized after the run.
-    conv_results = doc_converter.convert_all(
-        input_doc_paths,
-        raises_on_error=False,  # to let conversion run through all and examine results at the end
-    )
+    conv_results = []
+    failure_count = 0
+    with DoclingServiceClient(url=SERVE_URL) as client:
+        for input_doc_url in input_doc_urls:
+            try:
+                conv_result = client.convert(
+                    source=input_doc_url,
+                    options=options
+                )
+                conv_results.append(conv_result)
+            except Exception as e:
+                _log.error(f"Failed to convert {input_doc_url}: {e}")
+                failure_count += 1
+    
     # Write outputs to ./scratch and log a summary.
-    _success_count, _partial_success_count, failure_count = export_documents(
+    _success_count, _partial_success_count, export_failure_count = export_documents(
         conv_results, output_dir=Path("scratch")
     )
+    
+    # Add conversion failures to the total failure count
+    total_failures = failure_count + export_failure_count
 
     end_time = time.time() - start_time
 
     _log.info(f"Document conversion complete in {end_time:.2f} seconds.")
 
-    if failure_count > 0:
+    if total_failures > 0:
         raise RuntimeError(
-            f"The example failed converting {failure_count} on {len(input_doc_paths)}."
+            f"The example failed converting {total_failures} on {len(input_doc_urls)}."
         )
 
 

--- a/docs/examples/batch_convert.py
+++ b/docs/examples/batch_convert.py
@@ -40,8 +40,8 @@ from docling_core.types.doc.base import ImageRefMode
 from docling.datamodel.base_models import ConversionStatus
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import PdfPipelineOptions
-from docling.service_client import DoclingServiceClient
 from docling.datamodel.service.options import ConvertDocumentsOptions
+from docling.service_client import DoclingServiceClient
 
 _log = logging.getLogger(__name__)
 
@@ -171,7 +171,7 @@ def main():
     pipeline_options.generate_page_images = True
 
     SERVE_URL = "http://localhost:5001"
-    
+
     options = ConvertDocumentsOptions(
         do_ocr=pipeline_options.do_ocr,
         ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
@@ -186,20 +186,17 @@ def main():
     with DoclingServiceClient(url=SERVE_URL) as client:
         for input_doc_url in input_doc_urls:
             try:
-                conv_result = client.convert(
-                    source=input_doc_url,
-                    options=options
-                )
+                conv_result = client.convert(source=input_doc_url, options=options)
                 conv_results.append(conv_result)
             except Exception as e:
                 _log.error(f"Failed to convert {input_doc_url}: {e}")
                 failure_count += 1
-    
+
     # Write outputs to ./scratch and log a summary.
     _success_count, _partial_success_count, export_failure_count = export_documents(
         conv_results, output_dir=Path("scratch")
     )
-    
+
     # Add conversion failures to the total failure count
     total_failures = failure_count + export_failure_count
 

--- a/docs/examples/batch_convert.py
+++ b/docs/examples/batch_convert.py
@@ -1,20 +1,19 @@
 # %% [markdown]
-# Batch convert multiple PDF files and export results in several formats with Docling Serve.
+# Batch convert multiple PDF files and export results in several formats with Docling or Docling Serve.
 
 # What this example does
 # - Loads a small set of sample PDFs.
-# - Runs the Docling Serve PDF pipeline once per file.
+# - Runs the Docling PDF pipeline once per file.
 # - Writes outputs to `scratch/` in multiple formats (JSON, HTML, Markdown, text, doctags, YAML).
 
 # Prerequisites
-# - Install Docling, Docling Serve and dependencies as described in the repository README.
-# - Ensure you can import `docling.service_client` from your Python environment.
+# - Install Docling or Docling Serve and dependencies as described in the repository README.
+# - Ensure you can import `docling` from your Python environment.
 # <!-- YAML export requires `PyYAML` (`pip install pyyaml`). -->
 
 # Input documents
 # - Default set of sample PDFs.
-# - Update `input_doc_paths` to a desired list of file URLs.
-# - All input sources must start with `http://` or `https://`.
+# - Update `input_doc_paths` to a desired list of file paths.
 
 # Output formats (controlled by flags)
 # - `USE_V2 = True` enables the current Docling document exports (recommended).
@@ -37,10 +36,12 @@ from pathlib import Path
 import yaml
 from docling_core.types.doc.base import ImageRefMode
 
-from docling.datamodel.base_models import ConversionStatus
+from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
+from docling.datamodel.base_models import ConversionStatus, InputFormat
 from docling.datamodel.document import ConversionResult
-from docling.datamodel.pipeline_options import PdfPipelineOptions
+from docling.datamodel.pipeline_options import PdfBackend, PdfPipelineOptions
 from docling.datamodel.service.options import ConvertDocumentsOptions
+from docling.document_converter import DocumentConverter, PdfFormatOption
 from docling.service_client import DoclingServiceClient
 
 _log = logging.getLogger(__name__)
@@ -157,56 +158,88 @@ def export_documents(
 def main():
     logging.basicConfig(level=logging.INFO)
 
-    # Add your HTTP or HTTPS URLs here
-    input_doc_urls = [
-        "https://arxiv.org/pdf/1706.03762",
-        "https://arxiv.org/pdf/1103.0398",
-        "https://arxiv.org/pdf/2501.17887",
-        "https://arxiv.org/pdf/2408.09869",
+    # Location of sample PDFs used by this example. If your checkout does not
+    # include test data, change `data_folder` or point `input_doc_paths` to
+    # your own files.
+    data_folder = Path(__file__).parent / "../../tests/data"
+    input_doc_paths = [
+        data_folder / "pdf/2206.01062.pdf",
+        data_folder / "pdf/2203.01017v2.pdf",
+        data_folder / "pdf/2305.03393v1.pdf",
+        data_folder / "pdf/redp5110_sampled.pdf",
     ]
+
+    # buf = BytesIO((data_folder / "pdf/2206.01062.pdf").open("rb").read())
+    # docs = [DocumentStream(name="my_doc.pdf", stream=buf)]
+    # input = DocumentConversionInput.from_streams(docs)
+
+    # # Turn on inline debug visualizations:
+    # settings.debug.visualize_layout = True
+    # settings.debug.visualize_ocr = True
+    # settings.debug.visualize_tables = True
+    # settings.debug.visualize_cells = True
 
     # Configure the PDF pipeline. Enabling page image generation improves HTML
     # previews (embedded images) but adds processing time.
     pipeline_options = PdfPipelineOptions()
     pipeline_options.generate_page_images = True
 
-    SERVE_URL = "http://localhost:5001"
-
-    options = ConvertDocumentsOptions(
-        do_ocr=pipeline_options.do_ocr,
-        ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
-    )
-
     start_time = time.time()
 
-    # Convert all inputs. Set `raises_on_error=False` to keep processing other
-    # files even if one fails; errors are summarized after the run.
-    conv_results = []
-    failure_count = 0
-    with DoclingServiceClient(url=SERVE_URL) as client:
-        for input_doc_url in input_doc_urls:
-            try:
-                conv_result = client.convert(source=input_doc_url, options=options)
-                conv_results.append(conv_result)
-            except Exception as e:
-                _log.error(f"Failed to convert {input_doc_url}: {e}")
-                failure_count += 1
+    ###########################################################################
 
-    # Write outputs to ./scratch and log a summary.
-    _success_count, _partial_success_count, export_failure_count = export_documents(
-        conv_results, output_dir=Path("scratch")
+    # The two sections below are for either direct Docling usage or Docling Serve
+    # Uncomment exactly one section at a time
+
+    # Docling (local conversion)
+    # --------------------------------------
+    doc_converter = DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(
+                pipeline_options=pipeline_options, backend=DoclingParseDocumentBackend
+            )
+        }
+    )
+    conv_results = doc_converter.convert_all(
+        input_doc_paths,
+        raises_on_error=False,  # to let conversion run through all and examine results at the end
     )
 
-    # Add conversion failures to the total failure count
-    total_failures = failure_count + export_failure_count
+    # Docling Serve (remote conversion)
+    # --------------------------------------
+    # SERVE_URL = "http://localhost:5001"
+    # table_cell_matching = getattr(pipeline_options.table_structure_options, 'do_cell_matching', True) if pipeline_options.table_structure_options else True
+    # options = ConvertDocumentsOptions(
+    #     do_ocr=pipeline_options.do_ocr,
+    #     do_table_structure=pipeline_options.do_table_structure,
+    #     table_cell_matching=table_cell_matching,
+    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
+    #     pdf_backend=PdfBackend.DOCLING_PARSE,
+    # )
+    # # Convert all inputs. Set `raises_on_error=False` to keep processing other
+    # # files even if one fails; errors are summarized after the run.
+    # conv_results = []
+    # with DoclingServiceClient(url=SERVE_URL) as client:
+    #     for input_doc_path in input_doc_paths:
+    #         try:
+    #             conv_result = client.convert(source=input_doc_path, options=options)
+    #             conv_results.append(conv_result)
+    #         except Exception as e:
+    #             _log.error(f"Failed to convert {input_doc_path}: {e}")
+    ###########################################################################
+
+    # Write outputs to ./scratch and log a summary.
+    _success_count, _partial_success_count, failure_count = export_documents(
+        conv_results, output_dir=Path("scratch")
+    )
 
     end_time = time.time() - start_time
 
     _log.info(f"Document conversion complete in {end_time:.2f} seconds.")
 
-    if total_failures > 0:
+    if failure_count > 0:
         raise RuntimeError(
-            f"The example failed converting {total_failures} on {len(input_doc_urls)}."
+            f"The example failed converting {failure_count} on {len(input_doc_paths)}."
         )
 
 

--- a/docs/examples/custom_convert.py
+++ b/docs/examples/custom_convert.py
@@ -2,13 +2,13 @@
 # Customize PDF conversion by toggling OCR/backends and pipeline options.
 #
 # What this example does
-# - Shows several alternative configurations for the Docling PDF pipeline.
+# - Shows several alternative configurations for the Docling Serve PDF pipeline.
 # - Lets you try OCR engines (EasyOCR, Tesseract, system OCR) or no OCR.
 # - Converts a single sample PDF and exports results to `scratch/`.
 #
 # Prerequisites
-# - Install Docling and its optional OCR backends per the docs.
-# - Ensure you can import `docling` from your Python environment.
+# - Install Docling Serve and the docling optional OCR backends per the docs.
+# - Ensure you can import `docling.service_client` from your Python environment.
 #
 # How to run
 # - From the repository root, run: `python docs/examples/custom_convert.py`.
@@ -24,8 +24,10 @@
 #   - `from docling.datamodel.pipeline_options import TesseractOcrOptions, TesseractCliOcrOptions, OcrMacOptions`
 #
 # Input document
-# - Defaults to a single PDF from `tests/data/pdf/` in the repo.
-# - If you don't have the test data, update `input_doc_path` to a local PDF.
+# - Defaults to a sample PDF
+# - Update `input_doc_path` to a desired file URL
+# - All input sources must start with `http://` or `https://`.
+#
 #
 # Notes
 # - EasyOCR language: adjust `pipeline_options.ocr_options.lang` (e.g., ["en"], ["es"], ["en", "de"]).
@@ -40,12 +42,12 @@ import time
 from pathlib import Path
 
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
-from docling.datamodel.base_models import InputFormat
 from docling.datamodel.pipeline_options import (
     PdfPipelineOptions,
     TableStructureOptions,
 )
-from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.service_client import DoclingServiceClient
+from docling.datamodel.service.options import ConvertDocumentsOptions
 
 _log = logging.getLogger(__name__)
 
@@ -53,8 +55,8 @@ _log = logging.getLogger(__name__)
 def main():
     logging.basicConfig(level=logging.INFO)
 
-    data_folder = Path(__file__).parent / "../../tests/data"
-    input_doc_path = data_folder / "pdf/2206.01062.pdf"
+    input_doc_path = "https://arxiv.org/pdf/2408.09869"
+    SERVE_URL = "http://localhost:5001"
 
     ###########################################################################
 
@@ -68,12 +70,9 @@ def main():
     # pipeline_options.do_table_structure = True
     # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=False)
 
-    # doc_converter = DocumentConverter(
-    #     format_options={
-    #         InputFormat.PDF: PdfFormatOption(
-    #             pipeline_options=pipeline_options, backend=PyPdfiumDocumentBackend
-    #         )
-    #     }
+    # options = ConvertDocumentsOptions(
+    #     do_ocr=pipeline_options.do_ocr,
+    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     # )
 
     # PyPdfium with EasyOCR
@@ -83,12 +82,9 @@ def main():
     # pipeline_options.do_table_structure = True
     # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
 
-    # doc_converter = DocumentConverter(
-    #     format_options={
-    #         InputFormat.PDF: PdfFormatOption(
-    #             pipeline_options=pipeline_options, backend=PyPdfiumDocumentBackend
-    #         )
-    #     }
+    # options = ConvertDocumentsOptions(
+    #     do_ocr=pipeline_options.do_ocr,
+    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     # )
 
     # Docling Parse without EasyOCR
@@ -98,10 +94,9 @@ def main():
     # pipeline_options.do_table_structure = True
     # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
 
-    # doc_converter = DocumentConverter(
-    #     format_options={
-    #         InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
-    #     }
+    # options = ConvertDocumentsOptions(
+    #     do_ocr=pipeline_options.do_ocr,
+    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     # )
 
     # Docling Parse with EasyOCR (default)
@@ -119,10 +114,9 @@ def main():
         num_threads=4, device=AcceleratorDevice.AUTO
     )
 
-    doc_converter = DocumentConverter(
-        format_options={
-            InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
-        }
+    options = ConvertDocumentsOptions(
+        do_ocr=pipeline_options.do_ocr,
+        ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     )
 
     # Docling Parse with EasyOCR (CPU only)
@@ -133,10 +127,9 @@ def main():
     # pipeline_options.do_table_structure = True
     # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
 
-    # doc_converter = DocumentConverter(
-    #     format_options={
-    #         InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
-    #     }
+    # options = ConvertDocumentsOptions(
+    #     do_ocr=pipeline_options.do_ocr,
+    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     # )
 
     # Docling Parse with Tesseract
@@ -147,10 +140,9 @@ def main():
     # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
     # pipeline_options.ocr_options = TesseractOcrOptions()
 
-    # doc_converter = DocumentConverter(
-    #     format_options={
-    #         InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
-    #     }
+    # options = ConvertDocumentsOptions(
+    #     do_ocr=pipeline_options.do_ocr,
+    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     # )
 
     # Docling Parse with Tesseract CLI
@@ -161,10 +153,9 @@ def main():
     # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
     # pipeline_options.ocr_options = TesseractCliOcrOptions()
 
-    # doc_converter = DocumentConverter(
-    #     format_options={
-    #         InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
-    #     }
+    # options = ConvertDocumentsOptions(
+    #     do_ocr=pipeline_options.do_ocr,
+    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     # )
 
     # Docling Parse with ocrmac (macOS only)
@@ -175,16 +166,20 @@ def main():
     # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
     # pipeline_options.ocr_options = OcrMacOptions()
 
-    # doc_converter = DocumentConverter(
-    #     format_options={
-    #         InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
-    #     }
+    # options = ConvertDocumentsOptions(
+    #     do_ocr=pipeline_options.do_ocr,
+    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
     # )
-
     ###########################################################################
 
     start_time = time.time()
-    conv_result = doc_converter.convert(input_doc_path)
+    
+    with DoclingServiceClient(url=SERVE_URL) as client:
+        conv_result = client.convert(
+            source=str(input_doc_path),
+            options=options
+        )
+    
     end_time = time.time() - start_time
 
     _log.info(f"Document converted in {end_time:.2f} seconds.")
@@ -192,7 +187,7 @@ def main():
     ## Export results
     output_dir = Path("scratch")
     output_dir.mkdir(parents=True, exist_ok=True)
-    doc_filename = conv_result.input.file.stem
+    doc_filename = Path(input_doc_path).stem
 
     # Export Docling document JSON format:
     with (output_dir / f"{doc_filename}.json").open("w", encoding="utf-8") as fp:
@@ -213,3 +208,5 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+# Made with Bob

--- a/docs/examples/custom_convert.py
+++ b/docs/examples/custom_convert.py
@@ -46,8 +46,8 @@ from docling.datamodel.pipeline_options import (
     PdfPipelineOptions,
     TableStructureOptions,
 )
-from docling.service_client import DoclingServiceClient
 from docling.datamodel.service.options import ConvertDocumentsOptions
+from docling.service_client import DoclingServiceClient
 
 _log = logging.getLogger(__name__)
 
@@ -173,13 +173,10 @@ def main():
     ###########################################################################
 
     start_time = time.time()
-    
+
     with DoclingServiceClient(url=SERVE_URL) as client:
-        conv_result = client.convert(
-            source=str(input_doc_path),
-            options=options
-        )
-    
+        conv_result = client.convert(source=str(input_doc_path), options=options)
+
     end_time = time.time() - start_time
 
     _log.info(f"Document converted in {end_time:.2f} seconds.")

--- a/docs/examples/custom_convert.py
+++ b/docs/examples/custom_convert.py
@@ -2,13 +2,14 @@
 # Customize PDF conversion by toggling OCR/backends and pipeline options.
 #
 # What this example does
-# - Shows several alternative configurations for the Docling Serve PDF pipeline.
+# - Shows several alternative configurations for the Docling PDF pipeline.
 # - Lets you try OCR engines (EasyOCR, Tesseract, system OCR) or no OCR.
 # - Converts a single sample PDF and exports results to `scratch/`.
+# - Lets you try either the Docling or Docling Serve implementations
 #
 # Prerequisites
-# - Install Docling Serve and the docling optional OCR backends per the docs.
-# - Ensure you can import `docling.service_client` from your Python environment.
+# - Install Docling or Docling Serve and the docling optional OCR backends per the docs.
+# - Ensure you can import `docling` from your Python environment.
 #
 # How to run
 # - From the repository root, run: `python docs/examples/custom_convert.py`.
@@ -18,22 +19,16 @@
 # - Only one configuration block should be active at a time.
 # - Uncomment exactly one of the sections below to experiment.
 # - The file ships with "Docling Parse with EasyOCR" enabled as a sensible default.
-# - If you uncomment a backend or OCR option that is not imported above, also
-#   import its class, e.g.:
-#   - `from docling.backend.pypdfium2_backend import PyPdfiumDocumentBackend`
-#   - `from docling.datamodel.pipeline_options import TesseractOcrOptions, TesseractCliOcrOptions, OcrMacOptions`
 #
 # Input document
 # - Defaults to a sample PDF
-# - Update `input_doc_path` to a desired file URL
-# - All input sources must start with `http://` or `https://`.
+# - Update `input_doc_path` to a desired file path
 #
 #
 # Notes
 # - EasyOCR language: adjust `pipeline_options.ocr_options.lang` (e.g., ["en"], ["es"], ["en", "de"]).
 # - Accelerators: tune `AcceleratorOptions` to select CPU/GPU or threads.
 # - Exports: JSON, plain text, Markdown, and doctags are saved in `scratch/`.
-
 # %%
 
 import json
@@ -41,12 +36,19 @@ import logging
 import time
 from pathlib import Path
 
+from docling.backend.pypdfium2_backend import PyPdfiumDocumentBackend
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
+from docling.datamodel.base_models import InputFormat
 from docling.datamodel.pipeline_options import (
+    OcrMacOptions,
+    PdfBackend,
     PdfPipelineOptions,
     TableStructureOptions,
+    TesseractCliOcrOptions,
+    TesseractOcrOptions,
 )
 from docling.datamodel.service.options import ConvertDocumentsOptions
+from docling.document_converter import DocumentConverter, PdfFormatOption
 from docling.service_client import DoclingServiceClient
 
 _log = logging.getLogger(__name__)
@@ -55,8 +57,16 @@ _log = logging.getLogger(__name__)
 def main():
     logging.basicConfig(level=logging.INFO)
 
-    input_doc_path = "https://arxiv.org/pdf/2408.09869"
-    SERVE_URL = "http://localhost:5001"
+    def create_pipeline_options(
+        do_ocr: bool, do_table_structure: bool, do_cell_matching: bool
+    ) -> PdfPipelineOptions:
+        pipeline_options = PdfPipelineOptions()
+        pipeline_options.do_ocr = do_ocr
+        pipeline_options.do_table_structure = do_table_structure
+        pipeline_options.table_structure_options = TableStructureOptions(
+            do_cell_matching=do_cell_matching
+        )
+        return pipeline_options
 
     ###########################################################################
 
@@ -65,123 +75,99 @@ def main():
 
     # PyPdfium without EasyOCR
     # --------------------
-    # pipeline_options = PdfPipelineOptions()
-    # pipeline_options.do_ocr = False
-    # pipeline_options.do_table_structure = True
-    # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=False)
-
-    # options = ConvertDocumentsOptions(
-    #     do_ocr=pipeline_options.do_ocr,
-    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
-    # )
+    # pipeline_options = create_pipeline_options(do_ocr=False, do_table_structure=True, do_cell_matching=False)
+    # backend = PyPdfiumDocumentBackend
 
     # PyPdfium with EasyOCR
     # -----------------
-    # pipeline_options = PdfPipelineOptions()
-    # pipeline_options.do_ocr = True
-    # pipeline_options.do_table_structure = True
-    # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
-
-    # options = ConvertDocumentsOptions(
-    #     do_ocr=pipeline_options.do_ocr,
-    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
-    # )
+    # pipeline_options = create_pipeline_options(do_ocr=True, do_table_structure=True, do_cell_matching=True)
+    # backend = PyPdfiumDocumentBackend
 
     # Docling Parse without EasyOCR
     # -------------------------
-    # pipeline_options = PdfPipelineOptions()
-    # pipeline_options.do_ocr = False
-    # pipeline_options.do_table_structure = True
-    # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
-
-    # options = ConvertDocumentsOptions(
-    #     do_ocr=pipeline_options.do_ocr,
-    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
-    # )
+    # pipeline_options = create_pipeline_options(do_ocr=False, do_table_structure=True, do_cell_matching=True)
+    # backend = None
 
     # Docling Parse with EasyOCR (default)
     # -------------------------------
     # Enables OCR and table structure with EasyOCR, using automatic device
     # selection via AcceleratorOptions. Adjust languages as needed.
-    pipeline_options = PdfPipelineOptions()
-    pipeline_options.do_ocr = True
-    pipeline_options.do_table_structure = True
-    pipeline_options.table_structure_options = TableStructureOptions(
-        do_cell_matching=True
+    pipeline_options = create_pipeline_options(
+        do_ocr=True, do_table_structure=True, do_cell_matching=True
     )
     pipeline_options.ocr_options.lang = ["es"]
     pipeline_options.accelerator_options = AcceleratorOptions(
         num_threads=4, device=AcceleratorDevice.AUTO
     )
-
-    options = ConvertDocumentsOptions(
-        do_ocr=pipeline_options.do_ocr,
-        ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
-    )
+    backend = None
 
     # Docling Parse with EasyOCR (CPU only)
     # -------------------------------------
-    # pipeline_options = PdfPipelineOptions()
-    # pipeline_options.do_ocr = True
-    # pipeline_options.ocr_options.use_gpu = False  # <-- set this.
-    # pipeline_options.do_table_structure = True
-    # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
-
-    # options = ConvertDocumentsOptions(
-    #     do_ocr=pipeline_options.do_ocr,
-    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
-    # )
+    # pipeline_options = create_pipeline_options(do_ocr=True, do_table_structure=True, do_cell_matching=True)
+    # pipeline_options.ocr_options.use_gpu = False
+    # backend = None
 
     # Docling Parse with Tesseract
     # ----------------------------
-    # pipeline_options = PdfPipelineOptions()
-    # pipeline_options.do_ocr = True
-    # pipeline_options.do_table_structure = True
-    # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
+    # pipeline_options = create_pipeline_options(do_ocr=True, do_table_structure=True, do_cell_matching=True)
     # pipeline_options.ocr_options = TesseractOcrOptions()
-
-    # options = ConvertDocumentsOptions(
-    #     do_ocr=pipeline_options.do_ocr,
-    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
-    # )
+    # backend = None
 
     # Docling Parse with Tesseract CLI
     # --------------------------------
-    # pipeline_options = PdfPipelineOptions()
-    # pipeline_options.do_ocr = True
-    # pipeline_options.do_table_structure = True
-    # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
+    # pipeline_options = create_pipeline_options(do_ocr=True, do_table_structure=True, do_cell_matching=True)
     # pipeline_options.ocr_options = TesseractCliOcrOptions()
-
-    # options = ConvertDocumentsOptions(
-    #     do_ocr=pipeline_options.do_ocr,
-    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
-    # )
+    # backend = None
 
     # Docling Parse with ocrmac (macOS only)
     # --------------------------------------
-    # pipeline_options = PdfPipelineOptions()
-    # pipeline_options.do_ocr = True
-    # pipeline_options.do_table_structure = True
-    # pipeline_options.table_structure_options = TableStructureOptions(do_cell_matching=True)
+    # pipeline_options = create_pipeline_options(do_ocr=True, do_table_structure=True, do_cell_matching=True)
     # pipeline_options.ocr_options = OcrMacOptions()
+    # backend = None
 
-    # options = ConvertDocumentsOptions(
-    #     do_ocr=pipeline_options.do_ocr,
-    #     ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
-    # )
     ###########################################################################
+    data_folder = Path(__file__).parent / "../../tests/data"
+    input_doc_path = data_folder / "pdf/2206.01062.pdf"
 
     start_time = time.time()
 
-    with DoclingServiceClient(url=SERVE_URL) as client:
-        conv_result = client.convert(source=str(input_doc_path), options=options)
+    ###########################################################################
 
-    end_time = time.time() - start_time
+    # The two sections below are for either direct Docling usage or Docling Serve
+    # Uncomment exactly one section at a time
 
-    _log.info(f"Document converted in {end_time:.2f} seconds.")
+    # Docling (local conversion)
+    # --------------------------------------
+    doc_converter = DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(
+                pipeline_options=pipeline_options, backend=backend
+            )
+            if backend
+            else PdfFormatOption(pipeline_options=pipeline_options)
+        }
+    )
+    conv_result = doc_converter.convert(input_doc_path)
 
-    ## Export results
+    # Docling Serve (remote conversion)
+    # --------------------------------------
+    # SERVE_URL = "http://localhost:5001"
+    # table_cell_matching = getattr(pipeline_options.table_structure_options, 'do_cell_matching', True) if pipeline_options.table_structure_options else True
+    # pdf_backend = PdfBackend.PYPDFIUM2 if backend == PyPdfiumDocumentBackend else PdfBackend.DOCLING_PARSE
+    # options = ConvertDocumentsOptions(
+    #         do_ocr=pipeline_options.do_ocr,
+    #         do_table_structure=pipeline_options.do_table_structure,
+    #         table_cell_matching=table_cell_matching,
+    #         ocr_lang=pipeline_options.ocr_options.lang if pipeline_options.do_ocr else None,
+    #         pdf_backend=pdf_backend,
+    #     )
+    # with DoclingServiceClient(url=SERVE_URL) as client:
+    #     conv_result = client.convert(input_doc_path, options=options)
+
+    ###########################################################################
+    _log.info(f"Document converted in {time.time() - start_time:.2f} seconds.")
+
+    # Export results
     output_dir = Path("scratch")
     output_dir.mkdir(parents=True, exist_ok=True)
     doc_filename = Path(input_doc_path).stem
@@ -205,5 +191,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-
-# Made with Bob

--- a/docs/examples/minimal.py
+++ b/docs/examples/minimal.py
@@ -1,30 +1,30 @@
 # %% [markdown]
 # What this example does
 # - Converts a single source (URL or local file path) to a unified Docling
-#   document and prints Markdown to stdout.
+#   document with Docling Serve and prints Markdown to stdout.
 #
 # Requirements
-# - Python 3.9+
-# - Install Docling: `pip install docling`
+# - Python 3.10+
+# - Install Docling Serve: `pip install "docling-serve[ui]"`
+# - Run the Docling Serve Server: `docling-serve run --enable-ui`
+#
+# Notes
+# - The converter auto-detects supported formats (PDF, DOCX, HTML, PPTX, images, etc.).
+# - For batch processing or saving outputs to files, see `docs/examples/batch_convert.py`. 
 #
 # How to run
 # - Use the default sample URL: `python docs/examples/minimal.py`
 # - To use your own file or URL, edit the `source` variable below.
-#
-# Notes
-# - The converter auto-detects supported formats (PDF, DOCX, HTML, PPTX, images, etc.).
-# - For batch processing or saving outputs to files, see `docs/examples/batch_convert.py`.
 # %%
 
-from docling.document_converter import DocumentConverter
+from docling.service_client import DoclingServiceClient
 
-# Change this to a local path or another URL if desired.
-# Note: using the default URL requires network access; if offline, provide a
-# local file path (e.g., Path("/path/to/file.pdf")).
-source = "https://arxiv.org/pdf/2408.09869"
+# Replace SERVE_URL with your hosted URL if it's different
+SERVE_URL="http://localhost:5001"
 
-converter = DocumentConverter()
-result = converter.convert(source)
+with DoclingServiceClient(url=SERVE_URL) as client:
+    result = client.convert(
+        source="https://arxiv.org/pdf/2408.09869"
+    )
 
-# Print Markdown to stdout.
 print(result.document.export_to_markdown())

--- a/docs/examples/minimal.py
+++ b/docs/examples/minimal.py
@@ -1,28 +1,52 @@
 # %% [markdown]
 # What this example does
 # - Converts a single source (URL or local file path) to a unified Docling
-#   document with Docling Serve and prints Markdown to stdout.
+#   document and prints Markdown to stdout.
+# - You can either directly use Docling or host an instance of Docling Serve
 #
+# Using Docling
 # Requirements
+# - Python 3.9+
+# - Install Docling: `pip install docling`
+#
+# Using Docling Serve
 # - Python 3.10+
 # - Install Docling Serve: `pip install "docling-serve[ui]"`
 # - Run the Docling Serve Server: `docling-serve run --enable-ui`
 #
-# Notes
-# - The converter auto-detects supported formats (PDF, DOCX, HTML, PPTX, images, etc.).
-# - For batch processing or saving outputs to files, see `docs/examples/batch_convert.py`.
-#
 # How to run
 # - Use the default sample URL: `python docs/examples/minimal.py`
 # - To use your own file or URL, edit the `source` variable below.
+#
+# Notes
+# - The converter auto-detects supported formats (PDF, DOCX, HTML, PPTX, images, etc.).
+# - For batch processing or saving outputs to files, see `docs/examples/batch_convert.py`.
 # %%
 
+from docling.document_converter import DocumentConverter
 from docling.service_client import DoclingServiceClient
 
-# Replace SERVE_URL with your hosted URL if it's different
-SERVE_URL = "http://localhost:5001"
+# Change this to a local path or another URL if desired.
+# Note: using the default URL requires network access; if offline, provide a
+# local file path (e.g., Path("/path/to/file.pdf")).
+source = "https://arxiv.org/pdf/2408.09869"
 
-with DoclingServiceClient(url=SERVE_URL) as client:
-    result = client.convert(source="https://arxiv.org/pdf/2408.09869")
+###########################################################################
+# The two sections below are for either direct Docling usage or Docling Serve
+# Uncomment exactly one section at a time
+
+# Docling (local conversion)
+# --------------------------------------
+converter = DocumentConverter()
+result = converter.convert(source)
+
+# Docling Serve (remote conversion)
+# --------------------------------------
+# Replace SERVE_URL with your hosted URL if it's different
+# SERVE_URL = "http://localhost:5001"
+# with DoclingServiceClient(url=SERVE_URL) as client:
+#     result = client.convert(source=source)
+
+###########################################################################
 
 print(result.document.export_to_markdown())

--- a/docs/examples/minimal.py
+++ b/docs/examples/minimal.py
@@ -10,7 +10,7 @@
 #
 # Notes
 # - The converter auto-detects supported formats (PDF, DOCX, HTML, PPTX, images, etc.).
-# - For batch processing or saving outputs to files, see `docs/examples/batch_convert.py`. 
+# - For batch processing or saving outputs to files, see `docs/examples/batch_convert.py`.
 #
 # How to run
 # - Use the default sample URL: `python docs/examples/minimal.py`
@@ -20,11 +20,9 @@
 from docling.service_client import DoclingServiceClient
 
 # Replace SERVE_URL with your hosted URL if it's different
-SERVE_URL="http://localhost:5001"
+SERVE_URL = "http://localhost:5001"
 
 with DoclingServiceClient(url=SERVE_URL) as client:
-    result = client.convert(
-        source="https://arxiv.org/pdf/2408.09869"
-    )
+    result = client.convert(source="https://arxiv.org/pdf/2408.09869")
 
 print(result.document.export_to_markdown())


### PR DESCRIPTION
Instead of replacing the original docling examples (minimal, custom and batch), I split the use of DocumentConverter and the DoclingServiceClient into two sections. If users want to use DocumentConverter to convert their files, they can comment out the DoclingServiceClient section, and vice versa. 

I tried to separate the two code blocks completely in the minimal example, but the formatter insists on putting import statements at the top. This PR should be reviewed by @mingxzhao first before merging.