### PR TITLE
feat: accept HttpSource as a convert source for per-source headers

### DIFF
--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional, Type, Union
+from typing import TYPE_CHECKING, Annotated, Any, Optional, Type, Union
 
 import numpy as np
 from docling_core.types.doc import (
@@ -23,6 +23,7 @@ from docling_core.types.io import (
 # DO NOT REMOVE; explicitly exposed from this location
 from PIL.Image import Image
 from pydantic import (
+    AnyHttpUrl,
     AnyUrl,
     BaseModel,
     ConfigDict,
@@ -41,6 +42,30 @@ if TYPE_CHECKING:
 
 from docling.backend.abstract_backend import AbstractDocumentBackend
 from docling.datamodel.pipeline_options import PipelineOptions
+
+
+class HttpSource(BaseModel):
+    """A remote document source: a URL bundled with the headers used to fetch it.
+
+    Lives in the core datamodel (alongside ``DocumentStream``) so the converter
+    can accept it as an input; the serving layer subclasses it for its request
+    schema.
+    """
+
+    url: Annotated[
+        AnyHttpUrl,
+        Field(
+            description="HTTP url to process",
+            examples=["https://arxiv.org/pdf/2206.01062"],
+        ),
+    ]
+    headers: Annotated[
+        dict[str, Any],
+        Field(
+            description="Additional headers used to fetch the urls, "
+            "e.g. authorization, agent, etc"
+        ),
+    ] = {}
 
 
 class BaseFormatOption(BaseModel):

--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -65,6 +65,7 @@ from docling.datamodel.base_models import (
     FailureCategory,
     FormatToExtensions,
     FormatToMimeType,
+    HttpSource,
     InputFormat,
     MimeTypeToFormat,
     Page,
@@ -585,7 +586,7 @@ class _DummyBackend(AbstractDocumentBackend):
 
 
 class _DocumentConversionInput(BaseModel):
-    path_or_stream_iterator: Iterable[Union[Path, str, DocumentStream]]
+    path_or_stream_iterator: Iterable[Union[Path, str, DocumentStream, HttpSource]]
     headers: Optional[dict[str, str]] = None
     limits: Optional[DocumentLimits] = DocumentLimits()
 
@@ -594,11 +595,24 @@ class _DocumentConversionInput(BaseModel):
         format_options: Mapping[InputFormat, "BaseFormatOption"],
     ) -> Iterable[InputDocument]:
         for item in self.path_or_stream_iterator:
-            if isinstance(item, str):
+            # `backend_input` is what backend_options_for_input() sees: the raw
+            # URL string (not the HttpSource model) so HTML source_uri resolution
+            # keeps working unchanged.
+            backend_input: Union[Path, str, DocumentStream]
+            if isinstance(item, (str, HttpSource)):
+                if isinstance(item, HttpSource):
+                    source_uri = str(item.url)
+                    # Per-source headers override the batch-wide headers; the
+                    # batch dict stays the base so the `headers` arg keeps working.
+                    req_headers = {**(self.headers or {}), **item.headers}
+                else:
+                    source_uri = item
+                    req_headers = self.headers
+                backend_input = source_uri
                 try:
                     obj = resolve_source_to_stream(
-                        item,
-                        self.headers,
+                        source_uri,
+                        req_headers,
                         max_file_size=self.limits.max_file_size,
                     )
                 except FileSizeLimitExceededError as exc:
@@ -626,13 +640,14 @@ class _DocumentConversionInput(BaseModel):
                     # covers all HTTP fetch errors without importing requests here.
                     _log.error("Failed to resolve input source %r: %s", item, exc)
                     yield self._build_invalid_input_document(
-                        name=self._filename_from_source(item),
+                        name=self._filename_from_source(source_uri),
                         format_options=format_options,
                         rejection=self._classify_source_error(exc),
                     )
                     continue
             else:
                 obj = item
+                backend_input = item
             format = self._guess_format(obj)
             backend: Type[AbstractDocumentBackend]
             backend_options: Optional[BackendOptions] = None
@@ -645,7 +660,7 @@ class _DocumentConversionInput(BaseModel):
             else:
                 options = format_options[format]
                 backend = options.backend
-                backend_options = options.backend_options_for_input(item)
+                backend_options = options.backend_options_for_input(backend_input)
 
             path_or_stream: Union[BytesIO, Path]
             if isinstance(obj, Path):

--- a/docling/datamodel/service/sources.py
+++ b/docling/datamodel/service/sources.py
@@ -1,27 +1,14 @@
 import base64
 from io import BytesIO
-from typing import Annotated, Any
+from typing import Annotated
 
-from pydantic import AnyHttpUrl, BaseModel, Field, StrictStr
+from pydantic import BaseModel, Field, StrictStr
 
-from docling.datamodel.base_models import DocumentStream
+# HttpSource lives in the core datamodel so DocumentConverter can accept it as an
+# input source; re-exported here to keep the service-layer import path stable.
+from docling.datamodel.base_models import DocumentStream, HttpSource
 
-
-class HttpSource(BaseModel):
-    url: Annotated[
-        AnyHttpUrl,
-        Field(
-            description="HTTP url to process",
-            examples=["https://arxiv.org/pdf/2206.01062"],
-        ),
-    ]
-    headers: Annotated[
-        dict[str, Any],
-        Field(
-            description="Additional headers used to fetch the urls, "
-            "e.g. authorization, agent, etc"
-        ),
-    ] = {}
+__all__ = ["FileSource", "HttpSource", "S3Coordinates"]
 
 
 class FileSource(BaseModel):

--- a/docling/document_converter.py
+++ b/docling/document_converter.py
@@ -60,6 +60,7 @@ from docling.datamodel.base_models import (
     DocumentStream,
     ErrorItem,
     FailureCategory,
+    HttpSource,
     InputFormat,
 )
 from docling.datamodel.document import (
@@ -401,7 +402,7 @@ class DocumentConverter:
     @validate_call(config=ConfigDict(strict=True))
     def convert(
         self,
-        source: Union[Path, str, DocumentStream],  # TODO review naming
+        source: Union[Path, str, DocumentStream, HttpSource],  # TODO review naming
         headers: Optional[dict[str, str]] = None,
         raises_on_error: bool = True,
         max_num_pages: int = sys.maxsize,
@@ -414,10 +415,11 @@ class DocumentConverter:
         content), use the `convert_string` method.
 
         Args:
-            source: Source of input document given as file path, URL, or
-                DocumentStream.
+            source: Source of input document given as file path, URL,
+                DocumentStream, or HttpSource (a URL bundled with its own headers).
             headers: Optional headers given as a dictionary of string key-value pairs,
-                in case of URL input source.
+                in case of URL input source. Ignored for HttpSource inputs, which
+                carry their own headers (these override the batch headers per key).
             raises_on_error: Whether to raise an error on the first conversion failure.
                 If False, errors are captured in the ConversionResult objects.
             max_num_pages: Maximum number of pages accepted per document.
@@ -465,7 +467,9 @@ class DocumentConverter:
     @validate_call(config=ConfigDict(strict=True))
     def convert_all(
         self,
-        source: Iterable[Union[Path, str, DocumentStream]],  # TODO review naming
+        source: Iterable[
+            Union[Path, str, DocumentStream, HttpSource]
+        ],  # TODO review naming
         headers: Optional[dict[str, str]] = None,
         raises_on_error: bool = True,
         max_num_pages: int = sys.maxsize,
@@ -476,9 +480,10 @@ class DocumentConverter:
 
         Args:
             source: Source of input documents given as an iterable of file paths, URLs,
-                or DocumentStreams.
+                DocumentStreams, or HttpSources (a URL bundled with its own headers).
             headers: Optional headers given as a (single) dictionary of string
-                key-value pairs, in case of URL input source.
+                key-value pairs, in case of URL input source. Per-source HttpSource
+                headers override these (merged per key) for that source only.
             raises_on_error: Whether to raise an error on the first conversion failure.
             max_num_pages: Maximum number of pages accepted per document.
                 Documents exceeding this number will not be converted.


### PR DESCRIPTION
## Summary

`DocumentConverter.convert` / `convert_all` previously accepted only `Path | str | DocumentStream` with a single batch-wide `headers` dict applied to every URL, making it impossible to give two URLs in one batch different headers (e.g. distinct auth tokens). This PR adds `HttpSource` (a URL bundled with its own headers) as an accepted source type — the only way to express per-source headers locally.

`HttpSource` is the minimal carrier (`url` + `headers`) from the service datamodel. `HttpSourceRequest` already subclasses it (`HttpSourceRequest → AnyHttpSourceRequest → HttpSource`), so callers holding an `HttpSourceRequest` — including `DoclingServiceClient.convert` — pass it straight through with no cast.

## Changes

- Widen the `source` union on `convert` / `convert_all` to include `HttpSource`.
- Widen `_DocumentConversionInput.path_or_stream_iterator` and add an `HttpSource` branch in `docs()` that resolves `item.url` with merged headers.
- Pass the resolved URL string (not the model) to `backend_options_for_input`, so HTML `source_uri` resolution is unchanged.
- Update docstrings on the public methods.

## Header precedence

For an `HttpSource` input, per-source headers override the batch `headers` argument per key (`{**batch, **per_source}`). For `str` / `Path` / `DocumentStream` sources nothing changes — the `headers` argument keeps behaving exactly as before, so the change is fully backward compatible.

## Testing

- Confirmed `HttpSourceRequest` is an `isinstance` of `HttpSource` and the header merge produces the expected dict.
- Exercised the `docs()` branch with an `HttpSource` pointing at an unsafe URL: it resolves through the new path and degrades into a named invalid `InputDocument` rather than crashing, preserving batch-level error handling.
