### PR TITLE
fix: preserve OCR text from picture clusters during page assembly

### DIFF
--- a/docling/models/stages/page_assemble/page_assemble_model.py
+++ b/docling/models/stages/page_assemble/page_assemble_model.py
@@ -212,6 +212,25 @@ class PageAssembleModel(BasePageModel):
                             body.append(tbl)
                         elif cluster.label == LayoutModel.FIGURE_LABEL:
                             fig = None
+                            textlines = [
+                                cell.text.replace("\x02", "-").strip()
+                                for cell in cluster.cells
+                                if getattr(cell, "from_ocr", False)
+                                and len(cell.text.strip()) > 0
+                            ]
+                            if textlines:
+                                text = self.sanitize_text(textlines)
+                                text_el = TextElement(
+                                    label="text",
+                                    id=cluster.id,
+                                    text=text,
+                                    hyperlink=None,
+                                    page_no=page.page_no,
+                                    cluster=cluster,
+                                )
+                                elements.append(text_el)
+                                body.append(text_el)
+                                continue
                             if page.predictions.figures_classification:
                                 fig = page.predictions.figures_classification.figure_map.get(
                                     cluster.id, None


### PR DESCRIPTION
## Summary

While investigating #3569, I found that OCR text extracted from scanned PDFs can be lost during page assembly when the layout model classifies the page as a `picture` cluster.

In these cases:

* OCR extraction succeeds and produces valid `TextCell` objects.
* OCR cells are correctly stored in `parsed_page.textline_cells`.
* The layout model classifies the region as a `picture`.
* `PageAssembleModel` creates a `FigureElement`/picture element and the OCR text is not included in the exported document.
* Markdown and text exports therefore contain only `<!-- image -->` even though OCR text is available.

## Changes

This PR adds a fallback in `PageAssembleModel`:

* When a picture cluster contains OCR-generated text cells, a `TextElement` is created from those OCR cells.
* The extracted text is preserved in document assembly and becomes available in Markdown/Text export.
* Existing figure handling remains unchanged for picture clusters that do not contain OCR text.

## Reproduction

Before this change:

```text
OCR extraction -> succeeds
OCR cells -> present
Export -> <!-- image -->
Text output -> empty
```

After this change:

```text
OCR extraction -> succeeds
OCR cells -> present
Export -> OCR text preserved
Text output -> contains extracted text
```

## Notes

This PR addresses one root cause discovered during the investigation of #3569. Additional OCR-quality or language-specific issues may still require separate investigation.
