### PR TITLE
chore: clean up imports from docling-core

### DIFF
--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union
 
 import pypdfium2 as pdfium
-from docling_core.types.doc import BoundingBox, CoordOrigin
+from docling_core.types.doc import BoundingBox, CoordOrigin, Size
 from docling_core.types.doc.page import SegmentedPdfPage, TextCell
 from docling_parse.pdf_parser import (
     DoclingPdfParser,
@@ -29,7 +29,6 @@ from docling.datamodel.backend_options import (
     PdfBackendOptions,
     ThreadedDoclingParseBackendOptions,
 )
-from docling.datamodel.base_models import Size
 from docling.datamodel.settings import DEFAULT_PAGE_RANGE
 from docling.utils.locks import pypdfium2_lock
 

--- a/docling/backend/image_backend.py
+++ b/docling/backend/image_backend.py
@@ -3,7 +3,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Iterable, List, Optional, Union
 
-from docling_core.types.doc import BoundingBox, CoordOrigin
+from docling_core.types.doc import BoundingBox, CoordOrigin, Size
 from docling_core.types.doc.page import (
     BoundingRectangle,
     PdfPageBoundaryType,
@@ -16,7 +16,7 @@ from PIL import Image
 from docling.backend.abstract_backend import AbstractDocumentBackend
 from docling.backend.pdf_backend import PdfDocumentBackend, PdfPageBackend
 from docling.datamodel.backend_options import PdfBackendOptions
-from docling.datamodel.base_models import InputFormat, Size
+from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
 
 _log = logging.getLogger(__name__)

--- a/docling/experimental/models/table_crops_layout_model.py
+++ b/docling/experimental/models/table_crops_layout_model.py
@@ -8,10 +8,10 @@ from pathlib import Path
 from typing import Optional
 
 import numpy as np
-from docling_core.types.doc import DocItemLabel
+from docling_core.types.doc import BoundingBox, DocItemLabel
 
 from docling.datamodel.accelerator_options import AcceleratorOptions
-from docling.datamodel.base_models import BoundingBox, Cluster, LayoutPrediction, Page
+from docling.datamodel.base_models import Cluster, LayoutPrediction, Page
 from docling.datamodel.document import ConversionResult
 from docling.experimental.datamodel.table_crops_layout_options import (
     TableCropsLayoutOptions,

--- a/docling/models/stages/layout/layout_model.py
+++ b/docling/models/stages/layout/layout_model.py
@@ -6,11 +6,11 @@ from pathlib import Path
 from typing import List, Optional, Union
 
 import numpy as np
-from docling_core.types.doc import DocItemLabel
+from docling_core.types.doc import BoundingBox, DocItemLabel
 from PIL import Image
 
 from docling.datamodel.accelerator_options import AcceleratorOptions
-from docling.datamodel.base_models import BoundingBox, Cluster, LayoutPrediction, Page
+from docling.datamodel.base_models import Cluster, LayoutPrediction, Page
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.layout_model_specs import DOCLING_LAYOUT_V2, LayoutModelConfig
 from docling.datamodel.pipeline_options import LayoutOptions

--- a/docling/models/stages/layout/layout_object_detection_model.py
+++ b/docling/models/stages/layout/layout_object_detection_model.py
@@ -7,11 +7,11 @@ from pathlib import Path
 from typing import Dict, List, Optional, Sequence
 
 import numpy as np
-from docling_core.types.doc import CoordOrigin, DocItemLabel
+from docling_core.types.doc import BoundingBox, CoordOrigin, DocItemLabel
 from PIL import Image
 
 from docling.datamodel.accelerator_options import AcceleratorOptions
-from docling.datamodel.base_models import BoundingBox, Cluster, LayoutPrediction, Page
+from docling.datamodel.base_models import Cluster, LayoutPrediction, Page
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import LayoutObjectDetectionOptions
 from docling.models.base_layout_model import BaseLayoutModel

--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -3,11 +3,11 @@ import logging
 import sys
 from collections import defaultdict
 
-from docling_core.types.doc import DocItemLabel, Size
+from docling_core.types.doc import BoundingBox, DocItemLabel, Size
 from docling_core.types.doc.page import TextCell
 from rtree import index
 
-from docling.datamodel.base_models import BoundingBox, Cluster, Page
+from docling.datamodel.base_models import Cluster, Page
 from docling.datamodel.pipeline_options import (
     LayoutObjectDetectionOptions,
     LayoutOptions,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ requires-python = '>=3.10,<4.0'
 # MINIMAL BASE (8 packages) - ~50MB
 dependencies = [
   'pydantic>=2.0.0,<3.0.0',
-  'docling-core>=2.80.0,<3.0.0',
+  "docling-core>=2.83.1",
   'pydantic-settings>=2.3.0,<3.0.0',
   'filetype>=1.2.0,<2.0.0',
   'requests>=2.32.2,<3.0.0',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ requires-python = '>=3.10,<4.0'
 # MINIMAL BASE (8 packages) - ~50MB
 dependencies = [
   'pydantic>=2.0.0,<3.0.0',
-  "docling-core>=2.83.1",
+  'docling-core>=2.83.1,<3.0.0',
   'pydantic-settings>=2.3.0,<3.0.0',
   'filetype>=1.2.0,<2.0.0',
   'requests>=2.32.2,<3.0.0',

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import base64
+import re
 from io import BytesIO
 from pathlib import Path
 from typing import Any
@@ -46,7 +47,14 @@ def _assert_markdown_embeds_png(path: Path, image_bytes: bytes | None = None) ->
     assert "data:image/png;base64" in content
     assert "Image not available" not in content
     if image_bytes is not None:
-        assert base64.b64encode(image_bytes).decode() in content
+        # Compare decoded pixel content rather than exact base64: docling
+        # re-encodes the PNG, so the byte stream (and its base64) differs even
+        # though the image is identical.
+        match = re.search(r"data:image/png;base64,([A-Za-z0-9+/=]+)", content)
+        assert match is not None
+        embedded = Image.open(BytesIO(base64.b64decode(match.group(1))))
+        expected = Image.open(BytesIO(image_bytes))
+        assert embedded.convert("RGBA").tobytes() == expected.convert("RGBA").tobytes()
 
 
 def test_cli_help():
@@ -105,7 +113,7 @@ def test_cli_exports_doclang(tmp_path):
     converted = output / "input.dclg.xml"
     assert converted.exists()
     content = converted.read_text(encoding="utf-8")
-    assert "<doclang>" in content
+    assert re.search(r'<doclang version="\d+\.\d+">', content) is not None
     assert "DocLang CLI" in content
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'darwin'",
@@ -1348,7 +1348,7 @@ provides-extras = ["easyocr", "tesserocr", "ocrmac", "vlm", "rapidocr", "asr", "
 
 [[package]]
 name = "docling-core"
-version = "2.81.0"
+version = "2.83.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "defusedxml" },
@@ -1365,9 +1365,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/47/6d/0582f6c48d78b10b70b0519b3c295f716756a69ed3bbebcfc2335a9d87a5/docling_core-2.81.0.tar.gz", hash = "sha256:db496c2dd5aa71f0f6536eae4a4b5cda391a645eda97206cf8a8e8641b18a5a0", size = 350488, upload-time = "2026-06-10T14:26:08.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/04/0f62e8092dfeccf7d287b7898d8dcf793417e96f6976b41f5359bf143ebe/docling_core-2.83.1.tar.gz", hash = "sha256:e09ce91d18522bb161b45ca79b9bd2c94f0b38ca744a1f8605f3e1d9bff26902", size = 317894, upload-time = "2026-06-19T05:45:49.651Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/c2/6f102e0b6b7c6705807acbb0173d18179496406b754068e71a7da458f54a/docling_core-2.81.0-py3-none-any.whl", hash = "sha256:5ab2628fd389e9beeeebafceff9177457ba9d816b9533e3c1faa530b75c9c5ac", size = 297048, upload-time = "2026-06-10T14:26:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/7b/dfe63a732152097d6770a112389dbcc99f99928781d9f4ac72e29cadee91/docling_core-2.83.1-py3-none-any.whl", hash = "sha256:154db6d6be5ac0bc0affa272a39e81346dc953ea7ce5cd6f20809cc5272499c6", size = 257780, upload-time = "2026-06-19T05:45:47.866Z" },
 ]
 
 [package.optional-dependencies]
@@ -1756,7 +1756,7 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'format-html'", specifier = ">=4.12.3,<5.0.0" },
     { name = "certifi", specifier = ">=2024.7.4" },
     { name = "defusedxml", marker = "extra == 'models-local'", specifier = ">=0.7.1,<0.8.0" },
-    { name = "docling-core", specifier = ">=2.80.0,<3.0.0" },
+    { name = "docling-core", specifier = ">=2.83.1" },
     { name = "docling-core", extras = ["chunking"], marker = "extra == 'feat-chunking'", specifier = ">=2.73.0,<3.0.0" },
     { name = "docling-ibm-models", marker = "extra == 'models-local'", specifier = ">=3.13.0,<4" },
     { name = "docling-parse", marker = "extra == 'format-pdf-docling'", specifier = ">=6.2.0,<7.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1756,7 +1756,7 @@ requires-dist = [
     { name = "beautifulsoup4", marker = "extra == 'format-html'", specifier = ">=4.12.3,<5.0.0" },
     { name = "certifi", specifier = ">=2024.7.4" },
     { name = "defusedxml", marker = "extra == 'models-local'", specifier = ">=0.7.1,<0.8.0" },
-    { name = "docling-core", specifier = ">=2.83.1" },
+    { name = "docling-core", specifier = ">=2.83.1,<3.0.0" },
     { name = "docling-core", extras = ["chunking"], marker = "extra == 'feat-chunking'", specifier = ">=2.73.0,<3.0.0" },
     { name = "docling-ibm-models", marker = "extra == 'models-local'", specifier = ">=3.13.0,<4" },
     { name = "docling-parse", marker = "extra == 'format-pdf-docling'", specifier = ">=6.2.0,<7.0.0" },


### PR DESCRIPTION
  I extracted every class/enum defined in docling_core/types/doc/*.py, then AST-scanned all of ./docling for imports
  of those names coming from a docling module instead of from docling_core.

  Real issues found & fixed (6 sites)

  In every case, Size or BoundingBox — both genuine docling_core.types.doc classes — were being imported via
  docling.datamodel.base_models, which merely re-exposes them as a side effect of its own import. I moved each onto
  the existing from docling_core.types.doc import ... line:

  ```
  ┌───────────────────────────────────────────────────────────────┬─────────────┐
  │                             File                              │    Name     │
  ├───────────────────────────────────────────────────────────────┼─────────────┤
  │ docling/backend/docling_parse_backend.py                      │ Size        │
  ├───────────────────────────────────────────────────────────────┼─────────────┤
  │ docling/backend/image_backend.py                              │ Size        │
  ├───────────────────────────────────────────────────────────────┼─────────────┤
  │ docling/experimental/models/table_crops_layout_model.py       │ BoundingBox │
  ├───────────────────────────────────────────────────────────────┼─────────────┤
  │ docling/models/stages/layout/layout_model.py                  │ BoundingBox │
  ├───────────────────────────────────────────────────────────────┼─────────────┤
  │ docling/models/stages/layout/layout_object_detection_model.py │ BoundingBox │
  ├───────────────────────────────────────────────────────────────┼─────────────┤
  │ docling/utils/layout_postprocessor.py                         │ BoundingBox │
  └───────────────────────────────────────────────────────────────┴─────────────┘
  ```