### PR TITLE
fix: add images_scale for chart extraction and correctly set keep_backend flag in StandardPDFPipeline

### DIFF
--- a/docling/models/stages/chart_extraction/granite_vision.py
+++ b/docling/models/stages/chart_extraction/granite_vision.py
@@ -46,7 +46,7 @@ class _BaseChartExtractionModelGraniteVision(BaseItemAndImageEnrichmentModel):
     _model_repo_revision: str
 
     images_scale: float = 2.0
-    
+
     def __init__(
         self,
         enabled: bool,

--- a/docling/models/stages/chart_extraction/granite_vision.py
+++ b/docling/models/stages/chart_extraction/granite_vision.py
@@ -45,6 +45,8 @@ class _BaseChartExtractionModelGraniteVision(BaseItemAndImageEnrichmentModel):
     _model_repo_id: str
     _model_repo_revision: str
 
+    images_scale: float = 2.0
+    
     def __init__(
         self,
         enabled: bool,

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -547,6 +547,7 @@ class StandardPdfPipeline(ConvertPipeline):
                 self.pipeline_options.do_code_enrichment,
                 self.pipeline_options.do_picture_classification,
                 self.pipeline_options.do_picture_description,
+                self.pipeline_options.do_chart_extraction,
             )
         )
 


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

When running the following code, conversion fails with the error described in #3550, this PR adds a default `images_scale` for `_BaseChartExtractionModelGraniteVision`, I have currently defaulted it to `2` but in case there is some other default that is preferred I am happy to update that. It is also be possible to expose it via `ChartExtractionModelOptions` and then set it on `_BaseChartExtractionModelGraniteVision`, happy to update to that as well in case that is preferred.

```python
from docling.datamodel.base_models import InputFormat
from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
from docling.datamodel.backend_options import PdfBackendOptions
from docling.document_converter import DocumentConverter, PdfFormatOption
from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline
from docling.datamodel.pipeline_options import ThreadedPdfPipelineOptions

pipeline_options = ThreadedPdfPipelineOptions()
pipeline_options.do_chart_extraction = True
pipeline_options.do_picture_classification = True

# Didn't fail when these were on
# pipeline_options.generate_page_images = True
# pipeline_options.generate_picture_images = True

pipeline_options.images_scale = 1.0

converter = DocumentConverter(
    allowed_formats=[InputFormat.PDF],
    format_options={
        InputFormat.PDF: PdfFormatOption(
            backend=DoclingParseDocumentBackend,
            backend_options=PdfBackendOptions(kind="pdf"),
            pipeline_options=pipeline_options,
            pipeline_cls=StandardPdfPipeline,
        )
    },
)

result = converter.convert("docs/examples/data/chart_document.pdf")
```
Further, in `keep_backend` flag currently there is a check for if pipeline options supply picture classification, however, from the `ConvertPipeline` class it seems that [`do_picture_classification` is essentially `True`](https://github.com/docling-project/docling/blob/b613414044d493165cb1ec15b1a9a40bf5d3e392/docling/pipeline/base_pipeline.py#L155-L158) when `do_chart_extraction` is `True` however, since the pipeline options themselves are not mutated this does not carry to the [`keep_backend`](https://github.com/docling-project/docling/blob/b613414044d493165cb1ec15b1a9a40bf5d3e392/docling/pipeline/standard_pdf_pipeline.py#L544-L551) flag, hence added a check on `do_chart_extraction` as well when setting the `keep_backend` flag.


**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.

Resolves #3550
