### PR TITLE
docs: clarify example EPUB’s licence

### DIFF
--- a/docs/examples/epub_conversion.ipynb
+++ b/docs/examples/epub_conversion.ipynb
@@ -48,7 +48,7 @@
     "\n",
     "The book we'll use is \"Poetry\" by Sarah Louisa Forten Purvis, available at: https://standardebooks.org/ebooks/sarah-louisa-forten-purvis/poetry\n",
     "\n",
-    "Standard Ebooks dedicates their ebook files to the public domain via the CC0 1.0 Universal Public Domain Dedication."
+    "Standard Ebooks productions are in the US public domain."
    ]
   },
   {


### PR DESCRIPTION
SE productions are in the US public domain, but are not CC0. The parts of the production that are explicitly CC0 are the parts the producer has created for the work: typically the metadata.

You can check the licence for your example book at https://github.com/standardebooks/sarah-louisa-forten-purvis_poetry/blob/master/LICENSE.md.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
