### PR TITLE
fix(rapidocr): propagate num_threads to OpenVINO backend

### DIFF
--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -393,6 +393,8 @@ class RapidOcrModel(BaseOcrModel):
                 "Global.font_path": font_path,
                 # Engine-level ONNXRuntime settings
                 "EngineConfig.onnxruntime.intra_op_num_threads": intra_op_num_threads,
+                # Engine-level OpenVINO settings
+                "EngineConfig.openvino.inference_num_threads": intra_op_num_threads,
                 # "Global.verbose": self.options.print_verbose,
                 # Detection model settings
                 "Det.model_path": det_model_path,

--- a/tests/test_rapid_ocr_model.py
+++ b/tests/test_rapid_ocr_model.py
@@ -113,3 +113,44 @@ def test_rapidocr_model_initialization_uses_mobile_default_paths(
     assert Path(params["Rec.model_path"]).name == rec_name
     assert Path(params["Rec.rec_keys_path"]).name == "ppocr_keys_v1.txt"
     assert Path(params["Global.font_path"]).name == "FZYTK.TTF"
+
+
+@pytest.mark.parametrize(
+    ("backend", "engine_key"),
+    [
+        ("onnxruntime", "EngineConfig.onnxruntime.intra_op_num_threads"),
+        ("openvino", "EngineConfig.openvino.inference_num_threads"),
+    ],
+)
+def test_rapidocr_num_threads_propagated_per_engine(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+    engine_key: str,
+):
+    captured: dict[str, object] = {}
+
+    class FakeEngineType(str, Enum):
+        ONNXRUNTIME = "onnxruntime"
+        OPENVINO = "openvino"
+        PADDLE = "paddle"
+        TORCH = "torch"
+
+    class FakeRapidOCR:
+        def __init__(self, params):
+            captured["params"] = params
+
+    monkeypatch.setitem(
+        sys.modules,
+        "rapidocr",
+        SimpleNamespace(EngineType=FakeEngineType, RapidOCR=FakeRapidOCR),
+    )
+
+    RapidOcrModel(
+        enabled=True,
+        artifacts_path=None,
+        options=RapidOcrOptions(backend=backend),
+        accelerator_options=AcceleratorOptions(device="cpu", num_threads=4),
+    )
+
+    # num_threads must reach the engine actually in use, not only ONNXRuntime.
+    assert captured["params"][engine_key] == 4


### PR DESCRIPTION
With `backend="openvino"`, `AcceleratorOptions.num_threads` was ignored and eventually left unset. `RapidOcrModel` only populated `EngineConfig.onnxruntime.intra_op_num_threads`, never `EngineConfig.openvino.*`. OpenVINO then defaults to all physical cores per session, causing CPU oversubscription on wide multi-worker hosts with no docling-level control.

Map `num_threads -> EngineConfig.openvino.inference_num_threads`, mirroring the ONNXRuntime fix in #3062. Added a parametrized test that asserts the thread count reaches the engine in use for both backends.

Resolves #3665
