### PR TITLE
fix(asciidoc): parse table cells with format specifiers

### DIFF
--- a/docling/backend/asciidoc_backend.py
+++ b/docling/backend/asciidoc_backend.py
@@ -25,6 +25,10 @@ _log = logging.getLogger(__name__)
 DEFAULT_IMAGE_WIDTH: Final = 128
 DEFAULT_IMAGE_HEIGHT: Final = 128
 
+# Cell format specifier that may precede a "|" delimiter, e.g. "^.^h" in
+# "^.^h|Header": span (3*, 2+), alignment (<, ^, >, .^), style (a/d/e/h/l/m/s).
+_CELL_SPEC: Final = r"(?:\d+(?:\.\d+)?[*+])*[<^>]?(?:\.[<^>])?[adehlms]?"
+
 
 class AsciiDocBackend(DeclarativeDocumentBackend):
     def __init__(self, in_doc: "InputDocument", path_or_stream: Union[BytesIO, Path]):
@@ -357,10 +361,13 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
     #   =========   Tables
     @staticmethod
     def _is_table_line(line):
-        return re.match(r"^\|.*\|", line)
+        return re.match(rf"^{_CELL_SPEC}\|.*\|", line)
 
     @staticmethod
     def _parse_table_line(line):
+        # Drop cell specifiers glued to a "|" (e.g. "^.^h"); anchored to
+        # whitespace so content ending in a style letter (e.g. "Eth") survives.
+        line = re.sub(rf"(^|\s){_CELL_SPEC}(?=\|)", r"\1", line)
         # Split table cells and trim extra spaces
         return [cell.strip() for cell in line.split("|") if cell.strip()]
 
@@ -369,7 +376,7 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
         num_rows = len(table_data)
 
         # Adjust the table data into a grid format
-        num_cols = max(len(row) for row in table_data)
+        num_cols = max((len(row) for row in table_data), default=0)
 
         data = TableData(num_rows=num_rows, num_cols=num_cols, table_cells=[])
         for row_idx, row in enumerate(table_data):

--- a/tests/data/asciidoc/test_04.asciidoc
+++ b/tests/data/asciidoc/test_04.asciidoc
@@ -1,0 +1,19 @@
+= Tables with cell format specifiers
+
+A table whose header row uses alignment and style specifiers on every cell.
+
+[%autowidth, cols="^.^40,<.^60"]
+|===
+^.^h|Field ^.^h| Description
+| a | First column value
+| b | Second column value
+|===
+
+A table with single-letter cells that collide with style operators.
+
+|===
+^h| Code ^h| Name
+| s | Strong
+| h | Header
+| m | Monospace
+|===

--- a/tests/data/groundtruth/docling_v2/test_04.asciidoc.md
+++ b/tests/data/groundtruth/docling_v2/test_04.asciidoc.md
@@ -1,0 +1,18 @@
+# Tables with cell format specifiers
+
+A table whose header row uses alignment and style specifiers on every cell.
+
+| Field | Description |
+| - | - |
+| a | First column value |
+| b | Second column value |
+
+[%autowidth, cols="^.^40,&lt;.^60"]
+
+A table with single-letter cells that collide with style operators.
+
+| Code | Name |
+| - | - |
+| s | Strong |
+| h | Header |
+| m | Monospace |

--- a/tests/test_backend_asciidoc.py
+++ b/tests/test_backend_asciidoc.py
@@ -51,6 +51,38 @@ def test_parse_picture():
     )
 
 
+def test_table_cell_format_specifiers():
+    # A header row whose cells carry alignment + style specifiers ("^.^h|")
+    # must still be detected as a table line and parsed into clean cells.
+    line = "^.^h|Field               ^.^h| Description"
+    assert AsciiDocBackend._is_table_line(line)
+    assert AsciiDocBackend._parse_table_line(line) == ["Field", "Description"]
+
+    # A column-spanning specifier ("2+^|") is dropped from the cell text.
+    assert AsciiDocBackend._parse_table_line("2+^|Spanned ^|Next") == [
+        "Spanned",
+        "Next",
+    ]
+
+
+def test_table_cell_content_preserved():
+    # Single-letter cells that coincide with style operators (s, h, m, ...) and
+    # words ending in one (Eth) must not be mistaken for cell specifiers.
+    assert AsciiDocBackend._parse_table_line("| s | Strong") == ["s", "Strong"]
+    assert AsciiDocBackend._parse_table_line("| eth | Eth | Ethernet") == [
+        "eth",
+        "Eth",
+        "Ethernet",
+    ]
+
+
+def test_empty_table_does_not_crash():
+    # An empty table must yield an empty grid rather than raising.
+    data = AsciiDocBackend._populate_table_as_grid([])
+    assert data.num_rows == 0
+    assert data.num_cols == 0
+
+
 def test_asciidocs_examples():
     fnames = sorted(glob.glob("./tests/data/asciidoc/*.asciidoc"))
 


### PR DESCRIPTION
# PR body

<!-- Thank you for contributing to Docling! -->

The AsciiDoc table parser only recognized rows beginning with a bare `|`, so a row whose cells carry a format specifier (e.g. a header row `^.^h|Field ^.^h|Description`) was not detected as a table line. The table collected no rows and `_populate_table_as_grid` raised `ValueError: max() iterable argument is empty`, failing the whole conversion.

This PR:

- Recognizes a leading cell specifier in `_is_table_line` (alignment `<`/`^`/`>`, vertical alignment `.^`, the `a/d/e/h/l/m/s` styles, and `2+`/`3*` span/duplication).
- Strips specifiers glued to a `|` delimiter in `_parse_table_line`. The match is anchored to whitespace or line start so cell content that merely ends in a style letter (e.g. `Eth`) is preserved.
- Guards the empty-table case in `_populate_table_as_grid` (`max(..., default=0)`).

Added unit tests for specifier detection, content preservation, and the empty case, plus an end-to-end `test_04.asciidoc` fixture that crashed before this fix.

**Issue resolved by this Pull Request:**
Resolves #3646

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
