### PR TITLE
fix(backend): guard optional email and markdown imports for slim installs

### DIFF
--- a/docling/backend/email_backend.py
+++ b/docling/backend/email_backend.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 import logging
 import re
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
 
-import mailparser
 from docling_core.types.doc import DocItemLabel, DoclingDocument, DocumentOrigin
 
 from docling.backend.abstract_backend import DeclarativeDocumentBackend
@@ -14,11 +15,36 @@ from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
 from docling.exceptions import DocumentLoadError
 
+# mail-parser is only installed by the `format-email` extra, but
+# DocumentConverter imports every backend eagerly. Importing it at module load
+# would therefore break `import docling` on installs that omit the extra (the
+# slim packages in particular). Guard the import like the opendocument and xbrl
+# backends do, and surface the failure only when an email is actually parsed.
+# See https://github.com/docling-project/docling/issues/3613.
+_MAILPARSER_AVAILABLE: bool = False
+_MAILPARSER_IMPORT_ERROR: ImportError | None = None
+try:  # pragma: no cover - import-time guard
+    import mailparser
+
+    _MAILPARSER_AVAILABLE = True
+except ImportError as e:  # pragma: no cover - import-time guard
+    _MAILPARSER_IMPORT_ERROR = e
+
 _log = logging.getLogger(__name__)
+
+_INSTALL_HINT = (
+    "The 'mail-parser' package is required to process email files. "
+    "Install it with `pip install 'docling[format-email]'`."
+)
 
 
 class EmailDocumentBackend(DeclarativeDocumentBackend):
     def __init__(self, in_doc: InputDocument, path_or_stream: BytesIO | Path):
+        # Raised before super().__init__() so a missing optional dependency
+        # gives an actionable message rather than a NameError when mailparser
+        # is dereferenced below.
+        if not _MAILPARSER_AVAILABLE:
+            raise ImportError(_INSTALL_HINT) from _MAILPARSER_IMPORT_ERROR
         super().__init__(in_doc, path_or_stream)
 
         self.valid = False

--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import re
 import warnings
@@ -8,9 +10,6 @@ from io import BytesIO
 from pathlib import Path
 from typing import Literal, Optional, Union, cast
 
-import marko
-import marko.element
-import marko.inline
 from docling_core.types.doc import (
     DocItemLabel,
     DoclingDocument,
@@ -22,7 +21,6 @@ from docling_core.types.doc import (
     TableData,
     TextItem,
 )
-from marko import Markdown
 from pydantic import AnyUrl, BaseModel, Field, TypeAdapter
 from typing_extensions import Annotated, override
 
@@ -38,7 +36,30 @@ from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
 from docling.exceptions import DocumentLoadError
 
+# marko is only installed by the `format-markdown` extra, but DocumentConverter
+# imports every backend eagerly. Importing it at module load would therefore
+# break `import docling` on installs that omit the extra (the slim packages in
+# particular). Guard the imports like the opendocument and xbrl backends do, and
+# surface the failure only when Markdown is actually parsed.
+# See https://github.com/docling-project/docling/issues/3613.
+_MARKO_AVAILABLE: bool = False
+_MARKO_IMPORT_ERROR: ImportError | None = None
+try:  # pragma: no cover - import-time guard
+    import marko
+    import marko.element
+    import marko.inline
+    from marko import Markdown
+
+    _MARKO_AVAILABLE = True
+except ImportError as e:  # pragma: no cover - import-time guard
+    _MARKO_IMPORT_ERROR = e
+
 _log = logging.getLogger(__name__)
+
+_INSTALL_HINT = (
+    "The 'marko' package is required to process Markdown files. "
+    "Install it with `pip install 'docling[format-markdown]'`."
+)
 
 _MARKER_BODY = "DOCLING_DOC_MD_HTML_EXPORT"
 _START_MARKER = f"#_#_{_MARKER_BODY}_START_#_#"
@@ -130,6 +151,10 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         path_or_stream: Union[BytesIO, Path],
         options: Optional[MarkdownBackendOptions] = None,
     ):
+        # Raised first so a missing optional dependency gives an actionable
+        # message rather than a NameError when marko is dereferenced below.
+        if not _MARKO_AVAILABLE:
+            raise ImportError(_INSTALL_HINT) from _MARKO_IMPORT_ERROR
         if options is None:
             options = MarkdownBackendOptions()
         super().__init__(in_doc, path_or_stream, options)

--- a/tests/test_backend_optional_dependencies.py
+++ b/tests/test_backend_optional_dependencies.py
@@ -1,0 +1,74 @@
+"""Regression tests for optional format-backend dependencies.
+
+``DocumentConverter`` imports every format backend eagerly (see
+``docling/document_converter.py``), so a backend that imports a third-party
+package at module load breaks ``import docling`` for any install that omits the
+matching extra, such as the slim packages. These tests pin the contract that a
+missing optional dependency stays dormant until its backend is actually used.
+
+See https://github.com/docling-project/docling/issues/3613.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_EML_SAMPLE = Path(__file__).parent / "data" / "email" / "sources" / "eml_simple.eml"
+
+
+def _run_with_blocked_module(
+    blocked_module: str, body: str
+) -> subprocess.CompletedProcess:
+    # The optional packages are installed in the dev/CI environment, so to
+    # reproduce a slim install we block one inside a fresh interpreter. Mapping
+    # the name to None is what the import system sees for an uninstalled package:
+    # `import <name>` then raises ImportError. Doing it before docling is
+    # imported forces the backend modules to be loaded cold without the package.
+    script = f"import sys\nsys.modules[{blocked_module!r}] = None\n{body}"
+    return subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True
+    )
+
+
+@pytest.mark.parametrize(
+    "blocked_module",
+    ["mailparser", "marko"],
+)
+def test_converter_constructs_without_optional_backend_dependency(
+    blocked_module: str,
+) -> None:
+    # Constructing a default DocumentConverter resolves a FormatOption for every
+    # input format, so it fails on the eager-import regression and succeeds once
+    # the backend defers its optional import.
+    result = _run_with_blocked_module(
+        blocked_module,
+        "from docling.document_converter import DocumentConverter\nDocumentConverter()\n",
+    )
+    assert result.returncode == 0, result.stderr
+
+
+def test_email_backend_reports_missing_dependency_with_install_hint() -> None:
+    # Using a backend whose optional dependency is absent must fail with an
+    # actionable ImportError that names the extra to install, not a NameError or
+    # an error mislabeled as a corrupt-document failure.
+    body = (
+        "from pathlib import Path\n"
+        "from docling.backend.email_backend import EmailDocumentBackend\n"
+        "from docling.datamodel.base_models import InputFormat\n"
+        "from docling.datamodel.document import InputDocument\n"
+        f"path = Path({str(_EML_SAMPLE)!r})\n"
+        "try:\n"
+        "    InputDocument(\n"
+        "        path_or_stream=path, format=InputFormat.EMAIL, backend=EmailDocumentBackend\n"
+        "    )\n"
+        "except ImportError as exc:\n"
+        "    assert 'format-email' in str(exc), str(exc)\n"
+        "    print('actionable-error-raised')\n"
+        "else:\n"
+        "    raise AssertionError('expected ImportError when mail-parser is missing')\n"
+    )
+    result = _run_with_blocked_module("mailparser", body)
+    assert result.returncode == 0, result.stderr
+    assert "actionable-error-raised" in result.stdout


### PR DESCRIPTION
DocumentConverter imports every format backend at module load. The email and markdown backends imported their optional dependencies (`mailparser` and `marko`) at module top level without a guard, so `import docling` failed outright whenever those extras were not installed. This breaks the slim packages and any minimal install, which is what #3613 reports for `mailparser`.

The `opendocument` and `xbrl` backends already handle this case: they wrap the optional import in a `try/except ImportError` and raise a clear, install-pointing error from `__init__` only when the backend is actually used. This change brings the email and markdown backends in line with that convention.

After the change:

* `import docling` and `DocumentConverter()` work without `mail-parser` or `marko` installed.
* Constructing a backend whose dependency is missing raises an `ImportError` that names the extra to install (`docling[format-email]` or `docling[format-markdown]`).

The same eager-import pattern still exists in a few other backends (latex, docx, pptx, xlsx, and the bs4-based XML backends). I scoped this PR to the two backends named in the issue and can extend it to the others in a follow-up.

**Issue resolved by this Pull Request:**
Resolves #3613

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
