### PR TITLE
fix(layout): fix unreachable TABLE check in _handle_cross_type_overlaps

### DIFF
--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -395,30 +395,29 @@ class LayoutPostprocessor:
         """
         clusters_to_remove = set()
 
+        # TABLE is part of WRAPPER_TYPES and therefore always ends up in special_clusters,
+        # never in regular_clusters. Build the list from special_clusters so the check
+        # below can actually find TABLE proposals to compare against.
+        tables = [c for c in special_clusters if c.label == DocItemLabel.TABLE]
+
         for wrapper in special_clusters:
             if wrapper.label not in self.WRAPPER_TYPES:
-                continue  # only treat KEY_VALUE_REGION for now.
+                continue
+            if wrapper.label == DocItemLabel.TABLE:
+                continue  # TABLE cannot be a candidate for removal here
 
-            for regular in self.regular_clusters:
-                if regular.label == DocItemLabel.TABLE:
-                    # Calculate overlap
-                    overlap_ratio = wrapper.bbox.intersection_over_self(regular.bbox)
-
-                    conf_diff = wrapper.confidence - regular.confidence
-
-                    # If wrapper is mostly overlapping with a TABLE, remove the wrapper
-                    if (
-                        overlap_ratio > 0.9 and conf_diff < 0.1
-                    ):  # self.OVERLAP_PARAMS["wrapper"]["conf_threshold"]):  # 80% overlap threshold
-                        clusters_to_remove.add(wrapper.id)
-                        break
+            for table in tables:
+                overlap_ratio = wrapper.bbox.intersection_over_self(table.bbox)
+                conf_diff = wrapper.confidence - table.confidence
+                if overlap_ratio > 0.9 and conf_diff < 0.1:
+                    clusters_to_remove.add(wrapper.id)
+                    break
 
         # The picture/table buckets are de-overlapped independently elsewhere, so a
         # region the layout model proposes as BOTH a PICTURE and a TABLE survives twice.
         # When a PICTURE nearly coincides with a TABLE (high IoU), keep the structured
         # TABLE and drop the PICTURE. IoU (not containment) is used so a genuine small
         # figure fully inside a large table region is not removed.
-        tables = [c for c in special_clusters if c.label == DocItemLabel.TABLE]
         for picture in special_clusters:
             if picture.label != DocItemLabel.PICTURE:
                 continue

--- a/tests/test_layout_postprocessor.py
+++ b/tests/test_layout_postprocessor.py
@@ -89,3 +89,34 @@ def test_cross_type_overlaps_keeps_small_picture_inside_table() -> None:
 
     ids = {c.id for c in result}
     assert ids == {1, 2}
+
+
+def test_cross_type_overlaps_removes_kvregion_coinciding_with_table() -> None:
+    # A KEY_VALUE_REGION that nearly covers the same area as a TABLE should be
+    # dropped in favour of the TABLE. Previously this check was unreachable because
+    # TABLE is in WRAPPER_TYPES and therefore never appears in regular_clusters.
+    processor = object.__new__(LayoutPostprocessor)
+
+    table = _cluster(1, DocItemLabel.TABLE, (10, 10, 200, 150), confidence=0.85)
+    kvr = _cluster(
+        2, DocItemLabel.KEY_VALUE_REGION, (10, 10, 200, 150), confidence=0.80
+    )
+
+    result = processor._handle_cross_type_overlaps([table, kvr])
+
+    labels = {c.label for c in result}
+    assert DocItemLabel.TABLE in labels
+    assert DocItemLabel.KEY_VALUE_REGION not in labels
+
+
+def test_cross_type_overlaps_keeps_kvregion_not_overlapping_table() -> None:
+    # A KEY_VALUE_REGION on a different part of the page should not be affected.
+    processor = object.__new__(LayoutPostprocessor)
+
+    table = _cluster(1, DocItemLabel.TABLE, (10, 10, 200, 150))
+    kvr = _cluster(2, DocItemLabel.KEY_VALUE_REGION, (10, 300, 200, 450))
+
+    result = processor._handle_cross_type_overlaps([table, kvr])
+
+    ids = {c.id for c in result}
+    assert ids == {1, 2}


### PR DESCRIPTION
## What

`_handle_cross_type_overlaps` has a dead code path for KEY_VALUE_REGION vs TABLE deduplication:

```python
for regular in self.regular_clusters:
    if regular.label == DocItemLabel.TABLE:  # never True
```

`TABLE` is a member of `WRAPPER_TYPES`, which is a subset of `SPECIAL_TYPES`, so TABLE clusters always land in `special_clusters` and never in `regular_clusters`. This inner condition can never fire, so a KEY_VALUE_REGION that nearly coincides with a TABLE is never removed.

## Fix

The `tables` list is already built from `special_clusters` in the PICTURE block added by #3523. This PR moves that list above both loops so it's shared, then iterates it in the wrapper loop instead of `self.regular_clusters`. A `continue` guard skips TABLE itself so it can't remove itself.

No change to the PICTURE/TABLE path from #3523.

## Tests

Two new tests added to `test_layout_postprocessor.py`:
- a KEY_VALUE_REGION coinciding with a TABLE is removed
- a KEY_VALUE_REGION on a different part of the page is kept

Closes #3495