### PR TITLE
chore: remove all legacy references of docling-core

### DIFF
--- a/docs/examples/batch_convert.py
+++ b/docs/examples/batch_convert.py
@@ -16,11 +16,6 @@
 # - If you cloned without test data, or want to use your own files, edit
 #   `input_doc_paths` below to point to PDFs on your machine.
 
-# Output formats (controlled by flags)
-# - `USE_V2 = True` enables the current Docling document exports (recommended).
-# - `USE_LEGACY = False` keeps legacy Deep Search exports disabled.
-#   You can set it to `True` if you need legacy formats for compatibility tests.
-
 # Notes
 # - Set `pipeline_options.generate_page_images = True` to include page images in HTML.
 # - The script logs conversion progress and raises if any documents fail.
@@ -45,12 +40,6 @@ from docling.document_converter import DocumentConverter, PdfFormatOption
 
 _log = logging.getLogger(__name__)
 
-# Export toggles:
-# - USE_V2 controls modern Docling document exports.
-# - USE_LEGACY enables legacy Deep Search exports for comparison or migration.
-USE_V2 = True
-USE_LEGACY = False
-
 
 def export_documents(
     conv_results: Iterable[ConversionResult],
@@ -67,73 +56,44 @@ def export_documents(
             success_count += 1
             doc_filename = conv_res.input.file.stem
 
-            if USE_V2:
-                # Recommended modern Docling exports. These helpers mirror the
-                # lower-level "export_to_*" methods used below, but handle
-                # common details like image handling.
-                conv_res.document.save_as_json(
-                    output_dir / f"{doc_filename}.json",
-                    image_mode=ImageRefMode.PLACEHOLDER,
-                )
-                conv_res.document.save_as_html(
-                    output_dir / f"{doc_filename}.html",
-                    image_mode=ImageRefMode.EMBEDDED,
-                )
-                conv_res.document.save_as_doctags(
-                    output_dir / f"{doc_filename}.doctags.txt"
-                )
-                conv_res.document.save_as_markdown(
-                    output_dir / f"{doc_filename}.md",
-                    image_mode=ImageRefMode.PLACEHOLDER,
-                )
-                conv_res.document.save_as_markdown(
-                    output_dir / f"{doc_filename}.txt",
-                    image_mode=ImageRefMode.PLACEHOLDER,
-                    strict_text=True,
-                )
+            # These helpers mirror the lower-level "export_to_*" methods used below,
+            # but handle common details like image handling.
+            conv_res.document.save_as_json(
+                output_dir / f"{doc_filename}.json",
+                image_mode=ImageRefMode.PLACEHOLDER,
+            )
+            conv_res.document.save_as_html(
+                output_dir / f"{doc_filename}.html",
+                image_mode=ImageRefMode.EMBEDDED,
+            )
+            conv_res.document.save_as_doctags(
+                output_dir / f"{doc_filename}.doctags.txt"
+            )
+            conv_res.document.save_as_markdown(
+                output_dir / f"{doc_filename}.md",
+                image_mode=ImageRefMode.PLACEHOLDER,
+            )
+            conv_res.document.save_as_markdown(
+                output_dir / f"{doc_filename}.txt",
+                image_mode=ImageRefMode.PLACEHOLDER,
+                strict_text=True,
+            )
 
-                # Export Docling document format to YAML:
-                with (output_dir / f"{doc_filename}.yaml").open("w") as fp:
-                    fp.write(yaml.safe_dump(conv_res.document.export_to_dict()))
+            # Export Docling document format to YAML:
+            with (output_dir / f"{doc_filename}.yaml").open("w") as fp:
+                fp.write(yaml.safe_dump(conv_res.document.export_to_dict()))
 
-                # Export Docling document format to doctags:
-                with (output_dir / f"{doc_filename}.doctags.txt").open("w") as fp:
-                    fp.write(conv_res.document.export_to_doctags())
+            # Export Docling document format to doctags:
+            with (output_dir / f"{doc_filename}.doctags.txt").open("w") as fp:
+                fp.write(conv_res.document.export_to_doctags())
 
-                # Export Docling document format to markdown:
-                with (output_dir / f"{doc_filename}.md").open("w") as fp:
-                    fp.write(conv_res.document.export_to_markdown())
+            # Export Docling document format to markdown:
+            with (output_dir / f"{doc_filename}.md").open("w") as fp:
+                fp.write(conv_res.document.export_to_markdown())
 
-                # Export Docling document format to text:
-                with (output_dir / f"{doc_filename}.txt").open("w") as fp:
-                    fp.write(conv_res.document.export_to_markdown(strict_text=True))
-
-            if USE_LEGACY:
-                # Export Deep Search document JSON format:
-                with (output_dir / f"{doc_filename}.legacy.json").open(
-                    "w", encoding="utf-8"
-                ) as fp:
-                    fp.write(json.dumps(conv_res.legacy_document.export_to_dict()))
-
-                # Export Text format:
-                with (output_dir / f"{doc_filename}.legacy.txt").open(
-                    "w", encoding="utf-8"
-                ) as fp:
-                    fp.write(
-                        conv_res.legacy_document.export_to_markdown(strict_text=True)
-                    )
-
-                # Export Markdown format:
-                with (output_dir / f"{doc_filename}.legacy.md").open(
-                    "w", encoding="utf-8"
-                ) as fp:
-                    fp.write(conv_res.legacy_document.export_to_markdown())
-
-                # Export Document Tags format:
-                with (output_dir / f"{doc_filename}.legacy.doctags.txt").open(
-                    "w", encoding="utf-8"
-                ) as fp:
-                    fp.write(conv_res.legacy_document.export_to_document_tokens())
+            # Export Docling document format to text:
+            with (output_dir / f"{doc_filename}.txt").open("w") as fp:
+                fp.write(conv_res.document.export_to_markdown(strict_text=True))
 
         elif conv_res.status == ConversionStatus.PARTIAL_SUCCESS:
             _log.info(

--- a/docs/v2.md
+++ b/docs/v2.md
@@ -165,6 +165,13 @@ for item, level in conv_result.document.iterate_items():
         #...
 ```
 
+⚠️ **Deprecation Notice**: Support for the Docling v1 document representation (`conv_result.legacy_document`) has been completely removed. You must now use the modern Docling v2 format:
+
+```python
+## Use the updated v2 document representation
+conv_result.document
+```
+
 ### Export into JSON, Markdown, Doctags
 **Note**: All `render_...` methods in `ConversionResult` have been removed in Docling v2,
 and are now available on `DoclingDocument` as:
@@ -182,6 +189,13 @@ print(conv_res.document.export_to_markdown())
 print(conv_res.document.export_to_document_tokens())
 ```
 
+⚠️ **Deprecation Notice**: The `legacy_document` export pathways have been completely removed. For historical reference, the old v1 approach looked like this (the following code **will fail** in this release):
+```python
+## ❌ REMOVED: This v1 block is no longer operational
+print(json.dumps(conv_res.legacy_document.export_to_dict()))
+print(conv_res.legacy_document.export_to_markdown())
+print(conv_res.legacy_document.export_to_document_tokens())
+```
 
 ### Reload a `DoclingDocument` stored as JSON
 

--- a/docs/v2.md
+++ b/docs/v2.md
@@ -165,11 +165,6 @@ for item, level in conv_result.document.iterate_items():
         #...
 ```
 
-**Note**: While it is deprecated, you can _still_ work with the Docling v1 document representation, it is available as:
-```shell
-conv_result.legacy_document # provides the representation in previous ExportedCCSDocument type
-```
-
 ### Export into JSON, Markdown, Doctags
 **Note**: All `render_...` methods in `ConversionResult` have been removed in Docling v2,
 and are now available on `DoclingDocument` as:
@@ -187,14 +182,6 @@ print(conv_res.document.export_to_markdown())
 print(conv_res.document.export_to_document_tokens())
 ```
 
-**Note**: While it is deprecated, you can _still_ export Docling v1 JSON format. This is available through the same
-methods as on the `DoclingDocument` type:
-```shell
-## Export legacy document representation to desired format, for v1 compatibility:
-print(json.dumps(conv_res.legacy_document.export_to_dict()))
-print(conv_res.legacy_document.export_to_markdown())
-print(conv_res.legacy_document.export_to_document_tokens())
-```
 
 ### Reload a `DoclingDocument` stored as JSON
 

--- a/tests/verify_utils.py
+++ b/tests/verify_utils.py
@@ -14,7 +14,6 @@ from docling_core.types.doc import (
     TextItem,
 )
 from docling_core.types.doc.base import BoundingBox
-from docling_core.types.legacy_doc.document import ExportedCCSDocument as DsDocument
 from PIL import Image as PILImage
 from pydantic import BaseModel, TypeAdapter
 
@@ -130,78 +129,6 @@ def verify_cells(
     return True
 
 
-# def verify_maintext(doc_pred: DsDocument, doc_true: DsDocument):
-#     assert doc_true.main_text is not None, "doc_true cannot be None"
-#     assert doc_pred.main_text is not None, "doc_true cannot be None"
-#
-#     assert len(doc_true.main_text) == len(
-#         doc_pred.main_text
-#     ), f"document has different length of main-text than expected. {len(doc_true.main_text)}!={len(doc_pred.main_text)}"
-#
-#     for l, true_item in enumerate(doc_true.main_text):
-#         pred_item = doc_pred.main_text[l]
-#         # Validate type
-#         assert (
-#             true_item.obj_type == pred_item.obj_type
-#         ), f"Item[{l}] type does not match. expected[{true_item.obj_type}] != predicted [{pred_item.obj_type}]"
-#
-#         # Validate text ceels
-#         if isinstance(true_item, BaseText):
-#             assert isinstance(
-#                 pred_item, BaseText
-#             ), f"{pred_item} is not a BaseText element, but {true_item} is."
-#             assert true_item.text == pred_item.text
-#
-#     return True
-
-
-def verify_tables_v1(doc_pred: DsDocument, doc_true: DsDocument, fuzzy: bool):
-    if doc_true.tables is None:
-        # No tables to check
-        assert doc_pred.tables is None, "not expecting any table on this document"
-        return True
-
-    assert doc_pred.tables is not None, "no tables predicted, but expected in doc_true"
-
-    # print("Expected number of tables: {}, result: {}".format(len(doc_true.tables), len(doc_pred.tables)))
-
-    assert len(doc_true.tables) == len(doc_pred.tables), (
-        "document has different count of tables than expected."
-    )
-
-    for ix, true_item in enumerate(doc_true.tables):
-        pred_item = doc_pred.tables[ix]
-
-        assert true_item.num_rows == pred_item.num_rows, (
-            "table does not have the same #-rows"
-        )
-        assert true_item.num_cols == pred_item.num_cols, (
-            "table does not have the same #-cols"
-        )
-
-        assert true_item.data is not None, "documents are expected to have table data"
-        assert pred_item.data is not None, "documents are expected to have table data"
-
-        # print("True: \n", true_item.export_to_dataframe().to_markdown())
-        # print("Pred: \n", true_item.export_to_dataframe().to_markdown())
-
-        for i, row in enumerate(true_item.data):
-            for j, col in enumerate(true_item.data[i]):
-                # print("true: ", true_item.data[i][j].text)
-                # print("pred: ", pred_item.data[i][j].text)
-                # print("")
-
-                verify_text(
-                    true_item.data[i][j].text, pred_item.data[i][j].text, fuzzy=fuzzy
-                )
-
-                assert true_item.data[i][j].obj_type == pred_item.data[i][j].obj_type, (
-                    "table-cell does not have the same type"
-                )
-
-    return True
-
-
 def verify_table_v2(true_item: TableItem, pred_item: TableItem, fuzzy: bool):
     assert true_item.data.num_rows == pred_item.data.num_rows, (
         "table does not have the same #-rows"
@@ -251,12 +178,6 @@ def verify_picture_image_v2(
     assert true_image.mode == pred_item.mode
     # assert true_image.tobytes() == pred_item.tobytes()
     return True
-
-
-# def verify_output(doc_pred: DsDocument, doc_true: DsDocument):
-#     #assert verify_maintext(doc_pred, doc_true), "verify_maintext(doc_pred, doc_true)"
-#     assert verify_tables_v1(doc_pred, doc_true), "verify_tables(doc_pred, doc_true)"
-#     return True
 
 
 def verify_docitems(
@@ -393,76 +314,6 @@ def verify_md(doc_pred_md: str, doc_true_md: str, fuzzy: bool):
 
 def verify_dt(doc_pred_dt: str, doc_true_dt: str, fuzzy: bool):
     return verify_text(doc_true_dt, doc_pred_dt, fuzzy)
-
-
-"""
-def verify_conversion_result_v1(
-    input_path: Path,
-    doc_result: ConversionResult,
-    generate: bool = False,
-    ocr_engine: Optional[str] = None,
-    fuzzy: bool = False,
-    indent: int = 2,
-):
-    assert doc_result.status == ConversionStatus.SUCCESS, (
-        f"Doc {input_path} did not convert successfully."
-    )
-
-    with pytest.warns(DeprecationWarning, match="Use document instead"):
-        doc_pred: DsDocument = doc_result.legacy_document
-        doc_pred_md = doc_result.legacy_document.export_to_markdown()
-        doc_pred_dt = doc_result.legacy_document.export_to_document_tokens()
-
-    engine_suffix = "" if ocr_engine is None else f".{ocr_engine}"
-
-    gt_subpath = input_path.parent / "groundtruth" / "docling_v1" / input_path.name
-    if str(input_path.parent).endswith("pdf"):
-        gt_subpath = (
-            input_path.parent.parent / "groundtruth" / "docling_v1" / input_path.name
-        )
-
-    json_path = gt_subpath.with_suffix(f"{engine_suffix}.json")
-    md_path = gt_subpath.with_suffix(f"{engine_suffix}.md")
-    dt_path = gt_subpath.with_suffix(f"{engine_suffix}.doctags.txt")
-
-    if generate:  # only used when re-generating truth
-        json_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(json_path, mode="w", encoding="utf-8") as fw:
-            fw.write(json.dumps(doc_pred, default=pydantic_encoder, indent=indent))
-
-        md_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(md_path, mode="w", encoding="utf-8") as fw:
-            fw.write(doc_pred_md)
-
-        dt_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(dt_path, mode="w", encoding="utf-8") as fw:
-            fw.write(doc_pred_dt)
-    else:  # default branch in test
-        with open(json_path, encoding="utf-8") as fr:
-            doc_true: DsDocument = DsDocument.model_validate_json(fr.read())
-
-        with open(md_path, encoding="utf-8") as fr:
-            doc_true_md = fr.read()
-
-        with open(dt_path, encoding="utf-8") as fr:
-            doc_true_dt = fr.read()
-
-        # assert verify_output(
-        #    doc_pred, doc_true
-        # ), f"Mismatch in JSON prediction for {input_path}"
-
-        assert verify_tables_v1(doc_pred, doc_true, fuzzy=fuzzy), (
-            f"verify_tables(doc_pred, doc_true) mismatch for {input_path}"
-        )
-
-        assert verify_md(doc_pred_md, doc_true_md, fuzzy=fuzzy), (
-            f"Mismatch in Markdown prediction for {input_path}"
-        )
-
-        assert verify_dt(doc_pred_dt, doc_true_dt, fuzzy=fuzzy), (
-            f"Mismatch in DocTags prediction for {input_path}"
-        )
-"""
 
 
 def verify_conversion_result_v2(


### PR DESCRIPTION
This PR removes the remaining references to legacy document and search application from **docling-core**.

Basically:

- A test module: `tests/verify_utils.py`
- Documentation

This PR ensures that upgrading **docling-core** dependency after PR https://github.com/docling-project/docling-core/pull/644 will not break **docling** tests.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
