### PR TITLE
fix: avoid sending default service client from_formats

### DIFF
--- a/docling/service_client/client.py
+++ b/docling/service_client/client.py
@@ -552,12 +552,12 @@ class DoclingServiceClient:
             response = self._request_with_retry(
                 method="POST",
                 path="/v1/convert/source/async",
-                json=request.model_dump(mode="json"),
+                json=self._convert_request_payload(request),
                 headers=request_headers,
             )
         else:
             files = self._source_to_upload_files(source)
-            data = options.model_dump(mode="json", exclude_none=True)
+            data = self._convert_options_payload(options)
             data["target_type"] = target.kind
             response = self._request_with_retry(
                 method="POST",
@@ -594,7 +594,7 @@ class DoclingServiceClient:
                 chunking_options = HierarchicalChunkerOptions()
 
             payload = {
-                "convert_options": options.model_dump(mode="json", exclude_none=True),
+                "convert_options": self._convert_options_payload(options),
                 "chunking_options": chunking_options.model_dump(
                     mode="json", exclude_none=True
                 ),
@@ -612,9 +612,7 @@ class DoclingServiceClient:
             files = self._source_to_upload_files(source)
             data: dict[str, Any] = {
                 f"convert_{key}": value
-                for key, value in options.model_dump(
-                    mode="json", exclude_none=True
-                ).items()
+                for key, value in self._convert_options_payload(options).items()
             }
             chunk_model: HybridChunkerOptions | HierarchicalChunkerOptions
             if chunker == ChunkerKind.HYBRID:
@@ -799,7 +797,7 @@ class DoclingServiceClient:
         response = self._request_with_retry(
             method="POST",
             path="/v1/convert/source/batch",
-            json=request.model_dump(mode="json"),
+            json=self._convert_request_payload(request),
             headers=request_headers,
         )
         if response.status_code != 200:
@@ -1456,12 +1454,12 @@ class DoclingServiceClient:
                 async_client=async_client,
                 method="POST",
                 path="/v1/convert/source/async",
-                json=request.model_dump(mode="json"),
+                json=self._convert_request_payload(request),
                 headers=request_headers,
             )
         else:
             files = await self._source_to_upload_files_async(source)
-            data = options.model_dump(mode="json", exclude_none=True)
+            data = self._convert_options_payload(options)
             data["target_type"] = target.kind
             response = await self._request_with_retry_async(
                 async_client=async_client,
@@ -1483,6 +1481,24 @@ class DoclingServiceClient:
             status.task_position,
         )
         return status
+
+    @staticmethod
+    def _convert_options_payload(
+        options: ConvertDocumentsRequestOptions,
+    ) -> dict[str, Any]:
+        exclude: set[str] = set()
+        if "from_formats" not in options.model_fields_set:
+            exclude.add("from_formats")
+        return options.model_dump(mode="json", exclude_none=True, exclude=exclude)
+
+    @staticmethod
+    def _convert_request_payload(
+        request: ConvertDocumentsRequest | BatchConvertSourcesRequest,
+    ) -> dict[str, Any]:
+        exclude: dict[str, Any] = {}
+        if "from_formats" not in request.options.model_fields_set:
+            exclude["options"] = {"from_formats"}
+        return request.model_dump(mode="json", exclude=exclude)
 
     async def _poll_task_status_async(
         self,

--- a/tests/test_service_client_sdk_unit.py
+++ b/tests/test_service_client_sdk_unit.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import queue
 import threading
 import time
@@ -1396,6 +1397,68 @@ def test_submit_url_forwards_request_headers() -> None:
     assert captured["path"] == "/v1/convert/source/async"
     assert captured["header_tenant"] == "tenant-a"
     assert captured["header_api"] == "base-key"
+
+
+def test_submit_url_omits_default_from_formats_from_payload() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json=_status_response("task-default-formats", "pending").model_dump(
+                mode="json"
+            ),
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        client._http_client.close()
+        client._http_client = httpx.Client(
+            transport=transport,
+            timeout=client._http_client.timeout,
+        )
+        job = client.submit(
+            source="https://example.org/sample.pdf",
+            options=ConvertDocumentsRequestOptions(),
+            target=InBodyTarget(),
+        )
+
+    assert job.task_id == "task-default-formats"
+    assert "from_formats" not in captured["payload"]["options"]  # type: ignore[index]
+
+
+def test_submit_url_preserves_explicit_from_formats_in_payload() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = json.loads(request.content.decode("utf-8"))
+        return httpx.Response(
+            200,
+            json=_status_response("task-explicit-formats", "pending").model_dump(
+                mode="json"
+            ),
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        client._http_client.close()
+        client._http_client = httpx.Client(
+            transport=transport,
+            timeout=client._http_client.timeout,
+        )
+        job = client.submit(
+            source="https://example.org/sample.pdf",
+            options=ConvertDocumentsRequestOptions(from_formats=[InputFormat.PDF]),
+            target=InBodyTarget(),
+        )
+
+    assert job.task_id == "task-explicit-formats"
+    assert captured["payload"]["options"]["from_formats"] == [  # type: ignore[index]
+        InputFormat.PDF.value
+    ]
 
 
 def test_submit_file_forwards_request_headers(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- omit `from_formats` from Docling service client payloads when callers did not set it explicitly
- keep explicit `from_formats` serialized for callers that need to constrain accepted inputs
- add unit coverage for default and explicit `from_formats` submit payloads

Fixes #3548

## Tests
- `uv run --no-default-groups --group dev --extra service-client pytest tests/test_service_client_sdk_unit.py -q`
- `uv run --no-default-groups --group pr-fast-checks ruff check docling/service_client/client.py tests/test_service_client_sdk_unit.py`
- `uv run --no-default-groups --group pr-fast-checks ruff format --check docling/service_client/client.py tests/test_service_client_sdk_unit.py`
- `git diff --check`
