### PR TITLE
docs: polish OCR documentation wording

### DIFF
--- a/docs/examples/run_with_accelerator.py
+++ b/docs/examples/run_with_accelerator.py
@@ -50,7 +50,7 @@ def main():
     #     num_threads=8, device=AcceleratorDevice.CUDA
     # )
 
-    # easyocr doesnt support cuda:N allocation, defaults to cuda:0
+    # EasyOCR doesn't support cuda:N allocation, defaults to cuda:0
     # accelerator_options = AcceleratorOptions(num_threads=8, device="cuda:1")
 
     pipeline_options = PdfPipelineOptions()

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -81,7 +81,7 @@ the following engines.
 | [RapidOCR](https://github.com/RapidAI/RapidOCR) | `rapidocr` extra can or via `pip install rapidocr onnxruntime` | `RapidOcrOptions` |
 | [OnnxTR](https://github.com/felixdittrich92/OnnxTR) | Can be installed via the plugin system `pip install "docling-ocr-onnxtr[cpu]"`. Please take a look at [docling-OCR-OnnxTR](https://github.com/felixdittrich92/docling-OCR-OnnxTR).| `OnnxtrOcrOptions` |
 
-The Docling `DocumentConverter` allows to choose the OCR engine with the `ocr_options` settings. For example
+The Docling `DocumentConverter` allows you to choose the OCR engine with the `ocr_options` settings. For example
 
 ```python
 from docling.datamodel.base_models import InputFormat


### PR DESCRIPTION
## Description

Polishes two small wording issues in the OCR documentation and accelerator example comments.

## Checklist:

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.

## Testing

- `git diff --check`
