### PR TITLE
docs: add API server usage pages

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,7 @@ Docling simplifies document processing, parsing diverse formats — including ad
 * 👓 Support of several Visual Language Models ([GraniteDocling](https://huggingface.co/ibm-granite/granite-docling-258M))
 * 🎙️ Audio support with Automatic Speech Recognition (ASR) models
 * 🔌 Connect to any agent using the [MCP server](https://docling-project.github.io/docling/usage/mcp/)
+* 🌐 Run Docling as a service with the [API server](https://docling-project.github.io/docling/usage/api_server/) (docling-serve)
 * 💻 Simple and convenient CLI
 
 ### What's new

--- a/docs/usage/api_server/deployment.md
+++ b/docs/usage/api_server/deployment.md
@@ -138,4 +138,4 @@ These live in the docling-serve repo (run-time manifests aren't vendored here):
 - [Model-cache PVC/Job](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/models.md) (pre-baking weights)
 - KFP / Ray engines, OpenTelemetry, CUDA image-tagging policy → [serve repo](https://github.com/docling-project/docling-serve/tree/v1.21.0/docs)
 
-Prefer not to run any of this yourself? See the [fully managed](managed.md) option.
+Prefer not to run any of this yourself? See the [managed service](managed.md).

--- a/docs/usage/api_server/deployment.md
+++ b/docs/usage/api_server/deployment.md
@@ -6,17 +6,62 @@
 
 Get docling-serve running on one machine fast. For cluster/production hardening, follow the links to the [docling-serve repo](https://github.com/docling-project/docling-serve/tree/v1.21.0/docs).
 
-The four ways people describe "launching" docling-serve are really **two independent choices**:
+Two independent choices shape how you run it:
 
-- **How you start the process:** the `docling-serve` command, or **Docker Compose**.
-- **Which async engine runs the jobs** (`DOCLING_SERVE_ENG_KIND`): the in-process **Local** engine (default), or the Redis-backed **RQ** engine.
+- **How you start the process** — the `docling-serve` command, or **Docker Compose**.
+- **Which [compute engine](#compute-engines) runs the jobs** (`DOCLING_SERVE_ENG_KIND`) — the in-process **Local** engine (default), or the Redis-backed **RQ** engine.
 
 | | Local engine (default) | RQ engine (Redis + workers) |
 |---|---|---|
-| **`docling-serve` command** | Quickstart / dev — below | Distributed — below |
-| **Docker Compose** | Containerized single node (+GPU) — below | → [serve repo](https://github.com/docling-project/docling-serve/tree/v1.21.0/docs/deploy-examples) |
+| **`docling-serve` command** | Quickstart / dev | Distributed |
+| **Docker Compose** | Containerized single node (+GPU) | → [serve repo](https://github.com/docling-project/docling-serve/tree/v1.21.0/docs/deploy-examples) |
 
-## Simple command (Local engine — the default quickstart)
+## Configuration
+
+docling-serve is configured by **CLI flags or environment variables**. Precedence is **environment variable > config file > defaults**.
+
+!!! warning "Subprocess gotcha"
+    When uvicorn runs with `--reload` or `--workers > 1` it spawns subprocesses, and CLI flags (e.g. `--enable-ui`, `--artifacts-path`) are ignored. Use the `DOCLING_SERVE_*` environment variables in those deployments.
+
+### Most common settings
+
+| Setting (env var) | What it does | Default |
+|---|---|---|
+| `UVICORN_HOST` / `UVICORN_PORT` | bind address / port | `0.0.0.0` / `5001` |
+| `UVICORN_WORKERS` | uvicorn worker processes | `1` |
+| `DOCLING_SERVE_API_KEY` | require an `X-Api-Key` header | unset |
+| `DOCLING_SERVE_ENABLE_UI` | serve the Gradio demo UI at `/ui` | `false` |
+| `DOCLING_SERVE_ARTIFACTS_PATH` | local path to pre-downloaded models | unset (auto-download) |
+| `DOCLING_SERVE_MAX_NUM_PAGES` / `DOCLING_SERVE_MAX_FILE_SIZE` | per-request limits | unset |
+| `DOCLING_SERVE_ENG_KIND` | async engine: `local` or `rq` (also `kfp`/`ray` — see serve repo) | `local` |
+
+See the full reference in the source repo: [`configuration.md`](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/configuration.md) and [`.env.example`](https://github.com/docling-project/docling-serve/blob/v1.21.0/.env.example).
+
+### Docling settings (env vars)
+
+These tune Docling itself and are read by the server too:
+
+| Env var | What it does | Default |
+|---|---|---|
+| `DOCLING_DEVICE` | inference device: `cpu` / `cuda` / `mps` | auto |
+| `DOCLING_NUM_THREADS` | CPU threads | runtime default |
+| `DOCLING_PERF_PAGE_BATCH_SIZE` | pages per batch | runtime default |
+| `DOCLING_PERF_ELEMENTS_BATCH_SIZE` | elements per batch | runtime default |
+| `DOCLING_DEBUG_PROFILE_PIPELINE_TIMINGS` | log per-stage timings | `false` |
+
+For how to *choose* device/perf values see [GPU support](../gpu.md). For offline / air-gapped model setup see the [FAQ](../../faq/index.md) and [Advanced options](../advanced_options.md); set `DOCLING_SERVE_ARTIFACTS_PATH` to a pre-populated model directory.
+
+## Compute engines
+
+docling-serve runs each conversion as an asynchronous job dispatched to a **compute engine**, chosen with `DOCLING_SERVE_ENG_KIND`:
+
+- **Local** (`local`, the default) — jobs run in an in-process thread pool inside the server. No external services; everything stays on one host. Tunable with `DOCLING_SERVE_ENG_LOC_NUM_WORKERS` (default `2`) and `DOCLING_SERVE_ENG_LOC_SHARE_MODELS` (default `false`). Best for a single machine.
+- **RQ** (`rq`) — jobs are queued in **Redis** and executed by separate `docling-serve rq-worker` processes, so the API tier and the conversion workers scale independently. Best for horizontal scaling and higher throughput.
+- **KFP / Ray** — Kubeflow Pipelines and Ray engines for cluster orchestration; see the [serve repo](https://github.com/docling-project/docling-serve/tree/v1.21.0/docs).
+
+## Running it
+
+### Simple command (Local engine — the default quickstart)
 
 ```sh
 pip install "docling-serve[ui]"
@@ -24,12 +69,7 @@ docling-serve run --enable-ui      # production-style: reload off, binds 0.0.0.0
 # docling-serve dev                # dev: auto-reload, binds 127.0.0.1, UI on (localhost only)
 ```
 
-API at `http://localhost:5001`, interactive docs at `/docs`, demo UI at `/ui`.
-
-!!! note
-    The demo UI (`--enable-ui` / `DOCLING_SERVE_ENABLE_UI`) is a Gradio app; files it produces are cleared from its cache after ~10 hours. It is a demonstrator, not durable storage.
-
-Smoke test:
+API at `http://localhost:5001`, interactive docs at `/docs`, demo UI at `/ui`. Smoke test:
 
 ```sh
 curl -X POST "http://localhost:5001/v1/convert/source/async" \
@@ -37,34 +77,10 @@ curl -X POST "http://localhost:5001/v1/convert/source/async" \
   -d '{"http_sources": [{"url": "https://arxiv.org/pdf/2501.17887"}]}'
 ```
 
-!!! warning
-    When uvicorn runs with `--reload` or `--workers > 1` it spawns subprocesses, and CLI flags (e.g. `--enable-ui`, `--artifacts-path`) are ignored. Use the `DOCLING_SERVE_*` environment variables in those deployments.
+!!! note
+    The demo UI (`--enable-ui` / `DOCLING_SERVE_ENABLE_UI`) is a Gradio app; files it produces are cleared from its cache after ~10 hours. It is a demonstrator, not durable storage.
 
-The **Local engine** runs jobs in a small in-process thread pool — no Redis, no extra processes; bounded by the one host. Two knobs: `DOCLING_SERVE_ENG_LOC_NUM_WORKERS` (default `2`) and `DOCLING_SERVE_ENG_LOC_SHARE_MODELS` (default `false`). To scale past one process, use the RQ engine below.
-
-## RQ engine (distributed: Redis + separate workers)
-
-The API enqueues jobs to Redis; conversion runs in separate `docling-serve rq-worker` processes, so API and compute scale independently.
-
-```sh
-# 1) Redis
-docker run -p 6379:6379 redis:7-alpine
-
-# 2) API server (enqueues jobs)
-DOCLING_SERVE_ENG_KIND=rq \
-DOCLING_SERVE_ENG_RQ_REDIS_URL=redis://localhost:6379/0 \
-docling-serve run
-
-# 3) one or more workers (do the conversion)
-DOCLING_SERVE_ENG_KIND=rq \
-DOCLING_SERVE_ENG_RQ_REDIS_URL=redis://localhost:6379/0 \
-docling-serve rq-worker
-```
-
-!!! warning
-    The API alone *accepts* jobs but nothing runs them without at least one `rq-worker`. `DOCLING_SERVE_ENG_RQ_REDIS_URL` is required (no default) and must be identical across every API and worker process.
-
-## Docker Compose (Local engine, including local GPU)
+### Docker Compose (incl. local GPU)
 
 Same server, containerized. The shipped compose examples are all-in-one containers that don't set `ENG_KIND`, so they run the default Local engine.
 
@@ -89,6 +105,28 @@ Compose manifests: [`compose-nvidia.yaml`](https://github.com/docling-project/do
 !!! note
     The compose files pin older image tags (`-cu126:main`, `-rocm72:main`) than the README image table; treat the [README image table](https://github.com/docling-project/docling-serve/blob/v1.21.0/README.md) as the source of truth and adjust the `image:` line if needed. There is no shipped single-CPU compose file — use the `podman` one-liner for pure CPU.
 
+### RQ engine (distributed: Redis + separate workers)
+
+The API enqueues jobs to Redis; conversion runs in separate `docling-serve rq-worker` processes.
+
+```sh
+# 1) Redis
+docker run -p 6379:6379 redis:7-alpine
+
+# 2) API server (enqueues jobs)
+DOCLING_SERVE_ENG_KIND=rq \
+DOCLING_SERVE_ENG_RQ_REDIS_URL=redis://localhost:6379/0 \
+docling-serve run
+
+# 3) one or more workers (do the conversion)
+DOCLING_SERVE_ENG_KIND=rq \
+DOCLING_SERVE_ENG_RQ_REDIS_URL=redis://localhost:6379/0 \
+docling-serve rq-worker
+```
+
+!!! warning
+    The API alone *accepts* jobs but nothing runs them without at least one `rq-worker`. `DOCLING_SERVE_ENG_RQ_REDIS_URL` is required (no default) and must be identical across every API and worker process.
+
 ## Cluster, production & advanced variants
 
 These live in the docling-serve repo (run-time manifests aren't vendored here):
@@ -100,10 +138,4 @@ These live in the docling-serve repo (run-time manifests aren't vendored here):
 - [Model-cache PVC/Job](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/models.md) (pre-baking weights)
 - KFP / Ray engines, OpenTelemetry, CUDA image-tagging policy → [serve repo](https://github.com/docling-project/docling-serve/tree/v1.21.0/docs)
 
-## Fully-managed option
-
-!!! info "Don't want to operate it yourself?"
-
-    All of the launch modes above run **docling-serve** yourself. If you would rather not run, scale, or maintain the infrastructure, a **fully managed, hosted version** of the same service is available as **Docling for IBM watsonx**.
-
-    It exposes the same REST API described in these pages, so client code is portable — typically you only swap the base URL and supply a service-issued API key. Hosted-only concerns (account/key provisioning, quotas, SLA, and data handling) are documented separately and are out of scope for these self-hosting pages.
+Prefer not to run any of this yourself? See the [fully managed](managed.md) option.

--- a/docs/usage/api_server/deployment.md
+++ b/docs/usage/api_server/deployment.md
@@ -37,6 +37,9 @@ curl -X POST "http://localhost:5001/v1/convert/source/async" \
   -d '{"http_sources": [{"url": "https://arxiv.org/pdf/2501.17887"}]}'
 ```
 
+!!! warning
+    When uvicorn runs with `--reload` or `--workers > 1` it spawns subprocesses, and CLI flags (e.g. `--enable-ui`, `--artifacts-path`) are ignored. Use the `DOCLING_SERVE_*` environment variables in those deployments.
+
 The **Local engine** runs jobs in a small in-process thread pool — no Redis, no extra processes; bounded by the one host. Two knobs: `DOCLING_SERVE_ENG_LOC_NUM_WORKERS` (default `2`) and `DOCLING_SERVE_ENG_LOC_SHARE_MODELS` (default `false`). To scale past one process, use the RQ engine below.
 
 ## RQ engine (distributed: Redis + separate workers)

--- a/docs/usage/api_server/deployment.md
+++ b/docs/usage/api_server/deployment.md
@@ -1,0 +1,106 @@
+<!-- Source: docling-serve@v1.21.0 — keep in sync on serve releases that touch config/deployment/usage. -->
+!!! info "Synced from docling-serve v1.21.0"
+    This page summarizes the [docling-serve](https://github.com/docling-project/docling-serve) documentation at **v1.21.0**. For the exhaustive reference, follow the links to the source repository.
+
+# Deployment
+
+Get docling-serve running on one machine fast. For cluster/production hardening, follow the links to the [docling-serve repo](https://github.com/docling-project/docling-serve/tree/v1.21.0/docs).
+
+The four ways people describe "launching" docling-serve are really **two independent choices**:
+
+- **How you start the process:** the `docling-serve` command, or **Docker Compose**.
+- **Which async engine runs the jobs** (`DOCLING_SERVE_ENG_KIND`): the in-process **Local** engine (default), or the Redis-backed **RQ** engine.
+
+| | Local engine (default) | RQ engine (Redis + workers) |
+|---|---|---|
+| **`docling-serve` command** | Quickstart / dev — below | Distributed — below |
+| **Docker Compose** | Containerized single node (+GPU) — below | → [serve repo](https://github.com/docling-project/docling-serve/tree/v1.21.0/docs/deploy-examples) |
+
+## Simple command (Local engine — the default quickstart)
+
+```sh
+pip install "docling-serve[ui]"
+docling-serve run --enable-ui      # production-style: reload off, binds 0.0.0.0, UI off by default
+# docling-serve dev                # dev: auto-reload, binds 127.0.0.1, UI on (localhost only)
+```
+
+API at `http://localhost:5001`, interactive docs at `/docs`, demo UI at `/ui`.
+
+!!! note
+    The demo UI (`--enable-ui` / `DOCLING_SERVE_ENABLE_UI`) is a Gradio app; files it produces are cleared from its cache after ~10 hours. It is a demonstrator, not durable storage.
+
+Smoke test:
+
+```sh
+curl -X POST "http://localhost:5001/v1/convert/source/async" \
+  -H "Content-Type: application/json" \
+  -d '{"http_sources": [{"url": "https://arxiv.org/pdf/2501.17887"}]}'
+```
+
+The **Local engine** runs jobs in a small in-process thread pool — no Redis, no extra processes; bounded by the one host. Two knobs: `DOCLING_SERVE_ENG_LOC_NUM_WORKERS` (default `2`) and `DOCLING_SERVE_ENG_LOC_SHARE_MODELS` (default `false`). To scale past one process, use the RQ engine below.
+
+## RQ engine (distributed: Redis + separate workers)
+
+The API enqueues jobs to Redis; conversion runs in separate `docling-serve rq-worker` processes, so API and compute scale independently.
+
+```sh
+# 1) Redis
+docker run -p 6379:6379 redis:7-alpine
+
+# 2) API server (enqueues jobs)
+DOCLING_SERVE_ENG_KIND=rq \
+DOCLING_SERVE_ENG_RQ_REDIS_URL=redis://localhost:6379/0 \
+docling-serve run
+
+# 3) one or more workers (do the conversion)
+DOCLING_SERVE_ENG_KIND=rq \
+DOCLING_SERVE_ENG_RQ_REDIS_URL=redis://localhost:6379/0 \
+docling-serve rq-worker
+```
+
+!!! warning
+    The API alone *accepts* jobs but nothing runs them without at least one `rq-worker`. `DOCLING_SERVE_ENG_RQ_REDIS_URL` is required (no default) and must be identical across every API and worker process.
+
+## Docker Compose (Local engine, including local GPU)
+
+Same server, containerized. The shipped compose examples are all-in-one containers that don't set `ENG_KIND`, so they run the default Local engine.
+
+```sh
+# Pure CPU (no compose)
+podman run -p 5001:5001 -e DOCLING_SERVE_ENABLE_UI=1 quay.io/docling-project/docling-serve
+
+# NVIDIA GPU
+docker compose -f compose-nvidia.yaml up -d
+
+# AMD GPU
+docker compose -f compose-amd.yaml up -d
+```
+
+Compose manifests: [`compose-nvidia.yaml`](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/deploy-examples/compose-nvidia.yaml), [`compose-amd.yaml`](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/deploy-examples/compose-amd.yaml).
+
+**GPU prerequisites** (host side; for the Python `AcceleratorOptions` view see [GPU support](../gpu.md) and [RTX GPU](../../getting_started/rtx.md)):
+
+- NVIDIA — driver ≥ 550.54.14 + `nvidia-container-toolkit` + the nvidia container runtime.
+- AMD — AMDGPU/ROCm ≥ 6.3; the ROCm image is **not published**, build it with `make docling-serve-rocm-image`. Detailed GID wiring: [serve repo](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/deployment.md).
+
+!!! note
+    The compose files pin older image tags (`-cu126:main`, `-rocm72:main`) than the README image table; treat the [README image table](https://github.com/docling-project/docling-serve/blob/v1.21.0/README.md) as the source of truth and adjust the `image:` line if needed. There is no shipped single-CPU compose file — use the `podman` one-liner for pure CPU.
+
+## Cluster, production & advanced variants
+
+These live in the docling-serve repo (run-time manifests aren't vendored here):
+
+- [OpenShift — simple deployment](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/deploy-examples/docling-serve-simple.yaml)
+- [Multi-worker RQ on Kubernetes](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/deploy-examples/docling-serve-rq-workers.yaml) (Redis + worker pods + secret)
+- [Secure deployment with oauth-proxy / TLS / Route](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/deploy-examples/docling-serve-oauth.yaml)
+- [ReplicaSets with sticky sessions](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/deploy-examples/docling-serve-replicas-w-sticky-sessions.yaml) (task state is node-local)
+- [Model-cache PVC/Job](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/models.md) (pre-baking weights)
+- KFP / Ray engines, OpenTelemetry, CUDA image-tagging policy → [serve repo](https://github.com/docling-project/docling-serve/tree/v1.21.0/docs)
+
+## Fully-managed option
+
+!!! info "Don't want to operate it yourself?"
+
+    All of the launch modes above run **docling-serve** yourself. If you would rather not run, scale, or maintain the infrastructure, a **fully managed, hosted version** of the same service is available as **Docling for IBM watsonx**.
+
+    It exposes the same REST API described in these pages, so client code is portable — typically you only swap the base URL and supply a service-issued API key. Hosted-only concerns (account/key provisioning, quotas, SLA, and data handling) are documented separately and are out of scope for these self-hosting pages.

--- a/docs/usage/api_server/index.md
+++ b/docs/usage/api_server/index.md
@@ -13,7 +13,8 @@ Run Docling as an HTTP service with [docling-serve](https://github.com/docling-p
 - **[Jobkit](../jobkit.md)** — large-scale / distributed batch pipelines.
 - **[MCP server](../mcp.md)** — expose Docling as tools to AI agents.
 
-> On "fully managed": a hosted version of this same service is available as **Docling for IBM watsonx** — see the [managed option](deployment.md#fully-managed-option) on the Deployment page.
+!!! info "Fully managed option"
+    A hosted version of this same service is available as **Docling for IBM watsonx** — see the [managed option](deployment.md#fully-managed-option) on the Deployment page.
 
 !!! note "Two MCP modes"
     docling-serve can also expose Docling over MCP, bundled in the same image (streamable-http transport). That is distinct from the standalone [MCP server](../mcp.md), which remains the canonical MCP documentation. For the bundled mode see the serve [`mcp.md`](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/mcp.md).
@@ -50,7 +51,7 @@ The fastest way to make a conversion call. Both options hit the *same* REST API.
 
 ## How it works
 
-A request hits the docling-serve API, which runs the conversion through Docling core and returns the result (synchronously, or as an async task you poll). Background jobs run on a pluggable compute engine — in-process by default, or a Redis-backed queue for scaling. For Docling's internals see [Architecture](../../concepts/architecture.md); for the full API see [REST API](rest_api.md) and [Deployment](deployment.md).
+A request hits the docling-serve API, which runs the conversion through Docling and returns the result (synchronously, or as an async task you poll). Background jobs run on a pluggable compute engine — in-process by default, or a Redis-backed queue for scaling. For Docling's internals see [Architecture](../../concepts/architecture.md); for the full API see [REST API](rest_api.md) and [Deployment](deployment.md).
 
 ## Configuration model
 
@@ -69,11 +70,11 @@ docling-serve is configured by **CLI flags or environment variables**. Precedenc
 | `DOCLING_SERVE_ENABLE_UI` | serve the Gradio demo UI at `/ui` | `false` |
 | `DOCLING_SERVE_ARTIFACTS_PATH` | local path to pre-downloaded models | unset (auto-download) |
 | `DOCLING_SERVE_MAX_NUM_PAGES` / `DOCLING_SERVE_MAX_FILE_SIZE` | per-request limits | unset |
-| `DOCLING_SERVE_ENG_KIND` | async engine: `local` or `rq` | `local` |
+| `DOCLING_SERVE_ENG_KIND` | async engine: `local` or `rq` (also `kfp`/`ray` — see serve repo) | `local` |
 
 See the full reference in the source repo: [`configuration.md`](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/configuration.md) and [`.env.example`](https://github.com/docling-project/docling-serve/blob/v1.21.0/.env.example).
 
-### Docling core settings (env vars)
+### Docling settings (env vars)
 
 These tune Docling itself and are read by the server too:
 

--- a/docs/usage/api_server/index.md
+++ b/docs/usage/api_server/index.md
@@ -10,24 +10,17 @@ Run Docling as an HTTP service with [docling-serve](https://github.com/docling-p
 
 | You want to… | Use |
 |---|---|
-| Call Docling over HTTP from any language, or share one conversion service | the **API server** — [self-host](deployment.md) it, or use the [fully managed](managed.md) option |
-| Use Docling directly inside a Python application | the [Python library](../../getting_started/quickstart.md) |
+| Call Docling over HTTP from any language (including Python), or share one conversion service | the **API server** — [self-host](deployment.md) it, or use a [managed service](managed.md) |
+| Run Docling directly (in-process) in a Python application | the [Python library](../../getting_started/quickstart.md) |
 | Run large-scale or distributed batch conversions | [Jobkit](../jobkit.md) |
 | Expose Docling as tools to an AI agent | the [MCP server](../mcp.md) |
 
-!!! note "Two MCP modes"
-    docling-serve can also expose Docling over MCP, bundled in the same image (streamable-http transport). That is distinct from the standalone [MCP server](../mcp.md), which remains the canonical MCP documentation. For the bundled mode see the serve [`mcp.md`](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/mcp.md).
+!!! note "Using the API server from an MCP agent"
+    The [MCP server](../mcp.md) can convert through this REST API instead of running Docling locally — set `DOCLING_CONVERSION_MODE=remote` and point it at your service URL. See [MCP server](../mcp.md).
 
 ## Getting started
 
-Install and start the server:
-
-```sh
-pip install "docling-serve[ui]"
-docling-serve run --enable-ui
-```
-
-To call the API you need the **service URL** and, if the server requires one (`DOCLING_SERVE_API_KEY`), an **API key**. For a local run the service URL is `http://localhost:5001` — interactive API docs are at `/docs` and the demo UI at `/ui`.
+To use the API server you need a running endpoint — [run your own](deployment.md) or use a [managed service](managed.md) — plus its **service URL** and, if the server requires one (`DOCLING_SERVE_API_KEY`), an **API key**. A local server defaults to `http://localhost:5001` (interactive API docs at `/docs`):
 
 ```sh
 curl -X POST "http://localhost:5001/v1/convert/source/async" \
@@ -35,8 +28,8 @@ curl -X POST "http://localhost:5001/v1/convert/source/async" \
   -d '{"http_sources": [{"url": "https://arxiv.org/pdf/2501.17887"}]}'
 ```
 
-See [Deployment](deployment.md) for configuration and the other ways to run it, and [REST API](rest_api.md) for the full API.
+See [Deployment](deployment.md) to run and configure it, and [REST API](rest_api.md) for the full API.
 
 ## How it works
 
-A request hits the docling-serve API, which runs the conversion through Docling and returns the result (synchronously, or as an async task you poll). Background jobs run on a pluggable [compute engine](deployment.md#compute-engines) — in-process by default, or a Redis-backed queue for scaling. For Docling's internals see [Architecture](../../concepts/architecture.md); for the full API see [REST API](rest_api.md).
+A request hits the docling-serve API, which runs the conversion through Docling and returns the result (synchronously, or as an async task you poll). Background jobs run on a pluggable [compute engine](deployment.md#compute-engines) — in-process by default, or a Redis-backed queue for scaling. For the full API see [REST API](rest_api.md).

--- a/docs/usage/api_server/index.md
+++ b/docs/usage/api_server/index.md
@@ -1,0 +1,95 @@
+<!-- Source: docling-serve@v1.21.0 — keep in sync on serve releases that touch config/deployment/usage. -->
+!!! info "Synced from docling-serve v1.21.0"
+    This page summarizes the [docling-serve](https://github.com/docling-project/docling-serve) documentation at **v1.21.0**. For the exhaustive reference, follow the links to the source repository.
+
+# API server
+
+Run Docling as an HTTP service with [docling-serve](https://github.com/docling-project/docling-serve) — a FastAPI server that exposes Docling's document conversion over a REST API.
+
+## When to use it
+
+- **API server (self-hosted or fully managed)** — call Docling over HTTP from any language; good for multi-language clients, shared/remote conversion, and scaling out.
+- **Python library** — `import docling` in a Python app; best for in-process use.
+- **[Jobkit](../jobkit.md)** — large-scale / distributed batch pipelines.
+- **[MCP server](../mcp.md)** — expose Docling as tools to AI agents.
+
+> On "fully managed": a hosted version of this same service is available as **Docling for IBM watsonx** — see the [managed option](deployment.md#fully-managed-option) on the Deployment page.
+
+!!! note "Two MCP modes"
+    docling-serve can also expose Docling over MCP, bundled in the same image (streamable-http transport). That is distinct from the standalone [MCP server](../mcp.md), which remains the canonical MCP documentation. For the bundled mode see the serve [`mcp.md`](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/mcp.md).
+
+## Hello world
+
+The fastest way to make a conversion call. Both options hit the *same* REST API.
+
+=== "Managed (no install)"
+
+    On **Docling for IBM watsonx** there is nothing to install — point the call at your service base URL with a service-issued key:
+
+    ```sh
+    curl -X POST "https://<MANAGED_SERVICE_BASE_URL>/v1/convert/source/async" \
+      -H "Content-Type: application/json" \
+      -H "X-Api-Key: <YOUR_KEY>" \
+      -d '{"http_sources": [{"url": "https://arxiv.org/pdf/2501.17887"}]}'
+    ```
+
+=== "Self-hosted"
+
+    ```sh
+    pip install "docling-serve[ui]"
+    docling-serve run --enable-ui
+    ```
+
+    Then call the local server (API at `http://localhost:5001`, interactive docs at `/docs`, demo UI at `/ui`):
+
+    ```sh
+    curl -X POST "http://localhost:5001/v1/convert/source/async" \
+      -H "Content-Type: application/json" \
+      -d '{"http_sources": [{"url": "https://arxiv.org/pdf/2501.17887"}]}'
+    ```
+
+## How it works
+
+A request hits the docling-serve API, which runs the conversion through Docling core and returns the result (synchronously, or as an async task you poll). Background jobs run on a pluggable compute engine — in-process by default, or a Redis-backed queue for scaling. For Docling's internals see [Architecture](../../concepts/architecture.md); for the full API see [REST API](rest_api.md) and [Deployment](deployment.md).
+
+## Configuration model
+
+docling-serve is configured by **CLI flags or environment variables**. Precedence is **environment variable > config file > defaults**.
+
+!!! warning "Subprocess gotcha"
+    When uvicorn runs with `--reload` or `--workers > 1` it spawns subprocesses, and CLI flags (e.g. `--enable-ui`, `--artifacts-path`) are ignored. Use the `DOCLING_SERVE_*` environment variables in those deployments.
+
+### Most common settings
+
+| Setting (env var) | What it does | Default |
+|---|---|---|
+| `UVICORN_HOST` / `UVICORN_PORT` | bind address / port | `0.0.0.0` / `5001` |
+| `UVICORN_WORKERS` | uvicorn worker processes | `1` |
+| `DOCLING_SERVE_API_KEY` | require an `X-Api-Key` header | unset |
+| `DOCLING_SERVE_ENABLE_UI` | serve the Gradio demo UI at `/ui` | `false` |
+| `DOCLING_SERVE_ARTIFACTS_PATH` | local path to pre-downloaded models | unset (auto-download) |
+| `DOCLING_SERVE_MAX_NUM_PAGES` / `DOCLING_SERVE_MAX_FILE_SIZE` | per-request limits | unset |
+| `DOCLING_SERVE_ENG_KIND` | async engine: `local` or `rq` | `local` |
+
+See the full reference in the source repo: [`configuration.md`](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/configuration.md) and [`.env.example`](https://github.com/docling-project/docling-serve/blob/v1.21.0/.env.example).
+
+### Docling core settings (env vars)
+
+These tune Docling itself and are read by the server too:
+
+| Env var | What it does | Default |
+|---|---|---|
+| `DOCLING_DEVICE` | inference device: `cpu` / `cuda` / `mps` | auto |
+| `DOCLING_NUM_THREADS` | CPU threads | runtime default |
+| `DOCLING_PERF_PAGE_BATCH_SIZE` | pages per batch | runtime default |
+| `DOCLING_PERF_ELEMENTS_BATCH_SIZE` | elements per batch | runtime default |
+| `DOCLING_DEBUG_PROFILE_PIPELINE_TIMINGS` | log per-stage timings | `false` |
+
+For how to *choose* device/perf values see [GPU support](../gpu.md). For offline / air-gapped model setup see the [FAQ](../../faq/index.md) and [Advanced options](../advanced_options.md); set `DOCLING_SERVE_ARTIFACTS_PATH` to a pre-populated model directory.
+
+### Choosing a compute engine
+
+- **Local** (`DOCLING_SERVE_ENG_KIND=local`, default) — jobs run in-process; no extra services. Single machine.
+- **RQ** (`DOCLING_SERVE_ENG_KIND=rq`) — jobs go to Redis and run in separate worker processes; scales horizontally.
+
+See [Deployment](deployment.md) for how to launch each.

--- a/docs/usage/api_server/index.md
+++ b/docs/usage/api_server/index.md
@@ -6,91 +6,37 @@
 
 Run Docling as an HTTP service with [docling-serve](https://github.com/docling-project/docling-serve) — a FastAPI server that exposes Docling's document conversion over a REST API.
 
-## When to use it
+## When to use what?
 
-- **API server (self-hosted or fully managed)** — call Docling over HTTP from any language; good for multi-language clients, shared/remote conversion, and scaling out.
-- **Python library** — `import docling` in a Python app; best for in-process use.
-- **[Jobkit](../jobkit.md)** — large-scale / distributed batch pipelines.
-- **[MCP server](../mcp.md)** — expose Docling as tools to AI agents.
-
-!!! info "Fully managed option"
-    A hosted version of this same service is available as **Docling for IBM watsonx** — see the [managed option](deployment.md#fully-managed-option) on the Deployment page.
+| You want to… | Use |
+|---|---|
+| Call Docling over HTTP from any language, or share one conversion service | the **API server** — [self-host](deployment.md) it, or use the [fully managed](managed.md) option |
+| Use Docling directly inside a Python application | the [Python library](../../getting_started/quickstart.md) |
+| Run large-scale or distributed batch conversions | [Jobkit](../jobkit.md) |
+| Expose Docling as tools to an AI agent | the [MCP server](../mcp.md) |
 
 !!! note "Two MCP modes"
     docling-serve can also expose Docling over MCP, bundled in the same image (streamable-http transport). That is distinct from the standalone [MCP server](../mcp.md), which remains the canonical MCP documentation. For the bundled mode see the serve [`mcp.md`](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/mcp.md).
 
-## Hello world
+## Getting started
 
-The fastest way to make a conversion call. Both options hit the *same* REST API.
+Install and start the server:
 
-=== "Managed (no install)"
+```sh
+pip install "docling-serve[ui]"
+docling-serve run --enable-ui
+```
 
-    On **Docling for IBM watsonx** there is nothing to install — point the call at your service base URL with a service-issued key:
+To call the API you need the **service URL** and, if the server requires one (`DOCLING_SERVE_API_KEY`), an **API key**. For a local run the service URL is `http://localhost:5001` — interactive API docs are at `/docs` and the demo UI at `/ui`.
 
-    ```sh
-    curl -X POST "https://<MANAGED_SERVICE_BASE_URL>/v1/convert/source/async" \
-      -H "Content-Type: application/json" \
-      -H "X-Api-Key: <YOUR_KEY>" \
-      -d '{"http_sources": [{"url": "https://arxiv.org/pdf/2501.17887"}]}'
-    ```
+```sh
+curl -X POST "http://localhost:5001/v1/convert/source/async" \
+  -H "Content-Type: application/json" \
+  -d '{"http_sources": [{"url": "https://arxiv.org/pdf/2501.17887"}]}'
+```
 
-=== "Self-hosted"
-
-    ```sh
-    pip install "docling-serve[ui]"
-    docling-serve run --enable-ui
-    ```
-
-    Then call the local server (API at `http://localhost:5001`, interactive docs at `/docs`, demo UI at `/ui`):
-
-    ```sh
-    curl -X POST "http://localhost:5001/v1/convert/source/async" \
-      -H "Content-Type: application/json" \
-      -d '{"http_sources": [{"url": "https://arxiv.org/pdf/2501.17887"}]}'
-    ```
+See [Deployment](deployment.md) for configuration and the other ways to run it, and [REST API](rest_api.md) for the full API.
 
 ## How it works
 
-A request hits the docling-serve API, which runs the conversion through Docling and returns the result (synchronously, or as an async task you poll). Background jobs run on a pluggable compute engine — in-process by default, or a Redis-backed queue for scaling. For Docling's internals see [Architecture](../../concepts/architecture.md); for the full API see [REST API](rest_api.md) and [Deployment](deployment.md).
-
-## Configuration model
-
-docling-serve is configured by **CLI flags or environment variables**. Precedence is **environment variable > config file > defaults**.
-
-!!! warning "Subprocess gotcha"
-    When uvicorn runs with `--reload` or `--workers > 1` it spawns subprocesses, and CLI flags (e.g. `--enable-ui`, `--artifacts-path`) are ignored. Use the `DOCLING_SERVE_*` environment variables in those deployments.
-
-### Most common settings
-
-| Setting (env var) | What it does | Default |
-|---|---|---|
-| `UVICORN_HOST` / `UVICORN_PORT` | bind address / port | `0.0.0.0` / `5001` |
-| `UVICORN_WORKERS` | uvicorn worker processes | `1` |
-| `DOCLING_SERVE_API_KEY` | require an `X-Api-Key` header | unset |
-| `DOCLING_SERVE_ENABLE_UI` | serve the Gradio demo UI at `/ui` | `false` |
-| `DOCLING_SERVE_ARTIFACTS_PATH` | local path to pre-downloaded models | unset (auto-download) |
-| `DOCLING_SERVE_MAX_NUM_PAGES` / `DOCLING_SERVE_MAX_FILE_SIZE` | per-request limits | unset |
-| `DOCLING_SERVE_ENG_KIND` | async engine: `local` or `rq` (also `kfp`/`ray` — see serve repo) | `local` |
-
-See the full reference in the source repo: [`configuration.md`](https://github.com/docling-project/docling-serve/blob/v1.21.0/docs/configuration.md) and [`.env.example`](https://github.com/docling-project/docling-serve/blob/v1.21.0/.env.example).
-
-### Docling settings (env vars)
-
-These tune Docling itself and are read by the server too:
-
-| Env var | What it does | Default |
-|---|---|---|
-| `DOCLING_DEVICE` | inference device: `cpu` / `cuda` / `mps` | auto |
-| `DOCLING_NUM_THREADS` | CPU threads | runtime default |
-| `DOCLING_PERF_PAGE_BATCH_SIZE` | pages per batch | runtime default |
-| `DOCLING_PERF_ELEMENTS_BATCH_SIZE` | elements per batch | runtime default |
-| `DOCLING_DEBUG_PROFILE_PIPELINE_TIMINGS` | log per-stage timings | `false` |
-
-For how to *choose* device/perf values see [GPU support](../gpu.md). For offline / air-gapped model setup see the [FAQ](../../faq/index.md) and [Advanced options](../advanced_options.md); set `DOCLING_SERVE_ARTIFACTS_PATH` to a pre-populated model directory.
-
-### Choosing a compute engine
-
-- **Local** (`DOCLING_SERVE_ENG_KIND=local`, default) — jobs run in-process; no extra services. Single machine.
-- **RQ** (`DOCLING_SERVE_ENG_KIND=rq`) — jobs go to Redis and run in separate worker processes; scales horizontally.
-
-See [Deployment](deployment.md) for how to launch each.
+A request hits the docling-serve API, which runs the conversion through Docling and returns the result (synchronously, or as an async task you poll). Background jobs run on a pluggable [compute engine](deployment.md#compute-engines) — in-process by default, or a Redis-backed queue for scaling. For Docling's internals see [Architecture](../../concepts/architecture.md); for the full API see [REST API](rest_api.md).

--- a/docs/usage/api_server/managed.md
+++ b/docs/usage/api_server/managed.md
@@ -1,0 +1,22 @@
+# Fully managed
+
+Prefer not to run the server yourself? **Docling for IBM watsonx** is a fully managed, hosted instance of the same Docling service described in these pages.
+
+## Why use the managed service
+
+- **No infrastructure to run.** No servers, GPUs, scaling, upgrades, or operational monitoring to manage — the service is hosted and maintained for you.
+- **Simple integration.** It exposes the same [REST API](rest_api.md) as the self-hosted server, so wiring it into applications and AI agents is just an HTTP call — point your client at the managed endpoint and go. Client code stays portable: typically you only swap the base URL and supply your API key.
+- **Same Docling conversion.** The same document understanding and output formats as the open-source library and server.
+
+## Using it
+
+You need the **service URL** and an **API key** issued by the service, then call it exactly like the [REST API](rest_api.md):
+
+```sh
+curl -X POST "https://<MANAGED_SERVICE_BASE_URL>/v1/convert/source/async" \
+  -H "Content-Type: application/json" \
+  -H "X-Api-Key: <YOUR_KEY>" \
+  -d '{"http_sources": [{"url": "https://arxiv.org/pdf/2501.17887"}]}'
+```
+
+Account setup, API-key provisioning, quotas, SLA, and data handling are documented with the service itself.

--- a/docs/usage/api_server/managed.md
+++ b/docs/usage/api_server/managed.md
@@ -1,22 +1,16 @@
-# Fully managed
+# Why use the managed service
 
-Prefer not to run the server yourself? **Docling for IBM watsonx** is a fully managed, hosted instance of the same Docling service described in these pages.
+Running the API server yourself means operating infrastructure. A managed service removes that:
 
-## Why use the managed service
-
-- **No infrastructure to run.** No servers, GPUs, scaling, upgrades, or operational monitoring to manage — the service is hosted and maintained for you.
+- **No infrastructure to run.** No servers, GPUs, scaling, upgrades, or operational monitoring — it is hosted and maintained for you.
 - **Simple integration.** It exposes the same [REST API](rest_api.md) as the self-hosted server, so wiring it into applications and AI agents is just an HTTP call — point your client at the managed endpoint and go. Client code stays portable: typically you only swap the base URL and supply your API key.
 - **Same Docling conversion.** The same document understanding and output formats as the open-source library and server.
 
-## Using it
+## Available managed services
 
-You need the **service URL** and an **API key** issued by the service, then call it exactly like the [REST API](rest_api.md):
+### Docling for IBM watsonx
 
-```sh
-curl -X POST "https://<MANAGED_SERVICE_BASE_URL>/v1/convert/source/async" \
-  -H "Content-Type: application/json" \
-  -H "X-Api-Key: <YOUR_KEY>" \
-  -d '{"http_sources": [{"url": "https://arxiv.org/pdf/2501.17887"}]}'
-```
+A fully managed, hosted instance of the Docling service, exposing the same [REST API](rest_api.md) described in these pages. You provide the service URL and an API key, then call it like any other endpoint.
 
-Account setup, API-key provisioning, quotas, SLA, and data handling are documented with the service itself.
+- [Product page](https://www.ibm.com/products/docling)
+<!-- - [Free trial](https://www.ibm.com/products/docling) — hidden for the moment -->

--- a/docs/usage/api_server/rest_api.md
+++ b/docs/usage/api_server/rest_api.md
@@ -1,0 +1,132 @@
+<!-- Source: docling-serve@v1.21.0 — keep in sync on serve releases that touch config/deployment/usage. -->
+!!! info "Synced from docling-serve v1.21.0"
+    This page summarizes the [docling-serve](https://github.com/docling-project/docling-serve) documentation at **v1.21.0**. For the exhaustive reference, follow the links to the source repository.
+
+# REST API
+
+The docling-serve HTTP API. Examples target a local server at `http://localhost:5001`; on **Docling for IBM watsonx** use your service base URL and key.
+
+## Endpoints
+
+| Endpoint | Method | Purpose |
+|---|---|---|
+| `/v1/convert/source` | POST | convert from URLs / base64 sources (sync) |
+| `/v1/convert/file` | POST | convert uploaded files, multipart (sync) |
+| `/v1/convert/source/async`, `/v1/convert/file/async` | POST | submit an async task |
+| `/v1/status/poll/{task_id}` | GET | poll task status |
+| `/v1/status/ws/{task_id}` | WebSocket | subscribe to status |
+| `/v1/result/{task_id}` | GET | fetch a finished result |
+
+The full, interactive schema is always available at **`/docs`** (OpenAPI / Swagger) on any running server.
+
+## Authentication
+
+If `DOCLING_SERVE_API_KEY` is set on the server, send it on every request:
+
+```sh
+-H "X-Api-Key: <YOUR_KEY>"
+```
+
+## Conversion options (common)
+
+Pass these in the JSON body under `options`. This is the common subset — the **authoritative, full schema is the live OpenAPI docs at `/docs`** on any running server.
+
+| Option | Meaning |
+|---|---|
+| `from_formats` / `to_formats` | input / output formats (see [Supported formats](../supported_formats.md)) |
+| `image_export_mode` | how images are emitted (`placeholder` / `embedded` / `referenced`) |
+| `do_ocr` / `force_ocr` | enable / force OCR |
+| `ocr_engine` / `ocr_lang` | OCR engine and languages |
+| `table_mode` | table-structure mode (`fast` / `accurate`) |
+| `pdf_backend` | PDF parsing backend |
+| `pipeline` | processing pipeline (e.g. standard / VLM) |
+| enrichment flags | code, formula, picture classification/description, chart |
+
+For VLM / picture-description model configuration see [Vision models](../vision_models.md) and [Model catalog](../model_catalog.md).
+
+## Example: convert a URL (async)
+
+```sh
+curl -X POST "http://localhost:5001/v1/convert/source/async" \
+  -H "Content-Type: application/json" \
+  -d '{"http_sources": [{"url": "https://arxiv.org/pdf/2501.17887"}]}'
+```
+
+For a synchronous call use `/v1/convert/source` with the same body.
+
+## Example: upload a file (multipart)
+
+The `/v1/convert/file` endpoint accepts one or more files as `multipart/form-data`, with options as form fields:
+
+```sh
+curl -X POST "http://localhost:5001/v1/convert/file" \
+  -H "Content-Type: multipart/form-data" \
+  -F "files=@2206.01062v1.pdf;type=application/pdf" \
+  -F "from_formats=pdf" \
+  -F "to_formats=md" \
+  -F "do_ocr=true" \
+  -F "image_export_mode=embedded" \
+  -F "table_mode=fast"
+```
+
+## Response format
+
+A single-file conversion returns JSON:
+
+```jsonc
+{
+  "document": {
+    "md_content": "",
+    "json_content": {},
+    "html_content": "",
+    "text_content": "",
+    "doctags_content": ""
+  },
+  "status": "success",   // success | partial_success | skipped | failure
+  "processing_time": 0.0,
+  "timings": {},
+  "errors": []
+}
+```
+
+Only the `*_content` fields you requested via `to_formats` are populated. `processing_time` is in seconds; `timings` carries per-component detail when enabled. If you request the zip `target`, or the job produces multiple files, the response is a zip archive instead of JSON.
+
+## Asynchronous API
+
+Both convert endpoints have `/async` variants. Submitting returns a task descriptor:
+
+```jsonc
+{
+  "task_id": "<task_id>",
+  "task_status": "pending",   // pending | started | success | failure
+  "task_position": 1,
+  "task_meta": null
+}
+```
+
+**Poll** until done — `GET /v1/status/poll/{task_id}`:
+
+```python
+import time
+import httpx
+
+base_url = "http://localhost:5001/v1"
+task = response.json()  # from the /async submission
+
+while task["task_status"] not in ("success", "failure"):
+    task = httpx.get(f"{base_url}/status/poll/{task['task_id']}").json()
+    time.sleep(5)
+```
+
+**Subscribe** via WebSocket — `/v1/status/ws/{task_id}` — for push updates (messages are JSON with `message` = `connection | update | error` plus the task object).
+
+**Fetch** the result when finished — `GET /v1/result/{task_id}`.
+
+## Picture description (local vs API)
+
+When picture-description enrichment is on, choose an execution mode:
+
+- **local** — run the vision-language model in-process (`picture_description_local`, e.g. a Hugging Face `repo_id`).
+- **api** — call an external OpenAI-compatible endpoint (`picture_description_api`, with `url` / `params`). This requires launching the server with `DOCLING_SERVE_ENABLE_REMOTE_SERVICES=true`.
+
+See [Vision models](../vision_models.md) for model choices and configuration.

--- a/docs/usage/api_server/rest_api.md
+++ b/docs/usage/api_server/rest_api.md
@@ -36,13 +36,13 @@ Pass these in the JSON body under `options`. This is the common subset — the *
 | `from_formats` / `to_formats` | input / output formats (see [Supported formats](../supported_formats.md)) |
 | `image_export_mode` | how images are emitted (`placeholder` / `embedded` / `referenced`) |
 | `do_ocr` / `force_ocr` | enable / force OCR |
-| `ocr_engine` / `ocr_lang` | OCR engine and languages |
+| `ocr_preset` / `ocr_lang` | OCR preset and languages (`ocr_engine` is deprecated — prefer `ocr_preset`) |
 | `table_mode` | table-structure mode (`fast` / `accurate`) |
 | `pdf_backend` | PDF parsing backend |
 | `pipeline` | processing pipeline (e.g. standard / VLM) |
 | enrichment flags | code, formula, picture classification/description, chart |
 
-For VLM / picture-description model configuration see [Vision models](../vision_models.md) and [Model catalog](../model_catalog.md).
+For full-page VLM conversion models see [Vision models](../vision_models.md); for picture-description models see [Enrichment features](../enrichments.md#picture-description) and [Model catalog](../model_catalog.md).
 
 ## Example: convert a URL (async)
 
@@ -143,11 +143,11 @@ while task["task_status"] not in ("success", "failure"):
 
 **Fetch** the result when finished — `GET /v1/result/{task_id}`.
 
-## Picture description (local vs API)
+## Picture description
 
-When picture-description enrichment is on, choose an execution mode:
+When picture-description (image captioning) enrichment is on, select the model with `picture_description_preset` (a named preset) or, for full control, `picture_description_custom_config`. The model can run locally (in-process) or via a remote OpenAI-compatible API endpoint; the remote path requires launching the server with `DOCLING_SERVE_ENABLE_REMOTE_SERVICES=true`.
 
-- **local** — run the vision-language model in-process (`picture_description_local`, e.g. a Hugging Face `repo_id`).
-- **api** — call an external OpenAI-compatible endpoint (`picture_description_api`, with `url` / `params`). This requires launching the server with `DOCLING_SERVE_ENABLE_REMOTE_SERVICES=true`.
+!!! note
+    The older `picture_description_local` / `picture_description_api` parameters are deprecated at docling-serve v1.21.0 — migrate to `picture_description_preset` / `picture_description_custom_config`.
 
-See [Vision models](../vision_models.md) for model choices and configuration.
+See [Enrichment features](../enrichments.md#picture-description) for picture-description options, and [Model catalog](../model_catalog.md) for available models.

--- a/docs/usage/api_server/rest_api.md
+++ b/docs/usage/api_server/rest_api.md
@@ -27,6 +27,25 @@ If `DOCLING_SERVE_API_KEY` is set on the server, send it on every request:
 -H "X-Api-Key: <YOUR_KEY>"
 ```
 
+## Python client
+
+Docling ships a Python client for the API server, so you don't have to hand-roll HTTP calls. It takes the service URL and an optional API key, and returns the same `ConversionResult` as the local `DocumentConverter`:
+
+```python
+from docling.service_client import DoclingServiceClient
+from docling.datamodel.service.options import ConvertDocumentsOptions
+
+with DoclingServiceClient(url="http://localhost:5001", api_key="") as client:
+    result = client.convert(
+        source="https://arxiv.org/pdf/2501.17887",
+        options=ConvertDocumentsOptions(to_formats=["md"]),
+    )
+
+print(result.document.export_to_markdown())
+```
+
+`source` accepts a URL, a local path, or a `DocumentStream`; use `convert_all([...])` for batches. The `options` are the same [conversion options](#conversion-options-common) shown below. See the [examples](../../examples/index.md) for more recipes.
+
 ## Conversion options (common)
 
 Pass these in the JSON body under `options`. This is the common subset — the **authoritative, full schema is the live OpenAPI docs at `/docs`** on any running server.

--- a/docs/usage/api_server/rest_api.md
+++ b/docs/usage/api_server/rest_api.md
@@ -35,7 +35,7 @@ Docling ships a Python client for the API server, so you don't have to hand-roll
 from docling.service_client import DoclingServiceClient
 from docling.datamodel.service.options import ConvertDocumentsOptions
 
-with DoclingServiceClient(url="http://localhost:5001", api_key="") as client:
+with DoclingServiceClient(url="http://localhost:5001") as client:
     result = client.convert(
         source="https://arxiv.org/pdf/2501.17887",
         options=ConvertDocumentsOptions(to_formats=["md"]),
@@ -44,7 +44,7 @@ with DoclingServiceClient(url="http://localhost:5001", api_key="") as client:
 print(result.document.export_to_markdown())
 ```
 
-`source` accepts a URL, a local path, or a `DocumentStream`; use `convert_all([...])` for batches. The `options` are the same [conversion options](#conversion-options-common) shown below. See the [examples](../../examples/index.md) for more recipes.
+`source` accepts an HTTP/HTTPS URL string, a local `pathlib.Path`, or a `DocumentStream`; use `convert_all([...])` to stream multiple conversion results. The `options` are the same [conversion options](#conversion-options-common) shown below. See the [examples](../../examples/index.md) for more recipes.
 
 ## Conversion options (common)
 

--- a/docs/usage/api_server/rest_api.md
+++ b/docs/usage/api_server/rest_api.md
@@ -69,6 +69,27 @@ curl -X POST "http://localhost:5001/v1/convert/file" \
   -F "table_mode=fast"
 ```
 
+## Base64 file upload
+
+To send a file inline instead of multipart, POST to `/v1/convert/source` with `file_sources`. For large files, write the request body to a temp file and pass it with `-d @file` to avoid the shell's "Argument list too long" error:
+
+```sh
+# 1. base64-encode the file
+B64_DATA=$(base64 -w 0 /path/to/document.pdf)
+
+# 2. build the request body
+cat > /tmp/request_body.json <<EOF
+{
+  "file_sources": [{ "base64_string": "${B64_DATA}", "filename": "document.pdf" }]
+}
+EOF
+
+# 3. POST the request
+curl -X POST "http://localhost:5001/v1/convert/source" \
+  -H "Content-Type: application/json" \
+  -d @/tmp/request_body.json
+```
+
 ## Response format
 
 A single-file conversion returns JSON:

--- a/docs/usage/mcp.md
+++ b/docs/usage/mcp.md
@@ -28,4 +28,16 @@ In **[LM Studio](https://lmstudio.ai/)**, edit the `mcp.json` file with the appr
 [![Add MCP Server docling to LM Studio](https://files.lmstudio.ai/deeplink/mcp-install-light.svg)](https://lmstudio.ai/install-mcp?name=docling&config=eyJjb21tYW5kIjoidXZ4IiwiYXJncyI6WyItLWZyb209ZG9jbGluZy1tY3AiLCJkb2NsaW5nLW1jcC1zZXJ2ZXIiXX0%3D)
 
 
+## Using a remote Docling Serve API
+
+By default the MCP server converts documents locally. It can instead delegate conversion to a running [API server](api_server/index.md) — a self-hosted docling-serve instance or a [managed service](api_server/managed.md) — by setting these environment variables:
+
+```sh
+export DOCLING_SERVICE_URL=https://your-docling-service.example.com
+export DOCLING_SERVICE_API_KEY=your-api-key   # if the service requires one
+export DOCLING_CONVERSION_MODE=remote
+```
+
+To fall back to local processing when the remote service is unavailable, also set `DOCLING_FALLBACK_TO_LOCAL=true` (requires `pip install "docling-mcp[local]"`). See the [docling-mcp installation options](https://github.com/docling-project/docling-mcp#installation-options).
+
 Docling MCP also provides tools specific for some applications and frameworks. See the [Docling MCP](https://github.com/docling-project/docling-mcp) Server repository for more details. You will find examples of building agents powered by Docling capabilities and leveraging frameworks like [LlamaIndex](https://www.llamaindex.ai/), [Llama Stack](https://github.com/llamastack/llama-stack), [Pydantic AI](https://ai.pydantic.dev/), or [smolagents](https://github.com/huggingface/smolagents).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,10 @@ nav:
       - GPU support: usage/gpu.md
       - MCP server: usage/mcp.md
       - Jobkit: usage/jobkit.md
+      - API server:
+        - Overview: usage/api_server/index.md
+        - Deployment: usage/api_server/deployment.md
+        - REST API: usage/api_server/rest_api.md
     - FAQ:
       - FAQ: faq/index.md
   - Concepts:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,7 @@ nav:
         - Overview: usage/api_server/index.md
         - Deployment: usage/api_server/deployment.md
         - REST API: usage/api_server/rest_api.md
+        - Fully managed: usage/api_server/managed.md
     - FAQ:
       - FAQ: faq/index.md
   - Concepts:

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,7 +78,7 @@ nav:
         - Overview: usage/api_server/index.md
         - Deployment: usage/api_server/deployment.md
         - REST API: usage/api_server/rest_api.md
-        - Fully managed: usage/api_server/managed.md
+        - Managed service: usage/api_server/managed.md
     - FAQ:
       - FAQ: faq/index.md
   - Concepts:


### PR DESCRIPTION
## Summary
- Add API server overview, deployment, REST API, and managed-service docs.
- Link the API server pages from the docs nav and homepage.
- Document using MCP with a remote Docling API server.

## Checks
- `git diff --check upstream/main...HEAD`
- `make check` was run; formatting, Ruff, and tach passed, but the final max-lines check fails on `docling/pipeline/standard_pdf_pipeline.py` at 1011 lines.

## Follow-up
- Sync these pages with the latest `docling-serve` release; this branch currently references v1.21.0.
