### PR TITLE
fix(html): ensure proper ListGroup parent for description list items

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -2455,38 +2455,44 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
                     if current_dt_item:
                         self.parents[self.level + 1] = current_dt_item
 
-                        dd_count = 0
-                        for next_child in children[i + 1 :]:
-                            if isinstance(next_child, Tag):
-                                if next_child.name.lower() == "dd":
-                                    dd_count += 1
-                                elif next_child.name.lower() == "dt":
-                                    break
-
-                        if dd_count > 1:
+                elif child_name == "dd":
+                    has_nested_dl = child.find("dl", recursive=False) is not None
+                    if has_nested_dl:
+                        # Close current descriptions group before processing nested <dl>
+                        dd_group = None
+                        # If <dd> contains a nested <dl>, process it directly under the term item
+                        # Don't create a list item for the <dd> itself to avoid double indentation
+                        if current_dt_item:
+                            with self._use_list_item_context(current_dt_item):
+                                processed_elements = set()
+                                self._process_list_item_nested_content(
+                                    child, doc, processed_elements
+                                )
+                    else:
+                        # For regular <dd> without nested <dl>, create/use descriptions group
+                        if dd_group is None and current_dt_item:
                             dd_group = doc.add_list_group(
                                 name="descriptions",
                                 parent=current_dt_item,
                                 content_layer=self.content_layer,
                             )
 
-                elif child_name == "dd":
-                    dd_parent = dd_group or current_dt_item or list_group
+                        # dd_group should exist at this point (or fall back to list_group)
+                        dd_parent = dd_group or list_group
 
-                    dd_item = self._add_list_item_with_content(
-                        tag=child,
-                        doc=doc,
-                        parent=dd_parent,
-                    )
-
-                    # Process nested content (images, lists, etc.) in the description
-                    # Set parent for nested content (use dd_item if available, otherwise dd_parent)
-                    content_parent = dd_item or dd_parent
-                    with self._use_list_item_context(content_parent):
-                        processed_elements = set()
-                        self._process_list_item_nested_content(
-                            child, doc, processed_elements
+                        dd_item = self._add_list_item_with_content(
+                            tag=child,
+                            doc=doc,
+                            parent=dd_parent,
                         )
+
+                        # Process nested content (images, lists, etc.) in the description
+                        content_parent = dd_item or dd_parent
+                        with self._use_list_item_context(content_parent):
+                            processed_elements = set()
+                            self._process_list_item_nested_content(
+                                child, doc, processed_elements
+                            )
 
             self.parents[self.level + 1] = None
             self.level -= 1

--- a/tests/data/groundtruth/docling_v2/html_description_list.html.itxt
+++ b/tests/data/groundtruth/docling_v2/html_description_list.html.itxt
@@ -2,43 +2,57 @@ item-0 at level 0: unspecified: group _root_
   item-1 at level 1: title: Beverages
     item-2 at level 2: list: group description list
       item-3 at level 3: list_item: Coffee
-        item-4 at level 4: list: group group
+        item-4 at level 4: list: group descriptions
           item-5 at level 5: list_item: Black hot drink
       item-6 at level 3: list_item: Milk
-        item-7 at level 4: list: group group
+        item-7 at level 4: list: group descriptions
           item-8 at level 5: list_item: White cold drink
-    item-9 at level 2: section_header: Programming Languages
-      item-10 at level 3: list: group description list
-        item-11 at level 4: list_item: Python
-          item-12 at level 5: list: group descriptions
-            item-13 at level 6: list_item: A high-level programming language
-            item-14 at level 6: list_item: Known for its simplicity and readability
-        item-15 at level 4: list_item: JavaScript
-          item-16 at level 5: list: group group
-            item-17 at level 6: list_item: A scripting language for web browsers
-    item-18 at level 2: section_header: Complex Example
-      item-19 at level 3: list: group description list
-        item-20 at level 4: list_item: HTML
-          item-21 at level 5: list: group group
-            item-22 at level 6: list_item: 
-              item-23 at level 7: inline: group group
-                item-24 at level 8: text: HyperText Markup Language - used for
-                item-25 at level 8: text: structuring
-                item-26 at level 8: text: web content
-        item-27 at level 4: list_item: CSS
-          item-28 at level 5: list: group descriptions
-            item-29 at level 6: list_item: Cascading Style Sheets
-            item-30 at level 6: list_item: Used for styling and layout
-    item-31 at level 2: section_header: Nested Lists
-      item-32 at level 3: list: group description list
-        item-33 at level 4: list_item: Main Term 1
-          item-34 at level 5: list: group group
-            item-35 at level 6: list_item: Description for the first main term.
-        item-36 at level 4: list_item: Main Term 2 (Sub-categories)
-          item-37 at level 5: list: group description list
-            item-38 at level 6: list_item: Sub-term A
-              item-39 at level 7: list: group group
-                item-40 at level 8: list_item: Detail for sub-term A.
-            item-41 at level 6: list_item: Sub-term B
-              item-42 at level 7: list: group group
-                item-43 at level 8: list_item: Detail for sub-term B.
+      item-9 at level 3: list_item: Soda
+      item-10 at level 3: list_item: Water
+    item-11 at level 2: section_header: Programming Languages
+      item-12 at level 3: list: group description list
+        item-13 at level 4: list_item: Python
+          item-14 at level 5: list: group descriptions
+            item-15 at level 6: list_item: A high-level programming language
+            item-16 at level 6: list_item: Known for its simplicity and readability
+        item-17 at level 4: list_item: JavaScript
+          item-18 at level 5: list: group descriptions
+            item-19 at level 6: list_item: A scripting language for web browsers
+    item-20 at level 2: section_header: Complex Example
+      item-21 at level 3: list: group description list
+        item-22 at level 4: list_item: HTML
+          item-23 at level 5: list: group descriptions
+            item-24 at level 6: list_item: 
+              item-25 at level 7: inline: group group
+                item-26 at level 8: text: HyperText Markup Language - used for
+                item-27 at level 8: text: structuring
+                item-28 at level 8: text: web content
+        item-29 at level 4: list_item: CSS
+          item-30 at level 5: list: group descriptions
+            item-31 at level 6: list_item: Cascading Style Sheets
+            item-32 at level 6: list_item: Used for styling and layout
+    item-33 at level 2: section_header: Nested Lists
+      item-34 at level 3: list: group description list
+        item-35 at level 4: list_item: Main Term 1
+          item-36 at level 5: list: group descriptions
+            item-37 at level 6: list_item: Description for the first main term.
+        item-38 at level 4: list_item: Main Term 2 (Sub-categories)
+          item-39 at level 5: list: group description list
+            item-40 at level 6: list_item: Sub-term A
+              item-41 at level 7: list: group descriptions
+                item-42 at level 8: list_item: Detail for sub-term A.
+            item-43 at level 6: list_item: Sub-term B
+              item-44 at level 7: list: group descriptions
+                item-45 at level 8: list_item: Detail for sub-term B.
+        item-46 at level 4: list_item: Main Term 3 (Mixed)
+          item-47 at level 5: list: group descriptions
+            item-48 at level 6: list_item: This is a regular text description.
+          item-49 at level 5: list: group description list
+            item-50 at level 6: list_item: Sub-term C
+              item-51 at level 7: list: group descriptions
+                item-52 at level 8: list_item: Detail for sub-term C.
+            item-53 at level 6: list_item: Sub-term D
+              item-54 at level 7: list: group descriptions
+                item-55 at level 8: list_item: Detail for sub-term D.
+          item-56 at level 5: list: group descriptions
+            item-57 at level 6: list_item: Final regular text description.

--- a/tests/data/groundtruth/docling_v2/html_description_list.html.json
+++ b/tests/data/groundtruth/docling_v2/html_description_list.html.json
@@ -4,7 +4,7 @@
   "name": "html_description_list",
   "origin": {
     "mimetype": "text/html",
-    "binary_hash": 9131381286832314880,
+    "binary_hash": 3745372691947282921,
     "filename": "html_description_list.html"
   },
   "furniture": {
@@ -40,6 +40,12 @@
         },
         {
           "$ref": "#/texts/4"
+        },
+        {
+          "$ref": "#/texts/6"
+        },
+        {
+          "$ref": "#/texts/7"
         }
       ],
       "content_layer": "body",
@@ -57,7 +63,7 @@
         }
       ],
       "content_layer": "body",
-      "name": "group",
+      "name": "descriptions",
       "label": "list"
     },
     {
@@ -71,20 +77,20 @@
         }
       ],
       "content_layer": "body",
-      "name": "group",
+      "name": "descriptions",
       "label": "list"
     },
     {
       "self_ref": "#/groups/3",
       "parent": {
-        "$ref": "#/texts/6"
+        "$ref": "#/texts/8"
       },
       "children": [
         {
-          "$ref": "#/texts/7"
+          "$ref": "#/texts/9"
         },
         {
-          "$ref": "#/texts/10"
+          "$ref": "#/texts/12"
         }
       ],
       "content_layer": "body",
@@ -94,14 +100,14 @@
     {
       "self_ref": "#/groups/4",
       "parent": {
-        "$ref": "#/texts/7"
+        "$ref": "#/texts/9"
       },
       "children": [
         {
-          "$ref": "#/texts/8"
+          "$ref": "#/texts/10"
         },
         {
-          "$ref": "#/texts/9"
+          "$ref": "#/texts/11"
         }
       ],
       "content_layer": "body",
@@ -111,28 +117,28 @@
     {
       "self_ref": "#/groups/5",
       "parent": {
-        "$ref": "#/texts/10"
-      },
-      "children": [
-        {
-          "$ref": "#/texts/11"
-        }
-      ],
-      "content_layer": "body",
-      "name": "group",
-      "label": "list"
-    },
-    {
-      "self_ref": "#/groups/6",
-      "parent": {
         "$ref": "#/texts/12"
       },
       "children": [
         {
           "$ref": "#/texts/13"
+        }
+      ],
+      "content_layer": "body",
+      "name": "descriptions",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/6",
+      "parent": {
+        "$ref": "#/texts/14"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/15"
         },
         {
-          "$ref": "#/texts/18"
+          "$ref": "#/texts/20"
         }
       ],
       "content_layer": "body",
@@ -142,31 +148,31 @@
     {
       "self_ref": "#/groups/7",
       "parent": {
-        "$ref": "#/texts/13"
+        "$ref": "#/texts/15"
       },
       "children": [
         {
-          "$ref": "#/texts/14"
+          "$ref": "#/texts/16"
         }
       ],
       "content_layer": "body",
-      "name": "group",
+      "name": "descriptions",
       "label": "list"
     },
     {
       "self_ref": "#/groups/8",
       "parent": {
-        "$ref": "#/texts/14"
+        "$ref": "#/texts/16"
       },
       "children": [
         {
-          "$ref": "#/texts/15"
-        },
-        {
-          "$ref": "#/texts/16"
-        },
-        {
           "$ref": "#/texts/17"
+        },
+        {
+          "$ref": "#/texts/18"
+        },
+        {
+          "$ref": "#/texts/19"
         }
       ],
       "content_layer": "body",
@@ -176,14 +182,14 @@
     {
       "self_ref": "#/groups/9",
       "parent": {
-        "$ref": "#/texts/18"
+        "$ref": "#/texts/20"
       },
       "children": [
         {
-          "$ref": "#/texts/19"
+          "$ref": "#/texts/21"
         },
         {
-          "$ref": "#/texts/20"
+          "$ref": "#/texts/22"
         }
       ],
       "content_layer": "body",
@@ -193,14 +199,17 @@
     {
       "self_ref": "#/groups/10",
       "parent": {
-        "$ref": "#/texts/21"
+        "$ref": "#/texts/23"
       },
       "children": [
         {
-          "$ref": "#/texts/22"
+          "$ref": "#/texts/24"
         },
         {
-          "$ref": "#/texts/24"
+          "$ref": "#/texts/26"
+        },
+        {
+          "$ref": "#/texts/31"
         }
       ],
       "content_layer": "body",
@@ -210,28 +219,28 @@
     {
       "self_ref": "#/groups/11",
       "parent": {
-        "$ref": "#/texts/22"
-      },
-      "children": [
-        {
-          "$ref": "#/texts/23"
-        }
-      ],
-      "content_layer": "body",
-      "name": "group",
-      "label": "list"
-    },
-    {
-      "self_ref": "#/groups/12",
-      "parent": {
         "$ref": "#/texts/24"
       },
       "children": [
         {
           "$ref": "#/texts/25"
-        },
+        }
+      ],
+      "content_layer": "body",
+      "name": "descriptions",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/12",
+      "parent": {
+        "$ref": "#/texts/26"
+      },
+      "children": [
         {
           "$ref": "#/texts/27"
+        },
+        {
+          "$ref": "#/texts/29"
         }
       ],
       "content_layer": "body",
@@ -241,20 +250,6 @@
     {
       "self_ref": "#/groups/13",
       "parent": {
-        "$ref": "#/texts/25"
-      },
-      "children": [
-        {
-          "$ref": "#/texts/26"
-        }
-      ],
-      "content_layer": "body",
-      "name": "group",
-      "label": "list"
-    },
-    {
-      "self_ref": "#/groups/14",
-      "parent": {
         "$ref": "#/texts/27"
       },
       "children": [
@@ -263,7 +258,94 @@
         }
       ],
       "content_layer": "body",
-      "name": "group",
+      "name": "descriptions",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/14",
+      "parent": {
+        "$ref": "#/texts/29"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/30"
+        }
+      ],
+      "content_layer": "body",
+      "name": "descriptions",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/15",
+      "parent": {
+        "$ref": "#/texts/31"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/32"
+        }
+      ],
+      "content_layer": "body",
+      "name": "descriptions",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/16",
+      "parent": {
+        "$ref": "#/texts/31"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/33"
+        },
+        {
+          "$ref": "#/texts/35"
+        }
+      ],
+      "content_layer": "body",
+      "name": "description list",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/17",
+      "parent": {
+        "$ref": "#/texts/33"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/34"
+        }
+      ],
+      "content_layer": "body",
+      "name": "descriptions",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/18",
+      "parent": {
+        "$ref": "#/texts/35"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/36"
+        }
+      ],
+      "content_layer": "body",
+      "name": "descriptions",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/19",
+      "parent": {
+        "$ref": "#/texts/31"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/37"
+        }
+      ],
+      "content_layer": "body",
+      "name": "descriptions",
       "label": "list"
     }
   ],
@@ -290,13 +372,13 @@
           "$ref": "#/groups/0"
         },
         {
-          "$ref": "#/texts/6"
+          "$ref": "#/texts/8"
         },
         {
-          "$ref": "#/texts/12"
+          "$ref": "#/texts/14"
         },
         {
-          "$ref": "#/texts/21"
+          "$ref": "#/texts/23"
         }
       ],
       "content_layer": "body",
@@ -386,6 +468,48 @@
     {
       "self_ref": "#/texts/6",
       "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Soda",
+      "text": "Soda",
+      "formatting": {
+        "bold": true,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "script": "baseline"
+      },
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/7",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Water",
+      "text": "Water",
+      "formatting": {
+        "bold": true,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "script": "baseline"
+      },
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/8",
+      "parent": {
         "$ref": "#/texts/1"
       },
       "children": [
@@ -401,7 +525,7 @@
       "level": 1
     },
     {
-      "self_ref": "#/texts/7",
+      "self_ref": "#/texts/9",
       "parent": {
         "$ref": "#/groups/3"
       },
@@ -426,7 +550,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/8",
+      "self_ref": "#/texts/10",
       "parent": {
         "$ref": "#/groups/4"
       },
@@ -440,7 +564,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/9",
+      "self_ref": "#/texts/11",
       "parent": {
         "$ref": "#/groups/4"
       },
@@ -454,7 +578,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/10",
+      "self_ref": "#/texts/12",
       "parent": {
         "$ref": "#/groups/3"
       },
@@ -479,7 +603,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/11",
+      "self_ref": "#/texts/13",
       "parent": {
         "$ref": "#/groups/5"
       },
@@ -493,7 +617,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/12",
+      "self_ref": "#/texts/14",
       "parent": {
         "$ref": "#/texts/1"
       },
@@ -510,7 +634,7 @@
       "level": 1
     },
     {
-      "self_ref": "#/texts/13",
+      "self_ref": "#/texts/15",
       "parent": {
         "$ref": "#/groups/6"
       },
@@ -535,7 +659,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/14",
+      "self_ref": "#/texts/16",
       "parent": {
         "$ref": "#/groups/7"
       },
@@ -553,7 +677,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/15",
+      "self_ref": "#/texts/17",
       "parent": {
         "$ref": "#/groups/8"
       },
@@ -565,7 +689,7 @@
       "text": "HyperText Markup Language - used for"
     },
     {
-      "self_ref": "#/texts/16",
+      "self_ref": "#/texts/18",
       "parent": {
         "$ref": "#/groups/8"
       },
@@ -584,7 +708,7 @@
       }
     },
     {
-      "self_ref": "#/texts/17",
+      "self_ref": "#/texts/19",
       "parent": {
         "$ref": "#/groups/8"
       },
@@ -596,7 +720,7 @@
       "text": "web content"
     },
     {
-      "self_ref": "#/texts/18",
+      "self_ref": "#/texts/20",
       "parent": {
         "$ref": "#/groups/6"
       },
@@ -621,7 +745,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/19",
+      "self_ref": "#/texts/21",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -635,7 +759,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/20",
+      "self_ref": "#/texts/22",
       "parent": {
         "$ref": "#/groups/9"
       },
@@ -649,7 +773,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/21",
+      "self_ref": "#/texts/23",
       "parent": {
         "$ref": "#/texts/1"
       },
@@ -666,7 +790,7 @@
       "level": 1
     },
     {
-      "self_ref": "#/texts/22",
+      "self_ref": "#/texts/24",
       "parent": {
         "$ref": "#/groups/10"
       },
@@ -691,7 +815,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/23",
+      "self_ref": "#/texts/25",
       "parent": {
         "$ref": "#/groups/11"
       },
@@ -705,7 +829,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/24",
+      "self_ref": "#/texts/26",
       "parent": {
         "$ref": "#/groups/10"
       },
@@ -730,7 +854,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/25",
+      "self_ref": "#/texts/27",
       "parent": {
         "$ref": "#/groups/12"
       },
@@ -755,7 +879,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/26",
+      "self_ref": "#/texts/28",
       "parent": {
         "$ref": "#/groups/13"
       },
@@ -769,7 +893,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/27",
+      "self_ref": "#/texts/29",
       "parent": {
         "$ref": "#/groups/12"
       },
@@ -794,7 +918,7 @@
       "marker": ""
     },
     {
-      "self_ref": "#/texts/28",
+      "self_ref": "#/texts/30",
       "parent": {
         "$ref": "#/groups/14"
       },
@@ -804,6 +928,143 @@
       "prov": [],
       "orig": "Detail for sub-term B.",
       "text": "Detail for sub-term B.",
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/31",
+      "parent": {
+        "$ref": "#/groups/10"
+      },
+      "children": [
+        {
+          "$ref": "#/groups/15"
+        },
+        {
+          "$ref": "#/groups/16"
+        },
+        {
+          "$ref": "#/groups/19"
+        }
+      ],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Main Term 3 (Mixed)",
+      "text": "Main Term 3 (Mixed)",
+      "formatting": {
+        "bold": true,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "script": "baseline"
+      },
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/32",
+      "parent": {
+        "$ref": "#/groups/15"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "This is a regular text description.",
+      "text": "This is a regular text description.",
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/33",
+      "parent": {
+        "$ref": "#/groups/16"
+      },
+      "children": [
+        {
+          "$ref": "#/groups/17"
+        }
+      ],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Sub-term C",
+      "text": "Sub-term C",
+      "formatting": {
+        "bold": true,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "script": "baseline"
+      },
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/34",
+      "parent": {
+        "$ref": "#/groups/17"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Detail for sub-term C.",
+      "text": "Detail for sub-term C.",
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/35",
+      "parent": {
+        "$ref": "#/groups/16"
+      },
+      "children": [
+        {
+          "$ref": "#/groups/18"
+        }
+      ],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Sub-term D",
+      "text": "Sub-term D",
+      "formatting": {
+        "bold": true,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "script": "baseline"
+      },
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/36",
+      "parent": {
+        "$ref": "#/groups/18"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Detail for sub-term D.",
+      "text": "Detail for sub-term D.",
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/37",
+      "parent": {
+        "$ref": "#/groups/19"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Final regular text description.",
+      "text": "Final regular text description.",
       "enumerated": false,
       "marker": ""
     }

--- a/tests/data/groundtruth/docling_v2/html_description_list.html.md
+++ b/tests/data/groundtruth/docling_v2/html_description_list.html.md
@@ -4,6 +4,8 @@
     - Black hot drink
 - **Milk**
     - White cold drink
+- **Soda**
+- **Water**
 
 ## Programming Languages
 
@@ -30,3 +32,10 @@
         - Detail for sub-term A.
     - **Sub-term B**
         - Detail for sub-term B.
+- **Main Term 3 (Mixed)**
+    - This is a regular text description.
+    - **Sub-term C**
+        - Detail for sub-term C.
+    - **Sub-term D**
+        - Detail for sub-term D.
+    - Final regular text description.

--- a/tests/data/html/html_description_list.html
+++ b/tests/data/html/html_description_list.html
@@ -10,6 +10,8 @@
         <dd>Black hot drink</dd>
         <dt>Milk</dt>
         <dd>White cold drink</dd>
+        <dt>Soda</dt>
+        <dt>Water</dt>
     </dl>
 
     <h2>Programming Languages</h2>
@@ -44,6 +46,18 @@
         <dd>Detail for sub-term B.</dd>
         </dl>
     </dd>
+
+    <dt>Main Term 3 (Mixed)</dt>
+    <dd>This is a regular text description.</dd>
+    <dd>
+        <dl>
+        <dt>Sub-term C</dt>
+        <dd>Detail for sub-term C.</dd>
+        <dt>Sub-term D</dt>
+        <dd>Detail for sub-term D.</dd>
+        </dl>
+    </dd>
+    <dd>Final regular text description.</dd>
     </dl>
 </body>
 </html>


### PR DESCRIPTION
### Summary
Fixed HTMLDocumentBackend to ensure all ListItem objects in HTML description lists (`<dl>`, `<dt>`, `<dd>`) are properly nested under ListGroup objects, eliminating deprecation warnings while maintaining correct element order and avoiding double indentation in exports.

### Problem
When parsing HTML description lists, the first `<dd>` element was being appended directly to a ListItem (the `<dt>` term), violating the rule that ListItem parents must be ListGroup objects. This triggered the deprecation warning: `"ListItem parent must be a list group, creating one on the fly."`

### Solution
- **Always create "descriptions" ListGroup**: When encountering `<dd>` elements, a "descriptions" group is created under the term item to properly contain description list items
- **Smart handling of nested `<dl>`**: When a `<dd>` contains a nested description list:
  - Close current "descriptions" group (if exists)
  - Process nested `<dl>` directly under term item (avoiding double indentation)
  - Allow new "descriptions" group for subsequent regular `<dd>` elements
- **Preserve element order**: Process `<dd>` elements in their original sequence, maintaining document structure

### Example Output
**HTML Input:**
```html
<dt>Main Term 3 (Mixed)</dt>
<dd>This is a regular text description.</dd>
<dd>
    <dl>
        <dt>Sub-term C</dt>
        <dd>Detail for sub-term C.</dd>
    </dl>
</dd>
<dd>Final regular text description.</dd>
```

**Markdown Output:**
```markdown
- **Main Term 3 (Mixed)**
    - This is a regular text description.
    - **Sub-term C**
        - Detail for sub-term C.
    - Final regular text description.
```

The markdown export is rendered by VSC and Github in a similar way to how browsers render the HTML document.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
