### PR TITLE
test: add percentage-based tolerance for image size verification

### DIFF
--- a/tests/test_backend_msword.py
+++ b/tests/test_backend_msword.py
@@ -107,7 +107,7 @@ def _test_e2e_docx_conversions_impl(docx_paths: list[tuple[Path, DoclingDocument
         ), f"export to indented-text failed on {docx_path}"
 
         assert verify_document(
-            doc, str(docx_path) + ".json", generate=GENERATE, fuzzy=True
+            doc, str(docx_path) + ".json", generate=GENERATE, fuzzy=False
         ), f"DoclingDocument verification failed on {docx_path}"
 
         if docx_path.name in {"word_tables.docx", "docx_rich_cells.docx"}:

--- a/tests/test_verify_utils.py
+++ b/tests/test_verify_utils.py
@@ -103,9 +103,8 @@ def test_verify_docitems_rejects_picture_count_mismatch():
 
 
 def test_verify_docitems_uses_predicted_picture_image() -> None:
-    """Test that image size mismatches are detected."""
-    doc_true = _make_doc_with_picture(image_size=(10, 10))
-    doc_pred = _make_doc_with_picture(image_size=(15, 10))  # 5 pixel difference
+    doc_true = _make_doc_with_picture(image_size=(2, 2))
+    doc_pred = _make_doc_with_picture(image_size=(3, 2))
 
     with pytest.raises(AssertionError, match="Image width mismatch"):
         verify_docitems(
@@ -120,35 +119,60 @@ def test_verify_docitems_uses_predicted_picture_image() -> None:
     "true_size,pred_size,fuzzy,should_pass,expected_error",
     [
         # Strict mode (fuzzy=False): tolerance is 1.5% of image dimension
-        # For 254x267 image: width_tol=3.8px, height_tol=4px
+        # For 254x267 image: 3px = 1.18% width, 4px = 1.50% height
+        ((254, 267), (251, 267), False, True, None),  # 3px = 1.18% width: passes
         (
             (254, 267),
-            (251, 267),
+            (250, 267),
             False,
-            True,
-            None,
-        ),  # 3px width diff: passes (within 1.5%)
-        ((254, 267), (250, 267), False, False, "Image width mismatch"),  # 4px: fails
+            False,
+            "Image width mismatch",
+        ),  # 4px = 1.57%: fails
         (
             (254, 267),
             (254, 263),
             False,
             True,
             None,
-        ),  # 4px height diff: passes (within 1.5%)
-        ((254, 267), (254, 262), False, False, "Image height mismatch"),  # 5px: fails
+        ),  # 4px = 1.50% height: passes (at boundary)
+        (
+            (254, 267),
+            (254, 262),
+            False,
+            False,
+            "Image height mismatch",
+        ),  # 5px = 1.87%: fails
         # Fuzzy mode (fuzzy=True): tolerance is 5% of image dimension
-        # For 254x267 image: width_tol=12px, height_tol=13px
-        ((254, 267), (242, 254), True, True, None),  # 12-13px diff: passes (within 5%)
-        ((254, 267), (241, 267), True, False, "Image width mismatch"),  # 13px: fails
-        ((254, 267), (254, 253), True, False, "Image height mismatch"),  # 14px: fails
-        # Small images should have at least 1 pixel tolerance
-        ((10, 10), (9, 9), False, True, None),  # 1px diff on small image: passes
+        # For 254x267 image: 12px = 4.72% width, 13px = 4.87% height
+        ((254, 267), (242, 254), True, True, None),  # 12-13px = ~4.7-4.9%: passes
+        (
+            (254, 267),
+            (241, 267),
+            True,
+            False,
+            "Image width mismatch",
+        ),  # 13px = 5.12%: fails
+        (
+            (254, 267),
+            (254, 253),
+            True,
+            False,
+            "Image height mismatch",
+        ),  # 14px = 5.24%: fails
+        # Small images: percentage-based tolerance is precise
+        (
+            (10, 10),
+            (9, 9),
+            False,
+            False,
+            "Image width mismatch",
+        ),  # 1px = 10%: fails (>> 1.5%)
+        ((100, 100), (99, 99), False, True, None),  # 1px = 1%: passes (< 1.5%)
     ],
 )
 def test_verify_docitems_image_size_fuzziness(
-    true_size: tuple(int, int),
-    pred_size: tuple(int, int),
+    true_size: tuple[int, int],
+    pred_size: tuple[int, int],
     fuzzy: bool,
     should_pass: bool,
     expected_error: str | None,

--- a/tests/test_verify_utils.py
+++ b/tests/test_verify_utils.py
@@ -102,14 +102,73 @@ def test_verify_docitems_rejects_picture_count_mismatch():
         )
 
 
-def test_verify_docitems_uses_predicted_picture_image():
-    doc_true = _make_doc_with_picture(image_size=(2, 2))
-    doc_pred = _make_doc_with_picture(image_size=(3, 2))
+def test_verify_docitems_uses_predicted_picture_image() -> None:
+    """Test that image size mismatches are detected."""
+    doc_true = _make_doc_with_picture(image_size=(10, 10))
+    doc_pred = _make_doc_with_picture(image_size=(15, 10))  # 5 pixel difference
 
-    with pytest.raises(AssertionError):
+    with pytest.raises(AssertionError, match="Image width mismatch"):
         verify_docitems(
             doc_pred=doc_pred,
             doc_true=doc_true,
             fuzzy=False,
             pdf_filename="fixture.json",
         )
+
+
+@pytest.mark.parametrize(
+    "true_size,pred_size,fuzzy,should_pass,expected_error",
+    [
+        # Strict mode (fuzzy=False): tolerance is 1.5% of image dimension
+        # For 254x267 image: width_tol=3.8px, height_tol=4px
+        (
+            (254, 267),
+            (251, 267),
+            False,
+            True,
+            None,
+        ),  # 3px width diff: passes (within 1.5%)
+        ((254, 267), (250, 267), False, False, "Image width mismatch"),  # 4px: fails
+        (
+            (254, 267),
+            (254, 263),
+            False,
+            True,
+            None,
+        ),  # 4px height diff: passes (within 1.5%)
+        ((254, 267), (254, 262), False, False, "Image height mismatch"),  # 5px: fails
+        # Fuzzy mode (fuzzy=True): tolerance is 5% of image dimension
+        # For 254x267 image: width_tol=12px, height_tol=13px
+        ((254, 267), (242, 254), True, True, None),  # 12-13px diff: passes (within 5%)
+        ((254, 267), (241, 267), True, False, "Image width mismatch"),  # 13px: fails
+        ((254, 267), (254, 253), True, False, "Image height mismatch"),  # 14px: fails
+        # Small images should have at least 1 pixel tolerance
+        ((10, 10), (9, 9), False, True, None),  # 1px diff on small image: passes
+    ],
+)
+def test_verify_docitems_image_size_fuzziness(
+    true_size: tuple(int, int),
+    pred_size: tuple(int, int),
+    fuzzy: bool,
+    should_pass: bool,
+    expected_error: str | None,
+) -> None:
+    """Test image size verification with percentage-based tolerance in strict and fuzzy modes."""
+    doc_true = _make_doc_with_picture(image_size=true_size)
+    doc_pred = _make_doc_with_picture(image_size=pred_size)
+
+    if should_pass:
+        verify_docitems(
+            doc_pred=doc_pred,
+            doc_true=doc_true,
+            fuzzy=fuzzy,
+            pdf_filename="fixture.json",
+        )
+    else:
+        with pytest.raises(AssertionError, match=expected_error):
+            verify_docitems(
+                doc_pred=doc_pred,
+                doc_true=doc_true,
+                fuzzy=fuzzy,
+                pdf_filename="fixture.json",
+            )

--- a/tests/verify_utils.py
+++ b/tests/verify_utils.py
@@ -26,6 +26,8 @@ STRICT_BBOX_TOL_RATIO = 0.0025  # allow minor cross-platform layout variance
 FUZZY_BBOX_TOL_RATIO = (
     0.005  # OCR/image output varies more, but gross shifts should fail
 )
+STRICT_IMAGE_SIZE_TOL_RATIO = 0.015  # allow ~1.5% cross-platform image size variance
+FUZZY_IMAGE_SIZE_TOL_RATIO = 0.05  # OCR/image output varies more, allow ~5%
 
 
 class _TestPagesMeta(BaseModel):
@@ -171,13 +173,45 @@ def verify_table_v2(true_item: TableItem, pred_item: TableItem, fuzzy: bool):
 
 
 def verify_picture_image_v2(
-    true_image: PILImage.Image, pred_item: Optional[PILImage.Image]
-):
+    true_image: PILImage.Image, pred_item: Optional[PILImage.Image], fuzzy: bool = False
+) -> None:
+    """Compare image properties with optional fuzziness for cross-platform variance.
+
+    Args:
+        true_image: Ground truth image
+        pred_item: Predicted image
+        fuzzy: If True, allow larger size differences (e.g., OCR/image processing variance)
+
+    Note:
+        We don't compare image bytes as they can vary significantly across platforms even for visually identical images
+    """
     assert pred_item is not None, "predicted image is None"
-    assert true_image.size == pred_item.size
-    assert true_image.mode == pred_item.mode
-    # assert true_image.tobytes() == pred_item.tobytes()
-    return True
+
+    # Check image mode (should be exact)
+    assert true_image.mode == pred_item.mode, (
+        f"Image mode mismatch: {true_image.mode} vs {pred_item.mode}"
+    )
+
+    # Check image size with percentage-based tolerance
+    tol_ratio = FUZZY_IMAGE_SIZE_TOL_RATIO if fuzzy else STRICT_IMAGE_SIZE_TOL_RATIO
+    true_width, true_height = true_image.size
+    pred_width, pred_height = pred_item.size
+
+    # Calculate tolerance based on the true image dimensions
+    width_tol = max(1, int(true_width * tol_ratio))
+    height_tol = max(1, int(true_height * tol_ratio))
+
+    width_diff = abs(true_width - pred_width)
+    height_diff = abs(true_height - pred_height)
+
+    assert width_diff <= width_tol, (
+        f"Image width mismatch: {true_width} vs {pred_width} "
+        f"(diff: {width_diff}, tol: {width_tol} [{tol_ratio:.1%}])"
+    )
+    assert height_diff <= height_tol, (
+        f"Image height mismatch: {true_height} vs {pred_height} "
+        f"(diff: {height_diff}, tol: {height_tol} [{tol_ratio:.1%}])"
+    )
 
 
 def verify_docitems(
@@ -285,7 +319,7 @@ def verify_docitems(
             true_image = true_item.get_image(doc=doc_true)
             pred_image = pred_item.get_image(doc=doc_pred)
             if true_image is not None:
-                assert verify_picture_image_v2(true_image, pred_image), (
+                assert verify_picture_image_v2(true_image, pred_image, fuzzy=fuzzy), (
                     f"[{pdf_filename}] Picture image mismatch"
                 )
         # TODO: check picture annotations

--- a/tests/verify_utils.py
+++ b/tests/verify_utils.py
@@ -197,20 +197,20 @@ def verify_picture_image_v2(
     true_width, true_height = true_image.size
     pred_width, pred_height = pred_item.size
 
-    # Calculate tolerance based on the true image dimensions
-    width_tol = max(1, int(true_width * tol_ratio))
-    height_tol = max(1, int(true_height * tol_ratio))
-
     width_diff = abs(true_width - pred_width)
     height_diff = abs(true_height - pred_height)
 
-    assert width_diff <= width_tol, (
+    # Calculate actual percentage differences
+    width_diff_ratio = width_diff / true_width if true_width > 0 else 0
+    height_diff_ratio = height_diff / true_height if true_height > 0 else 0
+
+    assert width_diff_ratio <= tol_ratio, (
         f"Image width mismatch: {true_width} vs {pred_width} "
-        f"(diff: {width_diff}, tol: {width_tol} [{tol_ratio:.1%}])"
+        f"(diff: {width_diff} pixels, {width_diff_ratio:.1%} vs tolerance {tol_ratio:.1%})"
     )
-    assert height_diff <= height_tol, (
+    assert height_diff_ratio <= tol_ratio, (
         f"Image height mismatch: {true_height} vs {pred_height} "
-        f"(diff: {height_diff}, tol: {height_tol} [{tol_ratio:.1%}])"
+        f"(diff: {height_diff} pixels, {height_diff_ratio:.1%} vs tolerance {tol_ratio:.1%})"
     )
 
     return True

--- a/tests/verify_utils.py
+++ b/tests/verify_utils.py
@@ -174,7 +174,7 @@ def verify_table_v2(true_item: TableItem, pred_item: TableItem, fuzzy: bool):
 
 def verify_picture_image_v2(
     true_image: PILImage.Image, pred_item: Optional[PILImage.Image], fuzzy: bool = False
-) -> None:
+) -> bool:
     """Compare image properties with optional fuzziness for cross-platform variance.
 
     Args:
@@ -212,6 +212,8 @@ def verify_picture_image_v2(
         f"Image height mismatch: {true_height} vs {pred_height} "
         f"(diff: {height_diff}, tol: {height_tol} [{tol_ratio:.1%}])"
     )
+
+    return True
 
 
 def verify_docitems(


### PR DESCRIPTION
### Summary

Implements percentage-based tolerance for image size verification in `verify_picture_image_v2()` to handle cross-platform rendering differences, following the same pattern as bounding box verification.

### Problem

Image verification tests were failing when run on different platforms (Linux vs macOS) due to minor pixel differences in image dimensions caused by platform-specific rendering. These failures occurred even when the code was working correctly, blocking legitimate test runs.

Example failure:
- Ground truth: 254x267 pixels (generated on Linux)
- Test output: 251x267 pixels (generated on macOS)
- Difference: 3 pixels (~1.2%) - within normal cross-platform variance

### Solution

Added percentage-based tolerance thresholds similar to existing bbox verification:

**Constants added:**
- `STRICT_IMAGE_SIZE_TOL_RATIO = 0.015` (~1.5% tolerance for cross-platform variance)
- `FUZZY_IMAGE_SIZE_TOL_RATIO = 0.05` (~5% tolerance for OCR/image processing variance)

**Key features:**
1. True percentage-based comparison: Compares actual percentage differences against tolerance ratios
2. Precise for all image sizes: No minimum pixel tolerance that could allow excessive percentage differences
3. Independent width/height checks: Each dimension validated separately
4. Clear error messages: Shows actual values, pixel differences, and percentage differences vs tolerance
5. Consistent with existing patterns: Follows the same approach as `_assert_bbox_close()`
6.  Demonstrates that DOCX images now pass verification in strict mode with the new percentage-based tolerance

### Testing

✅ All existing tests pass (15 tests in `test_verify_utils.py`)
✅ New parameterized test covers 8 scenarios (strict/fuzzy modes, width/height, edge cases)
✅ Original failing case (254x267 vs 251x267) now passes in strict mode
✅ DOCX tests now run with `fuzzy=False`, demonstrating proper cross-platform handling
✅ Cross-platform compatibility verified on macOS and Fedora Linux

### Related Issues

Fixes #3659