### PR TITLE
fix(cli): pass accelerator options to VLM pipeline

### DIFF
--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -1016,6 +1016,7 @@ def convert(  # noqa: C901
 
         elif pipeline == ProcessingPipeline.VLM:
             pipeline_options = VlmPipelineOptions(
+                accelerator_options=accelerator_options,
                 enable_remote_services=enable_remote_services,
             )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -10,9 +10,10 @@ from typer.testing import CliRunner
 
 from docling.cli.export_utils import _should_generate_export_images, _split_list
 from docling.cli.main import app
+from docling.datamodel.accelerator_options import AcceleratorDevice
 from docling.datamodel.backend_options import ThreadedDoclingParseBackendOptions
 from docling.datamodel.base_models import InputFormat, OutputFormat
-from docling.datamodel.pipeline_options import PdfBackend
+from docling.datamodel.pipeline_options import PdfBackend, VlmPipelineOptions
 from docling.document_converter import PdfFormatOption
 
 runner = CliRunner()
@@ -522,3 +523,56 @@ def test_cli_accepts_threaded_docling_parse_backend(
     assert captured_backend_options is not None
     assert captured_backend_options.parser_threads == 7
     assert captured_backend_options.release_native_memory_every_n_pages == 64
+
+
+def test_cli_passes_accelerator_options_to_vlm_pipeline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured_pipeline_options: VlmPipelineOptions | None = None
+
+    class _FakeDocumentConverter:
+        def __init__(
+            self,
+            *,
+            allowed_formats: list[InputFormat],
+            format_options: dict[InputFormat, PdfFormatOption],
+        ) -> None:
+            nonlocal captured_pipeline_options
+            pdf_option = format_options[InputFormat.PDF]
+            assert format_options[InputFormat.IMAGE] is pdf_option
+            assert isinstance(pdf_option.pipeline_options, VlmPipelineOptions)
+            captured_pipeline_options = pdf_option.pipeline_options
+
+        def convert_all(
+            self,
+            input_doc_paths: list[Path],
+            headers: dict[str, str] | None = None,
+            raises_on_error: bool = False,
+        ) -> list[Any]:
+            assert len(input_doc_paths) == 1
+            return []
+
+    monkeypatch.setattr("docling.cli.main.DocumentConverter", _FakeDocumentConverter)
+
+    source = "./tests/data/pdf/2305.03393v1-pg9.pdf"
+    output = tmp_path / "out"
+
+    result = runner.invoke(
+        app,
+        [
+            source,
+            "--output",
+            str(output),
+            "--pipeline",
+            "vlm",
+            "--device",
+            "cpu",
+            "--num-threads",
+            "7",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured_pipeline_options is not None
+    assert captured_pipeline_options.accelerator_options.device == AcceleratorDevice.CPU
+    assert captured_pipeline_options.accelerator_options.num_threads == 7


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #3597

**Description:**

This passes the CLI-built `AcceleratorOptions` into `VlmPipelineOptions`, so `docling --pipeline vlm --device ... --num-threads ...` uses the same accelerator settings as the standard pipeline.

It also adds a CLI regression test that captures the VLM pipeline options without running an actual VLM conversion.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.