### PR TITLE
fix(ocr): honor requested languages in RapidOCR model selection

### DIFF
--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -73,6 +73,26 @@ _RAPIDOCR_ENGLISH_MODEL_PATHS: dict[_ModelPathEngines, dict[_ModelPathTypes, str
 }
 
 
+_RAPIDOCR_LATIN_MODEL_PATHS: dict[_ModelPathEngines, dict[_ModelPathTypes, str]] = {
+    # Latin-script European languages (German, French, Spanish, ...): the
+    # latin rec model + dict; detector/classifier mirror the english set.
+    "onnxruntime": {
+        "det_model_path": "onnx/PP-OCRv4/det/en_PP-OCRv3_det_mobile.onnx",
+        "cls_model_path": "onnx/PP-OCRv4/cls/ch_ppocr_mobile_v2.0_cls_mobile.onnx",
+        "rec_model_path": "onnx/PP-OCRv4/rec/latin_PP-OCRv3_rec_mobile.onnx",
+        "rec_keys_path": "paddle/PP-OCRv4/rec/latin_PP-OCRv3_rec_mobile/latin_dict.txt",
+        "font_path": "resources/fonts/FZYTK.TTF",
+    },
+    "torch": {
+        "det_model_path": "torch/PP-OCRv4/det/en_PP-OCRv3_det_mobile.pth",
+        "cls_model_path": "torch/PP-OCRv4/cls/ch_ptocr_mobile_v2.0_cls_mobile.pth",
+        "rec_model_path": "torch/PP-OCRv4/rec/latin_PP-OCRv3_rec_mobile.pth",
+        "rec_keys_path": "paddle/PP-OCRv4/rec/latin_PP-OCRv3_rec_mobile/latin_dict.txt",
+        "font_path": "resources/fonts/FZYTK.TTF",
+    },
+}
+
+
 def _build_model_detail(path: str) -> _ModelPathDetail:
     return {
         "url": f"{_RAPIDOCR_MODELSCOPE_BASE_URL}/{_RAPIDOCR_MODELSCOPE_RELEASE}/{path}",
@@ -80,15 +100,159 @@ def _build_model_detail(path: str) -> _ModelPathDetail:
     }
 
 
+# Maps user-facing language names (ISO 639-1/639-2 codes and English names,
+# tesseract-style values included) onto the bundled RapidOCR model sets.
+_RAPIDOCR_LANGUAGE_GROUPS: dict[str, str] = {
+    # english model set
+    "en": "english",
+    "eng": "english",
+    "english": "english",
+    # chinese model set
+    "ch": "chinese",
+    "chi": "chinese",
+    "zh": "chinese",
+    "zho": "chinese",
+    "chinese": "chinese",
+    # latin model set (latin_dict covers most Latin-script European languages)
+    "latin": "latin",
+    "de": "latin",
+    "deu": "latin",
+    "ger": "latin",
+    "german": "latin",
+    "fr": "latin",
+    "fra": "latin",
+    "fre": "latin",
+    "french": "latin",
+    "es": "latin",
+    "spa": "latin",
+    "spanish": "latin",
+    "it": "latin",
+    "ita": "latin",
+    "italian": "latin",
+    "pt": "latin",
+    "por": "latin",
+    "portuguese": "latin",
+    "nl": "latin",
+    "nld": "latin",
+    "dut": "latin",
+    "dutch": "latin",
+    "fi": "latin",
+    "fin": "latin",
+    "finnish": "latin",
+    "sv": "latin",
+    "swe": "latin",
+    "swedish": "latin",
+    "da": "latin",
+    "dan": "latin",
+    "danish": "latin",
+    "no": "latin",
+    "nor": "latin",
+    "norwegian": "latin",
+    "pl": "latin",
+    "pol": "latin",
+    "polish": "latin",
+    "cs": "latin",
+    "ces": "latin",
+    "cze": "latin",
+    "czech": "latin",
+    "ro": "latin",
+    "ron": "latin",
+    "rum": "latin",
+    "romanian": "latin",
+    "hu": "latin",
+    "hun": "latin",
+    "hungarian": "latin",
+    "tr": "latin",
+    "tur": "latin",
+    "turkish": "latin",
+    "hr": "latin",
+    "hrv": "latin",
+    "croatian": "latin",
+    "sk": "latin",
+    "slk": "latin",
+    "slovak": "latin",
+    "sl": "latin",
+    "slv": "latin",
+    "slovenian": "latin",
+    "ca": "latin",
+    "cat": "latin",
+    "catalan": "latin",
+    "id": "latin",
+    "ind": "latin",
+    "indonesian": "latin",
+}
+
+
 def _resolve_rapidocr_language(languages: list[str] | None) -> str:
+    """Map requested languages onto a bundled RapidOCR model set.
+
+    Falls back to the default set *loudly*: silently running the Chinese
+    recognition model on Latin-script documents drops inter-word spaces
+    (see docling issues #2887, #1635, #2927).
+    """
     if not languages:
         return _RAPIDOCR_DEFAULT_LANGUAGE
 
-    normalized_languages = {language.strip().lower() for language in languages}
-    if {"en", "english"} & normalized_languages:
-        return "english"
+    groups: list[str] = []
+    unknown: list[str] = []
+    for language in languages:
+        # "en-US" / "en_US" -> "en"
+        normalized = language.strip().lower().replace("_", "-").split("-")[0]
+        group = _RAPIDOCR_LANGUAGE_GROUPS.get(normalized)
+        if group is None:
+            unknown.append(language)
+        else:
+            groups.append(group)
 
-    return _RAPIDOCR_DEFAULT_LANGUAGE
+    if unknown:
+        _log.warning(
+            "RapidOCR has no bundled model set for language(s) %s; known values "
+            "map onto the 'english', 'latin' or 'chinese' model sets.",
+            unknown,
+        )
+    if not groups:
+        _log.warning(
+            "Falling back to the '%s' RapidOCR model set; note the Chinese "
+            "recognition model drops inter-word spaces in Latin-script text.",
+            _RAPIDOCR_DEFAULT_LANGUAGE,
+        )
+        return _RAPIDOCR_DEFAULT_LANGUAGE
+
+    distinct = set(groups)
+    if distinct == {"english"}:
+        return "english"
+    if distinct <= {"english", "latin"}:
+        # the latin set covers English plus other Latin-script languages
+        return "latin"
+    if len(distinct) == 1:
+        return groups[0]
+    _log.warning(
+        "Requested languages %s span multiple RapidOCR model sets %s; using "
+        "'%s' (first requested). Run separate conversions for the others.",
+        languages,
+        sorted(distinct),
+        groups[0],
+    )
+    return groups[0]
+
+
+def _rapidocr_lang_type_params(ocr_lang: str) -> dict[str, object]:
+    """Language params for the no-pinned-paths flow (no artifacts_path).
+
+    Without explicit model paths RapidOCR resolves models itself — and its
+    defaults are the Chinese set regardless of what was requested here, so the
+    resolved language must be passed through. Older rapidocr versions without
+    the typings module keep their defaults.
+    """
+    try:
+        from rapidocr.utils.typings import LangDet, LangRec  # type: ignore
+    except ImportError:
+        return {}
+    mapping: dict[str, dict[str, object]] = {
+        "english": {"Det.lang_type": LangDet.EN, "Rec.lang_type": LangRec.EN},
+        "latin": {"Det.lang_type": LangDet.EN, "Rec.lang_type": LangRec.LATIN},
+    }
+    return mapping.get(ocr_lang, {})
 
 
 class RapidOcrModel(BaseOcrModel):
@@ -110,6 +274,13 @@ class RapidOcrModel(BaseOcrModel):
             backend: {
                 key: _build_model_detail(path)
                 for key, path in _RAPIDOCR_ENGLISH_MODEL_PATHS[backend].items()
+            }
+            for backend in _RAPIDOCR_BACKENDS
+        },
+        "latin": {
+            backend: {
+                key: _build_model_detail(path)
+                for key, path in _RAPIDOCR_LATIN_MODEL_PATHS[backend].items()
             }
             for backend in _RAPIDOCR_BACKENDS
         },
@@ -250,6 +421,9 @@ class RapidOcrModel(BaseOcrModel):
                 _log.warning(
                     "The 'rec_font_path' option for RapidOCR is deprecated. Please use 'font_path' instead."
                 )
+            if det_model_path is None and rec_model_path is None:
+                params.update(_rapidocr_lang_type_params(ocr_lang))
+
             user_params = self.options.rapidocr_params
             if user_params:
                 _log.debug("Overwriting RapidOCR params with user-provided values.")

--- a/tests/test_rapid_ocr_lang.py
+++ b/tests/test_rapid_ocr_lang.py
@@ -194,7 +194,9 @@ def test_resolve_language_warns_on_silent_fallback(caplog) -> None:
     with caplog.at_level(logging.WARNING):
         resolved = _resolve_rapidocr_language(["klingon"])
     assert resolved == "chinese"
-    assert any("no bundled model set" in record.getMessage() for record in caplog.records)
+    assert any(
+        "no bundled model set" in record.getMessage() for record in caplog.records
+    )
     assert any(
         "drops inter-word spaces" in record.getMessage() for record in caplog.records
     )

--- a/tests/test_rapid_ocr_lang.py
+++ b/tests/test_rapid_ocr_lang.py
@@ -148,3 +148,80 @@ def test_model_downloader_fetches_both_rapidocr_language_sets(
         ("onnxruntime", "chinese"),
         ("onnxruntime", "english"),
     }
+
+
+def test_rapidocr_uses_latin_mobile_assets(monkeypatch, tmp_path: Path) -> None:
+    captured_params: list[dict[str, object]] = []
+    _install_fake_rapidocr(monkeypatch, captured_params)
+
+    RapidOcrModel(
+        enabled=True,
+        artifacts_path=tmp_path,
+        options=RapidOcrOptions(lang=["de", "fr"], backend="onnxruntime"),
+        accelerator_options=AcceleratorOptions(),
+    )
+
+    assert len(captured_params) == 1
+    params = captured_params[0]
+    assert params["Rec.model_path"] == (
+        tmp_path / "RapidOcr" / "onnx/PP-OCRv4/rec/latin_PP-OCRv3_rec_mobile.onnx"
+    )
+    assert params["Rec.rec_keys_path"] == (
+        tmp_path
+        / "RapidOcr"
+        / "paddle/PP-OCRv4/rec/latin_PP-OCRv3_rec_mobile/latin_dict.txt"
+    )
+
+
+def test_resolve_language_aliases_and_groups(caplog) -> None:
+    from docling.models.stages.ocr.rapid_ocr_model import _resolve_rapidocr_language
+
+    assert _resolve_rapidocr_language(["eng"]) == "english"
+    assert _resolve_rapidocr_language(["en-US"]) == "english"
+    assert _resolve_rapidocr_language(["deu"]) == "latin"
+    assert _resolve_rapidocr_language(["latin"]) == "latin"
+    # english + another Latin-script language -> latin covers both
+    assert _resolve_rapidocr_language(["en", "de"]) == "latin"
+    assert _resolve_rapidocr_language(["zh"]) == "chinese"
+    assert _resolve_rapidocr_language(None) == "chinese"
+
+
+def test_resolve_language_warns_on_silent_fallback(caplog) -> None:
+    import logging
+
+    from docling.models.stages.ocr.rapid_ocr_model import _resolve_rapidocr_language
+
+    with caplog.at_level(logging.WARNING):
+        resolved = _resolve_rapidocr_language(["klingon"])
+    assert resolved == "chinese"
+    assert any("no bundled model set" in record.getMessage() for record in caplog.records)
+    assert any(
+        "drops inter-word spaces" in record.getMessage() for record in caplog.records
+    )
+
+
+def test_rapidocr_passes_lang_type_without_artifacts(monkeypatch) -> None:
+    captured_params: list[dict[str, object]] = []
+    _install_fake_rapidocr(monkeypatch, captured_params)
+
+    fake_typings = ModuleType("rapidocr.utils.typings")
+    fake_typings.LangDet = SimpleNamespace(EN="en", CH="ch", MULTI="multi")
+    fake_typings.LangRec = SimpleNamespace(EN="en", LATIN="latin", CH="ch")
+    fake_utils = ModuleType("rapidocr.utils")
+    fake_utils.typings = fake_typings
+    monkeypatch.setitem(sys.modules, "rapidocr.utils", fake_utils)
+    monkeypatch.setitem(sys.modules, "rapidocr.utils.typings", fake_typings)
+
+    RapidOcrModel(
+        enabled=True,
+        artifacts_path=None,
+        options=RapidOcrOptions(lang=["en"], backend="onnxruntime"),
+        accelerator_options=AcceleratorOptions(),
+    )
+
+    assert len(captured_params) == 1
+    params = captured_params[0]
+    assert params["Rec.lang_type"] == "en"
+    assert params["Det.lang_type"] == "en"
+    # No pinned paths: rapidocr resolves the models itself.
+    assert params["Rec.model_path"] is None


### PR DESCRIPTION
**Issues resolved by this Pull Request:**
Resolves #2927

Also addresses the root cause behind #2887 and #1635 (analysis with measurements in [this comment](https://github.com/docling-project/docling/issues/2887#issuecomment-4682809758)).

## Problem

RapidOCR language handling silently degraded Latin-script OCR in two ways:

1. `_resolve_rapidocr_language` only recognized `en`/`english`; every other value (`eng`, `en-US`, `deu`, `latin`, …) silently fell back to the **Chinese** model set, whose recognition model drops inter-word spaces in Latin text (`Thisis thefirstparagraph of the sampledocument`). Measured on a 5-page degraded-scan set with exact ground truth: **CER 0.136 (ch models) vs 0.050 (en rec model)** — ~3× degradation on English documents.
2. Without `artifacts_path`, model paths stay `None` and RapidOCR resolves models itself — defaulting to the Chinese set regardless of the requested language, so even `lang=["english"]` had no effect in the default (non-offline) flow.

## Changes

- **Alias resolution**: `_resolve_rapidocr_language` now maps ISO 639-1/639-2 codes and English names onto the `english`/`chinese`/`latin` model sets; `en-US`-style region subtags normalize; mixed Latin-script requests (e.g. `["en", "de"]`) resolve to the `latin` set covering both; **unknown languages WARN instead of degrading silently**.
- **Latin model set**: `latin_PP-OCRv3_rec_mobile` + `latin_dict` from the same ModelScope release already used for ch/en (detector/classifier mirror the english set) — German/French/Spanish/etc. documents get a charset that fits.
- **No-artifacts flow**: `Det.lang_type`/`Rec.lang_type` are passed through to RapidOCR when no model paths are pinned, so the requested language is honored there too. Older `rapidocr` versions without the typings module keep current behavior.
- The `chinese` *default* is deliberately left unchanged (that's a more opinionated decision for maintainers); with the warning in place the degradation is at least no longer silent.

## Verification

- All 4 existing tests in `tests/test_rapid_ocr_lang.py` still pass; 4 new tests cover latin asset selection, alias resolution, the loud fallback, and the `lang_type` passthrough.
- Live end-to-end on a degraded English scan, default flow (no `artifacts_path`), `RapidOcrOptions(lang=["english"])`: output went from `'Thisis thefirstparagraph…'` to correctly spaced text.

**Checklist:**

- [x] Documentation has been updated, if necessary. *(behavior documented in docstrings + warnings; happy to add user-docs wording if maintainers point me at the right page)*
- [ ] Examples have been added, if necessary. *(n/a)*
- [x] Tests have been added, if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)