### PR TITLE
fix(jats): preserve structured abstract sections

### DIFF
--- a/docling/backend/xml/jats_backend.py
+++ b/docling/backend/xml/jats_backend.py
@@ -223,6 +223,36 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
         return JatsDocumentBackend._normalize_whitespace(" ".join(node.itertext()))
 
     @staticmethod
+    def _parse_abstract_section(section_node: etree._Element) -> str:
+        section_texts: list[str] = []
+
+        for child_node in section_node:
+            if child_node.tag == "p":
+                paragraph_text = JatsDocumentBackend._normalize_whitespace(
+                    JatsDocumentBackend._get_text(child_node)
+                )
+                if paragraph_text:
+                    section_texts.append(paragraph_text)
+            elif child_node.tag == "sec":
+                section_text = JatsDocumentBackend._parse_abstract_section(child_node)
+                if section_text:
+                    section_texts.append(section_text)
+
+        section_content = JatsDocumentBackend._normalize_whitespace(
+            " ".join(section_texts)
+        )
+        if not section_content:
+            return ""
+
+        label_node = section_node.xpath("title|label")
+        if len(label_node) > 0:
+            label = JatsDocumentBackend._get_node_text(label_node[0])
+            if label:
+                return f"{label}: {section_content}"
+
+        return section_content
+
+    @staticmethod
     def _parse_structured_name(name_node: etree._Element) -> str:
         name_parts: list[str] = []
         for tag_name in ["prefix", "given-names", "surname", "suffix"]:
@@ -295,19 +325,33 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
         return meta
 
     def _parse_abstract(self) -> list[Abstract]:
-        # TODO: address cases with multiple sections
         abs_list: list[Abstract] = []
 
         for abs_node in self.tree.xpath(".//abstract"):
             abstract: Abstract = dict(label="", content="")
-            texts = []
-            for abs_par in abs_node.xpath("p"):
-                texts.append(JatsDocumentBackend._get_text(abs_par).strip())
-            abstract["content"] = " ".join(texts)
+            texts: list[str] = []
+
+            for child_node in abs_node:
+                if child_node.tag == "p":
+                    paragraph_text = JatsDocumentBackend._normalize_whitespace(
+                        JatsDocumentBackend._get_text(child_node)
+                    )
+                    if paragraph_text:
+                        texts.append(paragraph_text)
+                elif child_node.tag == "sec":
+                    section_text = JatsDocumentBackend._parse_abstract_section(
+                        child_node
+                    )
+                    if section_text:
+                        texts.append(section_text)
+
+            abstract["content"] = JatsDocumentBackend._normalize_whitespace(
+                " ".join(texts)
+            )
 
             label_node = abs_node.xpath("title|label")
             if len(label_node) > 0:
-                abstract["label"] = label_node[0].text.strip()
+                abstract["label"] = JatsDocumentBackend._get_node_text(label_node[0])
 
             abs_list.append(abstract)
 

--- a/tests/test_backend_jats.py
+++ b/tests/test_backend_jats.py
@@ -26,24 +26,53 @@ def get_converter():
     return converter
 
 
-def convert_jats_contribs(contribs: str, affiliations: str = "") -> DoclingDocument:
+def convert_jats_article_meta(article_meta: str) -> DoclingDocument:
     xml = f"""<!DOCTYPE article
 PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN" "JATS-archivearticle1.dtd">
 <article article-type="research-article">
   <front>
     <article-meta>
-      <title-group><article-title>Author Variant Test</article-title></title-group>
-      <contrib-group>{contribs}</contrib-group>
-      {affiliations}
+      {article_meta}
     </article-meta>
   </front>
 </article>
 """
-    stream = DocumentStream(
-        name="author-variant-test.nxml", stream=BytesIO(xml.encode())
-    )
+    stream = DocumentStream(name="article-meta-test.nxml", stream=BytesIO(xml.encode()))
     conv_result: ConversionResult = get_converter().convert(stream)
     return conv_result.document
+
+
+def convert_jats_contribs(contribs: str, affiliations: str = "") -> DoclingDocument:
+    return convert_jats_article_meta(
+        f"""
+      <title-group><article-title>Author Variant Test</article-title></title-group>
+      <contrib-group>{contribs}</contrib-group>
+      {affiliations}
+"""
+    )
+
+
+def test_jats_structured_abstract_sections_are_preserved():
+    doc = convert_jats_article_meta(
+        """
+      <title-group><article-title>Structured Abstract Test</article-title></title-group>
+      <abstract>
+        <sec>
+          <title>Background</title>
+          <p>Background text.</p>
+        </sec>
+        <sec>
+          <title>Methods</title>
+          <p>Methods text.</p>
+        </sec>
+      </abstract>
+"""
+    )
+
+    md = doc.export_to_markdown()
+    assert "## Abstract" in md
+    assert "Background: Background text." in md
+    assert "Methods: Methods text." in md
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Refs #3583

## Summary
- preserve `<abstract><sec>` content when converting JATS metadata
- include section titles inline with their paragraph text in the abstract output
- add focused regression coverage for structured abstracts

## Validation
- `uv run pytest tests/test_backend_jats.py -k structured_abstract -q`
- `uv run pytest tests/test_backend_jats.py -q`
- `make validate`
- `make check` (fails on existing `docling/pipeline/standard_pdf_pipeline.py` max-lines limit; Ruff, ty, Tach passed before that failure)