### PR TITLE
fix(jats): preserve nested list structure in list items

### DIFF
--- a/docling/backend/xml/jats_backend.py
+++ b/docling/backend/xml/jats_backend.py
@@ -960,7 +960,8 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
                     label=GroupLabel.LIST, name="list", parent=parent
                 )
             elif child.tag == "list-item":
-                # TODO: address any type of content (another list, formula,...)
+                # TODO: address non-paragraph, non-list content inside list-item
+                #       (e.g. disp-formula, fig, table-wrap)
                 # TODO: address list type and item label
                 text_parts: list[str] = []
                 nested_lists: list[etree._Element] = []

--- a/docling/backend/xml/jats_backend.py
+++ b/docling/backend/xml/jats_backend.py
@@ -962,11 +962,14 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
             elif child.tag == "list-item":
                 # TODO: address any type of content (another list, formula,...)
                 # TODO: address list type and item label
-                text_parts = []
+                text_parts: list[str] = []
+                nested_lists: list[etree._Element] = []
 
                 for elem in child:
                     if elem.tag == "p":
                         text_parts.append(JatsDocumentBackend._get_text(elem).strip())
+                    elif elem.tag == "list":
+                        nested_lists.append(elem)
 
                 text = " ".join(part for part in text_parts if part)
 
@@ -975,9 +978,8 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
                     parent=parent,
                 )
 
-                for elem in child:
-                    if elem.tag == "list":
-                        self._walk_linear(doc, new_parent, elem)
+                for nested in nested_lists:
+                    self._walk_linear(doc, new_parent, nested)
 
                 stop_walk = True
 

--- a/docling/backend/xml/jats_backend.py
+++ b/docling/backend/xml/jats_backend.py
@@ -507,7 +507,8 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
 
         return
 
-    def _handle_inline_formula(self,
+    def _handle_inline_formula(
+        self,
         child: etree._Element,
         node: etree._Element,
         node_text: str,

--- a/docling/backend/xml/jats_backend.py
+++ b/docling/backend/xml/jats_backend.py
@@ -947,9 +947,25 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
             elif child.tag == "list-item":
                 # TODO: address any type of content (another list, formula,...)
                 # TODO: address list type and item label
-                text = JatsDocumentBackend._get_text(child).strip()
-                new_parent = doc.add_list_item(text=text, parent=parent)
+                text_parts = []
+
+                for elem in child:
+                    if elem.tag == "p":
+                        text_parts.append(JatsDocumentBackend._get_text(elem).strip())
+
+                text = " ".join(part for part in text_parts if part)
+
+                new_parent = doc.add_list_item(
+                    text=text,
+                    parent=parent,
+                )
+
+                for elem in child:
+                    if elem.tag == "list":
+                        self._walk_linear(doc, new_parent, elem)
+
                 stop_walk = True
+
             elif child.tag == "fig":
                 self._add_figure_captions(doc, parent, child)
                 stop_walk = True

--- a/docling/backend/xml/jats_backend.py
+++ b/docling/backend/xml/jats_backend.py
@@ -507,6 +507,20 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
 
         return
 
+    def _handle_inline_formula(self,
+        child: etree._Element,
+        node: etree._Element,
+        node_text: str,
+        inline_segments: list[tuple[DocItemLabel, str]],
+    ) -> str:
+        formula = self._get_inline_equation(child) if node.tag == "p" else None
+        if formula is not None:
+            if node_text.strip():
+                inline_segments.append((DocItemLabel.TEXT, node_text.strip()))
+                node_text = ""
+            inline_segments.append((DocItemLabel.FORMULA, formula))
+        return node_text
+
     def _parse_element_citation(self, node: etree._Element) -> str:
         citation: Citation = {
             "author_names": "",
@@ -1004,12 +1018,12 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
                 self._add_equation(doc, parent, child)
                 stop_walk = True
             elif child.tag == "inline-formula":
-                formula = self._get_inline_equation(child) if node.tag == "p" else None
-                if formula is not None:
-                    if node_text.strip():
-                        inline_segments.append((DocItemLabel.TEXT, node_text.strip()))
-                        node_text = ""
-                    inline_segments.append((DocItemLabel.FORMULA, formula))
+                node_text = self._handle_inline_formula(
+                    child,
+                    node,
+                    node_text,
+                    inline_segments,
+                )
                 stop_walk = True
 
             # step into child

--- a/tests/test_backend_jats.py
+++ b/tests/test_backend_jats.py
@@ -60,6 +60,27 @@ PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 201
     return conv_result.document
 
 
+def convert_jats_body(body_content: str) -> DoclingDocument:
+    xml = f"""<!DOCTYPE article
+PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN" "JATS-archivearticle1.dtd">
+<article article-type="research-article">
+  <front>
+    <article-meta>
+      <title-group>
+        <article-title>Body Test</article-title>
+      </title-group>
+    </article-meta>
+  </front>
+  <body>
+    {body_content}
+  </body>
+</article>
+"""
+    stream = DocumentStream(name="body-test.nxml", stream=BytesIO(xml.encode()))
+    conv_result: ConversionResult = get_converter().convert(stream)
+    return conv_result.document
+
+
 def convert_jats_contribs(contribs: str, affiliations: str = "") -> DoclingDocument:
     return convert_jats_article_meta(
         f"""
@@ -92,6 +113,33 @@ def test_jats_structured_abstract_sections_are_preserved():
     assert "Background: Background text." in md
     assert "Methods: Methods text." in md
 
+def test_jats_nested_lists_are_preserved():
+    doc = convert_jats_body(
+        """
+        <sec>
+          <title>List Test</title>
+          <list>
+            <list-item>
+              <p>Item 1</p>
+              <list>
+                <list-item>
+                  <p>Subitem A</p>
+                </list-item>
+              </list>
+            </list-item>
+          </list>
+        </sec>
+        """
+    )
+
+    md = doc.export_to_markdown()
+
+    print("\n----- NESTED LIST OUTPUT -----")
+    print(md)
+    print("------------------------------")
+
+    assert "Item 1" in md
+    assert "Subitem A" in md
 
 def _inline_group_items(doc: DoclingDocument) -> list[list]:
     """Return the resolved child items of every INLINE group, in document order."""

--- a/tests/test_backend_jats.py
+++ b/tests/test_backend_jats.py
@@ -3,7 +3,7 @@ from io import BytesIO
 from pathlib import Path
 
 import pytest
-from docling_core.types.doc import DocItemLabel, DoclingDocument, GroupLabel
+from docling_core.types.doc import DocItemLabel, DoclingDocument, GroupLabel, TextItem
 
 from docling.datamodel.base_models import DocumentStream, InputFormat
 from docling.datamodel.document import ConversionResult
@@ -115,14 +115,25 @@ def test_jats_nested_lists_are_preserved():
         """
     )
 
+    # Both items must appear in the rendered output.
     md = doc.export_to_markdown()
-
     assert "- Item 1" in md
     assert "Subitem A" in md
-    # Nested item should not be flattened into the parent item
-    assert (
-        "Item 1                                                   Subitem A" not in md
-    )
+
+    # Verify document structure
+    list_items = [
+        item
+        for item, _level in doc.iterate_items()
+        if isinstance(item, TextItem) and item.label == DocItemLabel.LIST_ITEM
+    ]
+    assert len(list_items) == 2
+
+    outer_item = next(item for item in list_items if item.text == "Item 1")
+    sub_item = next(item for item in list_items if item.text == "Subitem A")
+
+    sub_item_parent = sub_item.parent.resolve(doc)
+    assert sub_item_parent.label == GroupLabel.LIST
+    assert sub_item_parent.parent == outer_item.get_ref()
 
 
 def _inline_group_items(doc: DoclingDocument) -> list[list]:

--- a/tests/test_backend_jats.py
+++ b/tests/test_backend_jats.py
@@ -113,6 +113,7 @@ def test_jats_structured_abstract_sections_are_preserved():
     assert "Background: Background text." in md
     assert "Methods: Methods text." in md
 
+
 def test_jats_nested_lists_are_preserved():
     doc = convert_jats_body(
         """
@@ -134,12 +135,12 @@ def test_jats_nested_lists_are_preserved():
 
     md = doc.export_to_markdown()
 
-    print("\n----- NESTED LIST OUTPUT -----")
-    print(md)
-    print("------------------------------")
-
-    assert "Item 1" in md
+    assert "- Item 1" in md
     assert "Subitem A" in md
+    # Nested item should not be flattened into the parent item
+    assert (
+        "Item 1                                                   Subitem A" not in md
+    )
 
 def _inline_group_items(doc: DoclingDocument) -> list[list]:
     """Return the resolved child items of every INLINE group, in document order."""

--- a/tests/test_backend_jats.py
+++ b/tests/test_backend_jats.py
@@ -25,6 +25,7 @@ def get_converter():
     converter = DocumentConverter(allowed_formats=[InputFormat.XML_JATS])
     return converter
 
+
 def convert_jats_article_meta(article_meta: str) -> DoclingDocument:
     xml = f"""<!DOCTYPE article
 PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN" "JATS-archivearticle1.dtd">

--- a/tests/test_backend_jats.py
+++ b/tests/test_backend_jats.py
@@ -25,25 +25,6 @@ def get_converter():
     converter = DocumentConverter(allowed_formats=[InputFormat.XML_JATS])
     return converter
 
-
-def convert_jats_body(body: str) -> DoclingDocument:
-    xml = f"""<!DOCTYPE article
-PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN" "JATS-archivearticle1.dtd">
-<article article-type="research-article">
-  <body>
-    {body}
-  </body>
-</article>
-"""
-    stream = DocumentStream(
-        name="body-test.nxml",
-        stream=BytesIO(xml.encode()),
-    )
-
-    conv_result: ConversionResult = get_converter().convert(stream)
-    return conv_result.document
-
-
 def convert_jats_article_meta(article_meta: str) -> DoclingDocument:
     xml = f"""<!DOCTYPE article
 PUBLIC "-//NLM//DTD JATS (Z39.96) Journal Archiving and Interchange DTD v1.2 20190208//EN" "JATS-archivearticle1.dtd">
@@ -141,6 +122,7 @@ def test_jats_nested_lists_are_preserved():
     assert (
         "Item 1                                                   Subitem A" not in md
     )
+
 
 def _inline_group_items(doc: DoclingDocument) -> list[list]:
     """Return the resolved child items of every INLINE group, in document order."""


### PR DESCRIPTION
**Issue resolved by this Pull Request:**

**Summary**

* preserve nested JATS list structure inside `list-item`
* avoid flattening nested list content into parent list items
* add a regression test covering nested lists

**Checklist:**

* [x] Tests have been added.
* [ ] Documentation has been updated, if necessary.
* [ ] Examples have been added, if necessary.

