### PR TITLE
feat(jats/inline-formula): render inline tex-math formulas in paragraphs

### DIFF
--- a/docling/backend/xml/jats_backend.py
+++ b/docling/backend/xml/jats_backend.py
@@ -53,6 +53,7 @@ DEFAULT_HEADER_FOOTNOTES: Final[str] = "Footnotes"
 DEFAULT_HEADER_REFERENCES: Final[str] = "References"
 DEFAULT_TEXT_ETAL: Final[str] = "et al."
 
+
 class Abstract(TypedDict):
     label: str
     content: str

--- a/docling/backend/xml/jats_backend.py
+++ b/docling/backend/xml/jats_backend.py
@@ -53,7 +53,6 @@ DEFAULT_HEADER_FOOTNOTES: Final[str] = "Footnotes"
 DEFAULT_HEADER_REFERENCES: Final[str] = "References"
 DEFAULT_TEXT_ETAL: Final[str] = "et al."
 
-
 class Abstract(TypedDict):
     label: str
     content: str
@@ -627,6 +626,13 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
 
         return
 
+    def _get_inline_equation(self, node: etree._Element) -> str | None:
+        tex_math = node.find("tex-math")
+        if tex_math is None or not tex_math.text:
+            return None
+        math_parts = tex_math.text.split("$$")
+        return math_parts[1] if len(math_parts) == 3 else tex_math.text.strip()
+
     def _add_figure_captions(
         self, doc: DoclingDocument, parent: NodeItem, node: etree._Element
     ) -> None:
@@ -884,6 +890,7 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
         skip_tags = ["term"]
         flush_tags = ["ack", "sec", "list", "boxed-text", "disp-formula", "fig"]
         new_parent: NodeItem = parent
+        inline_segments: list[tuple[DocItemLabel, str]] = []
         node_text: str = (
             node.text.replace("\n", " ")
             if (node.tag not in skip_tags and node.text)
@@ -961,7 +968,12 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
                 self._add_equation(doc, parent, child)
                 stop_walk = True
             elif child.tag == "inline-formula":
-                # TODO: address inline formulas when supported by docling-core
+                formula = self._get_inline_equation(child) if node.tag == "p" else None
+                if formula is not None:
+                    if node_text.strip():
+                        inline_segments.append((DocItemLabel.TEXT, node_text.strip()))
+                        node_text = ""
+                    inline_segments.append((DocItemLabel.FORMULA, formula))
                 stop_walk = True
 
             # step into child
@@ -976,8 +988,19 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
             node_text += child.tail.replace("\n", " ") if child.tail else ""
 
         # create paragraph
-        if node.tag == "p" and node_text.strip():
-            doc.add_text(label=DocItemLabel.TEXT, text=node_text.strip(), parent=parent)
+        if node.tag == "p":
+            if node_text.strip():
+                inline_segments.append((DocItemLabel.TEXT, node_text.strip()))
+            if inline_segments:
+                # Wrap in an inline group only when several segments flow together
+                # (e.g. text + formula); a single segment is added directly.
+                container = (
+                    doc.add_inline_group(parent=parent)
+                    if len(inline_segments) > 1
+                    else parent
+                )
+                for label, text in inline_segments:
+                    doc.add_text(label=label, text=text, parent=container)
             return ""
         else:
             # backpropagate the text

--- a/tests/test_backend_jats.py
+++ b/tests/test_backend_jats.py
@@ -3,7 +3,7 @@ from io import BytesIO
 from pathlib import Path
 
 import pytest
-from docling_core.types.doc import DoclingDocument
+from docling_core.types.doc import DocItemLabel, DoclingDocument, GroupLabel
 
 from docling.datamodel.base_models import DocumentStream, InputFormat
 from docling.datamodel.document import ConversionResult
@@ -91,6 +91,83 @@ def test_jats_structured_abstract_sections_are_preserved():
     assert "## Abstract" in md
     assert "Background: Background text." in md
     assert "Methods: Methods text." in md
+
+
+def _inline_group_items(doc: DoclingDocument) -> list[list]:
+    """Return the resolved child items of every INLINE group, in document order."""
+    return [
+        [child.resolve(doc) for child in group.children]
+        for group in doc.groups
+        if group.label == GroupLabel.INLINE
+    ]
+
+
+@pytest.mark.parametrize(
+    ("paragraph", "expected"),
+    [
+        pytest.param(
+            "The mass energy relation <inline-formula><tex-math>$$E=mc^2$$</tex-math></inline-formula> is famous.",
+            [
+                (DocItemLabel.TEXT, "The mass energy relation"),
+                (DocItemLabel.FORMULA, "E=mc^2"),
+                (DocItemLabel.TEXT, "is famous."),
+            ],
+            id="text-formula-text",
+        ),
+        pytest.param(
+            "Given <inline-formula><tex-math>$$a^2$$</tex-math></inline-formula> and <inline-formula><tex-math>$$b^2$$</tex-math></inline-formula> we sum.",
+            [
+                (DocItemLabel.TEXT, "Given"),
+                (DocItemLabel.FORMULA, "a^2"),
+                (DocItemLabel.TEXT, "and"),
+                (DocItemLabel.FORMULA, "b^2"),
+                (DocItemLabel.TEXT, "we sum."),
+            ],
+            id="multiple-formulas",
+        ),
+        pytest.param(
+            # tex-math is not always wrapped in $$...$$ in real JATS files
+            "The relation <inline-formula><tex-math>E=mc^2</tex-math></inline-formula> holds.",
+            [
+                (DocItemLabel.TEXT, "The relation"),
+                (DocItemLabel.FORMULA, "E=mc^2"),
+                (DocItemLabel.TEXT, "holds."),
+            ],
+            id="bare-tex-math",
+        ),
+    ],
+)
+def test_jats_inline_formula_is_grouped(paragraph, expected):
+    doc = convert_jats_body(f"<sec><title>T</title><p>{paragraph}</p></sec>")
+
+    groups = _inline_group_items(doc)
+    assert len(groups) == 1
+    assert [(item.label, item.text) for item in groups[0]] == expected
+
+
+@pytest.mark.parametrize(
+    ("paragraph", "expected_formulas"),
+    [
+        pytest.param(
+            # a single segment is added directly, without an inline group
+            "<inline-formula><tex-math>$$E=mc^2$$</tex-math></inline-formula>",
+            ["E=mc^2"],
+            id="standalone-formula",
+        ),
+        pytest.param(
+            # an inline-formula with no usable tex-math is dropped
+            "Energy <inline-formula><tex-math/></inline-formula> equation.",
+            [],
+            id="no-usable-tex-math",
+        ),
+    ],
+)
+def test_jats_inline_formula_is_not_grouped(paragraph, expected_formulas):
+    doc = convert_jats_body(f"<sec><title>T</title><p>{paragraph}</p></sec>")
+
+    assert _inline_group_items(doc) == []
+    formulas = [t.text for t in doc.texts if t.label == DocItemLabel.FORMULA]
+    assert formulas == expected_formulas
 
 
 def test_jats_footnotes_are_preserved():


### PR DESCRIPTION
Implementation for resolving/parsing JATS inline formulas that carry tex-math content.

Part of the requested feature in #3583, and related to the discussion in #3656.
