### PR TITLE
feat(api): expose input document backend

### DIFF
--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -254,6 +254,11 @@ class InputDocument(BaseModel):
         if not self._backend.is_valid():
             self.valid = False
 
+    @property
+    def backend(self) -> AbstractDocumentBackend:
+        """Backend instance used to read and parse this input document."""
+        return self._backend
+
 
 class DocumentFormat(str, Enum):
     V2 = "v2"

--- a/tests/test_input_doc.py
+++ b/tests/test_input_doc.py
@@ -28,6 +28,14 @@ def test_in_doc_from_valid_path():
     assert doc.backend_options is None
 
 
+def test_in_doc_exposes_backend():
+    test_doc_path = Path("./tests/data/pdf/2206.01062.pdf")
+    doc = _make_input_doc(test_doc_path)
+
+    assert doc.backend is doc._backend
+    assert doc.backend.is_valid()
+
+
 def test_in_doc_from_invalid_path():
     test_doc_path = Path("./tests/does/not/exist.pdf")
 


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #3491

This adds a read-only `InputDocument.backend` property so callers can access the existing backend object through public API and call methods such as `unload()` without relying on the private `_backend` attribute.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.