### PR TITLE
fix: Update _DocumentConversionInput to avoid construction with too large HTTP inputs

### DIFF
--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -49,7 +49,7 @@ from docling_core.types.legacy_doc.document import (
     CCSFileInfoObject as DsFileInfoObject,
     ExportedCCSDocument as DsDocument,
 )
-from docling_core.utils.file import resolve_source_to_stream
+from docling_core.utils.file import FileSizeLimitExceededError, resolve_source_to_stream
 from docling_core.utils.legacy import docling_document_to_legacy
 from pydantic import BaseModel, Field
 from typing_extensions import deprecated
@@ -205,6 +205,37 @@ class InputDocument(BaseModel):
                 exc_info=e,
             )
             # raise
+
+    @classmethod
+    def create_invalid(
+        cls,
+        *,
+        filename: str,
+        format: InputFormat,
+        filesize: int,
+        limits: Optional[DocumentLimits] = None,
+    ) -> "InputDocument":
+        """Build an InputDocument flagged invalid without opening a backend.
+
+        Used when the input is rejected before a stream is available, e.g. an
+        HTTP download aborted for exceeding ``limits.max_file_size``. The normal
+        constructor derives ``filesize`` from the actual path/stream, which is
+        unavailable in that case, so the fields are set explicitly here.
+
+        ``__init__`` is overridden to load from a path/stream and open a backend,
+        so the validated constructor cannot be used to set bare field values;
+        ``model_construct`` is the supported way to do that. Only fields that
+        differ from their declared defaults are passed; the rest (e.g.
+        ``backend_options``, ``page_count``) fall back to those defaults.
+        """
+        return cls.model_construct(
+            file=PurePath(filename),
+            document_hash="",
+            valid=False,
+            limits=limits or DocumentLimits(),
+            format=format,
+            filesize=filesize,
+        )
 
     def _init_doc(
         self,
@@ -449,11 +480,22 @@ class _DocumentConversionInput(BaseModel):
         format_options: Mapping[InputFormat, "BaseFormatOption"],
     ) -> Iterable[InputDocument]:
         for item in self.path_or_stream_iterator:
-            obj = (
-                resolve_source_to_stream(item, self.headers)
-                if isinstance(item, str)
-                else item
-            )
+            if isinstance(item, str):
+                try:
+                    obj = resolve_source_to_stream(
+                        item,
+                        self.headers,
+                        max_file_size=self.limits.max_file_size,
+                    )
+                except FileSizeLimitExceededError as exc:
+                    yield self._build_invalid_input_document(
+                        name=exc.filename,
+                        format_options=format_options,
+                        file_size=exc.size,
+                    )
+                    continue
+            else:
+                obj = item
             format = self._guess_format(obj)
             backend: Type[AbstractDocumentBackend]
             backend_options: Optional[BackendOptions] = None
@@ -484,6 +526,23 @@ class _DocumentConversionInput(BaseModel):
                 backend=backend,
                 backend_options=backend_options,
             )
+
+    def _build_invalid_input_document(
+        self,
+        name: str,
+        format_options: Mapping[InputFormat, "BaseFormatOption"],
+        file_size: int,
+    ) -> InputDocument:
+        guessed_format = self._guess_format(DocumentStream(name=name, stream=BytesIO()))
+        if guessed_format is None:
+            guessed_format = next(iter(format_options.keys()))
+
+        return InputDocument.create_invalid(
+            filename=name,
+            format=guessed_format,
+            filesize=file_size,
+            limits=self.limits,
+        )
 
     def _guess_format(self, obj: Union[Path, DocumentStream]) -> Optional[InputFormat]:
         content = b""  # empty binary blob

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,6 +326,8 @@ members = ["packages/docling"]
 
 [tool.uv.sources]
 docling = { workspace = true }
+docling-core = { git = "https://github.com/docling-project/docling-core/", rev = "cau/http-download-max-size-guard" }
+
 
 [tool.uv]
 package = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,7 +326,7 @@ members = ["packages/docling"]
 
 [tool.uv.sources]
 docling = { workspace = true }
-docling-core = { git = "https://github.com/docling-project/docling-core/", rev = "cau/http-download-max-size-guard" }
+docling-core = { git = "https://github.com/docling-project/docling-core/", rev = "main" }
 
 
 [tool.uv]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,7 +326,7 @@ members = ["packages/docling"]
 
 [tool.uv.sources]
 docling = { workspace = true }
-docling-core = { git = "https://github.com/docling-project/docling-core/", rev = "main" }
+# docling-core = { git = "https://github.com/docling-project/docling-core/", rev = "main" }
 
 
 [tool.uv]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -177,6 +177,12 @@ def test_cli_html_fetches_remote_images_with_separate_headers(tmp_path, monkeypa
         def iter_content(self, chunk_size: int):
             yield self.content
 
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc):
+            return False
+
     def fake_get(self, url: str, **kwargs):
         calls.append((url, kwargs))
         if url == source_url:

--- a/tests/test_invalid_input.py
+++ b/tests/test_invalid_input.py
@@ -54,6 +54,9 @@ def test_convert_remote_too_large_filesize_limit_wout_exception(
         r = Response()
         r.status_code = 200
         r.headers["Content-Length"] = "10"
+        # A real streamed response always has a closeable ``raw``; provide one so
+        # resolve_source_to_stream can close the response on the size-limit abort.
+        r.raw = BytesIO(b"")
         return r
 
     monkeypatch.setattr(Session, "get", mock_get)
@@ -76,6 +79,9 @@ def test_convert_remote_too_large_filesize_limit_with_exception(
         r = Response()
         r.status_code = 200
         r.headers["Content-Length"] = "10"
+        # A real streamed response always has a closeable ``raw``; provide one so
+        # resolve_source_to_stream can close the response on the size-limit abort.
+        r.raw = BytesIO(b"")
         return r
 
     monkeypatch.setattr(Session, "get", mock_get)

--- a/tests/test_invalid_input.py
+++ b/tests/test_invalid_input.py
@@ -2,6 +2,7 @@ from io import BytesIO
 from pathlib import Path
 
 import pytest
+from requests import Response, Session
 
 from docling.datamodel.base_models import ConversionStatus, DocumentStream, InputFormat
 from docling.document_converter import ConversionError, DocumentConverter
@@ -44,6 +45,47 @@ def test_convert_too_small_filesize_limit_wout_exception(converter: DocumentConv
 def test_convert_too_small_filesize_limit_with_exception(converter: DocumentConverter):
     with pytest.raises(ConversionError):
         converter.convert(get_pdf_path(), max_file_size=1, raises_on_error=True)
+
+
+def test_convert_remote_too_large_filesize_limit_wout_exception(
+    converter: DocumentConverter, monkeypatch
+):
+    def mock_get(self, *args, **kwargs):
+        r = Response()
+        r.status_code = 200
+        r.headers["Content-Length"] = "10"
+        return r
+
+    monkeypatch.setattr(Session, "get", mock_get)
+
+    result = converter.convert(
+        "https://example.com/input.pdf",
+        max_file_size=5,
+        raises_on_error=False,
+    )
+    assert result.status == ConversionStatus.FAILURE
+    assert result.input.file.name == "input.pdf"
+    assert result.input.filesize == 10
+    assert result.input.valid is False
+
+
+def test_convert_remote_too_large_filesize_limit_with_exception(
+    converter: DocumentConverter, monkeypatch
+):
+    def mock_get(self, *args, **kwargs):
+        r = Response()
+        r.status_code = 200
+        r.headers["Content-Length"] = "10"
+        return r
+
+    monkeypatch.setattr(Session, "get", mock_get)
+
+    with pytest.raises(ConversionError):
+        converter.convert(
+            "https://example.com/input.pdf",
+            max_file_size=5,
+            raises_on_error=True,
+        )
 
 
 def test_convert_no_pipeline_wout_exception():

--- a/uv.lock
+++ b/uv.lock
@@ -1348,7 +1348,7 @@ provides-extras = ["easyocr", "tesserocr", "ocrmac", "vlm", "rapidocr", "asr", "
 [[package]]
 name = "docling-core"
 version = "2.80.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/docling-project/docling-core/?rev=cau%2Fhttp-download-max-size-guard#40f899e6df5d63d40a72c1e3484269263b2e6ae4" }
 dependencies = [
     { name = "defusedxml" },
     { name = "jsonref" },
@@ -1363,10 +1363,6 @@ dependencies = [
     { name = "tabulate" },
     { name = "typer" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/38/d2/1b0460ee245029604f1541b954c125207eb82d23f67d04a606d79f9adf5c/docling_core-2.80.0.tar.gz", hash = "sha256:7a89dda4a2cd406d7e0c85b8b14867d4fb2c6f261f39ca94f678e191b634a3ed", size = 349214, upload-time = "2026-06-09T13:38:56.16Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/c7/0610c9c764d31bd3fab4f976afd1a00bb1b614339a8504868d6605546c4b/docling_core-2.80.0-py3-none-any.whl", hash = "sha256:a8dcb87a445df08ac7608a0907d847a88aa7418c9da46608cb00fb9af06e279c", size = 296069, upload-time = "2026-06-09T13:38:54.361Z" },
 ]
 
 [package.optional-dependencies]
@@ -1749,8 +1745,8 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'format-html'", specifier = ">=4.12.3,<5.0.0" },
     { name = "certifi", specifier = ">=2024.7.4" },
     { name = "defusedxml", marker = "extra == 'models-local'", specifier = ">=0.7.1,<0.8.0" },
-    { name = "docling-core", specifier = ">=2.80.0,<3.0.0" },
-    { name = "docling-core", extras = ["chunking"], marker = "extra == 'feat-chunking'", specifier = ">=2.73.0,<3.0.0" },
+    { name = "docling-core", git = "https://github.com/docling-project/docling-core/?rev=cau%2Fhttp-download-max-size-guard" },
+    { name = "docling-core", extras = ["chunking"], marker = "extra == 'feat-chunking'", git = "https://github.com/docling-project/docling-core/?rev=cau%2Fhttp-download-max-size-guard" },
     { name = "docling-ibm-models", marker = "extra == 'models-local'", specifier = ">=3.13.0,<4" },
     { name = "docling-parse", marker = "extra == 'format-pdf-docling'", specifier = ">=6.2.0,<7.0.0" },
     { name = "docling-slim", extras = ["convert-core"], marker = "extra == 'extract-core'" },
@@ -1862,7 +1858,7 @@ examples = [
 ]
 pr-fast-checks = [
     { name = "boto3-stubs", specifier = "~=1.37" },
-    { name = "docling-core", extras = ["chunking"], specifier = ">=2.73.0,<3.0.0" },
+    { name = "docling-core", extras = ["chunking"], git = "https://github.com/docling-project/docling-core/?rev=cau%2Fhttp-download-max-size-guard" },
     { name = "pandas-stubs", specifier = "~=2.1" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.3.0,<3.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1348,7 +1348,7 @@ provides-extras = ["easyocr", "tesserocr", "ocrmac", "vlm", "rapidocr", "asr", "
 [[package]]
 name = "docling-core"
 version = "2.80.0"
-source = { git = "https://github.com/docling-project/docling-core/?rev=cau%2Fhttp-download-max-size-guard#40f899e6df5d63d40a72c1e3484269263b2e6ae4" }
+source = { git = "https://github.com/docling-project/docling-core/?rev=main#d585a1377528105b28a0072a587accc27406195f" }
 dependencies = [
     { name = "defusedxml" },
     { name = "jsonref" },
@@ -1745,8 +1745,8 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'format-html'", specifier = ">=4.12.3,<5.0.0" },
     { name = "certifi", specifier = ">=2024.7.4" },
     { name = "defusedxml", marker = "extra == 'models-local'", specifier = ">=0.7.1,<0.8.0" },
-    { name = "docling-core", git = "https://github.com/docling-project/docling-core/?rev=cau%2Fhttp-download-max-size-guard" },
-    { name = "docling-core", extras = ["chunking"], marker = "extra == 'feat-chunking'", git = "https://github.com/docling-project/docling-core/?rev=cau%2Fhttp-download-max-size-guard" },
+    { name = "docling-core", git = "https://github.com/docling-project/docling-core/?rev=main" },
+    { name = "docling-core", extras = ["chunking"], marker = "extra == 'feat-chunking'", git = "https://github.com/docling-project/docling-core/?rev=main" },
     { name = "docling-ibm-models", marker = "extra == 'models-local'", specifier = ">=3.13.0,<4" },
     { name = "docling-parse", marker = "extra == 'format-pdf-docling'", specifier = ">=6.2.0,<7.0.0" },
     { name = "docling-slim", extras = ["convert-core"], marker = "extra == 'extract-core'" },
@@ -1858,7 +1858,7 @@ examples = [
 ]
 pr-fast-checks = [
     { name = "boto3-stubs", specifier = "~=1.37" },
-    { name = "docling-core", extras = ["chunking"], git = "https://github.com/docling-project/docling-core/?rev=cau%2Fhttp-download-max-size-guard" },
+    { name = "docling-core", extras = ["chunking"], git = "https://github.com/docling-project/docling-core/?rev=main" },
     { name = "pandas-stubs", specifier = "~=2.1" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.3.0,<3.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1347,8 +1347,8 @@ provides-extras = ["easyocr", "tesserocr", "ocrmac", "vlm", "rapidocr", "asr", "
 
 [[package]]
 name = "docling-core"
-version = "2.80.0"
-source = { git = "https://github.com/docling-project/docling-core/?rev=main#d585a1377528105b28a0072a587accc27406195f" }
+version = "2.81.0"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "defusedxml" },
     { name = "jsonref" },
@@ -1363,6 +1363,9 @@ dependencies = [
     { name = "tabulate" },
     { name = "typer" },
     { name = "typing-extensions" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b5/c2/6f102e0b6b7c6705807acbb0173d18179496406b754068e71a7da458f54a/docling_core-2.81.0-py3-none-any.whl", hash = "sha256:5ab2628fd389e9beeeebafceff9177457ba9d816b9533e3c1faa530b75c9c5ac", size = 297048, upload-time = "2026-06-10T14:26:06.342Z" },
 ]
 
 [package.optional-dependencies]
@@ -1745,8 +1748,8 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'format-html'", specifier = ">=4.12.3,<5.0.0" },
     { name = "certifi", specifier = ">=2024.7.4" },
     { name = "defusedxml", marker = "extra == 'models-local'", specifier = ">=0.7.1,<0.8.0" },
-    { name = "docling-core", git = "https://github.com/docling-project/docling-core/?rev=main" },
-    { name = "docling-core", extras = ["chunking"], marker = "extra == 'feat-chunking'", git = "https://github.com/docling-project/docling-core/?rev=main" },
+    { name = "docling-core", specifier = ">=2.80.0,<3.0.0" },
+    { name = "docling-core", extras = ["chunking"], marker = "extra == 'feat-chunking'", specifier = ">=2.73.0,<3.0.0" },
     { name = "docling-ibm-models", marker = "extra == 'models-local'", specifier = ">=3.13.0,<4" },
     { name = "docling-parse", marker = "extra == 'format-pdf-docling'", specifier = ">=6.2.0,<7.0.0" },
     { name = "docling-slim", extras = ["convert-core"], marker = "extra == 'extract-core'" },
@@ -1858,7 +1861,7 @@ examples = [
 ]
 pr-fast-checks = [
     { name = "boto3-stubs", specifier = "~=1.37" },
-    { name = "docling-core", extras = ["chunking"], git = "https://github.com/docling-project/docling-core/?rev=main" },
+    { name = "docling-core", extras = ["chunking"], specifier = ">=2.73.0,<3.0.0" },
     { name = "pandas-stubs", specifier = "~=2.1" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.3.0,<3.0.0" },


### PR DESCRIPTION
### Summary

Propagate remote download size limits into document source resolution while preserving the existing invalid-input behavior for oversized documents.

### Problem

`docling` already enforces `max_file_size` for local files and in-memory streams by producing an `InputDocument` with `valid=False`. After adding bounded remote downloads in `docling-core`, oversized URL inputs must keep the same converter semantics instead of failing before `InputDocument` creation.

### Changes

- Pass `_DocumentConversionInput.limits.max_file_size` into `resolve_source_to_stream()`.
- Catch `FileSizeLimitExceededError` during source resolution for URL inputs.
- Convert oversized remote sources into `InputDocument(valid=False)` rather than propagating the low-level exception directly.
- Keep the existing conversion flow unchanged for invalid inputs.

### Resulting behavior

- Local oversized files continue to produce `InputDocument(valid=False)`.
- Remote oversized URLs now also produce `InputDocument(valid=False)`.
- `raises_on_error=False` continues to return a failed `ConversionResult`.
- `raises_on_error=True` continues to raise `ConversionError`.
- `max_file_size` handling remains consistent across local and remote sources.

see https://github.com/docling-project/docling-core/pull/635