### PR TITLE
docs: updating table export, hybrid chunking, and language detection examples to include both docling and docling-serve use cases

### DIFF
--- a/docs/examples/export_tables.py
+++ b/docs/examples/export_tables.py
@@ -1,15 +1,16 @@
 # %% [markdown]
-# Extract tables from a PDF and export them as CSV and HTML.
+# Extract tables from a PDF and export them as CSV and HTML using docling-serve.
 #
 # What this example does
-# - Converts a PDF and iterates detected tables.
+# - Converts a PDF using docling-serve API and iterates detected tables.
 # - Prints each table as Markdown to stdout, and saves CSV/HTML to `scratch/`.
 #
 # Prerequisites
-# - Install Docling and `pandas`.
+# - Install Docling service client and `pandas`.
+# - Set API_KEY and SERVICE_URL for your docling-serve instance.
 #
 # How to run
-# - From the repo root: `python docs/examples/export_tables.py`.
+# - From the repo root: `python docs/examples/tableexport.py`.
 # - Outputs are written to `scratch/`.
 #
 # Input document
@@ -27,45 +28,57 @@ import time
 from pathlib import Path
 
 import pandas as pd
+import os
 
-from docling.document_converter import DocumentConverter
+from docling.datamodel.base_models import OutputFormat
+from docling.datamodel.service.options import ConvertDocumentsOptions
+from docling.service_client import DoclingServiceClient
 
 _log = logging.getLogger(__name__)
 
+# Configure your SERVICE_URL, and your API_KEY should your service need authentication.
+SERVICE_URL = os.environ["DOCLING_SERVICE_URL"]
+API_KEY = os.environ.get("DOCLING_SERVICE_API_KEY")
 
 def main():
     logging.basicConfig(level=logging.INFO)
 
-    data_folder = Path(__file__).parent / "../../tests/data"
+    data_folder = Path(__file__).parent / "../docling/tests/data"
     input_doc_path = data_folder / "pdf/2206.01062.pdf"
     output_dir = Path("scratch")
 
-    doc_converter = DocumentConverter()
-
     start_time = time.time()
 
-    conv_res = doc_converter.convert(input_doc_path)
+    # Use DoclingServiceClient instead of DocumentConverter
+    with DoclingServiceClient(url=SERVICE_URL, api_key=API_KEY) as client:
+        conv_res = client.convert(
+            source=input_doc_path,
+            options=ConvertDocumentsOptions(
+                do_table_structure=True,  # Ensure table structure detection is enabled
+                to_formats=[OutputFormat.JSON],  # JSON format needed for table access
+            ),
+        )
 
-    output_dir.mkdir(parents=True, exist_ok=True)
+        output_dir.mkdir(parents=True, exist_ok=True)
 
-    doc_filename = conv_res.input.file.stem
+        doc_filename = conv_res.input.file.stem
 
-    # Export tables
-    for table_ix, table in enumerate(conv_res.document.tables):
-        table_df: pd.DataFrame = table.export_to_dataframe(doc=conv_res.document)
-        print(f"## Table {table_ix}")
-        print(table_df.to_markdown())
+        # Export tables
+        for table_ix, table in enumerate(conv_res.document.tables):
+            table_df: pd.DataFrame = table.export_to_dataframe(doc=conv_res.document)
+            print(f"## Table {table_ix}")
+            print(table_df.to_markdown())
 
-        # Save the table as CSV
-        element_csv_filename = output_dir / f"{doc_filename}-table-{table_ix + 1}.csv"
-        _log.info(f"Saving CSV table to {element_csv_filename}")
-        table_df.to_csv(element_csv_filename)
+            # Save the table as CSV
+            element_csv_filename = output_dir / f"{doc_filename}-table-{table_ix + 1}.csv"
+            _log.info(f"Saving CSV table to {element_csv_filename}")
+            table_df.to_csv(element_csv_filename)
 
-        # Save the table as HTML
-        element_html_filename = output_dir / f"{doc_filename}-table-{table_ix + 1}.html"
-        _log.info(f"Saving HTML table to {element_html_filename}")
-        with element_html_filename.open("w") as fp:
-            fp.write(table.export_to_html(doc=conv_res.document))
+            # Save the table as HTML
+            element_html_filename = output_dir / f"{doc_filename}-table-{table_ix + 1}.html"
+            _log.info(f"Saving HTML table to {element_html_filename}")
+            with element_html_filename.open("w") as fp:
+                fp.write(table.export_to_html(doc=conv_res.document))
 
     end_time = time.time() - start_time
 
@@ -74,3 +87,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+    

--- a/docs/examples/export_tables.py
+++ b/docs/examples/export_tables.py
@@ -1,16 +1,16 @@
 # %% [markdown]
-# Extract tables from a PDF and export them as CSV and HTML using docling-serve.
+# Extract tables from a PDF and export them as CSV and HTML.
 #
 # What this example does
-# - Converts a PDF using docling-serve API and iterates detected tables.
+# - Converts a PDF and iterates detected tables.
 # - Prints each table as Markdown to stdout, and saves CSV/HTML to `scratch/`.
 #
 # Prerequisites
-# - Install Docling service client and `pandas`.
-# - Set API_KEY and SERVICE_URL for your docling-serve instance.
+# - Install Docling or Docling Serve and `pandas`.
+# - If working with Docling Serve, set API_KEY and SERVICE_URL for your docling-serve instance.
 #
 # How to run
-# - From the repo root: `python docs/examples/tableexport.py`.
+# - From the repo root: `python docs/examples/export_tables.py`.
 # - Outputs are written to `scratch/`.
 #
 # Input document
@@ -21,15 +21,73 @@
 # - Printing via `DataFrame.to_markdown()` may require the optional `tabulate` package
 #   (`pip install tabulate`). If unavailable, skip the print or use `to_csv()`.
 
+# %% [markdown]
+# Using Docling:
+
 # %%
 
 import logging
 import time
 from pathlib import Path
+import pandas as pd
+from docling.document_converter import DocumentConverter
 
+_log = logging.getLogger(__name__)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO)
+
+    data_folder = Path(__file__).parent / "../../tests/data"
+    input_doc_path = data_folder / "pdf/2206.01062.pdf"
+    output_dir = Path("scratch")
+
+    doc_converter = DocumentConverter()
+
+    start_time = time.time()
+
+    conv_res = doc_converter.convert(input_doc_path)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    doc_filename = conv_res.input.file.stem
+
+    # Export tables
+    for table_ix, table in enumerate(conv_res.document.tables):
+        table_df: pd.DataFrame = table.export_to_dataframe(doc=conv_res.document)
+        print(f"## Table {table_ix}")
+        print(table_df.to_markdown())
+
+        # Save the table as CSV
+        element_csv_filename = output_dir / f"{doc_filename}-table-{table_ix + 1}.csv"
+        _log.info(f"Saving CSV table to {element_csv_filename}")
+        table_df.to_csv(element_csv_filename)
+
+        # Save the table as HTML
+        element_html_filename = output_dir / f"{doc_filename}-table-{table_ix + 1}.html"
+        _log.info(f"Saving HTML table to {element_html_filename}")
+        with element_html_filename.open("w") as fp:
+            fp.write(table.export_to_html(doc=conv_res.document))
+
+    end_time = time.time() - start_time
+
+    _log.info(f"Document converted and tables exported in {end_time:.2f} seconds.")
+
+
+if __name__ == "__main__":
+    main()
+
+
+# %% [markdown]
+# Using Docling Serve:
+
+# %%
+
+import logging
+import time
+from pathlib import Path
 import pandas as pd
 import os
-
 from docling.datamodel.base_models import OutputFormat
 from docling.datamodel.service.options import ConvertDocumentsOptions
 from docling.service_client import DoclingServiceClient
@@ -87,4 +145,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-    

--- a/docs/examples/hybrid_chunking.ipynb
+++ b/docs/examples/hybrid_chunking.ipynb
@@ -49,10 +49,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import os\n",
+    "\n",
+    "# Configure your SERVICE_URL, and your API_KEY should your service need authentication.\n",
+    "SERVICE_URL = os.environ[\"DOCLING_SERVICE_URL\"]\n",
+    "API_KEY = os.environ.get(\"DOCLING_SERVICE_API_KEY\")\n",
+    "\n",
     "DOC_SOURCE = \"../../tests/data/md/wiki.md\""
    ]
   },
@@ -72,13 +78,22 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "from docling.document_converter import DocumentConverter\n",
+    "from docling.datamodel.base_models import OutputFormat\n",
+    "from docling.datamodel.service.options import ConvertDocumentsOptions\n",
+    "from docling.service_client import DoclingServiceClient\n",
     "\n",
-    "doc = DocumentConverter().convert(source=DOC_SOURCE).document"
+    "with DoclingServiceClient(url=SERVICE_URL, api_key=API_KEY) as client:\n",
+    "    result = client.convert(\n",
+    "        source=DOC_SOURCE,\n",
+    "        options=ConvertDocumentsOptions(\n",
+    "            to_formats=[OutputFormat.JSON],  # JSON format needed for document structure\n",
+    "        ),\n",
+    "    )\n",
+    "    doc = result.document"
    ]
   },
   {
@@ -448,7 +463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "metadata": {},
    "outputs": [
     {
@@ -464,11 +479,17 @@
     }
    ],
    "source": [
-    "# Convert a CSV file with a wide table\n",
+    "# Convert a CSV file with a wide table using docling-serve\n",
     "CSV_SOURCE = \"../../tests/data/csv/csv-comma.csv\"\n",
     "\n",
-    "csv_result = DocumentConverter().convert(source=CSV_SOURCE)\n",
-    "csv_doc = csv_result.document\n",
+    "with DoclingServiceClient(url=SERVICE_URL, api_key=API_KEY) as client:\n",
+    "    csv_result = client.convert(\n",
+    "        source=CSV_SOURCE,\n",
+    "        options=ConvertDocumentsOptions(\n",
+    "            to_formats=[OutputFormat.JSON],  # JSON format needed for document structure\n",
+    "        ),\n",
+    "    )\n",
+    "    csv_doc = csv_result.document\n",
     "\n",
     "print(f\"Document has {len(list(csv_doc.iterate_items()))} items\")\n",
     "print(\"\\nFirst few lines of the CSV table:\")\n",

--- a/docs/examples/hybrid_chunking.ipynb
+++ b/docs/examples/hybrid_chunking.ipynb
@@ -31,6 +31,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For Docling:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
@@ -48,6 +55,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For Docling Serve:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%pip install -qU pip \"docling-serve[ui]\" transformers"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -55,10 +78,24 @@
    "source": [
     "import os\n",
     "\n",
-    "# Configure your SERVICE_URL, and your API_KEY should your service need authentication.\n",
+    "# Set your SERVICE_URL, and your API_KEY should your service require authentication.\n",
     "SERVICE_URL = os.environ[\"DOCLING_SERVICE_URL\"]\n",
-    "API_KEY = os.environ.get(\"DOCLING_SERVICE_API_KEY\")\n",
-    "\n",
+    "API_KEY = os.environ.get(\"DOCLING_SERVICE_API_KEY\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set your document source to its path or URL."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "DOC_SOURCE = \"../../tests/data/md/wiki.md\""
    ]
   },
@@ -73,7 +110,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We first convert the document:"
+    "We first convert the document."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using Docling:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from docling.document_converter import DocumentConverter\n",
+    "\n",
+    "doc = DocumentConverter().convert(source=DOC_SOURCE).document"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using Docling Serve:"
    ]
   },
   {
@@ -462,6 +524,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Converting the CSV file with Docling:"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -478,6 +547,30 @@
      ]
     }
    ],
+   "source": [
+    "# Convert a CSV file with a wide table\n",
+    "CSV_SOURCE = \"../../tests/data/csv/csv-comma.csv\"\n",
+    "\n",
+    "csv_result = DocumentConverter().convert(source=CSV_SOURCE)\n",
+    "csv_doc = csv_result.document\n",
+    "\n",
+    "print(f\"Document has {len(list(csv_doc.iterate_items()))} items\")\n",
+    "print(\"\\nFirst few lines of the CSV table:\")\n",
+    "print(csv_doc.export_to_markdown()[:500])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Converting the CSV file with Docling Serve:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "# Convert a CSV file with a wide table using docling-serve\n",
     "CSV_SOURCE = \"../../tests/data/csv/csv-comma.csv\"\n",

--- a/docs/examples/tesseract_lang_detection.py
+++ b/docs/examples/tesseract_lang_detection.py
@@ -1,34 +1,79 @@
 # %% [markdown]
-# Detect language automatically with Tesseract OCR using docling-serve and force full-age OCR.
+# Detect language automatically with Tesseract OCR and force full-page OCR.
 #
 # What this example does
-# - Uses docling-serve API to perform OCR with Tesseract and automatic language detection.
+# - Configures Tesseract (CLI in this snippet) with `lang=["auto"]`.
 # - Forces full-page OCR and prints the recognized text as Markdown.
 #
-# Prerequisites
-# - Install Docling service client.
-# - Set API_KEY and SERVICE_URL for your docling-serve instance.
+# Prerequisites  
+# - Install Docling or Docling Serve.
+# - If working with Docling Serve, set API_KEY and SERVICE_URL for your docling-serve instance.
 #
 # How to run
 # - From the repo root: `python docs/examples/tesseract_lang_detection.py`.
-# - Ensure the docling-serve backend is configured with Tesseract OCR.
-# 
+# - Ensure Tesseract CLI (or library) is installed and on PATH.
+#
 # Notes
-# - The docling-serve API handles Tesseract OCR configuration server-side.
-# - `ocr_preset="tesseract"` specifies Tesseract as the OCR engine.
-# - `force_ocr=True` forces full-page OCR.
-# - `ocr_lang=["auto"]` enables automatic language detection (server must support this).
+# - You can switch to `TesseractOcrOptions` instead of `TesseractCliOcrOptions`.
+# - Language packs must be installed; set `TESSDATA_PREFIX` if Tesseract
+#   cannot find language data. Using `lang=["auto"]` requires traineddata
+#   that supports script/language detection on your system.
+# - If working with docling-serve, the API handles Tesseract OCR configuration server-side.
+
+# %% [markdown]
+# Using Docling:
+
+# %%
+
+from pathlib import Path
+
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.pipeline_options import (
+    PdfPipelineOptions,
+    TesseractCliOcrOptions,
+)
+from docling.document_converter import DocumentConverter, PdfFormatOption
+
+
+def main():
+    data_folder = Path(__file__).parent / "../../tests/data"
+    input_doc_path = data_folder / "pdf/2206.01062.pdf"
+
+    # Set lang=["auto"] with a tesseract OCR engine: TesseractOcrOptions, TesseractCliOcrOptions
+    # ocr_options = TesseractOcrOptions(lang=["auto"])
+    ocr_options = TesseractCliOcrOptions(lang=["auto"])
+
+    pipeline_options = PdfPipelineOptions(
+        do_ocr=True, force_full_page_ocr=True, ocr_options=ocr_options
+    )
+
+    converter = DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(
+                pipeline_options=pipeline_options,
+            )
+        }
+    )
+
+    doc = converter.convert(input_doc_path).document
+    md = doc.export_to_markdown()
+    print(md)
+
+
+if __name__ == "__main__":
+    main()
+
+
+# %% [markdown]
+# Using Docling Serve:
 
 # %%
 
 from pathlib import Path
 import os
-
 from docling.datamodel.base_models import OutputFormat
 from docling.datamodel.service.options import ConvertDocumentsOptions
 from docling.service_client import DoclingServiceClient
-
-from DoclingTests.servetest import SERVICE_URL
 
 # Configure your SERVICE_URL, and your API_KEY should your service need authentication.
 SERVICE_URL = os.environ["DOCLING_SERVICE_URL"]

--- a/docs/examples/tesseract_lang_detection.py
+++ b/docs/examples/tesseract_lang_detection.py
@@ -1,55 +1,58 @@
 # %% [markdown]
-# Detect language automatically with Tesseract OCR and force full-page OCR.
+# Detect language automatically with Tesseract OCR using docling-serve and force full-age OCR.
 #
 # What this example does
-# - Configures Tesseract (CLI in this snippet) with `lang=["auto"]`.
+# - Uses docling-serve API to perform OCR with Tesseract and automatic language detection.
 # - Forces full-page OCR and prints the recognized text as Markdown.
+#
+# Prerequisites
+# - Install Docling service client.
+# - Set API_KEY and SERVICE_URL for your docling-serve instance.
 #
 # How to run
 # - From the repo root: `python docs/examples/tesseract_lang_detection.py`.
-# - Ensure Tesseract CLI (or library) is installed and on PATH.
-#
+# - Ensure the docling-serve backend is configured with Tesseract OCR.
+# 
 # Notes
-# - You can switch to `TesseractOcrOptions` instead of `TesseractCliOcrOptions`.
-# - Language packs must be installed; set `TESSDATA_PREFIX` if Tesseract
-#   cannot find language data. Using `lang=["auto"]` requires traineddata
-#   that supports script/language detection on your system.
+# - The docling-serve API handles Tesseract OCR configuration server-side.
+# - `ocr_preset="tesseract"` specifies Tesseract as the OCR engine.
+# - `force_ocr=True` forces full-page OCR.
+# - `ocr_lang=["auto"]` enables automatic language detection (server must support this).
 
 # %%
 
 from pathlib import Path
+import os
 
-from docling.datamodel.base_models import InputFormat
-from docling.datamodel.pipeline_options import (
-    PdfPipelineOptions,
-    TesseractCliOcrOptions,
-)
-from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.datamodel.base_models import OutputFormat
+from docling.datamodel.service.options import ConvertDocumentsOptions
+from docling.service_client import DoclingServiceClient
 
+from DoclingTests.servetest import SERVICE_URL
+
+# Configure your SERVICE_URL, and your API_KEY should your service need authentication.
+SERVICE_URL = os.environ["DOCLING_SERVICE_URL"]
+API_KEY = os.environ.get("DOCLING_SERVICE_API_KEY")
 
 def main():
-    data_folder = Path(__file__).parent / "../../tests/data"
+    data_folder = Path(__file__).parent / "../.../tests/data"
     input_doc_path = data_folder / "pdf/2206.01062.pdf"
 
-    # Set lang=["auto"] with a tesseract OCR engine: TesseractOcrOptions, TesseractCliOcrOptions
-    # ocr_options = TesseractOcrOptions(lang=["auto"])
-    ocr_options = TesseractCliOcrOptions(lang=["auto"])
+    with DoclingServiceClient(url=SERVICE_URL, api_key=API_KEY) as client:
+        result = client.convert(
+            source=input_doc_path,
+            options=ConvertDocumentsOptions(
+                do_ocr=True,              # Enable OCR
+                force_ocr=True,           # Force full-page OCR (equivalent to force_full_page_ocr)
+                ocr_preset="tesseract",   # Specify Tesseract as the OCR engine
+                ocr_lang=["auto"],        # Auto language detection (equivalent to lang=["auto"])
+                to_formats=[OutputFormat.MARKDOWN],  # Request markdown output
+            ),
+        )
 
-    pipeline_options = PdfPipelineOptions(
-        do_ocr=True, force_full_page_ocr=True, ocr_options=ocr_options
-    )
-
-    converter = DocumentConverter(
-        format_options={
-            InputFormat.PDF: PdfFormatOption(
-                pipeline_options=pipeline_options,
-            )
-        }
-    )
-
-    doc = converter.convert(input_doc_path).document
-    md = doc.export_to_markdown()
-    print(md)
+        # Export and print the markdown
+        md = result.document.export_to_markdown()
+        print(md)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Overview

Updating documentation for exporting tables, hybrid chunking, and language detection to include example use cases of docling-serve and DoclingServiceClient. Have tested exporting tables locally with success, will test the other examples in future. This PR is an updated version of PR #3513, in which examples are now updated to include both original Docling and Docling Serve use cases in separate coding blocks.

---

**To Do:**

- [ ] Testing examples for hybrid chunking and language detection locally
- [ ] Running hybrid chunking notebook on new code blocks to produce output
- [ ] Testing on server/off local machine

---

To be reviewed by @mingxzhao! If format for files are also incorrect, let me know and I will add a fix right away.