### PR TITLE
fix(service): JSON-encode nested options for multipart file uploads

### DIFF
--- a/docling/datamodel/service/options.py
+++ b/docling/datamodel/service/options.py
@@ -1,4 +1,5 @@
 # Define the input options for the API
+import json
 import warnings
 from typing import Annotated, Any, Optional, Union
 
@@ -820,6 +821,31 @@ class ConvertDocumentsOptions(BaseModel):
             ],
         ),
     ] = None
+
+    @field_validator(
+        "ocr_custom_config",
+        "table_structure_custom_config",
+        "layout_custom_config",
+        "picture_classification_custom_config",
+        mode="before",
+    )
+    @classmethod
+    def _decode_json_string_config(cls, value: Any) -> Any:
+        """Accept a JSON-encoded string for nested config fields.
+
+        Local-file conversions submit options as ``multipart/form-data``, where
+        nested configs are sent as JSON strings because form fields cannot carry
+        objects. Decode them back into dicts here. Values that already arrive as
+        objects (e.g. via JSON request bodies) are returned unchanged.
+        """
+        if isinstance(value, str):
+            try:
+                return json.loads(value)
+            except json.JSONDecodeError as exc:
+                raise ValueError(
+                    f"Invalid JSON for nested config field: {exc}"
+                ) from exc
+        return value
 
     # Field validators for deprecated fields - trigger warnings on assignment
     @field_validator("picture_description_api", mode="before")

--- a/docling/service_client/_async_client.py
+++ b/docling/service_client/_async_client.py
@@ -688,7 +688,7 @@ class AsyncDoclingServiceClient(_BaseDoclingServiceClient):
                 async_client=async_client,
                 method="POST",
                 path="/v1/convert/file/async",
-                data=data,
+                data=self._form_encode_options(data),
                 files=files,
                 headers=request_headers,
             )
@@ -782,7 +782,7 @@ class AsyncDoclingServiceClient(_BaseDoclingServiceClient):
             response = await self._request_with_retry(
                 method="POST",
                 path=f"/v1/chunk/{chunker.value}/file/async",
-                data=data,
+                data=self._form_encode_options(data),
                 files=files,
             )
 

--- a/docling/service_client/client.py
+++ b/docling/service_client/client.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import ipaddress
+import json
 import logging
 import mimetypes
 import re
@@ -268,6 +269,29 @@ class _BaseDoclingServiceClient:
             exclude_defaults=True,
             exclude_none=True,
         )
+
+    @staticmethod
+    def _form_encode_options(data: dict[str, Any]) -> dict[str, Any]:
+        """Make option values safe for ``multipart/form-data`` submission.
+
+        File uploads send each option as a form field, but multipart fields
+        accept only primitives or lists of primitives. Nested values (e.g.
+        ``ocr_custom_config``) are JSON-encoded so the service can rebuild
+        them; primitives and primitive lists are passed through unchanged.
+        """
+
+        def _is_primitive(value: Any) -> bool:
+            return value is None or isinstance(value, (str, int, float, bool))
+
+        encoded: dict[str, Any] = {}
+        for key, value in data.items():
+            if isinstance(value, dict) or (
+                isinstance(value, list) and not all(_is_primitive(v) for v in value)
+            ):
+                encoded[key] = json.dumps(value)
+            else:
+                encoded[key] = value
+        return encoded
 
     def _serialize_convert_request(
         self,
@@ -1132,7 +1156,7 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
             response = self._request_with_retry(
                 method="POST",
                 path="/v1/convert/file/async",
-                data=data,
+                data=self._form_encode_options(data),
                 files=files,
                 headers=request_headers,
             )
@@ -1199,7 +1223,7 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
             response = self._request_with_retry(
                 method="POST",
                 path=f"/v1/chunk/{chunker.value}/file/async",
-                data=data,
+                data=self._form_encode_options(data),
                 files=files,
             )
 

--- a/tests/test_service_client_sdk_unit.py
+++ b/tests/test_service_client_sdk_unit.py
@@ -1465,6 +1465,73 @@ def test_serialize_convert_options_omits_defaults_and_none() -> None:
     )
 
 
+def test_form_encode_options_jsonifies_nested_values() -> None:
+    encoded = DoclingServiceClient._form_encode_options(
+        {
+            "ocr_custom_config": {"kind": "rapidocr", "backend": "onnxruntime"},
+            "page_range": [3, 7],
+            "target_type": "inbody",
+        }
+    )
+    # Nested dicts become JSON strings the service can decode back...
+    assert encoded["ocr_custom_config"] == json.dumps(
+        {"kind": "rapidocr", "backend": "onnxruntime"}
+    )
+    # ...while primitives and primitive lists pass through unchanged.
+    assert encoded["page_range"] == [3, 7]
+    assert encoded["target_type"] == "inbody"
+
+
+def test_submit_file_jsonifies_nested_ocr_custom_config(tmp_path: Path) -> None:
+    captured: dict[str, object] = {}
+    sample = tmp_path / "sample.jpg"
+    sample.write_bytes(b"\xff\xd8\xff\xe0")  # JPEG magic bytes
+
+    def fake_request_with_retry(**kw: object) -> httpx.Response:
+        captured.update(kw)
+        return httpx.Response(
+            200,
+            json=_status_response("task-file-ocr", "pending").model_dump(mode="json"),
+        )
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        client._request_with_retry = fake_request_with_retry  # type: ignore[method-assign]
+        client.submit(
+            source=str(sample),
+            target=InBodyTarget(),
+            options=ConvertDocumentsRequestOptions(
+                page_range=(3, 7),
+                ocr_custom_config={
+                    "kind": "rapidocr",
+                    "backend": "onnxruntime",
+                    "lang": ["en"],
+                },
+            ),
+        )
+
+    assert captured["path"] == "/v1/convert/file/async"
+    data = captured["data"]
+    assert isinstance(data, dict)
+    # The nested config is JSON-encoded because multipart cannot carry a dict...
+    assert json.loads(data["ocr_custom_config"]) == {
+        "kind": "rapidocr",
+        "backend": "onnxruntime",
+        "lang": ["en"],
+    }
+    # ...and primitive lists are still sent unchanged.
+    assert data["page_range"] == [3, 7]
+
+
+def test_options_decode_json_string_ocr_custom_config() -> None:
+    options = ConvertDocumentsRequestOptions(
+        ocr_custom_config='{"kind": "rapidocr", "backend": "onnxruntime"}'
+    )
+    assert options.ocr_custom_config == {
+        "kind": "rapidocr",
+        "backend": "onnxruntime",
+    }
+
+
 def test_submit_source_serializes_convert_options_without_defaults() -> None:
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Problem

`DoclingServiceClient.convert()` (and `chunk()`) crash when a **local file** is submitted with a nested option such as `ocr_custom_config`:

```
TypeError: Invalid type for value. Expected primitive type, got
<class 'dict'>: {'kind': 'rapidocr', 'backend': 'onnxruntime'}
```

Local files are uploaded as `multipart/form-data` with each option sent as a form field, and multipart fields accept only primitives or lists of primitives. The nested `ocr_custom_config` dict is rejected by httpx's encoder — client-side,
before the request is ever sent. The URL/source path is unaffected because it posts a JSON body.

This breaks every nested option on the file-upload path: `ocr_custom_config`, `table_structure_custom_config`, `layout_custom_config`, `picture_classification_custom_config`.

Resolves #3667

## Fix

- **Client** (`_form_encode_options`): JSON-encode non-primitive form values before building the multipart `data`, at all four upload sites (convert + chunk, sync + async). Primitives and primitive lists pass through unchanged, so existing behavior (`page_range`, `to_formats`, …) is preserved.
- **Model** (`ConvertDocumentsOptions`): a `mode="before"` validator decodes a JSON string back into a dict for the nested config fields, so the round-trip completes server-side. No-op for the JSON/source path, where the value is already an object.

## Testing

- `test_form_encode_options_jsonifies_nested_values` — nested dicts become JSON strings; primitives and primitive lists are left unchanged.
- `test_submit_file_jsonifies_nested_ocr_custom_config` — a local-file submit sends `ocr_custom_config` as a JSON string while `page_range` stays a list.
- `test_options_decode_json_string_ocr_custom_config` — the model decodes a JSON-string config back into a dict.

## Note for reviewers

The model-side decode assumes `docling-serve` validates file uploads through this shared `ConvertDocumentsOptions` model. If it parses the form differently, the decode half can move server-side — but the client-side encoding is correct and necessary regardless, since today it's a hard client-side crash.
