### PR TITLE
feat(layout): recover text mislabeled as PICTURE without OCR/VLM

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1326,6 +1326,25 @@ class VlmPipelineOptions(PaginatedPipelineOptions):
     ] = _default_vlm_convert_options
 
 
+class TextInPictureHandling(str, Enum):
+    """How to handle extractable text inside a region labeled as PICTURE.
+
+    The layout model predicts region labels from the rendered page image alone,
+    so it can label a block of genuinely extractable text as a ``PICTURE``. By
+    default such text is absorbed into the picture and dropped from the document
+    body. These modes control that behavior for the false-picture case (a
+    text-covered region with no embedded bitmap underneath).
+    """
+
+    ABSORB = (
+        "absorb"  # current behavior: text is absorbed into the picture and not emitted
+    )
+    DEMOTE = (
+        "demote"  # drop the false picture, keeping its text as normal text elements
+    )
+    KEEP_TEXT = "keep_text"  # keep the picture element but also retain its text
+
+
 class BaseLayoutOptions(BaseOptions):
     """Base options for document layout analysis models.
 
@@ -1358,6 +1377,17 @@ class BaseLayoutOptions(BaseOptions):
             )
         ),
     ] = False
+    text_in_picture_handling: Annotated[
+        TextInPictureHandling,
+        Field(
+            description=(
+                "How to handle extractable text the layout model placed inside a PICTURE region. "
+                "'absorb' (default) keeps current behavior (text is swallowed by the picture and not emitted); "
+                "'demote' drops a false picture (text-covered region with no embedded bitmap) so its text flows "
+                "normally; 'keep_text' keeps the picture but also retains the text. No OCR/VLM involved."
+            )
+        ),
+    ] = TextInPictureHandling.ABSORB
 
 
 class LayoutOptions(BaseLayoutOptions):

--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -11,6 +11,7 @@ from docling.datamodel.base_models import BoundingBox, Cluster, Page
 from docling.datamodel.pipeline_options import (
     LayoutObjectDetectionOptions,
     LayoutOptions,
+    TextInPictureHandling,
 )
 
 _log = logging.getLogger(__name__)
@@ -171,6 +172,29 @@ class LayoutPostprocessor:
         DocItemLabel.DOCUMENT_INDEX,
     }
     SPECIAL_TYPES = WRAPPER_TYPES.union({DocItemLabel.PICTURE})
+
+    # Text-bearing labels used to detect a region the layout model called a
+    # PICTURE but which actually holds extractable text (mirrors
+    # LayoutModel.TEXT_ELEM_LABELS).
+    TEXT_LABELS = {
+        DocItemLabel.TEXT,
+        DocItemLabel.FOOTNOTE,
+        DocItemLabel.CAPTION,
+        DocItemLabel.CHECKBOX_UNSELECTED,
+        DocItemLabel.CHECKBOX_SELECTED,
+        DocItemLabel.SECTION_HEADER,
+        DocItemLabel.PAGE_HEADER,
+        DocItemLabel.PAGE_FOOTER,
+        DocItemLabel.CODE,
+        DocItemLabel.LIST_ITEM,
+        DocItemLabel.FORMULA,
+    }
+    # A PICTURE is treated as a false picture (mislabeled text) only if its
+    # contained text covers at least this fraction of the picture area ...
+    FALSE_PICTURE_TEXT_COVERAGE = 0.6
+    # ... and embedded bitmaps cover at most this fraction of it (a real raster
+    # image or, conservatively, a vector chart with a bitmap is left untouched).
+    FALSE_PICTURE_BITMAP_COVERAGE = 0.05
 
     CONFIDENCE_THRESHOLDS = {
         DocItemLabel.CAPTION: 0.5,
@@ -339,6 +363,7 @@ class LayoutPostprocessor:
                 )
             ]
 
+        demoted_picture_ids: set[int] = set()
         for special in special_clusters:
             contained = []
             for cluster in self.regular_clusters:
@@ -346,32 +371,54 @@ class LayoutPostprocessor:
                 if containment > 0.8:
                     contained.append(cluster)
 
-            if contained:
-                # Sort contained clusters by minimum cell ID:
-                contained = self._sort_clusters(contained, mode="id")
-                special.children = contained
+            if not contained:
+                continue
 
-                # Adjust bbox only for Form and Key-Value-Region, not Table or Picture
-                if special.label in [DocItemLabel.FORM, DocItemLabel.KEY_VALUE_REGION]:
-                    special.bbox = BoundingBox(
-                        l=min(c.bbox.l for c in contained),
-                        t=min(c.bbox.t for c in contained),
-                        r=max(c.bbox.r for c in contained),
-                        b=max(c.bbox.b for c in contained),
-                    )
+            # Sort contained clusters by minimum cell ID:
+            contained = self._sort_clusters(contained, mode="id")
 
-                # Conditionally collect cells from children
-                if not self.options.skip_cell_assignment:
-                    all_cells = []
-                    for child in contained:
-                        all_cells.extend(child.cells)
-                    special.cells = self._deduplicate_cells(all_cells)
-                    special.cells = self._sort_cells(special.cells)
-                else:
-                    special.cells = []
+            # A PICTURE covering extractable text with no bitmap underneath is a
+            # mislabel. Depending on configuration, recover that text instead of
+            # absorbing (and thereby dropping) it. In both non-absorb modes the
+            # contained text clusters are left as regular clusters so they survive
+            # into the document body; DEMOTE additionally drops the picture.
+            handling = self.options.text_in_picture_handling
+            if (
+                special.label == DocItemLabel.PICTURE
+                and handling != TextInPictureHandling.ABSORB
+                and self._is_false_picture(special, contained)
+            ):
+                special.children = []
+                special.cells = []
+                if handling == TextInPictureHandling.DEMOTE:
+                    demoted_picture_ids.add(special.id)
+                continue
+
+            special.children = contained
+
+            # Adjust bbox only for Form and Key-Value-Region, not Table or Picture
+            if special.label in [DocItemLabel.FORM, DocItemLabel.KEY_VALUE_REGION]:
+                special.bbox = BoundingBox(
+                    l=min(c.bbox.l for c in contained),
+                    t=min(c.bbox.t for c in contained),
+                    r=max(c.bbox.r for c in contained),
+                    b=max(c.bbox.b for c in contained),
+                )
+
+            # Conditionally collect cells from children
+            if not self.options.skip_cell_assignment:
+                all_cells = []
+                for child in contained:
+                    all_cells.extend(child.cells)
+                special.cells = self._deduplicate_cells(all_cells)
+                special.cells = self._sort_cells(special.cells)
+            else:
+                special.cells = []
 
         picture_clusters = [
-            c for c in special_clusters if c.label == DocItemLabel.PICTURE
+            c
+            for c in special_clusters
+            if c.label == DocItemLabel.PICTURE and c.id not in demoted_picture_ids
         ]
         picture_clusters = self._remove_overlapping_clusters(
             picture_clusters, "picture"
@@ -385,6 +432,60 @@ class LayoutPostprocessor:
         )
 
         return picture_clusters + wrapper_clusters
+
+    def _is_false_picture(self, picture: Cluster, contained: list[Cluster]) -> bool:
+        """Decide whether a PICTURE cluster is actually mislabeled text.
+
+        True only when the contained text clusters carry programmatic (non-OCR)
+        cells, cover most of the picture, and no embedded bitmap underlies the
+        region. This protects genuine figures (including vector charts whose
+        sparse labels cover little area, and any region backed by a real raster).
+        """
+        if self.options.skip_cell_assignment:
+            # Without cell assignment we have no text evidence to act on.
+            return False
+
+        text_children = [c for c in contained if c.label in self.TEXT_LABELS]
+        if not text_children:
+            return False
+
+        has_programmatic_text = any(
+            any(not cell.from_ocr for cell in c.cells) for c in text_children
+        )
+        if not has_programmatic_text:
+            return False
+
+        picture_area = picture.bbox.area()
+        if picture_area <= 0:
+            return False
+
+        text_area = sum(c.bbox.area() for c in text_children)
+        if text_area / picture_area < self.FALSE_PICTURE_TEXT_COVERAGE:
+            return False
+
+        return self._bitmap_coverage(picture.bbox) <= self.FALSE_PICTURE_BITMAP_COVERAGE
+
+    def _bitmap_coverage(self, bbox: BoundingBox) -> float:
+        """Fraction of ``bbox`` covered by embedded bitmap resources of the page."""
+        parsed_page = self.page.parsed_page
+        if (
+            parsed_page is None
+            or not parsed_page.bitmap_resources
+            or self.page_size is None
+        ):
+            return 0.0
+
+        bbox_area = bbox.area()
+        if bbox_area <= 0:
+            return 0.0
+
+        coverage = 0.0
+        for resource in parsed_page.bitmap_resources:
+            bitmap_bbox = resource.rect.to_bounding_box().to_top_left_origin(
+                self.page_size.height
+            )
+            coverage += bbox.intersection_over_self(bitmap_bbox)
+        return coverage
 
     def _handle_cross_type_overlaps(self, special_clusters) -> list[Cluster]:
         """Handle overlaps between regular and wrapper clusters before child assignment.

--- a/tests/test_text_in_picture_handling.py
+++ b/tests/test_text_in_picture_handling.py
@@ -1,0 +1,140 @@
+"""Tests for recovering extractable text the layout model mislabeled as a PICTURE.
+
+These exercise ``LayoutPostprocessor`` end-to-end (real cell assignment, special
+cluster handling and the false-picture discriminator), since the bug they guard
+against is the silent dropping of programmatic text swallowed by a picture.
+"""
+
+from docling_core.types.doc import BoundingBox, CoordOrigin, DocItemLabel, Size
+from docling_core.types.doc.page import (
+    BitmapResource,
+    BoundingRectangle,
+    PdfPageBoundaryType,
+    PdfPageGeometry,
+    SegmentedPdfPage,
+    TextCell,
+)
+
+from docling.datamodel.base_models import Cluster, Page
+from docling.datamodel.pipeline_options import LayoutOptions, TextInPictureHandling
+
+PAGE_SIZE = 100.0
+
+
+def _rect(left: float, top: float, right: float, bottom: float) -> BoundingRectangle:
+    return BoundingRectangle.from_bounding_box(
+        BoundingBox(l=left, t=top, r=right, b=bottom, coord_origin=CoordOrigin.TOPLEFT)
+    )
+
+
+def _cell(index: int, box: tuple[float, float, float, float]) -> TextCell:
+    return TextCell(
+        index=index,
+        rect=_rect(*box),
+        text=f"text-{index}",
+        orig=f"text-{index}",
+        from_ocr=False,
+    )
+
+
+def _cluster(
+    cid: int, label: DocItemLabel, box: tuple[float, float, float, float]
+) -> Cluster:
+    return Cluster(
+        id=cid,
+        label=label,
+        bbox=BoundingBox(
+            l=box[0], t=box[1], r=box[2], b=box[3], coord_origin=CoordOrigin.TOPLEFT
+        ),
+        confidence=0.9,
+        cells=[],
+    )
+
+
+def _page(*, bitmaps: list[BitmapResource] | None = None) -> Page:
+    full = BoundingBox(
+        l=0, t=0, r=PAGE_SIZE, b=PAGE_SIZE, coord_origin=CoordOrigin.TOPLEFT
+    )
+    geometry = PdfPageGeometry(
+        angle=0.0,
+        rect=_rect(0, 0, PAGE_SIZE, PAGE_SIZE),
+        boundary_type=PdfPageBoundaryType.CROP_BOX,
+        art_bbox=full,
+        bleed_bbox=full,
+        crop_bbox=full,
+        media_bbox=full,
+        trim_bbox=full,
+    )
+    parsed = SegmentedPdfPage(
+        dimension=geometry,
+        char_cells=[],
+        word_cells=[],
+        textline_cells=[_cell(0, (10, 10, 90, 90))],
+        bitmap_resources=bitmaps or [],
+    )
+    page = Page(page_no=0)
+    page.size = Size(width=PAGE_SIZE, height=PAGE_SIZE)
+    page.parsed_page = parsed
+    return page
+
+
+def _clusters() -> list[Cluster]:
+    # A PICTURE box that fully encloses a TEXT box covering most of its area.
+    return [
+        _cluster(1, DocItemLabel.PICTURE, (8, 8, 92, 92)),
+        _cluster(2, DocItemLabel.TEXT, (10, 10, 90, 90)),
+    ]
+
+
+def _run(page: Page, handling: TextInPictureHandling) -> list[Cluster]:
+    from docling.utils.layout_postprocessor import LayoutPostprocessor
+
+    options = LayoutOptions(text_in_picture_handling=handling)
+    clusters, _ = LayoutPostprocessor(page, _clusters(), options).postprocess()
+    return clusters
+
+
+def test_absorb_keeps_default_drop_behavior() -> None:
+    clusters = _run(_page(), TextInPictureHandling.ABSORB)
+
+    pictures = [c for c in clusters if c.label == DocItemLabel.PICTURE]
+    texts = [c for c in clusters if c.label == DocItemLabel.TEXT]
+
+    assert len(pictures) == 1
+    # Text is swallowed by the picture (current behavior) — no standalone text.
+    assert texts == []
+    assert pictures[0].cells, "absorbed text cells should live on the picture"
+
+
+def test_demote_recovers_text_and_drops_false_picture() -> None:
+    clusters = _run(_page(), TextInPictureHandling.DEMOTE)
+
+    pictures = [c for c in clusters if c.label == DocItemLabel.PICTURE]
+    texts = [c for c in clusters if c.label == DocItemLabel.TEXT]
+
+    assert pictures == []
+    assert len(texts) == 1
+    assert any(not cell.from_ocr for cell in texts[0].cells)
+
+
+def test_keep_text_retains_both_picture_and_text() -> None:
+    clusters = _run(_page(), TextInPictureHandling.KEEP_TEXT)
+
+    pictures = [c for c in clusters if c.label == DocItemLabel.PICTURE]
+    texts = [c for c in clusters if c.label == DocItemLabel.TEXT]
+
+    assert len(pictures) == 1
+    assert len(texts) == 1
+
+
+def test_real_bitmap_region_is_left_untouched() -> None:
+    # An embedded bitmap underlies the picture: it is a genuine image, so even
+    # in DEMOTE mode the text stays absorbed and the picture is preserved.
+    bitmap = BitmapResource(rect=_rect(8, 8, 92, 92))
+    clusters = _run(_page(bitmaps=[bitmap]), TextInPictureHandling.DEMOTE)
+
+    pictures = [c for c in clusters if c.label == DocItemLabel.PICTURE]
+    texts = [c for c in clusters if c.label == DocItemLabel.TEXT]
+
+    assert len(pictures) == 1
+    assert texts == []


### PR DESCRIPTION
The layout model predicts region labels from the rendered page image alone, so it can label a block of extractable programmatic text as a PICTURE. The postprocessor then absorbs that text into the picture and the assembler emits the figure with no text, silently dropping content that was perfectly extractable from the PDF text layer.

Add a configurable `text_in_picture_handling` option on layout options:
- absorb (default): unchanged current behavior
- demote: drop a false picture so its text flows as normal text
- keep_text: keep the picture but retain its text

A false picture is detected only when contained text carries programmatic (non-OCR) cells covering most of the region and no embedded bitmap underlies it, so genuine figures and vector charts are untouched.

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
