### PR TITLE
feat(pdf): recover non-repeating headers/footers mis-tagged as furniture 

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1643,6 +1643,95 @@ class HeadingHierarchyOptions(BaseModel):
     ] = 0.8
 
 
+class HeaderFooterOptions(BaseModel):
+    """Options for recovering page headers/footers that are actually body content.
+
+    The layout model labels regions as ``PAGE_HEADER``/``PAGE_FOOTER`` from per-page position
+    alone -- it has no notion of whether the text repeats across pages. A one-off heading
+    sitting at the top of a page therefore gets tagged as a page header, moved to the
+    ``FURNITURE`` content layer and silently dropped from the default export (which only emits
+    ``BODY``). See issue #3693.
+
+    When ``enabled``, :class:`HeaderFooterModel` runs just before the reading-order model and,
+    using whole-document context, demotes header/footer detections that are *not* genuine
+    running furniture back into the body. A detection is kept as furniture when **either**:
+
+    - its normalized text (digits stripped, so ``"Page 3 of 10"`` matches ``"Page 4 of 10"``)
+      repeats on at least ``min_repeat_pages`` pages -- a consistent running header/footer; or
+    - the side it belongs to (header vs footer) is present on at least ``min_coverage`` of the
+      pages -- a real running header/footer appears on (almost) every page, so even a
+      section-varying header is trusted, while a "header" that shows up on only a few scattered
+      pages is most likely mis-detected content.
+
+    Otherwise the detection is reclassified -- a non-repeating header becomes a
+    ``SECTION_HEADER`` (so the existing heading-hierarchy step can level it) when
+    ``promote_headers_to_section`` is set, a non-repeating footer becomes plain ``TEXT``. The
+    step never drops items and never touches genuine, repeating headers/footers.
+
+    Notes:
+        - Only applies to documents with at least ``min_pages`` pages; repetition and coverage
+          are not observable on 1-2 page documents, so those are left unchanged.
+        - Disabled by default to preserve current behavior; enable to recover dropped headings.
+    """
+
+    enabled: Annotated[
+        bool,
+        Field(
+            description=(
+                "Recover page headers/footers that are actually body content. When disabled "
+                "(default), the unchanged behavior applies and content the layout model tags as "
+                "a header/footer stays in the FURNITURE layer (dropped from default exports). "
+                "When enabled, non-repeating header/footer detections are demoted back into the "
+                "body so the content is not lost."
+            )
+        ),
+    ] = False
+    min_pages: Annotated[
+        int,
+        Field(
+            ge=1,
+            description=(
+                "Minimum number of pages for the recovery pass to run. Repetition and coverage "
+                "are not observable on very short documents, so 1-2 page documents are left "
+                "unchanged."
+            ),
+        ),
+    ] = 3
+    min_repeat_pages: Annotated[
+        int,
+        Field(
+            ge=2,
+            description=(
+                "A header/footer is treated as genuine running furniture when its normalized "
+                "text (digits stripped) appears on at least this many pages."
+            ),
+        ),
+    ] = 2
+    min_coverage: Annotated[
+        float,
+        Field(
+            ge=0.0,
+            le=1.0,
+            description=(
+                "A whole side (header or footer) is trusted as genuine -- even when its text "
+                "varies per page -- if it is present on at least this fraction of pages. Sides "
+                "appearing on fewer pages are considered mis-detections and their non-repeating "
+                "items are demoted to the body."
+            ),
+        ),
+    ] = 0.5
+    promote_headers_to_section: Annotated[
+        bool,
+        Field(
+            description=(
+                "Reclassify a recovered (non-repeating) header as a SECTION_HEADER so the "
+                "heading-hierarchy step can assign it a level. When False, recovered headers "
+                "become plain TEXT. Recovered footers always become plain TEXT."
+            )
+        ),
+    ] = True
+
+
 class PdfPipelineOptions(PaginatedPipelineOptions):
     """Configuration options for the PDF document processing pipeline.
 
@@ -1803,6 +1892,17 @@ class PdfPipelineOptions(PaginatedPipelineOptions):
             )
         ),
     ] = HeadingHierarchyOptions()
+    header_footer_options: Annotated[
+        HeaderFooterOptions,
+        Field(
+            description=(
+                "Configuration for recovering page headers/footers that are actually body "
+                "content. Disabled by default; when enabled, a pass before the reading-order "
+                "stage demotes non-repeating header/footer detections back into the body so "
+                "obvious headings are not silently dropped as furniture."
+            )
+        ),
+    ] = HeaderFooterOptions()
 
     ### Arguments for threaded PDF pipeline with batching and backpressure control
 

--- a/docling/models/stages/header_footer/header_footer_model.py
+++ b/docling/models/stages/header_footer/header_footer_model.py
@@ -1,0 +1,156 @@
+"""Recovery of page headers/footers that are actually body content.
+
+The layout model classifies regions as ``PAGE_HEADER``/``PAGE_FOOTER`` from per-page position
+only -- it has no notion of whether the text repeats across pages. A one-off heading sitting at
+the top of a page therefore gets tagged as a page header, moved to the ``FURNITURE`` content
+layer by the reading-order model and silently dropped from the default export (which only emits
+``BODY``). See issue #3693.
+
+:class:`HeaderFooterModel` runs just *before* the reading-order model -- the first stage with
+whole-document context -- and demotes header/footer detections that are not genuine running
+furniture back into the body, relabeling the assembled elements in place so the reading-order
+and heading-hierarchy stages then treat them as ordinary content.
+
+A detection is left untouched (kept as furniture) when **either**:
+
+1. **repetition** -- its normalized text (digits stripped, so ``"Page 3 of 10"`` matches
+   ``"Page 4 of 10"``) appears on at least ``min_repeat_pages`` pages, i.e. a consistent
+   running header/footer; or
+2. **coverage** -- the side it belongs to (header vs footer) is present on at least
+   ``min_coverage`` of the pages. A real running header/footer appears on (almost) every page,
+   so a side that only shows up on a few scattered pages is most likely mis-detected content
+   (issue #3693 has no genuine headers, only sparse mis-detections), whereas a header whose
+   text legitimately changes per section is still trusted because it covers most pages.
+
+Otherwise the detection is reclassified: a non-repeating header becomes ``SECTION_HEADER`` (so
+the heading-hierarchy step can level it) when ``promote_headers_to_section`` is set, a
+non-repeating footer becomes plain ``TEXT``. The step never drops or reorders items and never
+touches genuine, repeating headers/footers.
+"""
+
+import re
+from collections import defaultdict
+from typing import Protocol
+
+from docling_core.types.doc import DocItemLabel
+
+from docling.datamodel.document import ConversionResult
+from docling.datamodel.pipeline_options import HeaderFooterOptions
+
+_DIGITS_RE = re.compile(r"\d+")
+_WS_RE = re.compile(r"\s+")
+
+_HEADER_FOOTER_LABELS = (DocItemLabel.PAGE_HEADER, DocItemLabel.PAGE_FOOTER)
+
+
+class _Candidate(Protocol):
+    """Minimal interface the heuristic needs from an assembled element."""
+
+    label: DocItemLabel
+    page_no: int
+    text: str | None
+
+
+def _normalize_signature(text: str | None) -> str:
+    """Normalize header/footer text for cross-page comparison.
+
+    Digits are stripped so that running headers/footers differing only by a page number or
+    date ("Page 3 of 10" vs "Page 4 of 10") collapse to the same signature; whitespace is
+    folded and the result is lower-cased.
+    """
+    if not text:
+        return ""
+    return _WS_RE.sub(" ", _DIGITS_RE.sub("", text.lower())).strip()
+
+
+def select_header_footer_reclassifications(
+    elements: list[_Candidate],
+    page_count: int,
+    options: HeaderFooterOptions,
+) -> dict[int, DocItemLabel]:
+    """Decide which header/footer elements should be demoted into the body.
+
+    Pure function over the assembled elements: it only reads ``label``, ``page_no`` and
+    ``text`` and returns a mapping ``{index_in_elements: new_label}`` for the detections to
+    reclassify. Everything not in the mapping keeps its current label.
+    """
+    if not options.enabled or page_count < options.min_pages:
+        return {}
+
+    result: dict[int, DocItemLabel] = {}
+    for label in _HEADER_FOOTER_LABELS:
+        idxs = [i for i, el in enumerate(elements) if el.label == label]
+        if not idxs:
+            continue
+
+        # Coverage: fraction of pages on which this side appears at all (issue #3693 idea).
+        pages_on_side = {elements[i].page_no for i in idxs}
+        side_is_genuine = len(pages_on_side) / page_count >= options.min_coverage
+
+        # Repetition: pages each normalized text appears on.
+        sig_pages: dict[str, set[int]] = defaultdict(set)
+        for i in idxs:
+            sig_pages[_normalize_signature(elements[i].text)].add(elements[i].page_no)
+
+        if label == DocItemLabel.PAGE_HEADER and options.promote_headers_to_section:
+            body_label = DocItemLabel.SECTION_HEADER
+        else:
+            body_label = DocItemLabel.TEXT
+
+        for i in idxs:
+            sig = _normalize_signature(elements[i].text)
+            if not sig:
+                # Empty/blank detection carries no content to recover; leave as furniture.
+                continue
+            repeats = len(sig_pages[sig]) >= options.min_repeat_pages
+            if repeats or side_is_genuine:
+                continue
+            result[i] = body_label
+
+    return result
+
+
+class HeaderFooterModel:
+    """Demotes mis-detected page headers/footers back into the document body.
+
+    Mutates ``conv_res.assembled`` in place (so the reading-order model that runs next sees the
+    corrected labels) and returns ``conv_res`` for call-site symmetry with the other stages.
+    """
+
+    def __init__(self, options: HeaderFooterOptions):
+        self.options = options
+
+    def __call__(self, conv_res: ConversionResult) -> ConversionResult:
+        if not self.options.enabled or conv_res.assembled is None:
+            return conv_res
+
+        elements = conv_res.assembled.elements
+        page_count = len(conv_res.pages)
+        if page_count == 0:
+            return conv_res
+
+        reclassifications = select_header_footer_reclassifications(
+            elements, page_count, self.options
+        )
+        if not reclassifications:
+            return conv_res
+
+        reclassified = set()
+        for idx, new_label in reclassifications.items():
+            element = elements[idx]
+            element.label = new_label
+            # Keep the backing cluster label aligned with the element label.
+            element.cluster.label = new_label
+            reclassified.add(id(element))
+
+        # Keep the headers/body buckets consistent: a recovered header/footer is no longer
+        # furniture, so move it out of the headers bucket and into the body bucket.
+        assembled = conv_res.assembled
+        moved = [el for el in assembled.headers if id(el) in reclassified]
+        if moved:
+            assembled.headers = [
+                el for el in assembled.headers if id(el) not in reclassified
+            ]
+            assembled.body = assembled.body + moved
+
+        return conv_res

--- a/docling/pipeline/legacy_standard_pdf_pipeline.py
+++ b/docling/pipeline/legacy_standard_pdf_pipeline.py
@@ -23,6 +23,9 @@ from docling.models.stages.code_formula.code_formula_model import (
     CodeFormulaModel,
     CodeFormulaModelOptions,
 )
+from docling.models.stages.header_footer.header_footer_model import (
+    HeaderFooterModel,
+)
 from docling.models.stages.heading_hierarchy.heading_hierarchy_model import (
     HeadingHierarchyModel,
 )
@@ -58,6 +61,9 @@ class LegacyStandardPdfPipeline(PaginatedPipeline):
                 or self.pipeline_options.generate_table_images
             )
 
+        self.header_footer_model = HeaderFooterModel(
+            options=self.pipeline_options.header_footer_options
+        )
         self.reading_order_model = ReadingOrderModel(options=ReadingOrderOptions())
         self.heading_hierarchy_model = HeadingHierarchyModel(
             options=self.pipeline_options.heading_hierarchy_options
@@ -188,6 +194,7 @@ class LegacyStandardPdfPipeline(PaginatedPipeline):
             ):
                 conv_res._pdf_outline = conv_res.input._backend.get_document_outline()
 
+            conv_res = self.header_footer_model(conv_res)
             conv_res.document = self.reading_order_model(conv_res)
             conv_res.document = self.heading_hierarchy_model(conv_res)
 

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -56,6 +56,9 @@ from docling.models.factories import (
 from docling.models.stages.code_formula.code_formula_vlm_model import (
     CodeFormulaVlmModel,
 )
+from docling.models.stages.header_footer.header_footer_model import (
+    HeaderFooterModel,
+)
 from docling.models.stages.heading_hierarchy.heading_hierarchy_model import (
     HeadingHierarchyModel,
 )
@@ -613,6 +616,9 @@ class StandardPdfPipeline(ConvertPipeline):
             enable_remote_services=self.pipeline_options.enable_remote_services,
         )
         self.assemble_model = PageAssembleModel(options=PageAssembleOptions())
+        self.header_footer_model = HeaderFooterModel(
+            options=self.pipeline_options.header_footer_options
+        )
         self.reading_order_model = ReadingOrderModel(options=ReadingOrderOptions())
         self.heading_hierarchy_model = HeadingHierarchyModel(
             options=self.pipeline_options.heading_hierarchy_options
@@ -1005,6 +1011,7 @@ class StandardPdfPipeline(ConvertPipeline):
             conv_res.assembled = AssembledUnit(
                 elements=elements, headers=headers, body=body
             )
+            conv_res = self.header_footer_model(conv_res)
             conv_res.document = self.reading_order_model(conv_res)
             conv_res.document = self.heading_hierarchy_model(conv_res)
 

--- a/tach.toml
+++ b/tach.toml
@@ -342,6 +342,11 @@ depends_on = [
 ]
 
 [[modules]]
+path = "docling.models.stages.header_footer"
+layer = "models"
+depends_on = ["docling.datamodel"]
+
+[[modules]]
 path = "docling.models.stages.heading_hierarchy"
 layer = "models"
 depends_on = ["docling.datamodel"]

--- a/tests/test_header_footer.py
+++ b/tests/test_header_footer.py
@@ -1,0 +1,137 @@
+"""Tests for recovering mis-detected page headers/footers (issue #3693).
+
+The layout model labels regions as PAGE_HEADER/PAGE_FOOTER from per-page position only, so a
+non-repeating heading at the top of a page is tagged as a header, moved to the FURNITURE layer
+and dropped from the default export. The recovery pass demotes such non-repeating detections
+back into the body while leaving genuine running headers/footers as furniture.
+"""
+
+from types import SimpleNamespace
+
+from docling_core.types.doc import DocItemLabel
+
+from docling.datamodel.pipeline_options import HeaderFooterOptions
+from docling.models.stages.header_footer.header_footer_model import (
+    HeaderFooterModel,
+    select_header_footer_reclassifications,
+)
+
+
+def _el(label: DocItemLabel, page_no: int, text: str) -> SimpleNamespace:
+    return SimpleNamespace(label=label, page_no=page_no, text=text)
+
+
+def _select(elements, page_count, **opts) -> dict[int, DocItemLabel]:
+    options = HeaderFooterOptions(enabled=True, **opts)
+    return select_header_footer_reclassifications(elements, page_count, options)
+
+
+def test_sparse_nonrepeating_headers_are_recovered_genuine_footers_kept():
+    # Mirrors the affected PDF (#3693): no real running header, just a few scattered
+    # mis-detected top headings across an 8-page doc, plus a genuine footer on every page.
+    elements = [
+        _el(DocItemLabel.PAGE_HEADER, 1, "Compensation"),  # one-off heading
+        _el(DocItemLabel.PAGE_HEADER, 4, "Scheduling"),  # one-off heading
+        *[
+            _el(DocItemLabel.PAGE_FOOTER, p, f"Republic Airlines  -  {p}")
+            for p in range(1, 9)
+        ],
+    ]
+    result = _select(elements, page_count=8)
+
+    # Both bogus headers recovered as section headers; every genuine footer left untouched.
+    assert result == {0: DocItemLabel.SECTION_HEADER, 1: DocItemLabel.SECTION_HEADER}
+
+
+def test_running_header_and_footer_repeating_text_are_kept():
+    # Mirrors the "works well" PDF: identical running header + footer on every page.
+    elements = []
+    for p in range(1, 7):
+        elements.append(
+            _el(DocItemLabel.PAGE_HEADER, p, "Republic Airways Collective Agreement")
+        )
+        elements.append(_el(DocItemLabel.PAGE_FOOTER, p, f"Page {p} of 6"))
+    assert _select(elements, page_count=6) == {}
+
+
+def test_section_varying_header_is_kept_via_coverage():
+    # Header text changes per page but it is present on every page -> trusted by coverage,
+    # even though no single normalized signature repeats.
+    elements = [
+        _el(DocItemLabel.PAGE_HEADER, p, f"Chapter {chr(ord('A') + p)} Overview")
+        for p in range(6)
+    ]
+    assert _select(elements, page_count=6) == {}
+
+
+def test_footers_recover_as_plain_text_not_section_header():
+    elements = [
+        _el(DocItemLabel.PAGE_FOOTER, 2, "A note that only appears once"),
+        *[
+            _el(DocItemLabel.PAGE_HEADER, p, "Genuine Running Header")
+            for p in range(1, 7)
+        ],
+    ]
+    # Footer side coverage is 1/6 and the text does not repeat -> recovered as TEXT.
+    assert _select(elements, page_count=6) == {0: DocItemLabel.TEXT}
+
+
+def test_promote_headers_to_section_disabled_recovers_as_text():
+    elements = [
+        _el(DocItemLabel.PAGE_HEADER, 1, "Only Once"),
+        *[_el(DocItemLabel.PAGE_FOOTER, p, "running footer") for p in range(1, 6)],
+    ]
+    assert _select(elements, page_count=5, promote_headers_to_section=False) == {
+        0: DocItemLabel.TEXT
+    }
+
+
+def test_short_documents_are_left_unchanged():
+    elements = [_el(DocItemLabel.PAGE_HEADER, 1, "Title On Page One")]
+    # Below min_pages (default 3): repetition/coverage are not observable.
+    assert _select(elements, page_count=2) == {}
+
+
+def test_disabled_is_a_noop():
+    elements = [_el(DocItemLabel.PAGE_HEADER, p, f"unique {p}") for p in range(1, 9)]
+    options = HeaderFooterOptions(enabled=False)
+    assert select_header_footer_reclassifications(elements, 8, options) == {}
+
+
+def test_blank_detections_are_not_recovered():
+    elements = [
+        _el(DocItemLabel.PAGE_HEADER, 1, "   "),
+        _el(DocItemLabel.PAGE_HEADER, 5, ""),
+        *[_el(DocItemLabel.PAGE_FOOTER, p, "footer") for p in range(1, 9)],
+    ]
+    # Empty/blank headers carry no content to recover and stay as furniture.
+    assert _select(elements, page_count=8) == {}
+
+
+def test_model_relabels_elements_and_moves_them_out_of_headers_bucket():
+    header = _el(DocItemLabel.PAGE_HEADER, 1, "Compensation")
+    header.cluster = SimpleNamespace(label=DocItemLabel.PAGE_HEADER)
+    footers = []
+    for p in range(1, 9):
+        f = _el(DocItemLabel.PAGE_FOOTER, p, "running footer")
+        f.cluster = SimpleNamespace(label=DocItemLabel.PAGE_FOOTER)
+        footers.append(f)
+
+    assembled = SimpleNamespace(
+        elements=[header, *footers],
+        headers=[header],  # page_assemble files headers/footers in the headers bucket
+        body=list(footers),
+    )
+    conv_res = SimpleNamespace(assembled=assembled, pages=[object()] * 8)
+
+    model = HeaderFooterModel(HeaderFooterOptions(enabled=True))
+    model(conv_res)
+
+    # Element and its backing cluster are relabeled to a body heading...
+    assert header.label == DocItemLabel.SECTION_HEADER
+    assert header.cluster.label == DocItemLabel.SECTION_HEADER
+    # ...and it is moved out of the furniture headers bucket into the body bucket.
+    assert header not in assembled.headers
+    assert header in assembled.body
+    # Genuine footers are untouched.
+    assert all(f.label == DocItemLabel.PAGE_FOOTER for f in footers)


### PR DESCRIPTION
## Summary

This PR resolves #3693. The layout model labels regions as `PAGE_HEADER`/`PAGE_FOOTER` from per-page position alone. It has no notion of whether the text actually repeats across pages. A one-off heading sitting at the top of a page therefore gets tagged as a page header, moved to the `FURNITURE` content layer by the reading-order model, and silently dropped from the default export (which only emits `BODY`). On the affected PDF this removes obvious section headings.

This PR adds an **opt-in** document-level pass, `HeaderFooterModel`, that runs just before the reading-order model, the first stage with whole-document context, and demotes header/footer detections that are *not* genuine running furniture back into the body.

## Heuristic

A `PAGE_HEADER`/`PAGE_FOOTER` detection is **kept as furniture** when **either**:

1. **Repetition** — its normalized text (digits stripped, so `"Page 3 of 10"` matches `"Page 4 of 10"`) appears on ≥ `min_repeat_pages` pages (a consistent running header/footer); or
2. **Coverage** — the side it belongs to (header vs footer) is present on ≥ `min_coverage` of the pages. A real running header/footer appears on (almost) every page, so a side that only shows up on a few scattered pages is most likely mis-detected content, while a header whose text legitimately changes per section is still trusted because it covers most pages.

Otherwise it is reclassified: a non-repeating **header → `SECTION_HEADER`** (so the existing heading-hierarchy step can level it), a non-repeating **footer → `TEXT`**. The pass never drops, adds or reorders items, and never touches genuine repeating headers/footers. It only runs on documents with ≥ `min_pages` pages, since repetition/coverage aren't observable on 1–2 page docs.

## Configuration

New `HeaderFooterOptions`, exposed as `PdfPipelineOptions.header_footer_options`:

| field | default | meaning |
|---|---|---|
| `enabled` | `False` | turn the recovery pass on |
| `min_pages` | `3` | minimum pages for the pass to run |
| `min_repeat_pages` | `2` | a text repeating on this many pages is genuine furniture |
| `min_coverage` | `0.5` | a side present on this fraction of pages is genuine |
| `promote_headers_to_section` | `True` | recovered header → `SECTION_HEADER` (else `TEXT`) |


## Tests

`tests/test_header_footer.py` focused unit tests for the heuristic (both sample-PDF scenarios, section-varying headers, short-doc guard, footer/text targets, blank detections, disabled no-op) and the in-place relabeling + bucket move. All pass.

## Notes
- Wired into both `standard_pdf_pipeline` and `legacy_standard_pdf_pipeline`, before reading order.
- No new dependencies. Public API stays backward compatible (new field has a default).
