### PR TITLE
feat(asr): expose beam_size and condition_on_previous_text (native)

### DIFF
--- a/docling/datamodel/pipeline_options_asr_model.py
+++ b/docling/datamodel/pipeline_options_asr_model.py
@@ -171,6 +171,26 @@ class InlineAsrNativeWhisperOptions(InlineAsrOptions):
             )
         ),
     ] = True
+    beam_size: Annotated[
+        Optional[int],
+        Field(
+            description=(
+                "Beam size for decoding. `None` uses greedy decoding (whisper's "
+                "default); a value >= 1 enables beam search, which is more "
+                "robust against runaway repetition on long-form audio."
+            )
+        ),
+    ] = None
+    condition_on_previous_text: Annotated[
+        bool,
+        Field(
+            description=(
+                "Whether to feed the model's previous output as a prompt for "
+                "the next window. whisper's default is `True`; setting `False` "
+                "can reduce repetition loops on long or difficult audio."
+            )
+        ),
+    ] = True
 
 
 class InlineAsrMlxWhisperOptions(InlineAsrOptions):

--- a/docling/pipeline/asr_pipeline.py
+++ b/docling/pipeline/asr_pipeline.py
@@ -216,6 +216,8 @@ class _NativeWhisperModel:
             self.verbose = asr_options.verbose
             self.timestamps = asr_options.timestamps
             self.word_timestamps = asr_options.word_timestamps
+            self.beam_size = asr_options.beam_size
+            self.condition_on_previous_text = asr_options.condition_on_previous_text
 
     def run(self, conv_res: ConversionResult) -> ConversionResult:
         # Access the file path from the backend, similar to other pipelines
@@ -273,7 +275,11 @@ class _NativeWhisperModel:
 
     def transcribe(self, fpath: Path) -> list[_ConversationItem]:
         result = self.model.transcribe(
-            str(fpath), verbose=self.verbose, word_timestamps=self.word_timestamps
+            str(fpath),
+            verbose=self.verbose,
+            word_timestamps=self.word_timestamps,
+            beam_size=self.beam_size,
+            condition_on_previous_text=self.condition_on_previous_text,
         )
 
         convo: list[_ConversationItem] = []

--- a/tests/test_asr_pipeline.py
+++ b/tests/test_asr_pipeline.py
@@ -205,6 +205,36 @@ def test_native_and_mlx_transcribe_language_handling(monkeypatch, tmp_path):
         mm.mlx_whisper.transcribe.assert_called()
 
 
+def test_native_whisper_forwards_decode_params(tmp_path):
+    """beam_size and condition_on_previous_text reach whisper.transcribe."""
+    from docling.pipeline.asr_pipeline import _NativeWhisperModel
+
+    opts = InlineAsrNativeWhisperOptions(
+        repo_id="tiny",
+        inference_framework=InferenceAsrFramework.WHISPER,
+        verbose=False,
+        timestamps=False,
+        word_timestamps=False,
+        temperature=0.0,
+        max_new_tokens=1,
+        max_time_chunk=1.0,
+        language="en",
+        beam_size=5,
+        condition_on_previous_text=False,
+    )
+    with patch.dict("sys.modules", {"whisper": Mock()}):
+        model = _NativeWhisperModel(
+            True, None, AcceleratorOptions(device=AcceleratorDevice.CPU), opts
+        )
+        model.model = Mock()
+        model.model.transcribe.return_value = {"segments": []}
+        model.transcribe(tmp_path / "a.wav")
+
+    kwargs = model.model.transcribe.call_args.kwargs
+    assert kwargs["beam_size"] == 5
+    assert kwargs["condition_on_previous_text"] is False
+
+
 def test_native_init_with_artifacts_path_and_device_logging(tmp_path):
     """Cover _NativeWhisperModel init path with artifacts_path passed."""
     from docling.pipeline.asr_pipeline import _NativeWhisperModel


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #3703

## What

The native (openai-whisper) ASR backend forwarded only `verbose` and `word_timestamps` to `transcribe()` and exposed no decoding parameters on `InlineAsrNativeWhisperOptions`. With whisper's default greedy decoding (`beam_size=None`), long-form audio can spiral into runaway repetition and effectively hang, with no workaround available through the docling API. Root-cause isolation and benchmarks are in #3703.

This exposes two of whisper's decoding parameters on `InlineAsrNativeWhisperOptions` and forwards them in the native `transcribe()` call:

- `beam_size: Optional[int] = None`
- `condition_on_previous_text: bool = True`

Both default to whisper's own defaults, so **existing behaviour is unchanged**. Setting `beam_size=5` (beam search) or `condition_on_previous_text=False` reliably avoids the repetition hang on long-form audio.

## Modified files

- `docling/datamodel/pipeline_options_asr_model.py` — added `beam_size` and `condition_on_previous_text` to `InlineAsrNativeWhisperOptions`.
- `docling/pipeline/asr_pipeline.py` — read both in `_NativeWhisperModel` and forward them in `transcribe()`.
- `tests/test_asr_pipeline.py` — added `test_native_whisper_forwards_decode_params`.

## Notes

- **Conservative defaults on purpose.** I kept the defaults equal to whisper's rather than switching the default to beam search, to avoid changing existing output. Happy to default `beam_size` to a non-greedy value (e.g. `5`) if you'd prefer the hang fixed out-of-the-box.
- `temperature` and `language` were intentionally left out: forwarding `temperature=0.0` would change transcription output, and the option's `language="en"` default would regress non-English audio. Glad to add them in a follow-up if wanted.

**Checklist:**

- [x] Documentation has been updated, if necessary. (The new options are self-documenting via their `Field(description=...)`.)
- [x] Examples have been added, if necessary. (Not necessary — config-only change.)
- [x] Tests have been added, if necessary.
