### PR TITLE
feat: assign `ContentLayer.SHEET` to Excel worksheet groups

### DIFF
--- a/docling/backend/msexcel_backend.py
+++ b/docling/backend/msexcel_backend.py
@@ -946,9 +946,9 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         return None
 
     @staticmethod
-    def _get_sheet_content_layer(sheet: Worksheet) -> Optional[ContentLayer]:
+    def _get_sheet_content_layer(sheet: Worksheet) -> ContentLayer:
         return (
-            None
+            ContentLayer.SHEET
             if sheet.sheet_state == Worksheet.SHEETSTATE_VISIBLE
             else ContentLayer.INVISIBLE
         )

--- a/tests/test_backend_msexcel.py
+++ b/tests/test_backend_msexcel.py
@@ -23,6 +23,7 @@ from .verify_utils import verify_document, verify_export
 
 _log = logging.getLogger(__name__)
 
+
 GENERATE = GEN_TEST_DATA
 
 
@@ -142,6 +143,40 @@ def test_comment_cell_coordinates(documents) -> None:
     assert any("G12" in name for name in comment_names), (
         "Expected threaded comment for cell G12"
     )
+
+
+def test_sheet_content_layer_and_html_export(documents) -> None:
+    """Sheet groups carry ContentLayer.SHEET and HTML export wraps them in <section>."""
+    from docling_core.transforms.serializer.html import HTMLDocSerializer
+    from docling_core.types.doc import GroupItem
+
+    doc = next(item for path, item in documents if path.stem == "xlsx_01")
+
+    sheet_groups = [
+        g
+        for g in doc.groups
+        if isinstance(g, GroupItem) and g.label == GroupLabel.SHEET
+    ]
+    assert len(sheet_groups) > 0, "Expected at least one sheet group"
+    allowed_layers = {ContentLayer.SHEET, ContentLayer.INVISIBLE}
+    for g in sheet_groups:
+        assert g.content_layer in allowed_layers, (
+            f"Sheet {g.name!r}: content_layer must be SHEET or INVISIBLE, got {g.content_layer!r}"
+        )
+    visible_sheets = [g for g in sheet_groups if g.content_layer == ContentLayer.SHEET]
+    assert len(visible_sheets) > 0, (
+        "Expected at least one visible sheet (ContentLayer.SHEET)"
+    )
+
+    html = HTMLDocSerializer(doc=doc).serialize().text
+    assert '<section data-page-name="Sheet1">' in html, "Missing Sheet1 section in HTML"
+    assert '<section data-page-name="Sheet2">' in html, "Missing Sheet2 section in HTML"
+    assert '<section data-page-name="Sheet3">' in html, "Missing Sheet3 section in HTML"
+
+    md = MsExcelMarkdownDocSerializer(doc=doc).serialize().text
+    assert "## Sheet1" in md, "Missing Sheet1 heading in Markdown"
+    assert "## Sheet2" in md, "Missing Sheet2 heading in Markdown"
+    assert "## Sheet3" in md, "Missing Sheet3 heading in Markdown"
 
 
 def test_e2e_excel_conversions(documents) -> None:


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

Parent PR: https://github.com/docling-project/docling-core/pull/660

When converting a multi-sheet Excel file, there was no way to tell which table or piece of content belonged to which worksheet. This PR fixes that by ensuring visible sheets carry a dedicated content layer that serializers can act on, and adds a test to verify the behavior end to end.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
