### PR TITLE
feat(pptx): add optional slide-level visual composition

### DIFF
--- a/docling/backend/mspowerpoint_backend.py
+++ b/docling/backend/mspowerpoint_backend.py
@@ -30,6 +30,8 @@ from docling.backend.abstract_backend import (
     DeclarativeDocumentBackend,
     PaginatedDocumentBackend,
 )
+from docling.backend.pptx_slide_renderer import PptxSlideCompositionRenderer
+from docling.datamodel.backend_options import MsPowerpointBackendOptions
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
 
@@ -38,9 +40,12 @@ _log = logging.getLogger(__name__)
 
 class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBackend):
     def __init__(
-        self, in_doc: "InputDocument", path_or_stream: Union[BytesIO, Path]
+        self,
+        in_doc: "InputDocument",
+        path_or_stream: Union[BytesIO, Path],
+        options: Optional[MsPowerpointBackendOptions] = None,
     ) -> None:
-        super().__init__(in_doc, path_or_stream)
+        super().__init__(in_doc, path_or_stream, options=options)
         self.namespaces = {
             "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
             "c": "http://schemas.openxmlformats.org/drawingml/2006/chart",
@@ -579,6 +584,49 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
                 )
         return
 
+    def _get_pptx_options(self) -> MsPowerpointBackendOptions:
+        if isinstance(self.options, MsPowerpointBackendOptions):
+            return self.options
+
+        return MsPowerpointBackendOptions()
+
+    def _handle_slide_visual_composition(
+        self,
+        slide,
+        parent_slide,
+        slide_ind,
+        doc: DoclingDocument,
+        slide_size: Size,
+    ) -> None:
+        options = self._get_pptx_options()
+        renderer = PptxSlideCompositionRenderer(
+            dpi=options.slide_visual_composition_dpi,
+        )
+        pil_image = renderer.render(
+            slide=slide,
+            slide_width=slide_size.width,
+            slide_height=slide_size.height,
+        )
+
+        prov = ProvenanceItem(
+            page_no=slide_ind + 1,
+            charspan=[0, 0],
+            bbox=BoundingBox.from_tuple(
+                (0, 0, slide_size.width, slide_size.height),
+                origin=CoordOrigin.BOTTOMLEFT,
+            ),
+        )
+
+        doc.add_picture(
+            parent=parent_slide,
+            image=ImageRef.from_pil(
+                image=pil_image,
+                dpi=options.slide_visual_composition_dpi,
+            ),
+            caption=None,
+            prov=prov,
+        )
+
     def _handle_pictures(self, shape, parent_slide, slide_ind, doc, slide_size):
         # Open it with PIL
         try:
@@ -700,6 +748,15 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
 
             slide_size = Size(width=slide_width, height=slide_height)
             doc.add_page(page_no=slide_ind + 1, size=slide_size)
+
+            if self._get_pptx_options().create_slide_visual_composition:
+                self._handle_slide_visual_composition(
+                    slide=slide,
+                    parent_slide=parent_slide,
+                    slide_ind=slide_ind,
+                    doc=doc,
+                    slide_size=slide_size,
+                )
 
             def _safe_shape_type(shape):
                 """Return shape.shape_type, or None if unrecognized.

--- a/docling/backend/pptx_slide_renderer.py
+++ b/docling/backend/pptx_slide_renderer.py
@@ -1,0 +1,152 @@
+import logging
+from io import BytesIO
+
+from PIL import Image, ImageDraw, UnidentifiedImageError
+from pptx.enum.shapes import MSO_SHAPE_TYPE
+
+_log = logging.getLogger(__name__)
+
+EMU_PER_INCH = 914400
+
+
+class PptxSlideCompositionRenderer:
+    """Lightweight renderer for PPTX slide-level visual composition.
+
+    This is intentionally not a complete PowerPoint renderer. It captures the
+    main visual relationships needed by downstream VLM enrichment, especially
+    images connected by simple line/connector shapes.
+    """
+
+    def __init__(self, dpi: int = 144) -> None:
+        self.dpi = dpi
+
+    def emu_to_px(self, value: int | float) -> int:
+        return round(float(value) / EMU_PER_INCH * self.dpi)
+
+    def render(
+        self,
+        slide,
+        slide_width: int | float,
+        slide_height: int | float,
+    ) -> Image.Image:
+        width_px = max(1, self.emu_to_px(slide_width))
+        height_px = max(1, self.emu_to_px(slide_height))
+
+        canvas = Image.new("RGB", (width_px, height_px), "white")
+        draw = ImageDraw.Draw(canvas)
+
+        for shape in slide.shapes:
+            self._render_shape(shape, canvas, draw)
+
+        return canvas
+
+    def _render_shape(
+        self,
+        shape,
+        canvas: Image.Image,
+        draw: ImageDraw.ImageDraw,
+    ) -> None:
+        shape_type = self._safe_shape_type(shape)
+
+        if shape_type is None:
+            return
+
+        if shape_type == MSO_SHAPE_TYPE.GROUP:
+            for child in shape.shapes:
+                self._render_shape(child, canvas, draw)
+            return
+
+        if shape_type == MSO_SHAPE_TYPE.PICTURE:
+            self._render_picture(shape, canvas)
+            return
+
+        if shape_type == MSO_SHAPE_TYPE.LINE:
+            self._render_line(shape, draw)
+            return
+
+        if shape_type == MSO_SHAPE_TYPE.AUTO_SHAPE:
+            self._render_auto_shape(shape, draw)
+
+        if getattr(shape, "has_text_frame", False):
+            self._render_text(shape, draw)
+
+    def _safe_shape_type(self, shape):
+        try:
+            return shape.shape_type
+        except NotImplementedError:
+            _log.debug("Skipping shape with unrecognized type in slide rendering")
+            return None
+
+    def _render_picture(self, shape, canvas: Image.Image) -> None:
+        try:
+            image = Image.open(BytesIO(shape.image.blob)).convert("RGBA")
+        except (
+            UnidentifiedImageError,
+            OSError,
+            ValueError,
+            KeyError,
+            AttributeError,
+        ) as exc:
+            _log.debug("Skipping malformed picture in slide composition: %s", exc)
+            return
+
+        x = self.emu_to_px(shape.left)
+        y = self.emu_to_px(shape.top)
+        w = max(1, self.emu_to_px(shape.width))
+        h = max(1, self.emu_to_px(shape.height))
+
+        image = image.resize((w, h))
+        canvas.paste(image, (x, y), image)
+
+    def _render_line(self, shape, draw: ImageDraw.ImageDraw) -> None:
+        x1 = self.emu_to_px(shape.left)
+        y1 = self.emu_to_px(shape.top)
+        x2 = self.emu_to_px(shape.left + shape.width)
+        y2 = self.emu_to_px(shape.top + shape.height)
+
+        if x1 == x2 and y1 == y2:
+            return
+
+        draw.line(
+            (x1, y1, x2, y2),
+            fill="black",
+            width=self._line_width_px(shape),
+        )
+
+    def _render_auto_shape(self, shape, draw: ImageDraw.ImageDraw) -> None:
+        x1 = self.emu_to_px(shape.left)
+        y1 = self.emu_to_px(shape.top)
+        x2 = self.emu_to_px(shape.left + shape.width)
+        y2 = self.emu_to_px(shape.top + shape.height)
+
+        if x1 == x2 or y1 == y2:
+            return
+
+        draw.rectangle(
+            (x1, y1, x2, y2),
+            outline="black",
+            width=self._line_width_px(shape),
+        )
+
+    def _render_text(self, shape, draw: ImageDraw.ImageDraw) -> None:
+        text = getattr(shape, "text", "") or ""
+        text = text.strip()
+
+        if not text:
+            return
+
+        x = self.emu_to_px(shape.left) + 4
+        y = self.emu_to_px(shape.top) + 4
+
+        draw.text((x, y), text, fill="black")
+
+    def _line_width_px(self, shape) -> int:
+        try:
+            width = shape.line.width
+        except AttributeError:
+            width = None
+
+        if width is None:
+            return 2
+
+        return max(1, self.emu_to_px(width))

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -240,6 +240,25 @@ class MsExcelBackendOptions(BaseBackendOptions):
     )
 
 
+class MsPowerpointBackendOptions(BaseBackendOptions):
+    """Options specific to the MS PowerPoint backend."""
+
+    kind: Literal["pptx"] = Field("pptx", exclude=True, repr=False)
+
+    create_slide_visual_composition: bool = Field(
+        False,
+        description=(
+            "Whether to add a slide-level PictureItem that captures the full "
+            "visual composition of each PPTX slide."
+        ),
+    )
+
+    slide_visual_composition_dpi: PositiveInt = Field(
+        144,
+        description="DPI used when rasterizing slide-level visual compositions.",
+    )
+
+
 class LatexBackendOptions(BaseBackendOptions):
     """Options specific to the LaTeX backend."""
 
@@ -301,6 +320,7 @@ BackendOptions = Annotated[
         ThreadedDoclingParseBackendOptions,
         MetsGbsBackendOptions,
         MsExcelBackendOptions,
+        MsPowerpointBackendOptions,
         LatexBackendOptions,
         XBRLBackendOptions,
     ],

--- a/docling/document_converter.py
+++ b/docling/document_converter.py
@@ -45,6 +45,7 @@ from docling.datamodel.backend_options import (
     LatexBackendOptions,
     MarkdownBackendOptions,
     MetsGbsBackendOptions,
+    MsPowerpointBackendOptions,
     PdfBackendOptions,
     XBRLBackendOptions,
 )
@@ -114,6 +115,7 @@ class WordFormatOption(FormatOption):
 class PowerpointFormatOption(FormatOption):
     pipeline_cls: Type = SimplePipeline
     backend: Type[AbstractDocumentBackend] = MsPowerpointDocumentBackend
+    backend_options: Optional[MsPowerpointBackendOptions] = None
 
 
 class MarkdownFormatOption(FormatOption):

--- a/tests/test_backend_pptx.py
+++ b/tests/test_backend_pptx.py
@@ -1,10 +1,16 @@
 from pathlib import Path
 
 import pytest
+from docling_core.types.doc import DocItemLabel
+from PIL import Image, ImageDraw
+from pptx import Presentation
+from pptx.enum.shapes import MSO_CONNECTOR
+from pptx.util import Inches
 
+from docling.datamodel.backend_options import MsPowerpointBackendOptions
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import ConversionResult, DoclingDocument
-from docling.document_converter import DocumentConverter
+from docling.document_converter import DocumentConverter, PowerpointFormatOption
 
 from .test_data_gen_flag import GEN_TEST_DATA
 from .verify_utils import verify_document, verify_export
@@ -122,3 +128,88 @@ def test_pptx_page_range():
     assert "Second slide title" in pred_md
     assert "Test Table Slide" not in pred_md
     assert "List item4" not in pred_md
+
+
+def _make_pptx_with_two_images_and_connector(tmp_path):
+    left_img = tmp_path / "left.png"
+    right_img = tmp_path / "right.png"
+    pptx_path = tmp_path / "composition_arrow.pptx"
+
+    for img_path, label in [(left_img, "A"), (right_img, "B")]:
+        image = Image.new("RGB", (320, 220), "white")
+        draw = ImageDraw.Draw(image)
+        draw.rectangle((20, 20, 300, 200), outline="black", width=5)
+        draw.text((145, 100), label, fill="black")
+        image.save(img_path)
+
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+
+    slide.shapes.add_picture(
+        str(left_img),
+        Inches(1),
+        Inches(2),
+        width=Inches(2.5),
+        height=Inches(1.8),
+    )
+    slide.shapes.add_picture(
+        str(right_img),
+        Inches(6),
+        Inches(2),
+        width=Inches(2.5),
+        height=Inches(1.8),
+    )
+    slide.shapes.add_connector(
+        MSO_CONNECTOR.STRAIGHT,
+        Inches(3.7),
+        Inches(2.9),
+        Inches(5.8),
+        Inches(2.9),
+    )
+
+    prs.save(pptx_path)
+    return pptx_path
+
+
+def test_pptx_slide_visual_composition_is_opt_in(tmp_path):
+    pptx_path = _make_pptx_with_two_images_and_connector(tmp_path)
+
+    converter = DocumentConverter(allowed_formats=[InputFormat.PPTX])
+    result = converter.convert(pptx_path)
+
+    pictures = [
+        item
+        for item, _level in result.document.iterate_items()
+        if getattr(item, "label", None) == DocItemLabel.PICTURE
+    ]
+
+    assert len(pictures) == 2
+
+
+def test_pptx_slide_visual_composition_adds_slide_picture(tmp_path):
+    pptx_path = _make_pptx_with_two_images_and_connector(tmp_path)
+
+    converter = DocumentConverter(
+        format_options={
+            InputFormat.PPTX: PowerpointFormatOption(
+                backend_options=MsPowerpointBackendOptions(
+                    create_slide_visual_composition=True,
+                )
+            )
+        }
+    )
+    result = converter.convert(pptx_path)
+
+    pictures = [
+        item
+        for item, _level in result.document.iterate_items()
+        if getattr(item, "label", None) == DocItemLabel.PICTURE
+    ]
+
+    assert len(pictures) == 3
+
+    slide_picture = pictures[0]
+    assert slide_picture.prov
+    assert slide_picture.prov[0].page_no == 1
+    assert slide_picture.prov[0].bbox.l == 0
+    assert slide_picture.prov[0].bbox.b == 0


### PR DESCRIPTION
## Summary

Fixes #3533

This PR adds an opt-in PPTX backend option to create a slide-level `PictureItem` for each slide.

The existing shape-level extraction behavior remains unchanged by default.

PPTX slides often communicate meaning through the relationship between visual elements, such as:

- Images connected by arrows
- Flow diagrams
- Architecture diagrams
- Process charts
- Grouped visual layouts

Previously, Docling extracted individual `PictureItem`s from PPTX slides, but it did not preserve the full slide-level visual composition. As a result, downstream VLM enrichment could see separate images but miss the relationship between them.

With this PR, users can enable slide-level visual composition extraction so downstream VLM processing receives a full-slide visual representation.

## What Changed

- Added `MsPowerpointBackendOptions` support to the PPTX backend constructor.
- Added a new opt-in option:

  ```python
  create_slide_visual_composition: bool = False
  ```

- Added configurable DPI for slide visual composition rendering:

  ```python
  slide_visual_composition_dpi: PositiveInt = 144
  ```

- Added a lightweight PPTX slide composition renderer.
- Added slide-level `PictureItem` creation when the option is enabled.
- Preserved the existing default PPTX behavior.
- Added regression tests for:
  - Default behavior remaining unchanged.
  - Slide-level visual composition adding one extra `PictureItem`.

## Behavior

By default, PPTX conversion behaves the same as before.

When enabled:

```python
from docling.datamodel.base_models import InputFormat
from docling.datamodel.backend_options import MsPowerpointBackendOptions
from docling.document_converter import DocumentConverter, PowerpointFormatOption

converter = DocumentConverter(
    format_options={
        InputFormat.PPTX: PowerpointFormatOption(
            backend_options=MsPowerpointBackendOptions(
                create_slide_visual_composition=True,
            )
        )
    }
)
```

Docling adds one full-slide `PictureItem` per slide in addition to the existing extracted images.

## Reproduction

Given a PPTX slide containing:

- Left image
- Right image
- Connector/arrow between them

Previously, Docling produced:

```text
Picture items: 2
```

After enabling `create_slide_visual_composition`, Docling produces:

```text
Picture items: 3
```

The additional `PictureItem` represents the full slide visual composition.

## Tests

Ran:

```bash
uv run pytest tests/test_backend_pptx.py -q
```

Result:

```text
6 passed
```