### PR TITLE
fix(markdown): preserve heading hierarchy

### DIFF
--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -12,10 +12,13 @@ import marko
 import marko.element
 import marko.inline
 from docling_core.types.doc import (
+    DocItem,
     DocItemLabel,
     DoclingDocument,
     DocumentOrigin,
     Formatting,
+    GroupItem,
+    GroupLabel,
     ListItem,
     NodeItem,
     TableCell,
@@ -144,6 +147,13 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         self.md_table_buffer: list[str] = []
         self._html_blocks: int = 0
 
+        # Initialize hierarchy tracking (similar to HTML backend)
+        self.max_levels = 10
+        self.level = 0
+        self.parents: dict[int, Optional[Union[DocItem, GroupItem]]] = {}
+        for i in range(self.max_levels):
+            self.parents[i] = None
+
         try:
             if isinstance(self.path_or_stream, BytesIO):
                 text_stream = self.path_or_stream.getvalue().decode("utf-8")
@@ -255,21 +265,55 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         formatting: Optional[Formatting] = None,
         hyperlink: Optional[Union[AnyUrl, Path]] = None,
     ):
+        """
+        Create a heading item with proper hierarchy tracking.
+        Similar to HTML backend's _handle_heading method.
+        """
+        # Level 1 headings become titles and reset hierarchy
         if level == 1:
+            for key in self.parents.keys():
+                self.parents[key] = None
+            self.level = 0
             item = doc.add_title(
                 text=text,
                 parent=parent_item,
                 formatting=formatting,
                 hyperlink=hyperlink,
             )
+            self.parents[self.level + 1] = item
         else:
+            # Adjust level for heading (level 2+ in markdown becomes level 1+ in docling)
+            adjusted_level = level - 1
+            
+            if adjusted_level > self.level:
+                # Add invisible section groups for skipped levels
+                for i in range(self.level, adjusted_level):
+                    _log.debug(f"Adding invisible section group to level {i}")
+                    self.parents[i + 1] = doc.add_group(
+                        name=f"section-{i + 1}",
+                        label=GroupLabel.SECTION,
+                        parent=self.parents[i],
+                    )
+                self.level = adjusted_level
+            elif adjusted_level < self.level:
+                # Remove tail - clear deeper levels when going back up
+                for key in self.parents.keys():
+                    if key > adjusted_level + 1:
+                        _log.debug(f"Clearing parent at level {key}")
+                        self.parents[key] = None
+                self.level = adjusted_level
+            
+            # Create heading with proper parent from hierarchy
             item = doc.add_heading(
                 text=text,
-                level=level - 1,
-                parent=parent_item,
+                level=self.level,
+                parent=self.parents[self.level],
                 formatting=formatting,
                 hyperlink=hyperlink,
             )
+            self.parents[self.level + 1] = item
+        
+        self.level += 1
         return item
 
     def _flush_creation_stack(
@@ -312,17 +356,17 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                     list_last_item_by_ref[parent_ref] = cast(ListItem, parent_item)
 
             elif isinstance(to_create, _HeadingCreationPayload):
-                # Not keeping as parent_item as logic for correctly tracking
-                # that not implemented yet (section components not captured
-                # as heading children in marko)
-                self._create_heading_item(
+                # Create heading with hierarchy tracking
+                heading_item = self._create_heading_item(
                     doc=doc,
-                    parent_item=parent_item,
+                    parent_item=None,  # Hierarchy is managed internally
                     text=snippet_text,
                     level=to_create.level,
                     formatting=formatting,
                     hyperlink=hyperlink,
                 )
+                # Update parent_item to be the current section for subsequent content
+                parent_item = self.parents.get(self.level, None)
 
         return parent_item
 
@@ -341,6 +385,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         parent_item: Optional[NodeItem] = None,
         formatting: Optional[Formatting] = None,
         hyperlink: Optional[Union[AnyUrl, Path]] = None,
+        use_hierarchy: bool = True,
     ):
         if element in visited:
             return
@@ -359,14 +404,19 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
             )
 
             if len(element.children) > 1:  # inline group will be created further down
-                parent_item = self._create_heading_item(
+                heading_item = self._create_heading_item(
                     doc=doc,
-                    parent_item=parent_item,
+                    parent_item=parent_item if not use_hierarchy else None,
                     text="",
                     level=element.level,
                     formatting=formatting,
                     hyperlink=hyperlink,
                 )
+                # When using hierarchy, content should be children of the heading's section
+                if use_hierarchy:
+                    parent_item = self.parents.get(self.level, None)
+                else:
+                    parent_item = heading_item
             else:
                 creation_stack.append(_HeadingCreationPayload(level=element.level))
 
@@ -601,6 +651,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                     parent_item=parent_item,
                     formatting=formatting,
                     hyperlink=hyperlink,
+                    use_hierarchy=True,
                 )
 
     def is_valid(self) -> bool:
@@ -644,6 +695,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                 creation_stack=[],
                 list_ordered_flag_by_ref={},
                 list_last_item_by_ref={},
+                use_hierarchy=True,
             )
             self._close_table(doc=doc)  # handle any last hanging table
 

--- a/tests/data/md/hierarchy_test.md
+++ b/tests/data/md/hierarchy_test.md
@@ -1,0 +1,23 @@
+# Main Title
+
+This is content under the main title.
+
+## Section 1
+
+Content under section 1.
+
+### Subsection 1.1
+
+Content under subsection 1.1.
+
+### Subsection 1.2
+
+Content under subsection 1.2.
+
+## Section 2
+
+Content under section 2.
+
+### Subsection 2.1
+
+Content under subsection 2.1.

--- a/tests/test_markdown_hierarchy.py
+++ b/tests/test_markdown_hierarchy.py
@@ -1,0 +1,212 @@
+"""Test that Markdown parser respects heading hierarchy."""
+
+from pathlib import Path
+
+import pytest
+
+from docling.backend.md_backend import MarkdownDocumentBackend
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.document import InputDocument
+from docling_core.types.doc import DocItemLabel, GroupLabel
+
+pytestmark = pytest.mark.cross_platform
+
+
+def test_markdown_heading_hierarchy():
+    """Test that Markdown parser creates proper hierarchical structure."""
+    markdown_content = """# Main Title
+
+This is content under the main title.
+
+## Section 1
+
+Content under section 1.
+
+### Subsection 1.1
+
+Content under subsection 1.1.
+
+### Subsection 1.2
+
+Content under subsection 1.2.
+
+## Section 2
+
+Content under section 2.
+
+### Subsection 2.1
+
+Content under subsection 2.1.
+"""
+    
+    from io import BytesIO
+    
+    stream = BytesIO(markdown_content.encode("utf-8"))
+    in_doc = InputDocument(
+        path_or_stream=stream,
+        format=InputFormat.MD,
+        backend=MarkdownDocumentBackend,
+        filename="test.md",
+    )
+    backend = MarkdownDocumentBackend(
+        in_doc=in_doc,
+        path_or_stream=stream,
+    )
+    
+    doc = backend.convert()
+    
+    # Verify document structure
+    # The document should have a hierarchical structure where:
+    # - Main Title is at the root
+    # - Section 1 and Section 2 are children of Main Title (via section groups)
+    # - Subsections are children of their respective sections
+    
+    # Get all items
+    items = list(doc.iterate_items())
+    
+    # Find the title
+    titles = [item for item, _ in items if item.label == DocItemLabel.TITLE]
+    assert len(titles) == 1, "Should have exactly one title"
+    title = titles[0]
+    assert "Main Title" in title.text
+    
+    # Find headings (section headers)
+    headings = [item for item, _ in items if item.label == DocItemLabel.SECTION_HEADER]
+    
+    # We should have 5 headings total (2 level-2 and 3 level-3)
+    assert len(headings) >= 5, f"Should have at least 5 headings, found {len(headings)}"
+    
+    # Verify that we can find all expected sections
+    section_1 = next((h for h in headings if "Section 1" in h.text), None)
+    section_2 = next((h for h in headings if "Section 2" in h.text), None)
+    
+    assert section_1 is not None, "Should find Section 1"
+    assert section_2 is not None, "Should find Section 2"
+    
+    # Find subsections
+    subsection_1_1 = next((h for h in headings if "Subsection 1.1" in h.text), None)
+    subsection_1_2 = next((h for h in headings if "Subsection 1.2" in h.text), None)
+    subsection_2_1 = next((h for h in headings if "Subsection 2.1" in h.text), None)
+    
+    assert subsection_1_1 is not None, "Should find Subsection 1.1"
+    assert subsection_1_2 is not None, "Should find Subsection 1.2"
+    assert subsection_2_1 is not None, "Should find Subsection 2.1"
+    
+    # Verify hierarchical structure exists through parent relationships or document structure
+    # The document should maintain the heading hierarchy even if not through explicit section groups
+    all_items_with_labels = [(item, level) for item, level in items if hasattr(item, 'label')]
+    
+    # Check that we have a proper hierarchy by verifying levels
+    heading_levels = {}
+    for item, level in items:
+        if item.label == DocItemLabel.SECTION_HEADER:
+            heading_levels[item.text] = level
+    
+    # Level 2 headings (##) should be at a deeper level than the title
+    # Level 3 headings (###) should be at a deeper level than level 2 headings
+    if "Section 1" in heading_levels and "Subsection 1.1" in heading_levels:
+        assert heading_levels["Subsection 1.1"] > heading_levels["Section 1"], \
+            "Subsection 1.1 should be at a deeper level than Section 1"
+    
+    print("\n=== Document Structure ===")
+    for item, level in items:
+        indent = "  " * level
+        parent_ref = item.parent if hasattr(item, 'parent') else None
+        print(f"{indent}{item.label}: {getattr(item, 'text', '')[:50]} (parent: {parent_ref})")
+
+
+def test_markdown_vs_html_hierarchy_consistency():
+    """Test that Markdown and HTML produce similar hierarchical structures."""
+    markdown_content = """# Article Title
+
+Introduction text.
+
+## Methods
+
+Methods description.
+
+### Data Collection
+
+Data collection details.
+
+## Results
+
+Results description.
+"""
+    
+    html_content = """<!DOCTYPE html>
+<html>
+<body>
+<h1>Article Title</h1>
+<p>Introduction text.</p>
+<h2>Methods</h2>
+<p>Methods description.</p>
+<h3>Data Collection</h3>
+<p>Data collection details.</p>
+<h2>Results</h2>
+<p>Results description.</p>
+</body>
+</html>
+"""
+    
+    from io import BytesIO
+    from docling.backend.html_backend import HTMLDocumentBackend
+    
+    # Convert Markdown
+    md_stream = BytesIO(markdown_content.encode("utf-8"))
+    md_in_doc = InputDocument(
+        path_or_stream=md_stream,
+        format=InputFormat.MD,
+        backend=MarkdownDocumentBackend,
+        filename="test.md",
+    )
+    md_backend = MarkdownDocumentBackend(
+        in_doc=md_in_doc,
+        path_or_stream=md_stream,
+    )
+    md_doc = md_backend.convert()
+    
+    # Convert HTML
+    html_stream = BytesIO(html_content.encode("utf-8"))
+    html_in_doc = InputDocument(
+        path_or_stream=html_stream,
+        format=InputFormat.HTML,
+        backend=HTMLDocumentBackend,
+        filename="test.html",
+    )
+    html_backend = HTMLDocumentBackend(
+        in_doc=html_in_doc,
+        path_or_stream=html_stream,
+    )
+    html_doc = html_backend.convert()
+    
+    # Get headings from both
+    md_items = list(md_doc.iterate_items())
+    html_items = list(html_doc.iterate_items())
+    
+    md_headings = [
+        item for item, _ in md_items
+        if item.label in (DocItemLabel.TITLE, DocItemLabel.SECTION_HEADER)
+    ]
+    html_headings = [
+        item for item, _ in html_items
+        if item.label in (DocItemLabel.TITLE, DocItemLabel.SECTION_HEADER)
+    ]
+    
+    # Should have same number of headings
+    assert len(md_headings) == len(html_headings), (
+        f"Markdown has {len(md_headings)} headings, HTML has {len(html_headings)}"
+    )
+    
+    # Both should have hierarchical structure (headings with parents)
+    md_with_parents = sum(1 for h in md_headings if h.parent is not None)
+    html_with_parents = sum(1 for h in html_headings if h.parent is not None)
+    
+    # At least some headings should have parents (not all flat)
+    assert md_with_parents > 0, "Markdown headings should have hierarchical parents"
+    assert html_with_parents > 0, "HTML headings should have hierarchical parents"
+    
+    print(f"\nMarkdown: {md_with_parents}/{len(md_headings)} headings have parents")
+    print(f"HTML: {html_with_parents}/{len(html_headings)} headings have parents")
+
+# Made with Bob


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #3568

This PR fixes Markdown heading hierarchy handling in [`MarkdownDocumentBackend._create_heading_item()`](docling/backend/md_backend.py:259).

Issue [`#3568`](README.md:2) reports that the Markdown backend flattens document structure instead of respecting heading levels, while the HTML backend preserves the expected hierarchy. This change updates the Markdown backend to behave more consistently with [`HTMLDocumentBackend`](docling/backend/html_backend.py:2126).

Specifically, the change:
- resets hierarchy for level-1 headings
- creates intermediate section groups when heading levels increase
- clears deeper hierarchy levels when heading levels decrease
- preserves parent-child relationships for nested Markdown headings

It also adds regression coverage in [`tests/test_markdown_hierarchy.py`](tests/test_markdown_hierarchy.py) and a fixture in [`tests/data/md/hierarchy_test.md`](tests/data/md/hierarchy_test.md).

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
