### PR TITLE
fix(xlsx): respect page_range in MsExcelDocumentBackend

### DIFF
--- a/docling/backend/msexcel_backend.py
+++ b/docling/backend/msexcel_backend.py
@@ -139,6 +139,8 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
             options = MsExcelBackendOptions()
         super().__init__(in_doc, path_or_stream, options)
 
+        self.page_range = in_doc.limits.page_range
+
         # Initialise the parents for the hierarchy
         self.max_levels = 10
 
@@ -242,6 +244,8 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
                 else None
             )
 
+            start_page, end_page = self.page_range
+
             page_no = 0
             # Iterate over all sheets
             for idx, name in enumerate(self.workbook.sheetnames):
@@ -249,7 +253,17 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
                     _log.debug(f"Skipping sheet {idx}: {name} (filtered out)")
                     continue
 
+                # Page numbers are 1-based positions within the (optionally filtered)
+                # set of sheets. Increment before the range check so selected sheets
+                # keep their original page numbers (e.g. page_range=(2, 4) -> 2, 3, 4).
                 page_no += 1
+                if page_no < start_page or page_no > end_page:
+                    _log.debug(
+                        f"Skipping sheet {idx}: {name} "
+                        f"(page {page_no} outside range {start_page}-{end_page})"
+                    )
+                    continue
+
                 _log.info(f"Processing sheet {idx}: {name} as page {page_no}")
 
                 sheet = self.workbook[name]

--- a/tests/test_backend_msexcel.py
+++ b/tests/test_backend_msexcel.py
@@ -103,6 +103,45 @@ def test_pages(documents) -> None:
     assert doc.pages.get(4).size.as_tuple() == (0.0, 0.0)
 
 
+def test_page_range() -> None:
+    """Test that page_range selects a contiguous subset of sheets.
+
+    xlsx_01.xlsx has 4 sheets. Converting with page_range=(2, 4) should yield
+    only sheets 2-4, keeping their original page numbers (2, 3, 4).
+    """
+    path = next(item for item in get_excel_paths() if item.stem == "xlsx_01")
+
+    converter = get_converter()
+    doc = converter.convert(path, page_range=(2, 4)).document
+
+    assert set(doc.pages.keys()) == {2, 3, 4}
+    # original page numbering is preserved, so sizes match the full-document ones
+    assert doc.pages.get(2).size.as_tuple() == (9.0, 18.0)
+    assert doc.pages.get(3).size.as_tuple() == (13.0, 36.0)
+    assert doc.pages.get(4).size.as_tuple() == (0.0, 0.0)
+
+
+def test_page_range_with_sheet_names() -> None:
+    """Test that page_range applies to the sheet_names-filtered set.
+
+    With sheet_names dropping "Sheet2", the filtered sequence is
+    [Sheet1, Sheet3, Sheet4] at positions 1, 2, 3. page_range=(2, 3) then
+    selects Sheet3 and Sheet4 (pages 2 and 3 of the filtered set).
+    """
+    path = next(item for item in get_excel_paths() if item.stem == "xlsx_01")
+
+    options = MsExcelBackendOptions(sheet_names=["Sheet1", "Sheet3", "Sheet4"])
+    format_options = {InputFormat.XLSX: ExcelFormatOption(backend_options=options)}
+    converter = DocumentConverter(
+        allowed_formats=[InputFormat.XLSX], format_options=format_options
+    )
+    doc = converter.convert(path, page_range=(2, 3)).document
+
+    assert set(doc.pages.keys()) == {2, 3}
+    sheet_groups = [g.name for g in doc.groups if g.name.startswith("sheet: ")]
+    assert sheet_groups == ["sheet: Sheet3", "sheet: Sheet4"]
+
+
 def test_chartsheet(documents) -> None:
     """Test the conversion of Chartsheets.
 


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #3634

`MsExcelDocumentBackend` declares `supports_pagination() = True` and maps each
worksheet to a sequential page number, but `convert()` / `_convert_workbook()`
ignored `in_doc.limits.page_range`, so every sheet was always processed. This is
inconsistent with `MsPowerpointDocumentBackend`, which applies `page_range`.

**Changes:**
- Store `self.page_range = in_doc.limits.page_range` in `__init__`, mirroring the
  PowerPoint backend.
- Apply the range in `_convert_workbook()` **after** the existing `sheet_names`
  filter, so it stays consistent with `page_count()` (which already counts the
  filtered sheets). When `sheet_names` is set, `page_range` applies to that
  filtered sequence; otherwise to all sheets.
- Selected sheets keep their original page numbers (e.g. `page_range=(2, 4)`
  yields pages 2, 3, 4), matching the PowerPoint backend's behavior as agreed in
  the issue discussion.

**Tests added:**
- `test_page_range` — `(2, 4)` on the 4-sheet `xlsx_01` yields pages `{2, 3, 4}`
  with the original sizes/numbering preserved.
- `test_page_range_with_sheet_names` — with `Sheet2` filtered out, `(2, 3)`
  selects `Sheet3` and `Sheet4`, verifying `page_range` applies to the filtered set.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
