### PR TITLE
chore: normalize line endings and reorder pre-commit hooks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,24 @@
+# Normalize line endings for all text files
+* text=auto
+
+# Python source files - always use LF
+*.py text eol=lf
+
+# Jupyter notebooks - always use LF
+*.ipynb text eol=lf
+
+# Configuration files - always use LF
+*.yaml text eol=lf
+*.yml text eol=lf
+*.toml text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.txt text eol=lf
+
+# Shell scripts - always use LF
+*.sh text eol=lf
+
+# Linguist overrides
 tests/data/** linguist-vendored
 tests/data_scanned/** linguist-vendored
 docs/** linguist-vendored

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,15 +17,13 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.15.12
     hooks:
-      # Run the Ruff formatter.
-      - id: ruff-format
-        name: "Ruff formatter"
-        args: [--config=pyproject.toml]
-        files: '^(docling|tests|docs/examples|perfs).*\.(py|ipynb)$'
-      # Run the Ruff linter.
       - id: ruff
         name: "Ruff linter"
         args: [--exit-non-zero-on-fix, --fix, --config=pyproject.toml]
+        files: '^(docling|tests|docs/examples|perfs).*\.(py|ipynb)$'
+      - id: ruff-format
+        name: "Ruff formatter"
+        args: [--config=pyproject.toml]
         files: '^(docling|tests|docs/examples|perfs).*\.(py|ipynb)$'
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary

This PR includes two maintenance improvements to the project's development workflow:

1. Prevent line ending issues in cross-platform contributions (like in [PR 3707](https://github.com/docling-project/docling/pull/3707/changes#diff-675fdbad76d05a5c38c222b5f698f6f91829949056b0a776dc3cc070b0143a98)) by adding comprehensive `.gitattributes` rules
2. Improve pre-commit hook ordering by running the Ruff linter before the formatter

## Changes

### Fix: Normalize line endings across platforms

Added explicit line ending rules to `.gitattributes` to prevent cross-platform line ending issues that can make PR reviews impossible.

**Problem:** A contributor PR was affected by line ending conversions (likely edited on Windows or with a tool that converted `\n` to `\r\n`). Git showed every line as changed, making code review through the Git UI impractical.

**Solution:** Configure Git to automatically normalize line endings:
- Set `* text=auto` as the default behavior
- Explicitly enforce LF (`eol=lf`) for all text-based source files:
  - Python files (`.py`)
  - Jupyter notebooks (`.ipynb`)
  - Configuration files (`.yaml`, `.yml`, `.toml`, `.json`)
  - Documentation (`.md`, `.txt`)
  - Shell scripts (`.sh`)

This ensures consistent line endings across all platforms (Windows, macOS, Linux) and prevents spurious diffs in future PRs.

### Chore: Reorder Ruff linter and formatter in pre-commit

Reversed the execution order of Ruff hooks in `.pre-commit-config.yaml` to run the linter before the formatter.

**Rationale:**
- **Linter first:** The linter can make structural changes (fixing imports, removing unused variables, etc.) that may affect code layout
- **Formatter second:** The formatter then ensures consistent styling of the linter's output
- **Efficiency:** This order prevents the formatter from running twice when the linter makes changes that affect formatting
- **Logical flow:** It follows the principle of "fix issues, then polish" rather than "polish, then potentially mess up the polish"

This aligns with the recommended practice in the Ruff documentation and matches the typical workflow of other linting tools (e.g., ESLint + Prettier).

## Testing

- Verified `.gitattributes` rules are properly recognized by Git
- Confirmed pre-commit hooks execute in the new order and produce expected results