### PR TITLE
feat: add HWP backend via rhwp render tree

### DIFF
--- a/docling/backend/hwp_backend.py
+++ b/docling/backend/hwp_backend.py
@@ -100,7 +100,9 @@ class HwpDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBackend):
             return self.path_or_stream
 
         if isinstance(self.path_or_stream, BytesIO):
-            suffix = self.file.suffix if self.file.suffix in {".hwp", ".hwpx"} else ".hwp"
+            suffix = (
+                self.file.suffix if self.file.suffix in {".hwp", ".hwpx"} else ".hwp"
+            )
             input_path = tmp_path / f"input{suffix}"
             input_path.write_bytes(self.path_or_stream.getvalue())
             return input_path

--- a/docling/backend/hwp_backend.py
+++ b/docling/backend/hwp_backend.py
@@ -1,0 +1,315 @@
+import json
+import logging
+import subprocess
+import tempfile
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Optional, Union
+
+from docling_core.types.doc import (
+    BoundingBox,
+    ContentLayer,
+    CoordOrigin,
+    DocItemLabel,
+    DoclingDocument,
+    DocumentOrigin,
+    ProvenanceItem,
+    Size,
+    TableCell,
+    TableData,
+)
+from typing_extensions import override
+
+from docling.backend.abstract_backend import (
+    DeclarativeDocumentBackend,
+    PaginatedDocumentBackend,
+)
+from docling.datamodel.backend_options import HwpBackendOptions
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.document import InputDocument
+
+_log = logging.getLogger(__name__)
+
+
+class HwpDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBackend):
+    """Convert HWP/HWPX files through the external rhwp CLI.
+
+    The current implementation consumes `rhwp export-render-tree`, which exposes
+    page-local bounding boxes and text runs. This gives Docling a layout-grounded
+    first pass without introducing a Python/Rust extension dependency.
+    """
+
+    @override
+    def __init__(
+        self,
+        in_doc: InputDocument,
+        path_or_stream: Union[BytesIO, Path],
+        options: Optional[HwpBackendOptions] = None,
+    ) -> None:
+        hwp_options = options or HwpBackendOptions()
+        super().__init__(
+            in_doc,
+            path_or_stream=path_or_stream,
+            options=hwp_options,
+        )
+        self.hwp_options = hwp_options
+        self._doc_or_err = self._get_doc_or_err()
+
+    @override
+    def is_valid(self) -> bool:
+        return isinstance(self._doc_or_err, DoclingDocument)
+
+    @classmethod
+    @override
+    def supports_pagination(cls) -> bool:
+        return True
+
+    @override
+    def page_count(self) -> int:
+        if isinstance(self._doc_or_err, DoclingDocument):
+            return len(self._doc_or_err.pages)
+        return 0
+
+    @classmethod
+    @override
+    def supported_formats(cls) -> set[InputFormat]:
+        return {InputFormat.HWP}
+
+    @override
+    def convert(self) -> DoclingDocument:
+        if isinstance(self._doc_or_err, DoclingDocument):
+            return self._doc_or_err
+
+        raise self._doc_or_err
+
+    def _get_doc_or_err(self) -> Union[DoclingDocument, Exception]:
+        try:
+            with tempfile.TemporaryDirectory(prefix="docling-hwp-") as tmp:
+                tmp_path = Path(tmp)
+                input_path = self._materialize_input(tmp_path)
+                render_tree_dir = tmp_path / "render-tree"
+                render_tree_dir.mkdir()
+
+                self._run_rhwp_export_render_tree(input_path, render_tree_dir)
+                return self._convert_render_tree_dir(render_tree_dir)
+        except Exception as exc:
+            return exc
+
+    def _materialize_input(self, tmp_path: Path) -> Path:
+        if isinstance(self.path_or_stream, Path):
+            return self.path_or_stream
+
+        if isinstance(self.path_or_stream, BytesIO):
+            suffix = self.file.suffix if self.file.suffix in {".hwp", ".hwpx"} else ".hwp"
+            input_path = tmp_path / f"input{suffix}"
+            input_path.write_bytes(self.path_or_stream.getvalue())
+            return input_path
+
+        raise RuntimeError(f"Unexpected HWP input type: {type(self.path_or_stream)!r}")
+
+    def _run_rhwp_export_render_tree(self, input_path: Path, output_dir: Path) -> None:
+        cmd = [
+            self.hwp_options.rhwp_binary,
+            "export-render-tree",
+            str(input_path),
+            "-o",
+            str(output_dir),
+        ]
+        try:
+            completed = subprocess.run(
+                cmd,
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=self.hwp_options.export_timeout,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "The rhwp executable was not found. Install rhwp or set "
+                "HwpBackendOptions.rhwp_binary to its path."
+            ) from exc
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                "rhwp export-render-tree timed out after "
+                f"{self.hwp_options.export_timeout}s"
+            ) from exc
+
+        if completed.returncode != 0:
+            err = completed.stderr.strip() or completed.stdout.strip()
+            raise RuntimeError(f"rhwp export-render-tree failed: {err}")
+
+    def _convert_render_tree_dir(self, render_tree_dir: Path) -> DoclingDocument:
+        paths = sorted(render_tree_dir.glob("render_tree_*.json"))
+        if not paths:
+            raise RuntimeError("rhwp did not produce any render-tree JSON files.")
+
+        doc = DoclingDocument(name=self.file.stem or "file")
+        doc.origin = DocumentOrigin(
+            filename=self.file.name or "file",
+            mimetype="application/octet-stream",
+            binary_hash=_document_hash_as_int(self.document_hash),
+        )
+
+        for page_no, path in enumerate(paths, start=1):
+            root = json.loads(path.read_text(encoding="utf-8"))
+            bbox = root.get("bbox", {})
+            page_w = _float_or_default(bbox.get("w"), 0.0)
+            page_h = _float_or_default(bbox.get("h"), 0.0)
+            doc.add_page(page_no=page_no, size=Size(width=page_w, height=page_h))
+            self._add_nodes(doc, root.get("children", []), page_no=page_no)
+
+        return doc
+
+    def _add_nodes(
+        self,
+        doc: DoclingDocument,
+        nodes: list[dict[str, Any]],
+        *,
+        page_no: int,
+        furniture_label: Optional[DocItemLabel] = None,
+    ) -> None:
+        for node in nodes:
+            node_type = node.get("type")
+            if node_type == "Header":
+                self._add_nodes(
+                    doc,
+                    node.get("children", []),
+                    page_no=page_no,
+                    furniture_label=DocItemLabel.PAGE_HEADER,
+                )
+            elif node_type == "Footer":
+                self._add_nodes(
+                    doc,
+                    node.get("children", []),
+                    page_no=page_no,
+                    furniture_label=DocItemLabel.PAGE_FOOTER,
+                )
+            elif node_type == "Table":
+                self._add_table(doc, node, page_no=page_no)
+            elif node_type == "Image":
+                doc.add_picture(prov=_provenance(node, page_no))
+            elif node_type == "Equation":
+                doc.add_formula(text="", prov=_provenance(node, page_no))
+            elif node_type == "TextLine":
+                text = _node_text(node)
+                if text:
+                    label = furniture_label or DocItemLabel.TEXT
+                    doc.add_text(
+                        label=label,
+                        text=text,
+                        prov=_provenance(node, page_no, text=text),
+                        content_layer=ContentLayer.FURNITURE
+                        if furniture_label
+                        else None,
+                    )
+            elif node_type == "TextRun":
+                text = str(node.get("text", ""))
+                if text:
+                    doc.add_text(
+                        label=furniture_label or DocItemLabel.TEXT,
+                        text=text,
+                        prov=_provenance(node, page_no, text=text),
+                        content_layer=ContentLayer.FURNITURE
+                        if furniture_label
+                        else None,
+                    )
+            else:
+                self._add_nodes(
+                    doc,
+                    node.get("children", []),
+                    page_no=page_no,
+                    furniture_label=furniture_label,
+                )
+
+    def _add_table(
+        self, doc: DoclingDocument, node: dict[str, Any], *, page_no: int
+    ) -> None:
+        cells = _table_cells(node, page_no=page_no)
+        num_rows = max(
+            _int_or_default(node.get("rows"), 0),
+            max((cell.end_row_offset_idx for cell in cells), default=0),
+        )
+        num_cols = max(
+            _int_or_default(node.get("cols"), 0),
+            max((cell.end_col_offset_idx for cell in cells), default=0),
+        )
+        doc.add_table(
+            data=TableData(table_cells=cells, num_rows=num_rows, num_cols=num_cols),
+            prov=_provenance(node, page_no),
+        )
+
+
+def _table_cells(node: dict[str, Any], *, page_no: int) -> list[TableCell]:
+    cells: list[TableCell] = []
+    for cell_node in _iter_nodes(node):
+        if cell_node.get("type") != "Cell":
+            continue
+        row = _int_or_default(cell_node.get("row"), 0)
+        col = _int_or_default(cell_node.get("col"), 0)
+        cells.append(
+            TableCell(
+                bbox=_bbox(cell_node),
+                text=_node_text(cell_node),
+                row_span=1,
+                col_span=1,
+                start_row_offset_idx=row,
+                end_row_offset_idx=row + 1,
+                start_col_offset_idx=col,
+                end_col_offset_idx=col + 1,
+            )
+        )
+    return cells
+
+
+def _iter_nodes(node: dict[str, Any]):
+    yield node
+    for child in node.get("children", []):
+        yield from _iter_nodes(child)
+
+
+def _node_text(node: dict[str, Any]) -> str:
+    if node.get("type") == "TextRun":
+        return str(node.get("text", ""))
+    return "".join(_node_text(child) for child in node.get("children", []))
+
+
+def _provenance(
+    node: dict[str, Any], page_no: int, *, text: str = ""
+) -> Optional[ProvenanceItem]:
+    bbox = _bbox(node)
+    if bbox is None:
+        return None
+    return ProvenanceItem(page_no=page_no, bbox=bbox, charspan=(0, len(text)))
+
+
+def _bbox(node: dict[str, Any]) -> Optional[BoundingBox]:
+    raw = node.get("bbox")
+    if not isinstance(raw, dict):
+        return None
+
+    x = _float_or_default(raw.get("x"), 0.0)
+    y = _float_or_default(raw.get("y"), 0.0)
+    w = _float_or_default(raw.get("w"), 0.0)
+    h = _float_or_default(raw.get("h"), 0.0)
+    return BoundingBox.from_tuple((x, y, x + w, y + h), origin=CoordOrigin.TOPLEFT)
+
+
+def _document_hash_as_int(value: str) -> int:
+    try:
+        return int(value, 16) & 0xFFFFFFFFFFFFFFFF
+    except ValueError:
+        return 0
+
+
+def _float_or_default(value: Any, default: float) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _int_or_default(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default

--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -79,6 +79,7 @@ from docling.datamodel.asr_model_specs import (
 from docling.datamodel.backend_options import (
     EpubBackendOptions,
     HTMLBackendOptions,
+    HwpBackendOptions,
     LatexBackendOptions,
     PdfBackendOptions,
     ThreadedDoclingParseBackendOptions,
@@ -117,6 +118,7 @@ from docling.document_converter import (
     ExcelFormatOption,
     FormatOption,
     HTMLFormatOption,
+    HwpFormatOption,
     LatexFormatOption,
     MarkdownFormatOption,
     PdfFormatOption,
@@ -983,6 +985,10 @@ def convert(  # noqa: C901
                 ),
                 InputFormat.PPTX: PowerpointFormatOption(
                     pipeline_options=simple_format_option
+                ),
+                InputFormat.HWP: HwpFormatOption(
+                    pipeline_options=simple_format_option,
+                    backend_options=HwpBackendOptions(),
                 ),
                 InputFormat.XLSX: ExcelFormatOption(
                     pipeline_options=simple_format_option

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -136,6 +136,22 @@ class MarkdownBackendOptions(BaseBackendOptions):
     )
 
 
+class HwpBackendOptions(BaseBackendOptions):
+    """Options specific to the HWP/HWPX backend."""
+
+    kind: Literal["hwp"] = Field("hwp", exclude=True, repr=False)
+    rhwp_binary: str = Field(
+        "rhwp",
+        description=(
+            "Path to the rhwp executable used to export HWP/HWPX render-tree JSON."
+        ),
+    )
+    export_timeout: float = Field(
+        60.0,
+        description="Maximum time in seconds to wait for each rhwp export command.",
+    )
+
+
 class EpubBackendOptions(BaseBackendOptions):
     """Options specific to the EPUB backend."""
 
@@ -295,6 +311,7 @@ BackendOptions = Annotated[
     Union[
         DeclarativeBackendOptions,
         EpubBackendOptions,
+        HwpBackendOptions,
         HTMLBackendOptions,
         MarkdownBackendOptions,
         PdfBackendOptions,

--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -68,6 +68,7 @@ class InputFormat(str, Enum):
 
     DOCX = "docx"
     PPTX = "pptx"
+    HWP = "hwp"
     HTML = "html"
     IMAGE = "image"
     PDF = "pdf"
@@ -103,6 +104,7 @@ class OutputFormat(str, Enum):
 FormatToExtensions: dict[InputFormat, list[str]] = {
     InputFormat.DOCX: ["docx", "dotx", "docm", "dotm"],
     InputFormat.PPTX: ["pptx", "potx", "ppsx", "pptm", "potm", "ppsm"],
+    InputFormat.HWP: ["hwp", "hwpx"],
     InputFormat.PDF: ["pdf"],
     InputFormat.MD: ["md", "txt", "text", "qmd", "rmd", "Rmd"],
     InputFormat.HTML: ["html", "htm", "xhtml"],
@@ -132,6 +134,13 @@ FormatToMimeType: dict[InputFormat, list[str]] = {
         "application/vnd.openxmlformats-officedocument.presentationml.template",
         "application/vnd.openxmlformats-officedocument.presentationml.slideshow",
         "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    ],
+    InputFormat.HWP: [
+        "application/x-hwp",
+        "application/vnd.hancom.hwp",
+        "application/hwp+zip",
+        "application/x-hwpx",
+        "application/vnd.hancom.hwpx",
     ],
     InputFormat.HTML: ["text/html", "application/xhtml+xml"],
     InputFormat.XML_JATS: ["application/xml"],

--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -552,6 +552,8 @@ class _DocumentConversionInput(BaseModel):
         if isinstance(obj, Path):
             if _DocumentConversionInput._has_doclang_extension(obj.name):
                 return InputFormat.XML_DOCLANG
+            if _DocumentConversionInput._has_hwp_extension(obj.name):
+                return InputFormat.HWP
             mime = filetype.guess_mime(str(obj))
             obj_ext = obj.suffix[1:] if obj.suffix else ""
             if mime is None:
@@ -578,6 +580,8 @@ class _DocumentConversionInput(BaseModel):
         elif isinstance(obj, DocumentStream):
             if _DocumentConversionInput._has_doclang_extension(obj.name):
                 return InputFormat.XML_DOCLANG
+            if _DocumentConversionInput._has_hwp_extension(obj.name):
+                return InputFormat.HWP
             content = obj.stream.read(8192)
             obj.stream.seek(0)
             mime = filetype.guess_mime(content)
@@ -628,6 +632,11 @@ class _DocumentConversionInput(BaseModel):
     def _has_doclang_extension(name: str) -> bool:
         lower_name = name.lower()
         return lower_name.endswith((".dclg", ".dclg.xml"))
+
+    @staticmethod
+    def _has_hwp_extension(name: str) -> bool:
+        lower_name = name.lower()
+        return lower_name.endswith((".hwp", ".hwpx"))
 
     @staticmethod
     def _detect_office_mime_from_zip(
@@ -734,6 +743,8 @@ class _DocumentConversionInput(BaseModel):
             mime = FormatToMimeType[InputFormat.JSON_DOCLING][0]
         elif ext in FormatToExtensions[InputFormat.PDF]:
             mime = FormatToMimeType[InputFormat.PDF][0]
+        elif ext in FormatToExtensions[InputFormat.HWP]:
+            mime = FormatToMimeType[InputFormat.HWP][0]
         elif ext in FormatToExtensions[InputFormat.DOCX]:
             mime = FormatToMimeType[InputFormat.DOCX][0]
         elif ext in FormatToExtensions[InputFormat.PPTX]:

--- a/docling/document_converter.py
+++ b/docling/document_converter.py
@@ -24,6 +24,7 @@ from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
 from docling.backend.email_backend import EmailDocumentBackend
 from docling.backend.epub_backend import EpubDocumentBackend
 from docling.backend.html_backend import HTMLDocumentBackend
+from docling.backend.hwp_backend import HwpDocumentBackend
 from docling.backend.image_backend import ImageDocumentBackend
 from docling.backend.json.docling_json_backend import DoclingJSONBackend
 from docling.backend.latex_backend import LatexDocumentBackend
@@ -42,6 +43,7 @@ from docling.datamodel.backend_options import (
     BackendOptions,
     EpubBackendOptions,
     HTMLBackendOptions,
+    HwpBackendOptions,
     LatexBackendOptions,
     MarkdownBackendOptions,
     MetsGbsBackendOptions,
@@ -114,6 +116,12 @@ class WordFormatOption(FormatOption):
 class PowerpointFormatOption(FormatOption):
     pipeline_cls: Type = SimplePipeline
     backend: Type[AbstractDocumentBackend] = MsPowerpointDocumentBackend
+
+
+class HwpFormatOption(FormatOption):
+    pipeline_cls: Type = SimplePipeline
+    backend: Type[AbstractDocumentBackend] = HwpDocumentBackend
+    backend_options: Optional[HwpBackendOptions] = None
 
 
 class MarkdownFormatOption(FormatOption):
@@ -216,6 +224,7 @@ def _get_default_option(format: InputFormat) -> FormatOption:
         InputFormat.XLSX: ExcelFormatOption(),
         InputFormat.DOCX: WordFormatOption(),
         InputFormat.PPTX: PowerpointFormatOption(),
+        InputFormat.HWP: HwpFormatOption(),
         InputFormat.MD: MarkdownFormatOption(),
         InputFormat.ASCIIDOC: AsciiDocFormatOption(),
         InputFormat.HTML: HTMLFormatOption(),

--- a/docs/usage/supported_formats.md
+++ b/docs/usage/supported_formats.md
@@ -10,6 +10,7 @@ Below you can find a listing of all supported input and output formats.
 |--------|-------------|
 | PDF | |
 | DOCX, XLSX, PPTX | Default formats in MS Office 2007+, based on Office Open XML |
+| HWP, HWPX | Korean Hangul Word Processor formats; requires the external `rhwp` executable on `PATH` or configured through backend options |
 | EPUB | Electronic Publication format for e-books |
 | Markdown | |
 | AsciiDoc | Human-readable, plain-text markup language for structured technical content |

--- a/tests/test_backend_hwp.py
+++ b/tests/test_backend_hwp.py
@@ -1,0 +1,168 @@
+import json
+import subprocess
+import zipfile
+from io import BytesIO
+from pathlib import Path
+
+from docling_core.types.doc import CoordOrigin, DocItemLabel, TableItem
+
+from docling.datamodel.backend_options import HwpBackendOptions
+from docling.datamodel.base_models import DocumentStream, InputFormat
+from docling.datamodel.document import _DocumentConversionInput
+from docling.document_converter import DocumentConverter, HwpFormatOption
+
+
+def _fake_render_tree() -> dict:
+    return {
+        "type": "Page",
+        "bbox": {"x": 0, "y": 0, "w": 600, "h": 800},
+        "children": [
+            {
+                "type": "Body",
+                "bbox": {"x": 40, "y": 50, "w": 520, "h": 700},
+                "children": [
+                    {
+                        "type": "TextLine",
+                        "bbox": {"x": 50, "y": 80, "w": 180, "h": 20},
+                        "children": [
+                            {
+                                "type": "TextRun",
+                                "bbox": {"x": 50, "y": 80, "w": 90, "h": 20},
+                                "text": "Hello ",
+                                "pi": 0,
+                            },
+                            {
+                                "type": "TextRun",
+                                "bbox": {"x": 140, "y": 80, "w": 90, "h": 20},
+                                "text": "HWP",
+                                "pi": 0,
+                            },
+                        ],
+                    },
+                    {
+                        "type": "Table",
+                        "bbox": {"x": 50, "y": 130, "w": 200, "h": 40},
+                        "rows": 1,
+                        "cols": 2,
+                        "children": [
+                            {
+                                "type": "Cell",
+                                "bbox": {"x": 50, "y": 130, "w": 100, "h": 40},
+                                "row": 0,
+                                "col": 0,
+                                "children": [
+                                    {
+                                        "type": "TextRun",
+                                        "bbox": {
+                                            "x": 60,
+                                            "y": 140,
+                                            "w": 20,
+                                            "h": 16,
+                                        },
+                                        "text": "A",
+                                    }
+                                ],
+                            },
+                            {
+                                "type": "Cell",
+                                "bbox": {"x": 150, "y": 130, "w": 100, "h": 40},
+                                "row": 0,
+                                "col": 1,
+                                "children": [
+                                    {
+                                        "type": "TextRun",
+                                        "bbox": {
+                                            "x": 160,
+                                            "y": 140,
+                                            "w": 20,
+                                            "h": 16,
+                                        },
+                                        "text": "B",
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            }
+        ],
+    }
+
+
+def _patch_rhwp(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        assert cmd[:2] == ["rhwp-test", "export-render-tree"]
+        output_dir = Path(cmd[cmd.index("-o") + 1])
+        output_dir.mkdir(parents=True, exist_ok=True)
+        (output_dir / "render_tree_001.json").write_text(
+            json.dumps(_fake_render_tree()), encoding="utf-8"
+        )
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("docling.backend.hwp_backend.subprocess.run", fake_run)
+
+
+def _converter() -> DocumentConverter:
+    return DocumentConverter(
+        allowed_formats=[InputFormat.HWP],
+        format_options={
+            InputFormat.HWP: HwpFormatOption(
+                backend_options=HwpBackendOptions(rhwp_binary="rhwp-test")
+            )
+        },
+    )
+
+
+def test_hwp_backend_converts_render_tree_from_path(tmp_path: Path, monkeypatch):
+    _patch_rhwp(monkeypatch)
+    doc_path = tmp_path / "sample.hwp"
+    doc_path.write_bytes(b"fake-hwp")
+
+    result = _converter().convert(doc_path)
+
+    assert result.input.format == InputFormat.HWP
+    assert result.document.pages[1].size.width == 600
+    assert result.document.pages[1].size.height == 800
+    assert result.document.texts[0].label == DocItemLabel.TEXT
+    assert result.document.texts[0].text == "Hello HWP"
+    prov = result.document.texts[0].prov[0]
+    assert prov.page_no == 1
+    assert prov.bbox.coord_origin == CoordOrigin.TOPLEFT
+    assert prov.bbox.as_tuple() == (50.0, 80.0, 230.0, 100.0)
+
+    assert len(result.document.tables) == 1
+    table = result.document.tables[0]
+    assert isinstance(table, TableItem)
+    assert table.data.num_rows == 1
+    assert table.data.num_cols == 2
+    assert [[cell.text for cell in row] for row in table.data.grid] == [["A", "B"]]
+
+
+def test_hwp_backend_converts_stream(monkeypatch):
+    _patch_rhwp(monkeypatch)
+    stream = DocumentStream(name="sample.hwpx", stream=BytesIO(b"fake-hwpx"))
+
+    result = _converter().convert(stream)
+
+    assert result.input.format == InputFormat.HWP
+    assert result.document.export_to_markdown().startswith("Hello HWP")
+
+
+def test_hwp_guess_format_by_extension(tmp_path: Path):
+    dci = _DocumentConversionInput(path_or_stream_iterator=[])
+
+    hwp_path = tmp_path / "sample.hwp"
+    hwp_path.write_bytes(b"fake-hwp")
+    assert dci._guess_format(hwp_path) == InputFormat.HWP
+
+    hwpx_path = tmp_path / "sample.hwpx"
+    with zipfile.ZipFile(hwpx_path, "w") as zf:
+        zf.writestr("Contents/content.hpf", "<package/>")
+    assert dci._guess_format(hwpx_path) == InputFormat.HWP
+
+    stream_bytes = BytesIO()
+    with zipfile.ZipFile(stream_bytes, "w") as zf:
+        zf.writestr("Contents/content.hpf", "<package/>")
+    stream_bytes.seek(0)
+    stream = DocumentStream(name="sample.hwpx", stream=stream_bytes)
+    assert dci._guess_format(stream) == InputFormat.HWP


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

## Summary

This draft adds initial HWP/HWPX input support through a declarative backend that invokes the external `rhwp` executable and consumes its `export-render-tree` JSON output.

- registers `InputFormat.HWP` for `.hwp` and `.hwpx`
- adds `HwpBackendOptions` for the external `rhwp` binary path and timeout
- wires `HwpDocumentBackend` through `SimplePipeline`, `DocumentConverter`, and the CLI standard pipeline
- converts `rhwp` render-tree pages into `DoclingDocument` pages, text items, table items, picture placeholders, formula placeholders, and `ProvenanceItem` bbox data
- treats layout provenance as best-effort and does not require a Python/Rust extension dependency

## Notes

This draft uses the `rhwp` binary directly rather than a PyO3/Python binding. That avoids making Docling depend on Rust extension wheels for this format.

The current `rhwp export-render-tree` output carries page-local geometry and text runs, but it is not a full semantic document export. As a result, this PR should be reviewed as an initial backend scaffold and layout-provenance bridge. Higher-fidelity mapping for headings, rich lists, table spans, formulas, and notes will likely need a richer machine-readable `rhwp` export contract.

**Issue resolved by this Pull Request:**
Resolves #3602

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

## Validation

- `uv run --frozen ruff format --check docling/backend/hwp_backend.py docling/datamodel/base_models.py docling/datamodel/backend_options.py docling/datamodel/document.py docling/document_converter.py docling/cli/main.py tests/test_backend_hwp.py`
- `uv run --frozen ruff check docling/backend/hwp_backend.py docling/datamodel/base_models.py docling/datamodel/backend_options.py docling/datamodel/document.py docling/document_converter.py docling/cli/main.py tests/test_backend_hwp.py`
- `uv run --frozen pytest tests/test_backend_hwp.py`
