### PR TITLE
feat(convert): add page-level progress callback to DocumentConverter

### DIFF
--- a/docling/datamodel/progress.py
+++ b/docling/datamodel/progress.py
@@ -1,0 +1,81 @@
+"""In-process progress events for document conversion.
+
+These models describe page-level progress emitted by `DocumentConverter`
+during conversion, so callers can render progress bars or stream updates
+without polling. They mirror the discriminated-union style already used by
+`docling.datamodel.service.callbacks` for the HTTP service progress webhook,
+but are scoped to a single in-process conversion rather than a batch task.
+The names are deliberately distinct from that module to avoid confusing the
+in-process events with the HTTP-webhook ones.
+"""
+
+import enum
+from typing import Callable, Literal, Union
+
+from pydantic import BaseModel
+
+from docling.datamodel.base_models import ConversionStatus
+
+
+class ConversionProgressKind(str, enum.Enum):
+    PAGE_STARTED = "page_started"
+    PAGE_COMPLETED = "page_completed"
+    DOCUMENT_COMPLETED = "document_completed"
+
+
+class BaseConversionProgress(BaseModel):
+    kind: ConversionProgressKind
+
+
+class PageStartedProgress(BaseConversionProgress):
+    """Emitted when a page enters the conversion pipeline."""
+
+    kind: Literal[ConversionProgressKind.PAGE_STARTED] = (
+        ConversionProgressKind.PAGE_STARTED
+    )
+
+    page_no: int  # 1-based page number
+    # Number of pages being processed. When a ``page_range`` restricts the
+    # conversion, this is the count of pages in that range, not the physical
+    # page count of the document.
+    total_pages: int
+
+
+class PageCompletedProgress(BaseConversionProgress):
+    """Emitted when a page finishes processing (successfully or not)."""
+
+    kind: Literal[ConversionProgressKind.PAGE_COMPLETED] = (
+        ConversionProgressKind.PAGE_COMPLETED
+    )
+
+    page_no: int  # 1-based page number
+    total_pages: int  # see PageStartedProgress.total_pages
+    success: bool = True
+
+
+class DocumentCompletedProgress(BaseConversionProgress):
+    """Emitted once after a whole document finishes converting."""
+
+    kind: Literal[ConversionProgressKind.DOCUMENT_COMPLETED] = (
+        ConversionProgressKind.DOCUMENT_COMPLETED
+    )
+
+    num_pages: int
+    status: ConversionStatus
+
+
+ConversionProgressEvent = Union[
+    PageStartedProgress, PageCompletedProgress, DocumentCompletedProgress
+]
+
+# A user-supplied callback receiving conversion progress events.
+#
+# Thread-safety: ``StandardPdfPipeline`` (the default PDF pipeline) processes
+# pages on a background producer thread, so for PDFs the callback is always
+# invoked from more than one thread, even for a single document. Concurrent
+# document conversions (``settings.perf.doc_batch_concurrency > 1``) add
+# further concurrency. The callback must therefore be thread-safe. For the
+# threaded PDF pipeline no per-page ordering is guaranteed between
+# ``page_started`` and ``page_completed`` events. The terminal
+# ``document_completed`` event is always emitted last for a given document.
+ProgressCallback = Callable[[ConversionProgressEvent], None]

--- a/docling/document_converter.py
+++ b/docling/document_converter.py
@@ -69,6 +69,7 @@ from docling.datamodel.document import (
     build_invalid_input_errors,
 )
 from docling.datamodel.pipeline_options import ConvertPipelineOptions, PipelineOptions
+from docling.datamodel.progress import ProgressCallback
 from docling.datamodel.settings import (
     DEFAULT_PAGE_RANGE,
     DocumentLimits,
@@ -294,6 +295,7 @@ class DocumentConverter:
         self,
         allowed_formats: Optional[list[InputFormat]] = None,
         format_options: Optional[dict[InputFormat, FormatOption]] = None,
+        progress_callback: Optional[ProgressCallback] = None,
     ) -> None:
         """Initialize the converter based on format preferences.
 
@@ -301,6 +303,16 @@ class DocumentConverter:
             allowed_formats: List of allowed input formats. By default, any
                 format supported by Docling is allowed.
             format_options: Dictionary of format-specific options.
+            progress_callback: Optional callable invoked with page-level
+                progress events (``PageStartedProgress``,
+                ``PageCompletedProgress``, ``DocumentCompletedProgress``)
+                during conversion. The callback must be thread-safe: the
+                default PDF pipeline processes pages on a background thread, so
+                it is invoked from multiple threads even for a single document,
+                and concurrent conversions
+                (``settings.perf.doc_batch_concurrency > 1``) add further
+                concurrency. Exceptions raised by the callback are logged and
+                suppressed so they cannot interrupt conversion.
 
         Examples:
             Create a converter with default settings (all formats allowed):
@@ -328,6 +340,7 @@ class DocumentConverter:
         self.allowed_formats: list[InputFormat] = (
             allowed_formats if allowed_formats is not None else list(InputFormat)
         )
+        self.progress_callback: Optional[ProgressCallback] = progress_callback
 
         # Normalize format options: ensure IMAGE format uses ImageDocumentBackend
         # for backward compatibility (old code might use PdfFormatOption or other backends for images)
@@ -712,7 +725,11 @@ class DocumentConverter:
         if in_doc.valid:
             pipeline = self._get_pipeline(in_doc.format)
             if pipeline is not None:
-                conv_res = pipeline.execute(in_doc, raises_on_error=raises_on_error)
+                conv_res = pipeline.execute(
+                    in_doc,
+                    raises_on_error=raises_on_error,
+                    progress_callback=self.progress_callback,
+                )
             else:
                 if raises_on_error:
                     raise ConversionError(

--- a/docling/pipeline/asr_pipeline.py
+++ b/docling/pipeline/asr_pipeline.py
@@ -4,7 +4,7 @@ import sys
 import tempfile
 from io import BytesIO
 from pathlib import Path
-from typing import Final
+from typing import Final, Optional
 
 from docling_core.types.doc import (
     ContentLayer,
@@ -33,6 +33,7 @@ from docling.datamodel.pipeline_options_asr_model import (
     InlineAsrMlxWhisperOptions,
     InlineAsrNativeWhisperOptions,
 )
+from docling.datamodel.progress import ProgressCallback
 from docling.pipeline.base_pipeline import BasePipeline
 from docling.utils.accelerator_utils import decide_device
 from docling.utils.profiling import ProfilingScope, TimeRecorder
@@ -475,7 +476,14 @@ class AsrPipeline(BasePipeline):
     def get_default_options(cls) -> AsrPipelineOptions:
         return AsrPipelineOptions()
 
-    def _build_document(self, conv_res: ConversionResult) -> ConversionResult:
+    def _build_document(
+        self,
+        conv_res: ConversionResult,
+        progress_callback: Optional[ProgressCallback] = None,
+    ) -> ConversionResult:
+        # Audio transcription is not page-based, so no per-page events are
+        # emitted here; the document_completed event is emitted by
+        # BasePipeline.execute once conversion finishes.
         _log.info(f"start _build_document in AsrPipeline: {conv_res.input.file}")
         with TimeRecorder(conv_res, "doc_build", scope=ProfilingScope.DOCUMENT):
             self._model.run(conv_res=conv_res)

--- a/docling/pipeline/base_pipeline.py
+++ b/docling/pipeline/base_pipeline.py
@@ -30,6 +30,13 @@ from docling.datamodel.pipeline_options import (
     PdfPipelineOptions,
     PipelineOptions,
 )
+from docling.datamodel.progress import (
+    ConversionProgressEvent,
+    DocumentCompletedProgress,
+    PageCompletedProgress,
+    PageStartedProgress,
+    ProgressCallback,
+)
 from docling.datamodel.settings import settings
 from docling.models.base_model import GenericEnrichmentModel
 from docling.models.factories import get_picture_description_factory
@@ -66,7 +73,29 @@ class BasePipeline(ABC):
                 "When defined, it must point to a folder containing all models required by the pipeline."
             )
 
-    def execute(self, in_doc: InputDocument, raises_on_error: bool) -> ConversionResult:
+    @staticmethod
+    def _emit_progress(
+        progress_callback: Optional[ProgressCallback],
+        event: ConversionProgressEvent,
+    ) -> None:
+        """Invoke a user progress callback, isolating its failures.
+
+        A misbehaving callback must never break the conversion, so any
+        exception it raises is logged and swallowed.
+        """
+        if progress_callback is None:
+            return
+        try:
+            progress_callback(event)
+        except Exception:
+            _log.warning("progress_callback raised an exception", exc_info=True)
+
+    def execute(
+        self,
+        in_doc: InputDocument,
+        raises_on_error: bool,
+        progress_callback: Optional[ProgressCallback] = None,
+    ) -> ConversionResult:
         conv_res = ConversionResult(input=in_doc)
 
         _log.info(f"Processing document {in_doc.file.name}")
@@ -76,7 +105,7 @@ class BasePipeline(ABC):
             ):
                 # These steps are building and assembling the structure of the
                 # output DoclingDocument.
-                conv_res = self._build_document(conv_res)
+                conv_res = self._build_document(conv_res, progress_callback)
                 conv_res = self._assemble_document(conv_res)
                 # From this stage, all operations should rely only on conv_res.output
                 conv_res = self._enrich_document(conv_res)
@@ -98,11 +127,23 @@ class BasePipeline(ABC):
                 raise RuntimeError(f"Pipeline {self.__class__.__name__} failed") from e
         finally:
             self._unload(conv_res)
+            # Emitted in `finally` so callers always receive a terminal event,
+            # even when raises_on_error=True re-raises above.
+            self._emit_progress(
+                progress_callback,
+                DocumentCompletedProgress(
+                    num_pages=len(conv_res.pages), status=conv_res.status
+                ),
+            )
 
         return conv_res
 
     @abstractmethod
-    def _build_document(self, conv_res: ConversionResult) -> ConversionResult:
+    def _build_document(
+        self,
+        conv_res: ConversionResult,
+        progress_callback: Optional[ProgressCallback] = None,
+    ) -> ConversionResult:
         pass
 
     def _assemble_document(self, conv_res: ConversionResult) -> ConversionResult:
@@ -241,7 +282,11 @@ class PaginatedPipeline(ConvertPipeline):  # TODO this is a bad name.
 
         yield from page_batch
 
-    def _build_document(self, conv_res: ConversionResult) -> ConversionResult:
+    def _build_document(
+        self,
+        conv_res: ConversionResult,
+        progress_callback: Optional[ProgressCallback] = None,
+    ) -> ConversionResult:
         if not isinstance(conv_res.input._backend, PaginatedDocumentBackend):
             raise RuntimeError(
                 f"The selected backend {type(conv_res.input._backend).__name__} for {conv_res.input.file} is not a paginated backend. "
@@ -258,6 +303,10 @@ class PaginatedPipeline(ConvertPipeline):  # TODO this is a bad name.
                 if (start_page - 1) <= i <= (end_page - 1):
                     conv_res.pages.append(Page(page_no=i + 1))
 
+            total_pages = len(conv_res.pages)
+            started_page_nos: set[int] = set()
+            completed_page_nos: set[int] = set()
+
             try:
                 total_pages_processed = 0
                 # Iterate batches of pages (page_batch_size) in the doc
@@ -265,6 +314,15 @@ class PaginatedPipeline(ConvertPipeline):  # TODO this is a bad name.
                     conv_res.pages, settings.perf.page_batch_size
                 ):
                     start_batch_time = time.monotonic()
+
+                    for page in page_batch:
+                        started_page_nos.add(page.page_no)
+                        self._emit_progress(
+                            progress_callback,
+                            PageStartedProgress(
+                                page_no=page.page_no, total_pages=total_pages
+                            ),
+                        )
 
                     # 1. Initialise the page resources
                     init_pages = map(
@@ -275,6 +333,17 @@ class PaginatedPipeline(ConvertPipeline):  # TODO this is a bad name.
                     pipeline_pages = self._apply_on_pages(conv_res, init_pages)
 
                     for p in pipeline_pages:  # Must exhaust!
+                        completed_page_nos.add(p.page_no)
+                        self._emit_progress(
+                            progress_callback,
+                            PageCompletedProgress(
+                                page_no=p.page_no,
+                                total_pages=total_pages,
+                                success=p._backend is not None
+                                and p._backend.is_valid(),
+                            ),
+                        )
+
                         # Cleanup cached images
                         if not self.keep_images:
                             p._image_cache = {}
@@ -314,6 +383,20 @@ class PaginatedPipeline(ConvertPipeline):  # TODO this is a bad name.
                     total_pages_processed += len(page_batch)
                     _log.debug(
                         f"Finished converting pages {total_pages_processed}/{len(conv_res.pages)} time={end_batch_time:.3f}"
+                    )
+
+                # Pages that were announced as started but never completed
+                # (e.g. the in-flight batch when a document_timeout breaks the
+                # loop) get a terminal failure event so every page_started is
+                # balanced by a page_completed.
+                for page_no in sorted(started_page_nos - completed_page_nos):
+                    self._emit_progress(
+                        progress_callback,
+                        PageCompletedProgress(
+                            page_no=page_no,
+                            total_pages=total_pages,
+                            success=False,
+                        ),
                     )
 
             except Exception as e:

--- a/docling/pipeline/simple_pipeline.py
+++ b/docling/pipeline/simple_pipeline.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Optional
 
 from docling.backend.abstract_backend import (
     AbstractDocumentBackend,
@@ -7,6 +8,7 @@ from docling.backend.abstract_backend import (
 from docling.datamodel.base_models import ConversionStatus
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import ConvertPipelineOptions
+from docling.datamodel.progress import ProgressCallback
 from docling.pipeline.base_pipeline import ConvertPipeline
 from docling.utils.profiling import ProfilingScope, TimeRecorder
 
@@ -23,7 +25,14 @@ class SimplePipeline(ConvertPipeline):
     def __init__(self, pipeline_options: ConvertPipelineOptions):
         super().__init__(pipeline_options)
 
-    def _build_document(self, conv_res: ConversionResult) -> ConversionResult:
+    def _build_document(
+        self,
+        conv_res: ConversionResult,
+        progress_callback: Optional[ProgressCallback] = None,
+    ) -> ConversionResult:
+        # Declarative backends produce a DoclingDocument in one shot, so there
+        # are no per-page events here; the document_completed event is emitted
+        # by BasePipeline.execute once conversion finishes.
         if not isinstance(conv_res.input._backend, DeclarativeDocumentBackend):
             raise RuntimeError(
                 f"The selected backend {type(conv_res.input._backend).__name__} for {conv_res.input.file} is not a declarative backend. "

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -23,7 +23,7 @@ import warnings
 from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Iterable, Sequence, cast
+from typing import Any, Callable, Iterable, Optional, Sequence, cast
 
 import numpy as np
 from docling_core.types.doc import (
@@ -47,6 +47,11 @@ from docling.datamodel.base_models import (
 )
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import ThreadedPdfPipelineOptions
+from docling.datamodel.progress import (
+    PageCompletedProgress,
+    PageStartedProgress,
+    ProgressCallback,
+)
 from docling.datamodel.settings import settings
 from docling.models.factories import (
     get_layout_factory,
@@ -761,7 +766,11 @@ class StandardPdfPipeline(ConvertPipeline):
             )
         )
 
-    def _build_document(self, conv_res: ConversionResult) -> ConversionResult:
+    def _build_document(
+        self,
+        conv_res: ConversionResult,
+        progress_callback: Optional[ProgressCallback] = None,
+    ) -> ConversionResult:
         """Stream-build the document with a dedicated producer thread.
 
         Note: If a worker thread gets stuck in a blocking call (model inference or PDF backend
@@ -817,6 +826,12 @@ class StandardPdfPipeline(ConvertPipeline):
                     except Exception:
                         if page_backend.is_valid():
                             raise
+                    self._emit_progress(
+                        progress_callback,
+                        PageStartedProgress(
+                            page_no=page.page_no, total_pages=total_pages
+                        ),
+                    )
                     if not ctx.first_stage.input_queue.put(
                         ThreadedItem(
                             payload=page,
@@ -864,9 +879,25 @@ class StandardPdfPipeline(ConvertPipeline):
                     if itm.is_failed or itm.error:
                         error = itm.error or RuntimeError("unknown error")
                         proc.failed_pages.append((itm.page_no, error, itm.failure))
+                        self._emit_progress(
+                            progress_callback,
+                            PageCompletedProgress(
+                                page_no=itm.page_no,
+                                total_pages=total_pages,
+                                success=False,
+                            ),
+                        )
                     else:
                         assert itm.payload is not None
                         proc.pages.append(itm.payload)
+                        self._emit_progress(
+                            progress_callback,
+                            PageCompletedProgress(
+                                page_no=itm.payload.page_no,
+                                total_pages=total_pages,
+                                success=True,
+                            ),
+                        )
 
                 # Failure safety - downstream closed early
                 if not out_batch and ctx.output_queue.closed:
@@ -895,6 +926,15 @@ class StandardPdfPipeline(ConvertPipeline):
                                 for page_no in missing_page_nos
                             ]
                         )
+                        for page_no in missing_page_nos:
+                            self._emit_progress(
+                                progress_callback,
+                                PageCompletedProgress(
+                                    page_no=page_no,
+                                    total_pages=total_pages,
+                                    success=False,
+                                ),
+                            )
                     break
 
             # Mark remaining pages as failed if timeout occurred
@@ -916,6 +956,14 @@ class StandardPdfPipeline(ConvertPipeline):
                                 page_no=page_no,
                             ),
                         )
+                    )
+                    self._emit_progress(
+                        progress_callback,
+                        PageCompletedProgress(
+                            page_no=page_no,
+                            total_pages=total_pages,
+                            success=False,
+                        ),
                     )
         finally:
             for st in ctx.stages:

--- a/tests/test_progress_callback.py
+++ b/tests/test_progress_callback.py
@@ -1,0 +1,164 @@
+"""Tests for the page-level progress callback on DocumentConverter.
+
+The converter accepts an optional ``progress_callback`` that receives
+``PageStartedProgress`` / ``PageCompletedProgress`` events for paginated
+pipelines and a single ``DocumentCompletedProgress`` event for every
+conversion (paginated or not).
+
+Related issue: https://github.com/docling-project/docling/issues/3493
+"""
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from docling.datamodel.base_models import ConversionStatus, InputFormat
+from docling.datamodel.pipeline_options import PdfPipelineOptions
+from docling.datamodel.progress import (
+    ConversionProgressKind,
+    DocumentCompletedProgress,
+    PageCompletedProgress,
+    PageStartedProgress,
+)
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.pipeline.legacy_standard_pdf_pipeline import LegacyStandardPdfPipeline
+from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline
+
+
+@pytest.fixture
+def normal_4pages_path():
+    return Path("./tests/data/pdf/sources/normal_4pages.pdf")
+
+
+@pytest.fixture
+def markdown_path():
+    return Path("./tests/data/md/sources/duck.md")
+
+
+def _pdf_converter(callback, pipeline_cls=StandardPdfPipeline):
+    return DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(
+                pipeline_cls=pipeline_cls,
+                pipeline_options=PdfPipelineOptions(
+                    do_ocr=False,
+                    do_table_structure=False,
+                ),
+            )
+        },
+        progress_callback=callback,
+    )
+
+
+@pytest.mark.parametrize(
+    "pipeline_cls", [StandardPdfPipeline, LegacyStandardPdfPipeline]
+)
+def test_paginated_pdf_emits_page_and_document_events(normal_4pages_path, pipeline_cls):
+    """A 4-page PDF emits one started + one completed event per page and a
+    single document_completed event at the end, for both the threaded and the
+    legacy paginated pipelines."""
+    events = []
+    lock = threading.Lock()
+
+    def callback(event):
+        # Page events may arrive from the producer/drain threads.
+        with lock:
+            events.append(event)
+
+    converter = _pdf_converter(callback, pipeline_cls=pipeline_cls)
+    result = converter.convert(normal_4pages_path, raises_on_error=False)
+    assert result.status == ConversionStatus.SUCCESS
+
+    expected_pages = result.input.page_count
+    assert expected_pages == 4
+
+    started = [e for e in events if isinstance(e, PageStartedProgress)]
+    completed = [e for e in events if isinstance(e, PageCompletedProgress)]
+    document = [e for e in events if isinstance(e, DocumentCompletedProgress)]
+
+    assert {e.page_no for e in started} == set(range(1, expected_pages + 1))
+    assert {e.page_no for e in completed} == set(range(1, expected_pages + 1))
+    assert all(e.total_pages == expected_pages for e in started + completed)
+    assert all(e.success for e in completed)
+
+    assert len(document) == 1
+    assert document[0].num_pages == expected_pages
+    assert document[0].status == ConversionStatus.SUCCESS
+    # The document_completed event is always the final one emitted.
+    assert isinstance(events[-1], DocumentCompletedProgress)
+
+
+def test_non_paginated_emits_only_document_completed(markdown_path):
+    """A declarative (non-paginated) input emits no page events, only a single
+    document_completed event."""
+    events = []
+
+    converter = DocumentConverter(progress_callback=events.append)
+    result = converter.convert(markdown_path, raises_on_error=False)
+    assert result.status == ConversionStatus.SUCCESS
+
+    assert not [e for e in events if isinstance(e, PageStartedProgress)]
+    assert not [e for e in events if isinstance(e, PageCompletedProgress)]
+
+    document = [e for e in events if isinstance(e, DocumentCompletedProgress)]
+    assert len(document) == 1
+    assert document[0].kind == ConversionProgressKind.DOCUMENT_COMPLETED
+    assert document[0].status == ConversionStatus.SUCCESS
+
+
+def test_no_callback_is_a_noop(normal_4pages_path):
+    """Conversion works unchanged when no callback is provided."""
+    converter = _pdf_converter(None)
+    result = converter.convert(normal_4pages_path, raises_on_error=False)
+    assert result.status == ConversionStatus.SUCCESS
+
+
+def test_callback_exception_does_not_break_conversion(markdown_path):
+    """A callback that raises must not interrupt the conversion."""
+
+    def boom(event):
+        raise RuntimeError("callback failure")
+
+    converter = DocumentConverter(progress_callback=boom)
+    result = converter.convert(markdown_path, raises_on_error=False)
+    assert result.status == ConversionStatus.SUCCESS
+
+
+def test_callback_exception_on_page_events_does_not_break_pdf(normal_4pages_path):
+    """A callback raising on page events (from the threaded PDF pipeline) must
+    not interrupt the conversion."""
+
+    def boom(event):
+        raise RuntimeError("callback failure")
+
+    converter = _pdf_converter(boom)
+    result = converter.convert(normal_4pages_path, raises_on_error=False)
+    assert result.status == ConversionStatus.SUCCESS
+    assert len(result.document.pages) == 4
+
+
+def test_page_range_total_pages_reflects_requested_subset(normal_4pages_path):
+    """``total_pages`` and emitted page numbers follow the requested page_range,
+    not the physical page count."""
+    events = []
+    lock = threading.Lock()
+
+    def callback(event):
+        with lock:
+            events.append(event)
+
+    converter = _pdf_converter(callback)
+    result = converter.convert(
+        normal_4pages_path, raises_on_error=False, page_range=(2, 3)
+    )
+    assert result.status == ConversionStatus.SUCCESS
+
+    started = [e for e in events if isinstance(e, PageStartedProgress)]
+    completed = [e for e in events if isinstance(e, PageCompletedProgress)]
+    document = [e for e in events if isinstance(e, DocumentCompletedProgress)]
+
+    assert {e.page_no for e in started} == {2, 3}
+    assert {e.page_no for e in completed} == {2, 3}
+    assert all(e.total_pages == 2 for e in started + completed)
+    assert document[0].num_pages == 2


### PR DESCRIPTION
Closes #3493.

Adds an optional `progress_callback` to `DocumentConverter` that receives page-level conversion progress events, so callers can drive a progress bar or stream updates without polling.

This follows the design agreed with @ibrahimGoumrane in the issue:
- **Scope (v1):** page-level events only — `page_started`, `page_completed`, `document_completed`. Finer stages (OCR/model) can be a follow-up.
- **Event type:** Pydantic `BaseModel`, discriminated union, mirroring the style of `datamodel/service/callbacks.py` (names kept distinct to avoid confusing in-process events with the HTTP-webhook ones).
- **API:** constructor-level callback only, `DocumentConverter(progress_callback=...)`.
- **Thread safety:** documented (see below); no callback serialization.

## Usage

```python
from docling.document_converter import DocumentConverter
from docling.datamodel.progress import (
    PageStartedProgress, PageCompletedProgress, DocumentCompletedProgress,
)

def on_progress(event):
    if isinstance(event, PageCompletedProgress):
        print(f"page {event.page_no}/{event.total_pages} done (ok={event.success})")
    elif isinstance(event, DocumentCompletedProgress):
        print(f"document done: {event.num_pages} pages, {event.status}")

converter = DocumentConverter(progress_callback=on_progress)
converter.convert("document.pdf")
```

## Design notes

- The callback is **passed as a parameter** through `pipeline.execute(...)` → `_build_document(...)` rather than stored on the pipeline instance. Pipelines are cached and shared (`initialized_pipelines`) and re-entered concurrently when `doc_batch_concurrency > 1`, so storing the callback on the instance would be a data race. Passing it on the call stack keeps emission thread-safe with no shared mutable state.
- `document_completed` is emitted once per document in `BasePipeline.execute` inside the `finally` block, so a terminal event is delivered even when `raises_on_error=True` re-raises. This also gives non-paginated pipelines (`SimplePipeline`, `AsrPipeline`) a sensible single event.
- `page_started`/`page_completed` are emitted in `PaginatedPipeline` (Legacy, VLM) and the threaded `StandardPdfPipeline`. Pages started but never completed on a `document_timeout` receive a terminal failure event, so every `page_started` is balanced by a `page_completed`.
- Callback exceptions are logged and swallowed so a misbehaving callback can never break a conversion.

## Thread-safety / ordering

The callback must be **thread-safe**: the default PDF pipeline processes pages on a background producer thread, so the callback is invoked from more than one thread even for a single document. No per-page ordering between `page_started` and `page_completed` is guaranteed for the threaded pipeline; `document_completed` is always emitted last for a given document. This is documented on `ProgressCallback` and `DocumentConverter.__init__`.

## Tests

`tests/test_progress_callback.py` covers:
- paginated PDF — both `StandardPdfPipeline` (threaded) and `LegacyStandardPdfPipeline` (parametrized): one `page_started` + one `page_completed` per page, single final `document_completed`;
- non-paginated (Markdown / `SimplePipeline`): only `document_completed`, no page events;
- `page_range` subset: `total_pages` and page numbers follow the requested range;
- no-callback no-op;
- exception isolation on both the page-event (PDF) and document-event (Markdown) paths.

ruff check + format clean. No new mypy errors in the touched files.