### PR TITLE
fix(rapidocr): propagate num_threads and fix GPU device key for the paddle backend

### DIFF
--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -413,8 +413,9 @@ class RapidOcrModel(BaseOcrModel):
                 "Det.engine_type": backend_enum,
                 "Cls.engine_type": backend_enum,
                 "Rec.engine_type": backend_enum,
+                "EngineConfig.paddle.cpu_math_library_num_threads": intra_op_num_threads,
                 "EngineConfig.paddle.use_cuda": use_cuda,
-                "EngineConfig.paddle.gpu_id": gpu_id,
+                "EngineConfig.paddle.cuda_ep_cfg.device_id": gpu_id,
                 "EngineConfig.torch.use_cuda": use_cuda,
                 "EngineConfig.torch.cuda_ep_cfg.device_id": gpu_id,
             }

--- a/tests/test_rapid_ocr_model.py
+++ b/tests/test_rapid_ocr_model.py
@@ -120,6 +120,7 @@ def test_rapidocr_model_initialization_uses_mobile_default_paths(
     [
         ("onnxruntime", "EngineConfig.onnxruntime.intra_op_num_threads"),
         ("openvino", "EngineConfig.openvino.inference_num_threads"),
+        ("paddle", "EngineConfig.paddle.cpu_math_library_num_threads"),
     ],
 )
 def test_rapidocr_num_threads_propagated_per_engine(
@@ -154,3 +155,40 @@ def test_rapidocr_num_threads_propagated_per_engine(
 
     # num_threads must reach the engine actually in use, not only ONNXRuntime.
     assert captured["params"][engine_key] == 4
+
+
+@pytest.mark.parametrize("backend", ["paddle", "torch"])
+def test_rapidocr_gpu_device_uses_cuda_ep_cfg_key(
+    monkeypatch: pytest.MonkeyPatch,
+    backend: str,
+):
+    captured: dict[str, object] = {}
+
+    class FakeEngineType(str, Enum):
+        ONNXRUNTIME = "onnxruntime"
+        OPENVINO = "openvino"
+        PADDLE = "paddle"
+        TORCH = "torch"
+
+    class FakeRapidOCR:
+        def __init__(self, params):
+            captured["params"] = params
+
+    monkeypatch.setitem(
+        sys.modules,
+        "rapidocr",
+        SimpleNamespace(EngineType=FakeEngineType, RapidOCR=FakeRapidOCR),
+    )
+
+    RapidOcrModel(
+        enabled=True,
+        artifacts_path=None,
+        options=RapidOcrOptions(backend=backend),
+        accelerator_options=AcceleratorOptions(device="cpu"),
+    )
+
+    params = captured["params"]
+    # The GPU device id must use the engine's real key; the legacy top-level
+    # `gpu_id` key is not read by RapidOCR (see #3049 for the torch fix).
+    assert f"EngineConfig.{backend}.cuda_ep_cfg.device_id" in params
+    assert f"EngineConfig.{backend}.gpu_id" not in params


### PR DESCRIPTION
Two issues with the RapidOCR **paddle** backend, both mirroring fixes already
applied to the other engines:

1. **`accelerator_options.num_threads` was never mapped to paddle.** RapidOCR's paddle
   engine reads `EngineConfig.paddle.cpu_math_library_num_threads`
   (`set_cpu_math_library_num_threads`), but docling never set it — so the thread count
   was silently dropped. Same gap fixed for ONNXRuntime (#3062) and OpenVINO (#3666, issue #3665).

2. **GPU device id used a stale key.** docling set `EngineConfig.paddle.gpu_id`, which
   RapidOCR's paddle engine does not read (it uses `cuda_ep_cfg.device_id`), so a
   requested CUDA device was ignored. Same stale-key fix applied to torch in #3049 (issue #2997).

Adds parametrized test coverage: `num_threads` propagation now also covers paddle,
and a new test asserts paddle and torch both use `cuda_ep_cfg.device_id` (not legacy `gpu_id`).

Resolves #3681
