### PR TITLE
fix: Make explicit device selection fail hard when device unavailable

### DIFF
--- a/docling/exceptions.py
+++ b/docling/exceptions.py
@@ -17,4 +17,3 @@ class SecurityError(BaseError):
 class AcceleratorDeviceNotAvailableError(BaseError):
     """Raised when an explicitly requested accelerator device is not available."""
 
-    pass

--- a/docling/exceptions.py
+++ b/docling/exceptions.py
@@ -12,3 +12,9 @@ class OperationNotAllowed(BaseError):
 
 class SecurityError(BaseError):
     pass
+
+
+class AcceleratorDeviceNotAvailableError(BaseError):
+    """Raised when an explicitly requested accelerator device is not available."""
+
+    pass

--- a/docling/exceptions.py
+++ b/docling/exceptions.py
@@ -16,4 +16,3 @@ class SecurityError(BaseError):
 
 class AcceleratorDeviceNotAvailableError(BaseError):
     """Raised when an explicitly requested accelerator device is not available."""
-

--- a/docling/utils/accelerator_utils.py
+++ b/docling/utils/accelerator_utils.py
@@ -2,6 +2,7 @@ import logging
 from typing import List, Optional
 
 from docling.datamodel.accelerator_options import AcceleratorDevice
+from docling.exceptions import AcceleratorDeviceNotAvailableError
 
 _log = logging.getLogger(__name__)
 
@@ -59,31 +60,40 @@ def decide_device(
                 if cuda_index < torch.cuda.device_count():
                     device = f"cuda:{cuda_index}"
                 else:
-                    _log.warning(
-                        "CUDA device 'cuda:%d' is not available. Fall back to 'CPU'.",
-                        cuda_index,
+                    raise AcceleratorDeviceNotAvailableError(
+                        f"CUDA device 'cuda:{cuda_index}' is not available. "
+                        f"Available CUDA devices: 0-{torch.cuda.device_count() - 1}"
                     )
             elif len(parts) == 1:  # just "cuda"
                 device = "cuda:0"
             else:
-                _log.warning(
-                    "Invalid CUDA device format '%s'. Fall back to 'CPU'",
-                    accelerator_device,
+                raise AcceleratorDeviceNotAvailableError(
+                    f"Invalid CUDA device format '{accelerator_device}'. "
+                    f"Use 'cuda' or 'cuda:N' where N is a valid device index."
                 )
         else:
-            _log.warning("CUDA is not available in the system. Fall back to 'CPU'")
+            raise AcceleratorDeviceNotAvailableError(
+                "CUDA is not available in the system. "
+                "Please ensure PyTorch with CUDA support is installed, or use --device auto/cpu."
+            )
 
     elif accelerator_device == AcceleratorDevice.MPS.value:
         if has_mps:
             device = "mps"
         else:
-            _log.warning("MPS is not available in the system. Fall back to 'CPU'")
+            raise AcceleratorDeviceNotAvailableError(
+                "MPS is not available in the system. "
+                "Please ensure you are running on Apple Silicon with MPS support, or use --device auto/cpu."
+            )
 
     elif accelerator_device == AcceleratorDevice.XPU.value:
         if has_xpu:
             device = "xpu"
         else:
-            _log.warning("XPU is not available in the system. Fall back to 'CPU'")
+            raise AcceleratorDeviceNotAvailableError(
+                "XPU is not available in the system. "
+                "Please ensure PyTorch with Intel XPU support is installed, or use --device auto/cpu."
+            )
 
     elif accelerator_device == AcceleratorDevice.CPU.value:
         device = "cpu"

--- a/docling/utils/accelerator_utils.py
+++ b/docling/utils/accelerator_utils.py
@@ -51,6 +51,14 @@ def decide_device(
             device = "xpu"
 
     elif accelerator_device.startswith("cuda"):
+        if (
+            supported_devices is not None
+            and AcceleratorDevice.CUDA not in supported_devices
+        ):
+            raise AcceleratorDeviceNotAvailableError(
+                f"CUDA is not supported by this model. Supported devices: {[d.value for d in supported_devices]}"
+            )
+
         if has_cuda:
             # if cuda device index specified extract device id
             parts = accelerator_device.split(":")
@@ -78,6 +86,14 @@ def decide_device(
             )
 
     elif accelerator_device == AcceleratorDevice.MPS.value:
+        if (
+            supported_devices is not None
+            and AcceleratorDevice.MPS not in supported_devices
+        ):
+            raise AcceleratorDeviceNotAvailableError(
+                f"MPS is not supported by this model. Supported devices: {[d.value for d in supported_devices]}"
+            )
+
         if has_mps:
             device = "mps"
         else:
@@ -87,6 +103,14 @@ def decide_device(
             )
 
     elif accelerator_device == AcceleratorDevice.XPU.value:
+        if (
+            supported_devices is not None
+            and AcceleratorDevice.XPU not in supported_devices
+        ):
+            raise AcceleratorDeviceNotAvailableError(
+                f"XPU is not supported by this model. Supported devices: {[d.value for d in supported_devices]}"
+            )
+
         if has_xpu:
             device = "xpu"
         else:
@@ -99,8 +123,9 @@ def decide_device(
         device = "cpu"
 
     else:
-        _log.warning(
-            "Unknown device option '%s'. Fall back to 'CPU'", accelerator_device
+        raise AcceleratorDeviceNotAvailableError(
+            f"Unknown device option '{accelerator_device}'. "
+            f"Valid options are: auto, cpu, cuda, mps, xpu, or cuda:N"
         )
 
     _log.info("Accelerator device: '%s'", device)

--- a/tests/test_asr_pipeline.py
+++ b/tests/test_asr_pipeline.py
@@ -197,7 +197,7 @@ def test_native_and_mlx_transcribe_language_handling(monkeypatch, tmp_path):
     )
     with patch.dict("sys.modules", {"mlx_whisper": Mock()}):
         mm = _MlxWhisperModel(
-            True, None, AcceleratorOptions(device=AcceleratorDevice.MPS), opts_m
+            True, None, AcceleratorOptions(device=AcceleratorDevice.CPU), opts_m
         )
         mm.mlx_whisper = Mock()
         mm.mlx_whisper.transcribe.return_value = {"segments": []}
@@ -387,7 +387,7 @@ def test_mlx_whisper_reports_missing_ffmpeg_before_transcription(
         model = _MlxWhisperModel(
             enabled=True,
             artifacts_path=None,
-            accelerator_options=AcceleratorOptions(device=AcceleratorDevice.MPS),
+            accelerator_options=AcceleratorOptions(device=AcceleratorDevice.CPU),
             asr_options=options,
         )
 
@@ -421,7 +421,7 @@ def test_mlx_run_success_and_failure(tmp_path):
             language="en",
         )
         model = _MlxWhisperModel(
-            True, None, AcceleratorOptions(device=AcceleratorDevice.MPS), opts
+            True, None, AcceleratorOptions(device=AcceleratorDevice.CPU), opts
         )
         model.mlx_whisper = Mock()
         model.mlx_whisper.transcribe.return_value = {
@@ -444,7 +444,7 @@ def test_mlx_run_success_and_failure(tmp_path):
             language="en",
         )
         model2 = _MlxWhisperModel(
-            True, None, AcceleratorOptions(device=AcceleratorDevice.MPS), opts2
+            True, None, AcceleratorOptions(device=AcceleratorDevice.CPU), opts2
         )
         model2.mlx_whisper = Mock()
         model2.mlx_whisper.transcribe.side_effect = RuntimeError("fail")
@@ -523,7 +523,7 @@ def test_mlx_whisper_handles_zero_duration_timestamps(tmp_path):
             language="en",
         )
         model = _MlxWhisperModel(
-            True, None, AcceleratorOptions(device=AcceleratorDevice.MPS), opts
+            True, None, AcceleratorOptions(device=AcceleratorDevice.CPU), opts
         )
         model.mlx_whisper = Mock()
 


### PR DESCRIPTION

Resolves #3605

Summary :-

Docling was logging warnings and falling back to CPU when explicit devices were unavailable. Now with this fix, when users explicitly specify --device cuda/mps/xpu and the device is not available, docling raises `AcceleratorDeviceNotAvailableError` with a clear error message instead of silently falling back to CPU. 

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
