### PR TITLE
feat(pdf): infer PDF heading levels so the hierarchy isn't flattened

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1495,18 +1495,19 @@ class HeadingHierarchyOptions(BaseModel):
 
     The layout model only flags regions as ``SECTION_HEADER`` without a level, so every
     heading produced by the PDF path defaults to ``level=1`` and the document hierarchy is
-    flattened. When ``enabled``, a post-assembly step in the reading-order stage assigns
-    ``SectionHeaderItem.level`` from (in precedence order) numbering, font style and -- once
-    the backend plumbing lands -- PDF bookmarks. The step only changes heading levels; it
-    never adds, removes or reorders items, and headings for which no signal applies keep
-    their current level.
+    flattened. When ``enabled``, :class:`HeadingHierarchyModel` runs right after the
+    reading-order model and assigns ``SectionHeaderItem.level`` from (in precedence order)
+    numbering and font style. The step only changes heading levels; it never adds, removes
+    or reorders items, and headings for which no signal applies keep their current level.
+
+    PDF bookmark/outline inference (the most authoritative signal) is planned as a separate
+    follow-up.
 
     Notes:
         - ``use_style`` requires the parsed PDF cells to still be available when the
-          reading-order stage runs, i.e. ``PdfPipelineOptions.generate_parsed_pages=True``.
-          Without them, style inference is silently skipped (numbering still applies).
-        - ``use_bookmarks`` is reserved for the PDF-outline signal and is a no-op until the
-          backend outline extraction is implemented (tracked as a follow-up).
+          heading-hierarchy step runs, i.e.
+          ``PdfPipelineOptions.generate_parsed_pages=True``. Without them, style inference is
+          silently skipped (numbering still applies).
     """
 
     enabled: Annotated[
@@ -1538,15 +1539,6 @@ class HeadingHierarchyOptions(BaseModel):
             )
         ),
     ] = True
-    use_bookmarks: Annotated[
-        bool,
-        Field(
-            description=(
-                "Use the PDF outline/bookmarks as an authoritative signal. Reserved for a "
-                "follow-up; currently a no-op until backend outline extraction is added."
-            )
-        ),
-    ] = False
     numbering_schemes: Annotated[
         Optional[list[str]],
         Field(

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1490,6 +1490,84 @@ class VlmExtractionPipelineOptions(PipelineOptions):
     ] = ExtractionPromptStyle.NUEXTRACT
 
 
+class HeadingHierarchyOptions(BaseModel):
+    """Options for inferring section-header levels in the PDF/image pipeline.
+
+    The layout model only flags regions as ``SECTION_HEADER`` without a level, so every
+    heading produced by the PDF path defaults to ``level=1`` and the document hierarchy is
+    flattened. When ``enabled``, a post-assembly step in the reading-order stage assigns
+    ``SectionHeaderItem.level`` from (in precedence order) numbering, font style and -- once
+    the backend plumbing lands -- PDF bookmarks. The step only changes heading levels; it
+    never adds, removes or reorders items, and headings for which no signal applies keep
+    their current level.
+
+    Notes:
+        - ``use_style`` requires the parsed PDF cells to still be available when the
+          reading-order stage runs, i.e. ``PdfPipelineOptions.generate_parsed_pages=True``.
+          Without them, style inference is silently skipped (numbering still applies).
+        - ``use_bookmarks`` is reserved for the PDF-outline signal and is a no-op until the
+          backend outline extraction is implemented (tracked as a follow-up).
+    """
+
+    enabled: Annotated[
+        bool,
+        Field(
+            description=(
+                "Enable inference of section-header levels for the PDF/image pipeline. When "
+                "disabled (default), all detected headings remain at level 1 (unchanged "
+                "behavior)."
+            )
+        ),
+    ] = False
+    use_numbering: Annotated[
+        bool,
+        Field(
+            description=(
+                "Use legal/outline numbering (e.g. PART I -> 1. -> 1.1 -> (a) -> (i), Roman "
+                "vs Arabic numerals) as the primary signal for heading level."
+            )
+        ),
+    ] = True
+    use_style: Annotated[
+        bool,
+        Field(
+            description=(
+                "Use font size (approximated from parsed PDF cell heights) as a fallback for "
+                "headings without recognizable numbering. Requires "
+                "`generate_parsed_pages=True`."
+            )
+        ),
+    ] = True
+    use_bookmarks: Annotated[
+        bool,
+        Field(
+            description=(
+                "Use the PDF outline/bookmarks as an authoritative signal. Reserved for a "
+                "follow-up; currently a no-op until backend outline extraction is added."
+            )
+        ),
+    ] = False
+    numbering_schemes: Annotated[
+        Optional[list[str]],
+        Field(
+            description=(
+                "Optional override of the numbering-scheme precedence (highest level first). "
+                "Known schemes: 'part', 'chapter', 'article', 'roman_u', 'arabic', "
+                "'alpha_u', 'alpha_l', 'roman_l'. When None, a default legal/regulatory "
+                "ordering is used."
+            )
+        ),
+    ] = None
+    max_level: Annotated[
+        int,
+        Field(
+            ge=1,
+            le=100,
+            description="Maximum heading level to assign. Deeper levels are clamped.",
+        ),
+    ] = 6
+
+
 class PdfPipelineOptions(PaginatedPipelineOptions):
     """Configuration options for the PDF document processing pipeline.
 
@@ -1639,6 +1717,17 @@ class PdfPipelineOptions(PaginatedPipelineOptions):
             )
         ),
     ] = False
+    heading_hierarchy_options: Annotated[
+        HeadingHierarchyOptions,
+        Field(
+            description=(
+                "Configuration for inferring section-header levels from numbering, font "
+                "style and (future) PDF bookmarks. Disabled by default; when enabled, the "
+                "reading-order stage assigns SectionHeaderItem.level instead of leaving every "
+                "heading at level 1."
+            )
+        ),
+    ] = HeadingHierarchyOptions()
 
     ### Arguments for threaded PDF pipeline with batching and backpressure control
 

--- a/docling/models/stages/heading_hierarchy/heading_hierarchy_model.py
+++ b/docling/models/stages/heading_hierarchy/heading_hierarchy_model.py
@@ -13,9 +13,8 @@ produced by the PDF path defaults to ``level=1`` and the document hierarchy is f
 2. **style** -- font size approximated from the parsed PDF cells, used only for headings
    that have no recognizable numbering.
 
-Bookmark / PDF-outline inference (the most authoritative signal) requires new backend
-plumbing and is intentionally left as a follow-up; :func:`_infer_from_bookmarks` is the
-extension point and currently a no-op.
+Bookmark / PDF-outline inference (the most authoritative signal) would require new backend
+plumbing and is planned as a separate follow-up.
 
 The model only ever rewrites heading levels -- it never adds, removes or reorders items. The
 core (:meth:`HeadingHierarchyModel.assign_heading_levels`) works on a bare
@@ -244,17 +243,6 @@ def _infer_from_style(
     return {i: ranked[size] for i, size in rounded.items()}
 
 
-def _infer_from_bookmarks(
-    headings: list[SectionHeaderItem], options: HeadingHierarchyOptions
-) -> dict[int, int]:
-    """Reserved: map heading index -> level from the PDF outline/bookmarks.
-
-    Authoritative when present, but the PDF backends do not yet surface the document
-    outline. This is the extension point for that follow-up; it is currently a no-op.
-    """
-    return {}
-
-
 class HeadingHierarchyModel:
     """Assigns ``SectionHeaderItem.level`` on an already-assembled ``DoclingDocument``.
 
@@ -288,9 +276,9 @@ class HeadingHierarchyModel:
     ) -> DoclingDocument:
         """Assign heading levels in place from the configured signals.
 
-        Numbering wins over style; bookmarks (once implemented) win over both. Headings with
-        no applicable signal keep their existing level. ``parsed_pages`` (page number ->
-        parsed page) is only needed for the style fallback.
+        Numbering wins over style. Headings with no applicable signal keep their existing
+        level. ``parsed_pages`` (page number -> parsed page) is only needed for the style
+        fallback.
         """
         headings = [
             item for item in document.texts if isinstance(item, SectionHeaderItem)
@@ -306,10 +294,6 @@ class HeadingHierarchyModel:
                 headings, parsed_pages, self.options
             ).items():
                 levels.setdefault(i, level)  # do not override a numbering-derived level
-        if self.options.use_bookmarks:
-            levels.update(
-                _infer_from_bookmarks(headings, self.options)
-            )  # authoritative
 
         for i, heading in enumerate(headings):
             level = levels.get(i)

--- a/docling/models/stages/heading_hierarchy/heading_hierarchy_model.py
+++ b/docling/models/stages/heading_hierarchy/heading_hierarchy_model.py
@@ -1,11 +1,11 @@
-"""Section-header level inference for the PDF/image reading-order stage.
+"""Section-header level inference for the PDF/image pipeline.
 
-The layout model classifies regions as ``SECTION_HEADER`` without a level, so every
-heading produced by the PDF path defaults to ``level=1`` and the document hierarchy is
-flattened (Roman-numeral parts and Arabic-numeral subsections collapse to the same depth).
+The layout model classifies regions as ``SECTION_HEADER`` without a level, so every heading
+produced by the PDF path defaults to ``level=1`` and the document hierarchy is flattened
+(Roman-numeral parts and Arabic-numeral subsections collapse to the same depth).
 
-This module assigns ``SectionHeaderItem.level`` *after* the reading-order document has been
-assembled, using -- in precedence order:
+:class:`HeadingHierarchyModel` runs right after the reading-order model and assigns
+``SectionHeaderItem.level`` using -- in precedence order:
 
 1. **numbering** -- legal/outline numbering such as ``PART I -> 1. -> 1.1 -> (a) -> (i)``.
    This is the primary signal: on legal/regulatory documents numbering is far more reliable
@@ -17,8 +17,10 @@ Bookmark / PDF-outline inference (the most authoritative signal) requires new ba
 plumbing and is intentionally left as a follow-up; :func:`_infer_from_bookmarks` is the
 extension point and currently a no-op.
 
-The whole step is opt-in (``HeadingHierarchyOptions.enabled``) and only ever rewrites
-heading levels -- it never adds, removes or reorders document items.
+The model only ever rewrites heading levels -- it never adds, removes or reorders items. The
+core (:meth:`HeadingHierarchyModel.assign_heading_levels`) works on a bare
+``DoclingDocument`` so it can be reused outside the pipeline; the font-based fallback simply
+needs the parsed pages passed in.
 """
 
 import re
@@ -27,6 +29,7 @@ from statistics import median
 
 from docling_core.types.doc import DoclingDocument
 from docling_core.types.doc.document import SectionHeaderItem
+from docling_core.types.doc.page import SegmentedPdfPage
 
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import HeadingHierarchyOptions
@@ -191,19 +194,21 @@ def _infer_from_numbering(
     return {i: key_to_level[key] for i, key in keys.items()}
 
 
-def _heading_font_size(item: SectionHeaderItem, pages_by_no: dict) -> float | None:
+def _heading_font_size(
+    item: SectionHeaderItem, parsed_pages: dict[int, SegmentedPdfPage]
+) -> float | None:
     """Median height of parsed PDF cells overlapping the heading, as a font-size proxy."""
     if not item.prov:
         return None
     prov = item.prov[0]
-    page = pages_by_no.get(prov.page_no)
-    if page is None or page.parsed_page is None:
+    parsed = parsed_pages.get(prov.page_no)
+    if parsed is None:
         return None
 
-    page_height = page.size.height
+    page_height = parsed.dimension.height
     hbox = prov.bbox.to_top_left_origin(page_height)
     heights: list[float] = []
-    for cell in page.parsed_page.textline_cells:
+    for cell in parsed.textline_cells:
         if not cell.text or not cell.text.strip():
             continue
         cbox = cell.rect.to_bounding_box().to_top_left_origin(page_height)
@@ -216,16 +221,15 @@ def _heading_font_size(item: SectionHeaderItem, pages_by_no: dict) -> float | No
 
 def _infer_from_style(
     headings: list[SectionHeaderItem],
-    conv_res: ConversionResult | None,
+    parsed_pages: dict[int, SegmentedPdfPage],
     options: HeadingHierarchyOptions,
 ) -> dict[int, int]:
     """Map heading index -> level from font size buckets (larger size = higher level)."""
-    if conv_res is None:
+    if not parsed_pages:
         return {}
-    pages_by_no = {page.page_no: page for page in conv_res.pages}
     sizes: dict[int, float] = {}
     for i, heading in enumerate(headings):
-        size = _heading_font_size(heading, pages_by_no)
+        size = _heading_font_size(heading, parsed_pages)
         if size is not None:
             sizes[i] = size
     if not sizes:
@@ -241,9 +245,7 @@ def _infer_from_style(
 
 
 def _infer_from_bookmarks(
-    headings: list[SectionHeaderItem],
-    conv_res: ConversionResult | None,
-    options: HeadingHierarchyOptions,
+    headings: list[SectionHeaderItem], options: HeadingHierarchyOptions
 ) -> dict[int, int]:
     """Reserved: map heading index -> level from the PDF outline/bookmarks.
 
@@ -253,33 +255,64 @@ def _infer_from_bookmarks(
     return {}
 
 
-def assign_heading_levels(
-    document: DoclingDocument,
-    conv_res: ConversionResult | None,
-    options: HeadingHierarchyOptions,
-) -> None:
-    """Assign ``SectionHeaderItem.level`` in place from the configured signals.
+class HeadingHierarchyModel:
+    """Assigns ``SectionHeaderItem.level`` on an already-assembled ``DoclingDocument``.
 
-    Numbering wins over style; bookmarks (when implemented) win over both. Headings with no
-    applicable signal keep their existing level. ``conv_res`` may be ``None`` when only
-    ``conv_res``-independent signals (numbering) are enabled.
+    Intended to run right after the reading-order model. It accepts a ``ConversionResult``
+    and returns the (in-place modified) ``DoclingDocument``. The core logic is exposed via
+    :meth:`assign_heading_levels`, which works on a bare ``DoclingDocument`` (plus optional
+    parsed pages for the style fallback) so it can be reused outside the pipeline.
     """
-    headings = [item for item in document.texts if isinstance(item, SectionHeaderItem)]
-    if not headings:
-        return
 
-    levels: dict[int, int] = {}
-    if options.use_numbering:
-        levels.update(_infer_from_numbering(headings, options))
-    if options.use_style:
-        for i, level in _infer_from_style(headings, conv_res, options).items():
-            levels.setdefault(i, level)  # do not override a numbering-derived level
-    if options.use_bookmarks:
-        levels.update(
-            _infer_from_bookmarks(headings, conv_res, options)
-        )  # authoritative
+    def __init__(self, options: HeadingHierarchyOptions):
+        self.options = options
 
-    for i, heading in enumerate(headings):
-        level = levels.get(i)
-        if level is not None:
-            heading.level = max(1, min(int(level), options.max_level))
+    def __call__(self, conv_res: ConversionResult) -> DoclingDocument:
+        document = conv_res.document
+        if not self.options.enabled:
+            return document
+
+        parsed_pages: dict[int, SegmentedPdfPage] = {}
+        if self.options.use_style:
+            parsed_pages = {
+                page.page_no: page.parsed_page
+                for page in conv_res.pages
+                if page.parsed_page is not None
+            }
+        return self.assign_heading_levels(document, parsed_pages=parsed_pages)
+
+    def assign_heading_levels(
+        self,
+        document: DoclingDocument,
+        parsed_pages: dict[int, SegmentedPdfPage] | None = None,
+    ) -> DoclingDocument:
+        """Assign heading levels in place from the configured signals.
+
+        Numbering wins over style; bookmarks (once implemented) win over both. Headings with
+        no applicable signal keep their existing level. ``parsed_pages`` (page number ->
+        parsed page) is only needed for the style fallback.
+        """
+        headings = [
+            item for item in document.texts if isinstance(item, SectionHeaderItem)
+        ]
+        if not headings:
+            return document
+
+        levels: dict[int, int] = {}
+        if self.options.use_numbering:
+            levels.update(_infer_from_numbering(headings, self.options))
+        if self.options.use_style and parsed_pages:
+            for i, level in _infer_from_style(
+                headings, parsed_pages, self.options
+            ).items():
+                levels.setdefault(i, level)  # do not override a numbering-derived level
+        if self.options.use_bookmarks:
+            levels.update(
+                _infer_from_bookmarks(headings, self.options)
+            )  # authoritative
+
+        for i, heading in enumerate(headings):
+            level = levels.get(i)
+            if level is not None:
+                heading.level = max(1, min(int(level), self.options.max_level))
+        return document

--- a/docling/models/stages/reading_order/heading_hierarchy.py
+++ b/docling/models/stages/reading_order/heading_hierarchy.py
@@ -216,10 +216,12 @@ def _heading_font_size(item: SectionHeaderItem, pages_by_no: dict) -> float | No
 
 def _infer_from_style(
     headings: list[SectionHeaderItem],
-    conv_res: ConversionResult,
+    conv_res: ConversionResult | None,
     options: HeadingHierarchyOptions,
 ) -> dict[int, int]:
     """Map heading index -> level from font size buckets (larger size = higher level)."""
+    if conv_res is None:
+        return {}
     pages_by_no = {page.page_no: page for page in conv_res.pages}
     sizes: dict[int, float] = {}
     for i, heading in enumerate(headings):
@@ -240,7 +242,7 @@ def _infer_from_style(
 
 def _infer_from_bookmarks(
     headings: list[SectionHeaderItem],
-    conv_res: ConversionResult,
+    conv_res: ConversionResult | None,
     options: HeadingHierarchyOptions,
 ) -> dict[int, int]:
     """Reserved: map heading index -> level from the PDF outline/bookmarks.
@@ -253,13 +255,14 @@ def _infer_from_bookmarks(
 
 def assign_heading_levels(
     document: DoclingDocument,
-    conv_res: ConversionResult,
+    conv_res: ConversionResult | None,
     options: HeadingHierarchyOptions,
 ) -> None:
     """Assign ``SectionHeaderItem.level`` in place from the configured signals.
 
     Numbering wins over style; bookmarks (when implemented) win over both. Headings with no
-    applicable signal keep their existing level.
+    applicable signal keep their existing level. ``conv_res`` may be ``None`` when only
+    ``conv_res``-independent signals (numbering) are enabled.
     """
     headings = [item for item in document.texts if isinstance(item, SectionHeaderItem)]
     if not headings:

--- a/docling/models/stages/reading_order/heading_hierarchy.py
+++ b/docling/models/stages/reading_order/heading_hierarchy.py
@@ -1,0 +1,282 @@
+"""Section-header level inference for the PDF/image reading-order stage.
+
+The layout model classifies regions as ``SECTION_HEADER`` without a level, so every
+heading produced by the PDF path defaults to ``level=1`` and the document hierarchy is
+flattened (Roman-numeral parts and Arabic-numeral subsections collapse to the same depth).
+
+This module assigns ``SectionHeaderItem.level`` *after* the reading-order document has been
+assembled, using -- in precedence order:
+
+1. **numbering** -- legal/outline numbering such as ``PART I -> 1. -> 1.1 -> (a) -> (i)``.
+   This is the primary signal: on legal/regulatory documents numbering is far more reliable
+   than styling, which is often uniform.
+2. **style** -- font size approximated from the parsed PDF cells, used only for headings
+   that have no recognizable numbering.
+
+Bookmark / PDF-outline inference (the most authoritative signal) requires new backend
+plumbing and is intentionally left as a follow-up; :func:`_infer_from_bookmarks` is the
+extension point and currently a no-op.
+
+The whole step is opt-in (``HeadingHierarchyOptions.enabled``) and only ever rewrites
+heading levels -- it never adds, removes or reorders document items.
+"""
+
+import re
+from dataclasses import dataclass
+from statistics import median
+
+from docling_core.types.doc import DoclingDocument
+from docling_core.types.doc.document import SectionHeaderItem
+
+from docling.datamodel.document import ConversionResult
+from docling.datamodel.pipeline_options import HeadingHierarchyOptions
+
+# Default precedence of numbering schemes, highest hierarchy level first. ``dotted`` shares
+# the ``arabic`` rank and is ordered below it by its segment depth (1.1 below 1.).
+_DEFAULT_FAMILY_ORDER = [
+    "part",  # PART I / TITLE I / BOOK I
+    "chapter",  # CHAPTER 1
+    "article",  # ARTICLE 1 / SECTION 1 / Clause / § 1
+    "roman_u",  # I. II. III.
+    "arabic",  # 1. 2. 3.  (and dotted 1.1, 1.1.1 by depth)
+    "alpha_u",  # A. B. C.
+    "alpha_l",  # (a) (b) (c)
+    "roman_l",  # (i) (ii) (iii)
+]
+
+# Single characters that are valid Roman numerals and therefore ambiguous with alpha markers
+# (e.g. "I." may be Roman "1" or alpha "9"). Resolved in :func:`_resolve_ambiguous`.
+_ROMAN_SINGLES = set("IVXLCDMivxlcdm")
+
+# Canonical Roman-numeral validator (1..3999), case-insensitive via ``.upper()``.
+_ROMAN_RE = re.compile(
+    r"^M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$", re.IGNORECASE
+)
+
+_KW_PART = re.compile(r"^(part|title|book)\b", re.IGNORECASE)
+_KW_CHAPTER = re.compile(r"^(chapter)\b", re.IGNORECASE)
+_KW_ARTICLE = re.compile(
+    r"^(article|section|clause|schedule|annex|appendix|rule)\b", re.IGNORECASE
+)
+_SECTION_SYMBOL = re.compile(r"^§+\s*\d")  # § 1 / §§ 1.2
+# Dotted decimal outline (1.1, 1.1.1, ...), terminated by space/end/punctuation.
+_DOTTED = re.compile(r"^(\d+(?:\.\d+)+)(?:[.)\]\s]|$)")
+# Single Arabic index (1. / 2)).
+_ARABIC = re.compile(r"^(\d+)[.)]")
+# Single/multi letter marker, optionally parenthesized: (a) / A. / (iv) / IV.
+_LETTER = re.compile(r"^\(?\s*([A-Za-z]+)\s*[).]")
+
+
+@dataclass
+class _Marker:
+    """A parsed leading numbering marker for a heading."""
+
+    family: str  # canonical scheme family (see _DEFAULT_FAMILY_ORDER)
+    depth: int = 1  # dotted-decimal segment count; 1 for everything else
+    token: str | None = None  # raw alpha/roman token, kept for ambiguity resolution
+    ambiguous: bool = False  # single-letter Roman/alpha that needs context to resolve
+
+
+def _is_roman(token: str) -> bool:
+    return bool(token) and _ROMAN_RE.fullmatch(token) is not None
+
+
+def _classify_letter(token: str) -> _Marker | None:
+    """Classify a bare alpha/Roman token (``A``, ``iv``, ``i`` ...) into a marker."""
+    upper = token.isupper()
+    if len(token) == 1:
+        if token in _ROMAN_SINGLES:
+            # Ambiguous: could be Roman or the Nth letter; resolved later by context.
+            return _Marker(
+                family="roman_u" if upper else "roman_l", token=token, ambiguous=True
+            )
+        return _Marker(family="alpha_u" if upper else "alpha_l", token=token)
+    # Multi-letter tokens only count as numbering if they are valid Roman numerals;
+    # otherwise they are plain words (e.g. "Summary."), not a numbered heading.
+    if _is_roman(token):
+        return _Marker(family="roman_u" if upper else "roman_l", token=token)
+    return None
+
+
+def _parse_marker(text: str) -> _Marker | None:
+    """Extract the leading numbering marker from a heading, or None if unnumbered."""
+    s = (text or "").strip()
+    if not s:
+        return None
+
+    if _KW_PART.match(s):
+        return _Marker(family="part")
+    if _KW_CHAPTER.match(s):
+        return _Marker(family="chapter")
+    if _KW_ARTICLE.match(s) or _SECTION_SYMBOL.match(s):
+        return _Marker(family="article")
+
+    m = _DOTTED.match(s)
+    if m:
+        return _Marker(family="dotted", depth=m.group(1).count(".") + 1)
+    if _ARABIC.match(s):
+        return _Marker(family="arabic")
+
+    m = _LETTER.match(s)
+    if m:
+        return _classify_letter(m.group(1))
+    return None
+
+
+def _resolve_ambiguous(markers: list[_Marker | None]) -> None:
+    """Resolve single-letter Roman/alpha markers in place using document-wide evidence.
+
+    A lone ``I.`` is Roman when the document also contains unambiguous Roman markers
+    (``II``, ``III`` ...) and alpha when it contains unambiguous alpha markers (``B``, ``F``
+    ...). When evidence is absent or conflicting, ``I``/``i`` default to Roman (the common
+    legal case) and other letters to alpha.
+    """
+
+    def _has(family: str) -> bool:
+        return any(
+            m is not None and not m.ambiguous and m.family == family for m in markers
+        )
+
+    upper_roman, upper_alpha = _has("roman_u"), _has("alpha_u")
+    lower_roman, lower_alpha = _has("roman_l"), _has("alpha_l")
+
+    for m in markers:
+        if m is None or not m.ambiguous or m.token is None:
+            continue
+        upper = m.token.isupper()
+        has_roman = upper_roman if upper else lower_roman
+        has_alpha = upper_alpha if upper else lower_alpha
+        if has_roman and not has_alpha:
+            roman = True
+        elif has_alpha and not has_roman:
+            roman = False
+        else:
+            roman = m.token in ("I", "i")
+        if roman:
+            m.family = "roman_u" if upper else "roman_l"
+        else:
+            m.family = "alpha_u" if upper else "alpha_l"
+        m.ambiguous = False
+
+
+def _family_rank(family: str, order: list[str]) -> int:
+    key = "arabic" if family == "dotted" else family
+    try:
+        return order.index(key)
+    except ValueError:
+        return len(order)  # unknown scheme -> lowest priority
+
+
+def _infer_from_numbering(
+    headings: list[SectionHeaderItem], options: HeadingHierarchyOptions
+) -> dict[int, int]:
+    """Map heading index -> level from numbering markers (relative, compressed levels)."""
+    order = options.numbering_schemes or _DEFAULT_FAMILY_ORDER
+    markers = [_parse_marker(h.text) for h in headings]
+    _resolve_ambiguous(markers)
+
+    keys: dict[int, tuple[int, int]] = {}
+    for i, m in enumerate(markers):
+        if m is None:
+            continue
+        keys[i] = (_family_rank(m.family, order), m.depth)
+    if not keys:
+        return {}
+
+    # Compress the distinct (rank, depth) keys actually present into contiguous levels, so a
+    # document that starts at "1." is not forced to start at depth 2.
+    key_to_level = {
+        key: lvl for lvl, key in enumerate(sorted(set(keys.values())), start=1)
+    }
+    return {i: key_to_level[key] for i, key in keys.items()}
+
+
+def _heading_font_size(item: SectionHeaderItem, pages_by_no: dict) -> float | None:
+    """Median height of parsed PDF cells overlapping the heading, as a font-size proxy."""
+    if not item.prov:
+        return None
+    prov = item.prov[0]
+    page = pages_by_no.get(prov.page_no)
+    if page is None or page.parsed_page is None:
+        return None
+
+    page_height = page.size.height
+    hbox = prov.bbox.to_top_left_origin(page_height)
+    heights: list[float] = []
+    for cell in page.parsed_page.textline_cells:
+        if not cell.text or not cell.text.strip():
+            continue
+        cbox = cell.rect.to_bounding_box().to_top_left_origin(page_height)
+        if hbox.overlaps(cbox):
+            heights.append(cell.rect.height)
+    if not heights:
+        return None
+    return median(heights)
+
+
+def _infer_from_style(
+    headings: list[SectionHeaderItem],
+    conv_res: ConversionResult,
+    options: HeadingHierarchyOptions,
+) -> dict[int, int]:
+    """Map heading index -> level from font size buckets (larger size = higher level)."""
+    pages_by_no = {page.page_no: page for page in conv_res.pages}
+    sizes: dict[int, float] = {}
+    for i, heading in enumerate(headings):
+        size = _heading_font_size(heading, pages_by_no)
+        if size is not None:
+            sizes[i] = size
+    if not sizes:
+        return {}
+
+    # Bucket by rounded point size; the largest size becomes level 1.
+    rounded = {i: round(size) for i, size in sizes.items()}
+    ranked = {
+        size: lvl
+        for lvl, size in enumerate(sorted(set(rounded.values()), reverse=True), start=1)
+    }
+    return {i: ranked[size] for i, size in rounded.items()}
+
+
+def _infer_from_bookmarks(
+    headings: list[SectionHeaderItem],
+    conv_res: ConversionResult,
+    options: HeadingHierarchyOptions,
+) -> dict[int, int]:
+    """Reserved: map heading index -> level from the PDF outline/bookmarks.
+
+    Authoritative when present, but the PDF backends do not yet surface the document
+    outline. This is the extension point for that follow-up; it is currently a no-op.
+    """
+    return {}
+
+
+def assign_heading_levels(
+    document: DoclingDocument,
+    conv_res: ConversionResult,
+    options: HeadingHierarchyOptions,
+) -> None:
+    """Assign ``SectionHeaderItem.level`` in place from the configured signals.
+
+    Numbering wins over style; bookmarks (when implemented) win over both. Headings with no
+    applicable signal keep their existing level.
+    """
+    headings = [item for item in document.texts if isinstance(item, SectionHeaderItem)]
+    if not headings:
+        return
+
+    levels: dict[int, int] = {}
+    if options.use_numbering:
+        levels.update(_infer_from_numbering(headings, options))
+    if options.use_style:
+        for i, level in _infer_from_style(headings, conv_res, options).items():
+            levels.setdefault(i, level)  # do not override a numbering-derived level
+    if options.use_bookmarks:
+        levels.update(
+            _infer_from_bookmarks(headings, conv_res, options)
+        )  # authoritative
+
+    for i, heading in enumerate(headings):
+        level = levels.get(i)
+        if level is not None:
+            heading.level = max(1, min(int(level), options.max_level))

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -30,6 +30,8 @@ from docling.datamodel.base_models import (
     TextElement,
 )
 from docling.datamodel.document import ConversionResult
+from docling.datamodel.pipeline_options import HeadingHierarchyOptions
+from docling.models.stages.reading_order.heading_hierarchy import assign_heading_levels
 from docling.utils.profiling import ProfilingScope, TimeRecorder
 
 
@@ -37,6 +39,7 @@ class ReadingOrderOptions(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
     model_names: str = ""  # e.g. "language;term;reference"
+    heading_hierarchy: HeadingHierarchyOptions = HeadingHierarchyOptions()
 
 
 class ReadingOrderModel:
@@ -465,5 +468,10 @@ class ReadingOrderModel:
                 el_to_footnotes_mapping,
                 el_merges_mapping,
             )
+
+            if self.options.heading_hierarchy.enabled:
+                assign_heading_levels(
+                    docling_doc, conv_res, self.options.heading_hierarchy
+                )
 
         return docling_doc

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -30,8 +30,6 @@ from docling.datamodel.base_models import (
     TextElement,
 )
 from docling.datamodel.document import ConversionResult
-from docling.datamodel.pipeline_options import HeadingHierarchyOptions
-from docling.models.stages.reading_order.heading_hierarchy import assign_heading_levels
 from docling.utils.profiling import ProfilingScope, TimeRecorder
 
 
@@ -39,7 +37,6 @@ class ReadingOrderOptions(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
     model_names: str = ""  # e.g. "language;term;reference"
-    heading_hierarchy: HeadingHierarchyOptions = HeadingHierarchyOptions()
 
 
 class ReadingOrderModel:
@@ -468,10 +465,5 @@ class ReadingOrderModel:
                 el_to_footnotes_mapping,
                 el_merges_mapping,
             )
-
-            if self.options.heading_hierarchy.enabled:
-                assign_heading_levels(
-                    docling_doc, conv_res, self.options.heading_hierarchy
-                )
 
         return docling_doc

--- a/docling/pipeline/legacy_standard_pdf_pipeline.py
+++ b/docling/pipeline/legacy_standard_pdf_pipeline.py
@@ -23,6 +23,9 @@ from docling.models.stages.code_formula.code_formula_model import (
     CodeFormulaModel,
     CodeFormulaModelOptions,
 )
+from docling.models.stages.heading_hierarchy.heading_hierarchy_model import (
+    HeadingHierarchyModel,
+)
 from docling.models.stages.page_assemble.page_assemble_model import (
     PageAssembleModel,
     PageAssembleOptions,
@@ -55,10 +58,9 @@ class LegacyStandardPdfPipeline(PaginatedPipeline):
                 or self.pipeline_options.generate_table_images
             )
 
-        self.reading_order_model = ReadingOrderModel(
-            options=ReadingOrderOptions(
-                heading_hierarchy=self.pipeline_options.heading_hierarchy_options
-            )
+        self.reading_order_model = ReadingOrderModel(options=ReadingOrderOptions())
+        self.heading_hierarchy_model = HeadingHierarchyModel(
+            options=self.pipeline_options.heading_hierarchy_options
         )
 
         ocr_model = self.get_ocr_model(artifacts_path=self.artifacts_path)
@@ -177,6 +179,7 @@ class LegacyStandardPdfPipeline(PaginatedPipeline):
             )
 
             conv_res.document = self.reading_order_model(conv_res)
+            conv_res.document = self.heading_hierarchy_model(conv_res)
 
             # Generate page images in the output
             if self.pipeline_options.generate_page_images:

--- a/docling/pipeline/legacy_standard_pdf_pipeline.py
+++ b/docling/pipeline/legacy_standard_pdf_pipeline.py
@@ -55,7 +55,11 @@ class LegacyStandardPdfPipeline(PaginatedPipeline):
                 or self.pipeline_options.generate_table_images
             )
 
-        self.reading_order_model = ReadingOrderModel(options=ReadingOrderOptions())
+        self.reading_order_model = ReadingOrderModel(
+            options=ReadingOrderOptions(
+                heading_hierarchy=self.pipeline_options.heading_hierarchy_options
+            )
+        )
 
         ocr_model = self.get_ocr_model(artifacts_path=self.artifacts_path)
 

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -516,7 +516,11 @@ class StandardPdfPipeline(ConvertPipeline):
             enable_remote_services=self.pipeline_options.enable_remote_services,
         )
         self.assemble_model = PageAssembleModel(options=PageAssembleOptions())
-        self.reading_order_model = ReadingOrderModel(options=ReadingOrderOptions())
+        self.reading_order_model = ReadingOrderModel(
+            options=ReadingOrderOptions(
+                heading_hierarchy=self.pipeline_options.heading_hierarchy_options
+            )
+        )
 
         # --- optional enrichment ------------------------------------------------
         # Create a copy to avoid mutating pipeline_options in-place,

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -55,6 +55,9 @@ from docling.models.factories import (
 from docling.models.stages.code_formula.code_formula_vlm_model import (
     CodeFormulaVlmModel,
 )
+from docling.models.stages.heading_hierarchy.heading_hierarchy_model import (
+    HeadingHierarchyModel,
+)
 from docling.models.stages.page_assemble.page_assemble_model import (
     PageAssembleModel,
     PageAssembleOptions,
@@ -516,10 +519,9 @@ class StandardPdfPipeline(ConvertPipeline):
             enable_remote_services=self.pipeline_options.enable_remote_services,
         )
         self.assemble_model = PageAssembleModel(options=PageAssembleOptions())
-        self.reading_order_model = ReadingOrderModel(
-            options=ReadingOrderOptions(
-                heading_hierarchy=self.pipeline_options.heading_hierarchy_options
-            )
+        self.reading_order_model = ReadingOrderModel(options=ReadingOrderOptions())
+        self.heading_hierarchy_model = HeadingHierarchyModel(
+            options=self.pipeline_options.heading_hierarchy_options
         )
 
         # --- optional enrichment ------------------------------------------------
@@ -868,6 +870,7 @@ class StandardPdfPipeline(ConvertPipeline):
                 elements=elements, headers=headers, body=body
             )
             conv_res.document = self.reading_order_model(conv_res)
+            conv_res.document = self.heading_hierarchy_model(conv_res)
 
             # Generate page images in the output
             if self.pipeline_options.generate_page_images:

--- a/tach.toml
+++ b/tach.toml
@@ -342,6 +342,11 @@ depends_on = [
 ]
 
 [[modules]]
+path = "docling.models.stages.heading_hierarchy"
+layer = "models"
+depends_on = ["docling.datamodel"]
+
+[[modules]]
 path = "docling.models.stages.reading_order"
 layer = "models"
 depends_on = ["docling.datamodel", "docling.utils"]
@@ -480,6 +485,7 @@ depends_on = [
   "docling.datamodel",
   "docling.models.factories",
   "docling.models.stages.code_formula",
+  "docling.models.stages.heading_hierarchy",
   "docling.models.stages.page_assemble",
   "docling.models.stages.page_preprocessing",
   "docling.models.stages.reading_order",
@@ -502,6 +508,7 @@ depends_on = [
   "docling.models",
   "docling.models.factories",
   "docling.models.stages.code_formula",
+  "docling.models.stages.heading_hierarchy",
   "docling.models.stages.page_assemble",
   "docling.models.stages.page_preprocessing",
   "docling.models.stages.reading_order",

--- a/tests/test_heading_hierarchy.py
+++ b/tests/test_heading_hierarchy.py
@@ -1,9 +1,7 @@
 """Tests for section-header level inference in the PDF/image pipeline."""
 
-from pathlib import Path
 from types import SimpleNamespace
 
-import pytest
 from docling_core.types.doc import (
     BoundingBox,
     CoordOrigin,
@@ -20,22 +18,12 @@ from docling_core.types.doc.page import (
     SegmentedPdfPage,
 )
 
-from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
-from docling.datamodel.accelerator_options import AcceleratorDevice
-from docling.datamodel.base_models import InputFormat
-from docling.datamodel.document import InputDocument
-from docling.datamodel.pipeline_options import (
-    HeadingHierarchyOptions,
-    PdfPipelineOptions,
-)
-from docling.datamodel.settings import DocumentLimits
+from docling.datamodel.pipeline_options import HeadingHierarchyOptions
 from docling.models.stages.heading_hierarchy.heading_hierarchy_model import (
     HeadingHierarchyModel,
     _infer_from_numbering,
     _parse_marker,
 )
-from docling.pipeline.legacy_standard_pdf_pipeline import LegacyStandardPdfPipeline
-from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline
 
 
 def _levels(texts: list[str], **opts) -> dict[int, int]:
@@ -221,39 +209,3 @@ def test_style_fallback_assigns_levels_by_font_size():
     model.assign_heading_levels(doc, parsed_pages={1: page})
 
     assert [h.level for h in doc.texts] == [1, 2]
-
-
-@pytest.mark.ml_pdf_model
-@pytest.mark.parametrize(
-    "pipeline_cls",
-    [StandardPdfPipeline, LegacyStandardPdfPipeline],
-)
-def test_pdf_pipeline_assigns_heading_levels_from_existing_fixture(
-    pipeline_cls,
-) -> None:
-    pipeline_options = PdfPipelineOptions()
-    pipeline_options.do_ocr = False
-    pipeline_options.do_table_structure = False
-    pipeline_options.generate_parsed_pages = True
-    pipeline_options.accelerator_options.device = AcceleratorDevice.CPU
-    pipeline_options.heading_hierarchy_options = HeadingHierarchyOptions(enabled=True)
-
-    input_document = InputDocument(
-        path_or_stream=Path("tests/data/pdf/2203.01017v2.pdf"),
-        format=InputFormat.PDF,
-        backend=DoclingParseDocumentBackend,
-        limits=DocumentLimits(page_range=(1, 6)),
-    )
-
-    result = pipeline_cls(pipeline_options).execute(
-        input_document, raises_on_error=True
-    )
-    headings = {
-        item.text: item.level
-        for item in result.document.texts
-        if isinstance(item, SectionHeaderItem)
-    }
-
-    assert headings["1. Introduction"] == 1
-    assert headings["4.1. Model architecture."] == 2
-    assert headings["5.1. Implementation Details"] == 2

--- a/tests/test_heading_hierarchy.py
+++ b/tests/test_heading_hierarchy.py
@@ -1,7 +1,9 @@
-"""Tests for numbering-based section-header level inference (PDF/image pipeline)."""
+"""Tests for section-header level inference in the PDF/image pipeline."""
 
+from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from docling_core.types.doc import (
     BoundingBox,
     CoordOrigin,
@@ -16,13 +18,22 @@ from docling_core.types.doc.page import (
     PdfTextCell,
     SegmentedPdfPage,
 )
+from docling_core.types.doc.document import SectionHeaderItem
 
+from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
+from docling.datamodel.accelerator_options import AcceleratorDevice
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.document import InputDocument
 from docling.datamodel.pipeline_options import HeadingHierarchyOptions
+from docling.datamodel.pipeline_options import PdfPipelineOptions
+from docling.datamodel.settings import DocumentLimits
 from docling.models.stages.heading_hierarchy.heading_hierarchy_model import (
     HeadingHierarchyModel,
     _infer_from_numbering,
     _parse_marker,
 )
+from docling.pipeline.legacy_standard_pdf_pipeline import LegacyStandardPdfPipeline
+from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline
 
 
 def _levels(texts: list[str], **opts) -> dict[int, int]:
@@ -208,3 +219,39 @@ def test_style_fallback_assigns_levels_by_font_size():
     model.assign_heading_levels(doc, parsed_pages={1: page})
 
     assert [h.level for h in doc.texts] == [1, 2]
+
+
+@pytest.mark.ml_pdf_model
+@pytest.mark.parametrize(
+    "pipeline_cls",
+    [StandardPdfPipeline, LegacyStandardPdfPipeline],
+)
+def test_pdf_pipeline_assigns_heading_levels_from_existing_fixture(
+    pipeline_cls,
+) -> None:
+    pipeline_options = PdfPipelineOptions()
+    pipeline_options.do_ocr = False
+    pipeline_options.do_table_structure = False
+    pipeline_options.generate_parsed_pages = True
+    pipeline_options.accelerator_options.device = AcceleratorDevice.CPU
+    pipeline_options.heading_hierarchy_options = HeadingHierarchyOptions(enabled=True)
+
+    input_document = InputDocument(
+        path_or_stream=Path("tests/data/pdf/2203.01017v2.pdf"),
+        format=InputFormat.PDF,
+        backend=DoclingParseDocumentBackend,
+        limits=DocumentLimits(page_range=(1, 6)),
+    )
+
+    result = pipeline_cls(pipeline_options).execute(
+        input_document, raises_on_error=True
+    )
+    headings = {
+        item.text: item.level
+        for item in result.document.texts
+        if isinstance(item, SectionHeaderItem)
+    }
+
+    assert headings["1. Introduction"] == 1
+    assert headings["4.1. Model architecture."] == 2
+    assert headings["5.1. Implementation Details"] == 2

--- a/tests/test_heading_hierarchy.py
+++ b/tests/test_heading_hierarchy.py
@@ -1,0 +1,132 @@
+"""Tests for numbering-based section-header level inference (PDF/image pipeline)."""
+
+from types import SimpleNamespace
+
+from docling_core.types.doc import DoclingDocument
+
+from docling.datamodel.pipeline_options import HeadingHierarchyOptions
+from docling.models.stages.reading_order.heading_hierarchy import (
+    _infer_from_numbering,
+    _parse_marker,
+    assign_heading_levels,
+)
+
+
+def _levels(texts: list[str], **opts) -> dict[int, int]:
+    headings = [SimpleNamespace(text=t) for t in texts]
+    return _infer_from_numbering(headings, HeadingHierarchyOptions(**opts))
+
+
+def test_roman_sections_outrank_arabic_subsections():
+    # The headline bug: Roman parts and Arabic subsections must not collapse to one level.
+    levels = _levels(
+        [
+            "I. Introduction",
+            "1. Background",
+            "2. Motivation",
+            "II. Methodology",
+            "1. Data Collection",
+        ]
+    )
+    assert levels == {0: 1, 1: 2, 2: 2, 3: 1, 4: 2}
+
+
+def test_legal_numbering_stack():
+    # PART -> 1. -> 1.1 -> (a)/(b) -> (i)/(ii) yields five descending levels.
+    levels = _levels(
+        [
+            "PART I",
+            "1. Definitions",
+            "1.1 Interpretation",
+            "(a) First",
+            "(b) Second",
+            "(i) Sub-first",
+            "(ii) Sub-second",
+        ]
+    )
+    assert levels == {0: 1, 1: 2, 2: 3, 3: 4, 4: 4, 5: 5, 6: 5}
+
+
+def test_levels_are_relative_to_schemes_present():
+    # A document that starts at "1." is not forced to start at depth 2.
+    assert _levels(["1. A", "1.1 B", "1.1.1 C"]) == {0: 1, 1: 2, 2: 3}
+
+
+def test_dotted_decimal_depth():
+    # A bare integer needs trailing "." or ")"; dotted forms do not.
+    assert _levels(["1. A", "1.2 B", "1.2.3 C"]) == {0: 1, 1: 2, 2: 3}
+
+
+def test_unnumbered_headings_have_no_numbering_level():
+    levels = _levels(["Introduction", "1. Scope", "Summary"])
+    assert levels == {1: 1}  # only the numbered heading gets a level
+
+
+def test_ambiguous_single_letter_resolves_roman_in_roman_context():
+    markers = [_parse_marker(t) for t in ["I. A", "II. B", "III. C"]]
+    assert [m.family for m in markers] == ["roman_u", "roman_u", "roman_u"]
+
+
+def test_ambiguous_single_letter_resolves_alpha_in_alpha_context():
+    # A. B. C. -> alpha (B is not a Roman numeral, so it anchors the family; C is ambiguous).
+    markers = [_parse_marker(t) for t in ["A. A", "B. B", "C. C"]]
+    families = [m.family for m in markers]
+    levels = _levels(["A. A", "B. B", "C. C"])
+    assert families[0] == "alpha_u" and families[1] == "alpha_u"
+    assert levels == {0: 1, 1: 1, 2: 1}  # same scheme -> same level
+
+
+def test_keyword_part_and_article():
+    assert _parse_marker("PART I").family == "part"
+    assert _parse_marker("Article 1 - Scope").family == "article"
+    assert _parse_marker("Section 2").family == "article"
+    assert _parse_marker("§ 1.2 Liability").family == "article"
+
+
+def test_non_marker_text_is_ignored():
+    assert _parse_marker("Summary") is None
+    assert _parse_marker("Introduction to the topic") is None
+    assert _parse_marker("ABSTRACT") is None
+
+
+def test_custom_numbering_scheme_order():
+    # Override so Arabic outranks Roman.
+    levels = _levels(
+        ["I. A", "1. B"],
+        numbering_schemes=["arabic", "roman_u"],
+    )
+    assert levels == {0: 2, 1: 1}
+
+
+def test_max_level_clamping_on_document():
+    doc = DoclingDocument(name="t")
+    for text in ["1. A", "1.1 B", "1.1.1 C", "1.1.1.1 D"]:
+        doc.add_heading(text=text)
+    assign_heading_levels(
+        doc,
+        conv_res=None,
+        options=HeadingHierarchyOptions(
+            enabled=True, use_style=False, use_bookmarks=False, max_level=2
+        ),
+    )
+    assert [h.level for h in doc.texts] == [1, 2, 2, 2]
+
+
+def test_assign_updates_document_levels_and_markdown():
+    doc = DoclingDocument(name="t")
+    for text in ["I. Introduction", "1. Background", "2. Motivation", "II. Methods"]:
+        doc.add_heading(text=text)
+
+    assign_heading_levels(
+        doc,
+        conv_res=None,
+        options=HeadingHierarchyOptions(
+            enabled=True, use_style=False, use_bookmarks=False
+        ),
+    )
+
+    assert [h.level for h in doc.texts] == [1, 2, 2, 1]
+    md = doc.export_to_markdown()
+    assert "# I. Introduction" in md
+    assert "## 1. Background" in md
+    assert "# II. Methods" in md

--- a/tests/test_heading_hierarchy.py
+++ b/tests/test_heading_hierarchy.py
@@ -116,9 +116,7 @@ def test_max_level_clamping_on_document():
     for text in ["1. A", "1.1 B", "1.1.1 C", "1.1.1.1 D"]:
         doc.add_heading(text=text)
     model = HeadingHierarchyModel(
-        options=HeadingHierarchyOptions(
-            use_style=False, use_bookmarks=False, max_level=2
-        )
+        options=HeadingHierarchyOptions(use_style=False, max_level=2)
     )
     model.assign_heading_levels(doc)
     assert [h.level for h in doc.texts] == [1, 2, 2, 2]
@@ -129,9 +127,7 @@ def test_assign_updates_document_levels_and_markdown():
     for text in ["I. Introduction", "1. Background", "2. Motivation", "II. Methods"]:
         doc.add_heading(text=text)
 
-    model = HeadingHierarchyModel(
-        options=HeadingHierarchyOptions(use_style=False, use_bookmarks=False)
-    )
+    model = HeadingHierarchyModel(options=HeadingHierarchyOptions(use_style=False))
     model.assign_heading_levels(doc)
 
     assert [h.level for h in doc.texts] == [1, 2, 2, 1]
@@ -207,9 +203,7 @@ def test_style_fallback_assigns_levels_by_font_size():
     )
 
     model = HeadingHierarchyModel(
-        options=HeadingHierarchyOptions(
-            use_numbering=False, use_style=True, use_bookmarks=False
-        )
+        options=HeadingHierarchyOptions(use_numbering=False, use_style=True)
     )
     model.assign_heading_levels(doc, parsed_pages={1: page})
 

--- a/tests/test_heading_hierarchy.py
+++ b/tests/test_heading_hierarchy.py
@@ -10,6 +10,7 @@ from docling_core.types.doc import (
     DoclingDocument,
     ProvenanceItem,
 )
+from docling_core.types.doc.document import SectionHeaderItem
 from docling_core.types.doc.page import (
     BoundingRectangle,
     PdfCellRenderingMode,
@@ -18,14 +19,15 @@ from docling_core.types.doc.page import (
     PdfTextCell,
     SegmentedPdfPage,
 )
-from docling_core.types.doc.document import SectionHeaderItem
 
 from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
 from docling.datamodel.accelerator_options import AcceleratorDevice
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
-from docling.datamodel.pipeline_options import HeadingHierarchyOptions
-from docling.datamodel.pipeline_options import PdfPipelineOptions
+from docling.datamodel.pipeline_options import (
+    HeadingHierarchyOptions,
+    PdfPipelineOptions,
+)
 from docling.datamodel.settings import DocumentLimits
 from docling.models.stages.heading_hierarchy.heading_hierarchy_model import (
     HeadingHierarchyModel,

--- a/tests/test_heading_hierarchy.py
+++ b/tests/test_heading_hierarchy.py
@@ -2,13 +2,26 @@
 
 from types import SimpleNamespace
 
-from docling_core.types.doc import DoclingDocument
+from docling_core.types.doc import (
+    BoundingBox,
+    CoordOrigin,
+    DoclingDocument,
+    ProvenanceItem,
+)
+from docling_core.types.doc.page import (
+    BoundingRectangle,
+    PdfCellRenderingMode,
+    PdfPageBoundaryType,
+    PdfPageGeometry,
+    PdfTextCell,
+    SegmentedPdfPage,
+)
 
 from docling.datamodel.pipeline_options import HeadingHierarchyOptions
-from docling.models.stages.reading_order.heading_hierarchy import (
+from docling.models.stages.heading_hierarchy.heading_hierarchy_model import (
+    HeadingHierarchyModel,
     _infer_from_numbering,
     _parse_marker,
-    assign_heading_levels,
 )
 
 
@@ -102,13 +115,12 @@ def test_max_level_clamping_on_document():
     doc = DoclingDocument(name="t")
     for text in ["1. A", "1.1 B", "1.1.1 C", "1.1.1.1 D"]:
         doc.add_heading(text=text)
-    assign_heading_levels(
-        doc,
-        conv_res=None,
+    model = HeadingHierarchyModel(
         options=HeadingHierarchyOptions(
-            enabled=True, use_style=False, use_bookmarks=False, max_level=2
-        ),
+            use_style=False, use_bookmarks=False, max_level=2
+        )
     )
+    model.assign_heading_levels(doc)
     assert [h.level for h in doc.texts] == [1, 2, 2, 2]
 
 
@@ -117,16 +129,88 @@ def test_assign_updates_document_levels_and_markdown():
     for text in ["I. Introduction", "1. Background", "2. Motivation", "II. Methods"]:
         doc.add_heading(text=text)
 
-    assign_heading_levels(
-        doc,
-        conv_res=None,
-        options=HeadingHierarchyOptions(
-            enabled=True, use_style=False, use_bookmarks=False
-        ),
+    model = HeadingHierarchyModel(
+        options=HeadingHierarchyOptions(use_style=False, use_bookmarks=False)
     )
+    model.assign_heading_levels(doc)
 
     assert [h.level for h in doc.texts] == [1, 2, 2, 1]
     md = doc.export_to_markdown()
     assert "# I. Introduction" in md
     assert "## 1. Background" in md
     assert "# II. Methods" in md
+
+
+def _bbox(left, top, right, bottom):
+    return BoundingBox(
+        l=left, t=top, r=right, b=bottom, coord_origin=CoordOrigin.TOPLEFT
+    )
+
+
+def _cell(text, left, top, right, bottom):
+    return PdfTextCell(
+        index=0,
+        rect=BoundingRectangle.from_bounding_box(_bbox(left, top, right, bottom)),
+        text=text,
+        orig=text,
+        rendering_mode=PdfCellRenderingMode.FILL_TEXT,
+        widget=False,
+        font_key="F1",
+        font_name="Helvetica",
+    )
+
+
+def _segmented_page(cells, width=600, height=800):
+    full = _bbox(0, 0, width, height)
+    geometry = PdfPageGeometry(
+        angle=0,
+        boundary_type=PdfPageBoundaryType.CROP_BOX,
+        rect=BoundingRectangle.from_bounding_box(full),
+        art_bbox=full,
+        bleed_bbox=full,
+        crop_bbox=full,
+        media_bbox=full,
+        trim_bbox=full,
+    )
+    return SegmentedPdfPage(
+        dimension=geometry,
+        textline_cells=cells,
+        char_cells=[],
+        word_cells=[],
+        has_chars=False,
+        has_words=False,
+        has_lines=True,
+    )
+
+
+def test_style_fallback_assigns_levels_by_font_size():
+    # No numbering -> fall back to font size: the larger heading becomes the higher level.
+    doc = DoclingDocument(name="t")
+    doc.add_heading(
+        text="Overview",
+        prov=ProvenanceItem(
+            page_no=1,
+            charspan=(0, 8),
+            bbox=_bbox(100, 50, 300, 70),  # height 20
+        ),
+    )
+    doc.add_heading(
+        text="Details",
+        prov=ProvenanceItem(
+            page_no=1,
+            charspan=(0, 7),
+            bbox=_bbox(100, 88, 300, 100),  # height 12
+        ),
+    )
+    page = _segmented_page(
+        [_cell("Overview", 100, 50, 300, 70), _cell("Details", 100, 88, 300, 100)]
+    )
+
+    model = HeadingHierarchyModel(
+        options=HeadingHierarchyOptions(
+            use_numbering=False, use_style=True, use_bookmarks=False
+        )
+    )
+    model.assign_heading_levels(doc, parsed_pages={1: page})
+
+    assert [h.level for h in doc.texts] == [1, 2]

--- a/tests/test_heading_hierarchy_pdf.py
+++ b/tests/test_heading_hierarchy_pdf.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+
+import pytest
+from docling_core.types.doc.document import SectionHeaderItem
+
+from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
+from docling.datamodel.accelerator_options import AcceleratorDevice
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.document import InputDocument
+from docling.datamodel.pipeline_options import (
+    HeadingHierarchyOptions,
+    PdfPipelineOptions,
+)
+from docling.datamodel.settings import DocumentLimits
+from docling.pipeline.legacy_standard_pdf_pipeline import LegacyStandardPdfPipeline
+from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline
+
+pytestmark = pytest.mark.ml_pdf_model
+
+
+@pytest.mark.parametrize(
+    "pipeline_cls",
+    [StandardPdfPipeline, LegacyStandardPdfPipeline],
+)
+def test_pdf_pipeline_assigns_heading_levels_from_existing_fixture(
+    pipeline_cls,
+) -> None:
+    pipeline_options = PdfPipelineOptions()
+    pipeline_options.do_ocr = False
+    pipeline_options.do_table_structure = False
+    pipeline_options.generate_parsed_pages = True
+    pipeline_options.accelerator_options.device = AcceleratorDevice.CPU
+    pipeline_options.heading_hierarchy_options = HeadingHierarchyOptions(enabled=True)
+
+    input_document = InputDocument(
+        path_or_stream=Path("tests/data/pdf/2203.01017v2.pdf"),
+        format=InputFormat.PDF,
+        backend=DoclingParseDocumentBackend,
+        limits=DocumentLimits(page_range=(1, 6)),
+    )
+
+    result = pipeline_cls(pipeline_options).execute(
+        input_document, raises_on_error=True
+    )
+    headings = {
+        item.text: item.level
+        for item in result.document.texts
+        if isinstance(item, SectionHeaderItem)
+    }
+
+    assert headings["1. Introduction"] == 1
+    assert headings["4.1. Model architecture."] == 2
+    assert headings["5.1. Implementation Details"] == 2


### PR DESCRIPTION
# Infer PDF heading levels so the hierarchy isn't flattened

## The problem

I hit this while converting legal contracts to Markdown for an LLM pipeline: every heading Docling pulls out of a PDF comes back as a level-1 `#`, so the whole document goes flat. Something structured like

```
PART I
1. Definitions
1.1 Interpretation
(a) ...
```

ends up as a flat run of `#` headings, and the parent/child relationship between the parts, the numbered sections and the sub-clauses is just gone. Anything downstream that leans on heading depth to understand the document (RAG, summarisation, navigation) loses that structure.

This is the issue reported in #3555, and the same thing has come up before in #386, #1170 and #2774. There were also two earlier attempts to infer levels from font information (#2676, #2421) that never landed. The standalone post-processor [`krrome/docling-hierarchical-pdf`](https://github.com/krrome/docling-hierarchical-pdf) (MIT) already does this *after* conversion — this PR brings the same idea into the pipeline itself.

## Why it happens

It isn't really a detection bug — Docling finds the headings fine, it just never gives them a level. In `readingorder_model.py`, both places that create a heading call `add_heading()` with no `level=`, so it falls back to `1`:

```python
# _handle_text_element (the SECTION_HEADER branch)
new_item = out_doc.add_heading(
    text=cap_text, prov=prov, hyperlink=element.hyperlink
)  # no level= -> defaults to 1

# _add_child_elements
doc.add_heading(parent=doc_item, text=c_text, prov=c_prov)  # no level=
```

`DoclingDocument.add_heading()` already accepts a `level` (1–100) and the Markdown/HTML exporters already render it. The DOCX, LaTeX and HTML backends pass it because they have real heading markup to read; the PDF path has none, so nothing ever computes a level. So this is closer to a missing feature than a regression.

## What I changed

I added a small, self-contained step (`docling/models/stages/reading_order/heading_hierarchy.py`) that runs from `ReadingOrderModel.__call__` once the document is assembled. It walks the headings in reading order and assigns each one a level. It only rewrites levels — it never adds, removes or reorders anything.

Doing this inside the pipeline (instead of as a post-processor on the finished document) matters: the font data lives on `conv_res.pages[i].parsed_page` and never makes it into the final `DoclingDocument`, so only an in-pipeline step can actually use it. It also fixes every PDF/image backend at once, since they all share this stage.

There are two signals, with numbering as the primary one.

### Numbering

A small grammar reads each heading's leading marker and maps it to a scheme:

| Example marker | Scheme |
| --- | --- |
| `PART I`, `TITLE II` | part |
| `Article 1`, `Section 2`, `§ 1.2` | article |
| `I.`, `II.`, `III.` | upper roman |
| `1.`, `2.` | arabic |
| `1.1`, `1.1.1` | dotted decimal (depth from segment count) |
| `(a)`, `A.` | alpha |
| `(i)`, `(ii)` | lower roman |

Levels are worked out *relatively* from the schemes that actually appear, so a document that starts at `1.` isn't forced to start at depth 2, and `1.1` / `1.1.1` nest by how many segments they have. I went with numbering as the main signal on purpose — in legal and regulatory documents the numbering is far more reliable than the styling, which is often completely uniform.

Single letters that are also valid Roman numerals (`I`, `V`, `C`, …) are genuinely ambiguous, so they're resolved from the surrounding markers: `I. / II. / III.` reads as Roman, while `A. / B. / C.` reads as alphabetic. There's also a `numbering_schemes` option to override the ordering for house styles.

### Style (fallback)

For headings that have no recognisable number, it falls back to font size: it matches the heading's box against the parsed PDF cells and uses their median height as a size proxy — bigger text becomes a higher level. There's no explicit font-size field on the cells, so height is the best proxy available.

One caveat worth knowing: the parsed pages get dropped right before the reading-order stage unless you keep them, so the style fallback needs `generate_parsed_pages=True`. Without it, style just no-ops and numbering still works.

## How to use it

It's opt-in and off by default, so nothing changes for anyone unless they turn it on:

```python
from docling.datamodel.base_models import InputFormat
from docling.datamodel.pipeline_options import (
    HeadingHierarchyOptions,
    PdfPipelineOptions,
)
from docling.document_converter import DocumentConverter, PdfFormatOption

opts = PdfPipelineOptions()
opts.heading_hierarchy_options = HeadingHierarchyOptions(enabled=True)
opts.generate_parsed_pages = True  # only needed for the style fallback

converter = DocumentConverter(
    format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=opts)}
)
doc = converter.convert("contract.pdf").document
print(doc.export_to_markdown())
```

The new options:

```python
enabled: bool = False          # master switch
use_numbering: bool = True     # primary signal
use_style: bool = True         # fallback; needs generate_parsed_pages=True
use_bookmarks: bool = False    # reserved for the follow-up below
numbering_schemes: list[str] | None = None
max_level: int = 6
```

## Tests

`tests/test_heading_hierarchy.py` covers the headline case (Roman sections staying above Arabic subsections), the full legal stack (`PART → 1. → 1.1 → (a) → (i)`), relative/compressed levels, dotted-decimal depth, custom scheme order, `max_level` clamping, the Roman-vs-alpha disambiguation, the negative cases (plain words and bare numbers shouldn't be treated as markers), and the end-to-end effect on `export_to_markdown`.

No reference data changes, since the feature is off by default and existing fixtures stay byte-identical.

## What I deliberately left out

- **Bookmarks / PDF outline.** This is usually the most authoritative signal, but it needs new plumbing in the PDF backends (the outline isn't surfaced anywhere today), so I kept it out to keep this PR focused. `_infer_from_bookmarks()` is already there as a no-op extension point, so it can be added later without disturbing this structure.
- **Bold/italic from font names.** A natural extension to the style signal, but not needed for the legal use case and easy to bolt on afterwards.

## Honest limitations

- The style fallback relies on geometric matching between the heading box and the parsed cells, which has rough edges (multi-line headings, rotated text, OCR cells with no font), so numbering carries the weight.
- On scanned / VLM-parsed PDFs the font data is often missing, so it degrades to numbering-only.
- A lone `(i)` with no sibling `(ii)` next to an `(a)` list can be misread — it needs a real sequence to anchor the Roman-vs-alpha call.

## A couple of things I'd like your take on

- Off by default (what I went with) vs. on with regenerated references?
- I assign the level in a post-assembly pass rather than at the `add_heading` call sites — happy to move it if you'd prefer.
- Should style auto-keep `parsed_page` when it's enabled, instead of asking the user to also set `generate_parsed_pages=True`?
- Is building on the `krrome/docling-hierarchical-pdf` approach (with attribution) fine?

Closes #3555.
