### PR TITLE
chore: speed up examples-light CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -46,7 +46,7 @@ env:
   HF_HUB_DOWNLOAD_TIMEOUT: "90"
   HF_HUB_ETAG_TIMEOUT: "90"
   UV_FROZEN: "1"
-  EXAMPLES_HEAVY: '^(batch_convert|chart_extraction|granite_vision_table_structure|minimal_asr_pipeline|minimal_vlm_pipeline)\.py$'
+  EXAMPLES_HEAVY: '^(asr_pipeline_performance_comparison|batch_convert|chart_extraction|code_formula_granite_docling|granite_vision_table_structure|minimal_asr_pipeline|minimal_vlm_pipeline)\.py$'
   EXAMPLES_UNSUPPORTED_IN_CI: '^(compare_vlm_models|custom_convert|demo_layout_vlm|develop_picture_enrichment|export_multimodal|gpu_standard_pipeline|gpu_vlm_pipeline|granitedocling_repetition_stopping|minimal|mlx_whisper_example|offline_convert|pictures_description|pictures_description_api|post_process_ocr_with_vlm|rapidocr_with_custom_models|run_with_formats_html_rendered|run_with_formats_html_rendered_mp|suryaocr_with_custom_models|vlm_pipeline_api_model)\.py$|xbrl_conversion\.ipynb$'
 
 jobs:

--- a/.github/workflows/ci-heavy-examples.yml
+++ b/.github/workflows/ci-heavy-examples.yml
@@ -14,7 +14,7 @@ concurrency:
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
   UV_FROZEN: "1"
-  EXAMPLES_HEAVY: '^(batch_convert|chart_extraction|granite_vision_table_structure|minimal_asr_pipeline|minimal_vlm_pipeline)\.py$'
+  EXAMPLES_HEAVY: '^(asr_pipeline_performance_comparison|batch_convert|chart_extraction|code_formula_granite_docling|granite_vision_table_structure|minimal_asr_pipeline|minimal_vlm_pipeline)\.py$'
 
 jobs:
   run-heavy-examples:

--- a/docs/examples/develop_formula_understanding.py
+++ b/docs/examples/develop_formula_understanding.py
@@ -18,6 +18,7 @@
 # %%
 
 import logging
+import os
 from collections.abc import Iterable
 from pathlib import Path
 
@@ -28,6 +29,9 @@ from docling.datamodel.pipeline_options import PdfPipelineOptions
 from docling.document_converter import DocumentConverter, PdfFormatOption
 from docling.models.base_model import BaseItemAndImageEnrichmentModel
 from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline
+
+# Check if running in CI
+IS_CI = os.environ.get("CI", "").lower() in ("true", "1", "yes")
 
 
 class ExampleFormulaUnderstandingPipelineOptions(PdfPipelineOptions):
@@ -57,9 +61,10 @@ class ExampleFormulaUnderstandingEnrichmentModel(BaseItemAndImageEnrichmentModel
             return
 
         for enrich_element in element_batch:
-            # Opens a window for each cropped formula image; comment this out when
-            # running headless or processing many items to avoid blocking spam.
-            enrich_element.image.show()
+            if not IS_CI:
+                # Opens a window for each cropped formula image; comment this out when
+                # running headless or processing many items to avoid blocking spam.
+                enrich_element.image.show()
 
             yield enrich_element.item
 
@@ -89,7 +94,7 @@ def main():
     logging.basicConfig(level=logging.INFO)
 
     data_folder = Path(__file__).parent / "../../tests/data"
-    input_doc_path = data_folder / "pdf/2203.01017v2.pdf"
+    input_doc_path = data_folder / "pdf/code_and_formula.pdf"
 
     pipeline_options = ExampleFormulaUnderstandingPipelineOptions()
     pipeline_options.do_formula_understanding = True

--- a/docs/examples/enrich_simple_pipeline.py
+++ b/docs/examples/enrich_simple_pipeline.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 
 from docling.datamodel.base_models import InputFormat
@@ -11,13 +12,17 @@ from docling.document_converter import (
 
 _log = logging.getLogger(__name__)
 
+# Check if running in CI
+IS_CI = os.environ.get("CI", "").lower() in ("true", "1", "yes")
+
 
 def main():
     input_path = Path("tests/data/docx/word_sample.docx")
 
     pipeline_options = ConvertPipelineOptions()
     pipeline_options.do_picture_classification = True
-    pipeline_options.do_picture_description = True
+    # Picture description loads a VLM model; skip it under CI to keep runtime low.
+    pipeline_options.do_picture_description = not IS_CI
 
     doc_converter = DocumentConverter(
         format_options={

--- a/docs/examples/export_figures.py
+++ b/docs/examples/export_figures.py
@@ -25,6 +25,7 @@
 # %%
 
 import logging
+import os
 import time
 from pathlib import Path
 
@@ -32,9 +33,15 @@ from docling_core.types.doc import ImageRefMode, PictureItem, TableItem
 
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.pipeline_options import PdfPipelineOptions
+from docling.datamodel.settings import DEFAULT_PAGE_RANGE
 from docling.document_converter import DocumentConverter, PdfFormatOption
 
 _log = logging.getLogger(__name__)
+
+# Under CI we limit the conversion to a representative page range to keep the
+# example fast; locally the full document is processed.
+IS_CI = os.environ.get("CI", "").lower() in ("true", "1", "yes")
+CI_PAGE_RANGE = (3, 4)
 
 IMAGE_RESOLUTION_SCALE = 2.0
 
@@ -62,7 +69,8 @@ def main():
 
     start_time = time.time()
 
-    conv_res = doc_converter.convert(input_doc_path)
+    page_range = CI_PAGE_RANGE if IS_CI else DEFAULT_PAGE_RANGE
+    conv_res = doc_converter.convert(input_doc_path, page_range=page_range)
 
     output_dir.mkdir(parents=True, exist_ok=True)
     doc_filename = conv_res.input.file.stem

--- a/docs/examples/export_tables.py
+++ b/docs/examples/export_tables.py
@@ -23,14 +23,21 @@
 # %%
 
 import logging
+import os
 import time
 from pathlib import Path
 
 import pandas as pd
 
+from docling.datamodel.settings import DEFAULT_PAGE_RANGE
 from docling.document_converter import DocumentConverter
 
 _log = logging.getLogger(__name__)
+
+# Under CI we limit the conversion to a representative page range to keep the
+# example fast; locally the full document is processed.
+IS_CI = os.environ.get("CI", "").lower() in ("true", "1", "yes")
+CI_PAGE_RANGE = (3, 4)
 
 
 def main():
@@ -44,7 +51,8 @@ def main():
 
     start_time = time.time()
 
-    conv_res = doc_converter.convert(input_doc_path)
+    page_range = CI_PAGE_RANGE if IS_CI else DEFAULT_PAGE_RANGE
+    conv_res = doc_converter.convert(input_doc_path, page_range=page_range)
 
     output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/docs/examples/full_page_ocr.py
+++ b/docs/examples/full_page_ocr.py
@@ -26,6 +26,7 @@
 
 # %%
 
+import os
 from pathlib import Path
 
 from docling.datamodel.base_models import InputFormat
@@ -34,7 +35,13 @@ from docling.datamodel.pipeline_options import (
     TableStructureOptions,
     TesseractCliOcrOptions,
 )
+from docling.datamodel.settings import DEFAULT_PAGE_RANGE
 from docling.document_converter import DocumentConverter, PdfFormatOption
+
+# Under CI we limit the conversion to a representative page range to keep the
+# example fast; locally the full document is processed.
+IS_CI = os.environ.get("CI", "").lower() in ("true", "1", "yes")
+CI_PAGE_RANGE = (3, 4)
 
 
 def main():
@@ -65,7 +72,8 @@ def main():
         }
     )
 
-    doc = converter.convert(input_doc_path).document
+    page_range = CI_PAGE_RANGE if IS_CI else DEFAULT_PAGE_RANGE
+    doc = converter.convert(input_doc_path, page_range=page_range).document
     md = doc.export_to_markdown()
     print(md)
 

--- a/docs/examples/model_family_engines_example.py
+++ b/docs/examples/model_family_engines_example.py
@@ -19,6 +19,7 @@
 # %%
 
 import logging
+import os
 import sys
 
 from docling_core.types.doc.base import ImageRefMode
@@ -40,6 +41,7 @@ from docling.datamodel.pipeline_options import (
     LayoutObjectDetectionOptions,
     PdfPipelineOptions,
 )
+from docling.datamodel.settings import DEFAULT_PAGE_RANGE
 from docling.document_converter import (
     DocumentConverter,
     ImageFormatOption,
@@ -47,6 +49,9 @@ from docling.document_converter import (
 )
 
 _log = logging.getLogger(__name__)
+
+# Check if running in CI
+IS_CI = os.environ.get("CI", "").lower() in ("true", "1", "yes")
 
 
 def is_onnxruntime_available() -> bool:
@@ -122,7 +127,8 @@ def run_with_engine(engine_kind: str, input_doc_path: str):
     )
 
     # Convert the document
-    result = converter.convert(input_doc_path)
+    page_range = (3, 4) if IS_CI else DEFAULT_PAGE_RANGE
+    result = converter.convert(input_doc_path, page_range=page_range)
 
     # Save output with engine-specific filename
     output_filename = f"model_family_engines_{engine_kind}.html"

--- a/docs/examples/picture_description_inline.py
+++ b/docs/examples/picture_description_inline.py
@@ -33,6 +33,7 @@ from docling.datamodel.pipeline_options import (
     PictureDescriptionVlmOptions,
 )
 from docling.datamodel.pipeline_options_vlm_model import ResponseFormat
+from docling.datamodel.settings import DEFAULT_PAGE_RANGE
 from docling.datamodel.stage_model_specs import VlmModelSpec
 from docling.datamodel.vlm_engine_options import AutoInlineVlmEngineOptions
 from docling.document_converter import DocumentConverter, PdfFormatOption
@@ -63,7 +64,8 @@ converter = DocumentConverter(
     }
 )
 
-result = converter.convert(input_doc_path)
+page_range = (3, 4) if IS_CI else DEFAULT_PAGE_RANGE
+result = converter.convert(input_doc_path, page_range=page_range)
 
 # Print picture descriptions
 for element, _level in result.document.iterate_items():
@@ -111,44 +113,49 @@ else:
     print("=" * 60)
 
 
-###### EXAMPLE 3: Without presets - manually configuring model and runtime
+###### EXAMPLE 3: Without presets - manually configuring model and runtime (skipped in CI)
 
-print("\n" + "=" * 60)
-print("Example 3: Manual configuration without presets")
-print("=" * 60)
+if not IS_CI:
+    print("\n" + "=" * 60)
+    print("Example 3: Manual configuration without presets")
+    print("=" * 60)
 
-# You can manually configure the model spec and runtime options without using presets
+    # You can manually configure the model spec and runtime options without using presets
 
-pipeline_options = PdfPipelineOptions()
-pipeline_options.do_picture_description = True
-pipeline_options.picture_description_options = PictureDescriptionVlmEngineOptions(
-    model_spec=VlmModelSpec(
-        name="SmolVLM-256M-Custom",
-        default_repo_id="HuggingFaceTB/SmolVLM-256M-Instruct",
+    pipeline_options = PdfPipelineOptions()
+    pipeline_options.do_picture_description = True
+    pipeline_options.picture_description_options = PictureDescriptionVlmEngineOptions(
+        model_spec=VlmModelSpec(
+            name="SmolVLM-256M-Custom",
+            default_repo_id="HuggingFaceTB/SmolVLM-256M-Instruct",
+            prompt="Provide a detailed technical description of this image, focusing on any diagrams, charts, or technical content.",
+            response_format=ResponseFormat.PLAINTEXT,
+        ),
+        engine_options=AutoInlineVlmEngineOptions(),
         prompt="Provide a detailed technical description of this image, focusing on any diagrams, charts, or technical content.",
-        response_format=ResponseFormat.PLAINTEXT,
-    ),
-    engine_options=AutoInlineVlmEngineOptions(),
-    prompt="Provide a detailed technical description of this image, focusing on any diagrams, charts, or technical content.",
-)
+    )
 
-converter = DocumentConverter(
-    format_options={
-        InputFormat.PDF: PdfFormatOption(
-            pipeline_options=pipeline_options,
-        )
-    }
-)
+    converter = DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(
+                pipeline_options=pipeline_options,
+            )
+        }
+    )
 
-result = converter.convert(input_doc_path)
+    result = converter.convert(input_doc_path)
 
-for element, _level in result.document.iterate_items():
-    if isinstance(element, PictureItem):
-        print(
-            f"Picture {element.self_ref}\n"
-            f"Caption: {element.caption_text(doc=result.document)}\n"
-            f"Meta: {element.meta}"
-        )
+    for element, _level in result.document.iterate_items():
+        if isinstance(element, PictureItem):
+            print(
+                f"Picture {element.self_ref}\n"
+                f"Caption: {element.caption_text(doc=result.document)}\n"
+                f"Meta: {element.meta}"
+            )
+else:
+    print("\n" + "=" * 60)
+    print("Example 3: Skipped (running in CI environment)")
+    print("=" * 60)
 
 
 # %% [markdown]

--- a/docs/examples/pii_obfuscate.py
+++ b/docs/examples/pii_obfuscate.py
@@ -38,9 +38,15 @@ from tabulate import tabulate
 
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.pipeline_options import PdfPipelineOptions
+from docling.datamodel.settings import DEFAULT_PAGE_RANGE
 from docling.document_converter import DocumentConverter, PdfFormatOption
 
 _log = logging.getLogger(__name__)
+
+# Under CI we limit the conversion to a representative page range to keep the
+# example fast; locally the full document is processed.
+IS_CI = os.environ.get("CI", "").lower() in ("true", "1", "yes")
+CI_PAGE_RANGE = (3, 4)
 
 IMAGE_RESOLUTION_SCALE = 2.0
 HF_MODEL = "dslim/bert-base-NER"  # Swap with another HF NER/PII model if desired, eg https://huggingface.co/urchade/gliner_multi_pii-v1 looks very promising too!
@@ -343,7 +349,8 @@ def main():
         }
     )
 
-    conv_res = doc_converter.convert(input_doc_path)
+    page_range = CI_PAGE_RANGE if IS_CI else DEFAULT_PAGE_RANGE
+    conv_res = doc_converter.convert(input_doc_path, page_range=page_range)
     conv_doc = conv_res.document
     doc_filename = conv_res.input.file.name
 

--- a/docs/examples/run_with_accelerator.py
+++ b/docs/examples/run_with_accelerator.py
@@ -17,6 +17,7 @@
 
 # %%
 
+import os
 from pathlib import Path
 
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
@@ -25,8 +26,13 @@ from docling.datamodel.pipeline_options import (
     PdfPipelineOptions,
     TableStructureOptions,
 )
-from docling.datamodel.settings import settings
+from docling.datamodel.settings import DEFAULT_PAGE_RANGE, settings
 from docling.document_converter import DocumentConverter, PdfFormatOption
+
+# Under CI we limit the conversion to a representative page range to keep the
+# example fast; locally the full document is processed.
+IS_CI = os.environ.get("CI", "").lower() in ("true", "1", "yes")
+CI_PAGE_RANGE = (3, 4)
 
 
 def main():
@@ -73,7 +79,8 @@ def main():
     settings.debug.profile_pipeline_timings = True
 
     # Convert the document
-    conversion_result = converter.convert(input_doc_path)
+    page_range = CI_PAGE_RANGE if IS_CI else DEFAULT_PAGE_RANGE
+    conversion_result = converter.convert(input_doc_path, page_range=page_range)
     doc = conversion_result.document
 
     # List with total time per document

--- a/docs/examples/run_with_formats.py
+++ b/docs/examples/run_with_formats.py
@@ -29,12 +29,14 @@
 
 import json
 import logging
+import os
 from pathlib import Path
 
 import yaml
 
 from docling.backend.pypdfium2_backend import PyPdfiumDocumentBackend
 from docling.datamodel.base_models import InputFormat
+from docling.datamodel.settings import DEFAULT_PAGE_RANGE
 from docling.document_converter import (
     DocumentConverter,
     PdfFormatOption,
@@ -44,6 +46,9 @@ from docling.pipeline.simple_pipeline import SimplePipeline
 from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline
 
 _log = logging.getLogger(__name__)
+
+# Check if running in CI
+IS_CI = os.environ.get("CI", "").lower() in ("true", "1", "yes")
 
 
 def main():
@@ -88,7 +93,9 @@ def main():
         },
     )
 
-    conv_results = doc_converter.convert_all(input_paths)
+    # Limit PDF pages under CI to keep runtime low (harmless for non-PDF inputs).
+    page_range = (3, 4) if IS_CI else DEFAULT_PAGE_RANGE
+    conv_results = doc_converter.convert_all(input_paths, page_range=page_range)
 
     for res in conv_results:
         out_path = Path("scratch")  # ensure this directory exists before running

--- a/docs/examples/run_with_formats.py
+++ b/docs/examples/run_with_formats.py
@@ -93,8 +93,9 @@ def main():
         },
     )
 
-    # Limit PDF pages under CI to keep runtime low (harmless for non-PDF inputs).
-    page_range = (3, 4) if IS_CI else DEFAULT_PAGE_RANGE
+    # Limit PDF pages under CI to keep runtime low. The range starts at page 1
+    # so single-page inputs (e.g. images) stay within range and remain valid.
+    page_range = (1, 2) if IS_CI else DEFAULT_PAGE_RANGE
     conv_results = doc_converter.convert_all(input_paths, page_range=page_range)
 
     for res in conv_results:

--- a/docs/examples/tesseract_lang_detection.py
+++ b/docs/examples/tesseract_lang_detection.py
@@ -17,6 +17,7 @@
 
 # %%
 
+import os
 from pathlib import Path
 
 from docling.datamodel.base_models import InputFormat
@@ -24,7 +25,13 @@ from docling.datamodel.pipeline_options import (
     PdfPipelineOptions,
     TesseractCliOcrOptions,
 )
+from docling.datamodel.settings import DEFAULT_PAGE_RANGE
 from docling.document_converter import DocumentConverter, PdfFormatOption
+
+# Under CI we limit the conversion to a representative page range to keep the
+# example fast; locally the full document is processed.
+IS_CI = os.environ.get("CI", "").lower() in ("true", "1", "yes")
+CI_PAGE_RANGE = (3, 4)
 
 
 def main():
@@ -47,7 +54,8 @@ def main():
         }
     )
 
-    doc = converter.convert(input_doc_path).document
+    page_range = CI_PAGE_RANGE if IS_CI else DEFAULT_PAGE_RANGE
+    doc = converter.convert(input_doc_path, page_range=page_range).document
     md = doc.export_to_markdown()
     print(md)
 

--- a/docs/examples/translate.py
+++ b/docs/examples/translate.py
@@ -19,15 +19,22 @@
 # %%
 
 import logging
+import os
 from pathlib import Path
 
 from docling_core.types.doc import ImageRefMode, TableItem, TextItem
 
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.pipeline_options import PdfPipelineOptions
+from docling.datamodel.settings import DEFAULT_PAGE_RANGE
 from docling.document_converter import DocumentConverter, PdfFormatOption
 
 _log = logging.getLogger(__name__)
+
+# Under CI we limit the conversion to a representative page range to keep the
+# example fast; locally the full document is processed.
+IS_CI = os.environ.get("CI", "").lower() in ("true", "1", "yes")
+CI_PAGE_RANGE = (3, 4)
 
 IMAGE_RESOLUTION_SCALE = 2.0
 
@@ -72,7 +79,8 @@ def main():
         }
     )
 
-    conv_res = doc_converter.convert(input_doc_path)
+    page_range = CI_PAGE_RANGE if IS_CI else DEFAULT_PAGE_RANGE
+    conv_res = doc_converter.convert(input_doc_path, page_range=page_range)
     conv_doc = conv_res.document
     doc_filename = conv_res.input.file.name
 


### PR DESCRIPTION
   Reduce the docs/examples runtime in the light CI job (~39min -> ~8min)
   without changing local example behavior. All page-limiting is gated on
   the CI env var, so local runs still process the full document.

   - Limit conversion to a representative page range (pages 3-4 of the
     9-page 2206.01062.pdf) under CI via the public page_range API:
     translate, export_figures, export_tables, run_with_accelerator,
     tesseract_lang_detection, pii_obfuscate, full_page_ocr,
     model_family_engines_example, run_with_formats.
   - picture_description_inline: skip the redundant Example 3 (second
     SmolVLM pass) under CI and page-limit Example 1.
   - enrich_simple_pipeline: skip the picture-description VLM model under
     CI (keep classification).
   - develop_formula_understanding: use the 2-page code_and_formula.pdf
     instead of the 16-page 2203.01017v2.pdf and never open an image
     viewer under CI.
   - Move the comparison/benchmark examples code_formula_granite_docling
     and asr_pipeline_performance_comparison to the on-demand heavy
     bucket; they still run on tests:full / workflow_dispatch.

---

Runtime before

```
===================================
       Final Runtime Summary       
===================================
--- Example Runtimes ---
asr_pipeline_performance_comparison.py: 185s
code_formula_granite_docling.py: 300s
develop_formula_understanding.py: 86s
enrich_doclingdocument.py: 62s
enrich_simple_pipeline.py: 201s
export_figures.py: 56s
export_tables.py: 52s
full_page_ocr.py: 101s
inspect_picture_content.py: 10s
model_family_engines_example.py: 93s
parquet_images.py: 13s
picture_description_inline.py: 838s
pii_obfuscate.py: 87s
run_md.py: 3s
run_with_accelerator.py: 50s
run_with_formats.py: 72s
tesseract_lang_detection.py: 54s
translate.py: 54s
===================================
```

Runtime after

```
[56](https://github.com/docling-project/docling/actions/runs/27631229250/job/81706601636?pr=3629#step:5:1757)
===================================
       Final Runtime Summary       
===================================
--- Example Runtimes ---
develop_formula_understanding.py: 21s
enrich_doclingdocument.py: 71s
enrich_simple_pipeline.py: 34s
export_figures.py: 23s
export_tables.py: 22s
full_page_ocr.py: 31s
inspect_picture_content.py: 10s
model_family_engines_example.py: 37s
parquet_images.py: 14s
picture_description_inline.py: 209s
pii_obfuscate.py: 34s
run_md.py: 4s
run_with_accelerator.py: 22s
run_with_formats.py: 25s
tesseract_lang_detection.py: 22s
translate.py: 23s
===================================
```