### PR TITLE
fix: expose CLI entry points when installing docling meta-package

### DIFF
--- a/packages/docling/pyproject.toml
+++ b/packages/docling/pyproject.toml
@@ -60,6 +60,14 @@ repository = "https://github.com/docling-project/docling"
 issues = "https://github.com/docling-project/docling/issues"
 changelog = "https://github.com/docling-project/docling/blob/main/CHANGELOG.md"
 
+# Re-declared here (identical to docling-slim) so that `uv tool install docling`
+# links these entry points into ~/.local/bin. uv only exposes the named
+# package's own scripts, never a dependency's. The referenced modules are
+# provided at runtime by the docling-slim dependency.
+[project.scripts]
+docling = "docling.cli.main:app"
+docling-tools = "docling.cli.tools:app"
+
 [tool.uv.sources]
 # For local development: use workspace member
 docling-slim = { workspace = true }


### PR DESCRIPTION
Fixes #3446

## What

Re-declare the `docling` and `docling-tools` console scripts in the `docling` meta-package (`packages/docling/pyproject.toml`).

## Why

After moving the CLI (and its `[project.scripts]`) into `docling-slim`, `uv tool install docling` stopped linking the CLI into `~/.local/bin`.

`uv tool install <pkg>` only links the entry points declared by the **named package itself** — never those of its dependencies. Since the `docling` meta-package is a dependency-only wheel with no `[project.scripts]`, nothing was exposed (uv even warns *"No executables are provided by `docling`"*), so `docling` / `docling-tools` were missing after install.

## How

The scripts are re-declared in the meta-package, identical to `docling-slim`. Entry points are metadata-only and are **not** validated against the wheel's own modules at build time; at runtime the launchers `import docling.cli.*`, which is provided by the `docling-slim` dependency.

## Notes for reviewers

- Both wheels now declare the same script names. Installing both into one environment writes the identical launcher (last-wins, no conflict). The two blocks must be kept in sync if entry points change.
- Verified by building the meta-package wheel: its `entry_points.txt` now contains both `console_scripts`.

```
[console_scripts]
docling = docling.cli.main:app
docling-tools = docling.cli.tools:app
```