### PR TITLE
feat(table): add try_table_on_picture fallback for tables misclassified as pictures

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -118,6 +118,18 @@ class BaseTableStructureOptions(BaseOptions):
         `TableStructureOptions`: Default TableFormer-based implementation.
     """
 
+    try_table_on_picture: Annotated[
+        bool,
+        Field(
+            description=(
+                "Also run table structure recognition on regions the layout model labeled as pictures, "
+                "keeping the result only when it resolves to a real table. Recovers tables that are "
+                "misclassified as images because their rows embed icons or diagrams. Disabled by default "
+                "because it runs the table model on every picture, which increases processing time."
+            )
+        ),
+    ] = False
+
 
 class TableStructureOptions(BaseTableStructureOptions):
     """Options for the table structure (TableFormer V1)."""

--- a/docling/models/base_table_model.py
+++ b/docling/models/base_table_model.py
@@ -4,10 +4,33 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from typing import Type
 
+from docling_core.types.doc import DocItemLabel
+
 from docling.datamodel.base_models import Page, TableStructurePrediction
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import BaseTableStructureOptions
 from docling.models.base_model import BaseModelWithOptions, BasePageModel
+
+
+def table_candidate_labels(try_table_on_picture: bool) -> list[DocItemLabel]:
+    """Labels a table backend runs structure recognition on.
+
+    Pictures are included only when ``try_table_on_picture`` is set, to recover
+    tables the layout model mislabels as images when their rows embed icons (#3410).
+    """
+    labels = [DocItemLabel.TABLE, DocItemLabel.DOCUMENT_INDEX]
+    if try_table_on_picture:
+        labels.append(DocItemLabel.PICTURE)
+    return labels
+
+
+def is_table_like(num_rows: int, num_cols: int) -> bool:
+    """Whether a prediction is solid enough to promote a picture to a table.
+
+    Requires a real grid (two or more rows and columns) so an image is not
+    relabeled a table just because the model forced some structure onto it.
+    """
+    return num_rows >= 2 and num_cols >= 2
 
 
 class BaseTableStructureModel(BasePageModel, BaseModelWithOptions, ABC):

--- a/docling/models/stages/table_structure/table_structure_model.py
+++ b/docling/models/stages/table_structure/table_structure_model.py
@@ -21,7 +21,11 @@ from docling.datamodel.pipeline_options import (
     TableStructureOptions,
 )
 from docling.datamodel.settings import settings
-from docling.models.base_table_model import BaseTableStructureModel
+from docling.models.base_table_model import (
+    BaseTableStructureModel,
+    is_table_like,
+    table_candidate_labels,
+)
 from docling.models.utils.hf_model_download import download_hf_model
 from docling.utils.accelerator_utils import decide_device
 from docling.utils.profiling import TimeRecorder
@@ -200,6 +204,9 @@ class TableStructureModel(BaseTableStructureModel):
                 table_prediction = TableStructurePrediction()
                 page.predictions.tablestructure = table_prediction
 
+                candidate_labels = table_candidate_labels(
+                    self.options.try_table_on_picture
+                )
                 in_tables = [
                     (
                         cluster,
@@ -211,8 +218,7 @@ class TableStructureModel(BaseTableStructureModel):
                         ],
                     )
                     for cluster in page.predictions.layout.clusters
-                    if cluster.label
-                    in [DocItemLabel.TABLE, DocItemLabel.DOCUMENT_INDEX]
+                    if cluster.label in candidate_labels
                 ]
                 if not in_tables:
                     predictions.append(table_prediction)
@@ -283,6 +289,12 @@ class TableStructureModel(BaseTableStructureModel):
                         .get("prediction", {})
                         .get("rs_seq", [])
                     )
+
+                    # Only promote a picture to a table when a real grid was found.
+                    if table_cluster.label == DocItemLabel.PICTURE:
+                        if not is_table_like(num_rows, num_cols):
+                            continue
+                        table_cluster.label = DocItemLabel.TABLE
 
                     tbl = Table(
                         otsl_seq=otsl_seq,

--- a/docling/models/stages/table_structure/table_structure_model_granite_vision.py
+++ b/docling/models/stages/table_structure/table_structure_model_granite_vision.py
@@ -14,7 +14,11 @@ from docling.datamodel.accelerator_options import AcceleratorDevice, Accelerator
 from docling.datamodel.base_models import Page, Table, TableStructurePrediction
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import GraniteVisionTableStructureOptions
-from docling.models.base_table_model import BaseTableStructureModel
+from docling.models.base_table_model import (
+    BaseTableStructureModel,
+    is_table_like,
+    table_candidate_labels,
+)
 from docling.models.utils.hf_model_download import download_hf_model
 from docling.utils.accelerator_utils import decide_device
 from docling.utils.profiling import TimeRecorder
@@ -248,10 +252,13 @@ class GraniteVisionTableStructureModel(BaseTableStructureModel):
                 table_prediction = TableStructurePrediction()
                 page.predictions.tablestructure = table_prediction
 
+                candidate_labels = table_candidate_labels(
+                    self.options.try_table_on_picture
+                )
                 clusters = [
                     c
                     for c in page.predictions.layout.clusters
-                    if c.label in (DocItemLabel.TABLE, DocItemLabel.DOCUMENT_INDEX)
+                    if c.label in candidate_labels
                 ]
 
                 if not clusters or not self.enabled:
@@ -327,6 +334,12 @@ class GraniteVisionTableStructureModel(BaseTableStructureModel):
                             f"Failed to parse OTSL output for table cluster {cluster.id}: {exc}"
                         )
                         otsl_seq, table_cells, num_rows, num_cols = [], [], 0, 0
+
+                    # Only promote a picture to a table when a real grid was found.
+                    if cluster.label == DocItemLabel.PICTURE:
+                        if not is_table_like(num_rows, num_cols):
+                            continue
+                        cluster.label = DocItemLabel.TABLE
 
                     tbl = Table(
                         otsl_seq=otsl_seq,

--- a/docling/models/stages/table_structure/table_structure_model_v2.py
+++ b/docling/models/stages/table_structure/table_structure_model_v2.py
@@ -19,7 +19,11 @@ from docling.datamodel.base_models import Cluster, Page, Table, TableStructurePr
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import TableStructureV2Options
 from docling.datamodel.settings import settings
-from docling.models.base_table_model import BaseTableStructureModel
+from docling.models.base_table_model import (
+    BaseTableStructureModel,
+    is_table_like,
+    table_candidate_labels,
+)
 from docling.models.utils.hf_model_download import download_hf_model
 from docling.utils.accelerator_utils import decide_device
 from docling.utils.profiling import TimeRecorder
@@ -378,6 +382,9 @@ class TableStructureModelV2(BaseTableStructureModel):
                 table_prediction = TableStructurePrediction()
                 page.predictions.tablestructure = table_prediction
 
+                candidate_labels = table_candidate_labels(
+                    self.options.try_table_on_picture
+                )
                 in_tables = [
                     (
                         cluster,
@@ -389,8 +396,7 @@ class TableStructureModelV2(BaseTableStructureModel):
                         ],
                     )
                     for cluster in page.predictions.layout.clusters
-                    if cluster.label
-                    in [DocItemLabel.TABLE, DocItemLabel.DOCUMENT_INDEX]
+                    if cluster.label in candidate_labels
                 ]
 
                 if not in_tables:
@@ -453,6 +459,12 @@ class TableStructureModelV2(BaseTableStructureModel):
                             element["bbox"]["token"] = text_piece
                         tc = TableCell.model_validate(element)
                         table_cells.append(tc)
+
+                    # Only promote a picture to a table when a real grid was found.
+                    if table_cluster.label == DocItemLabel.PICTURE:
+                        if not is_table_like(num_rows, num_cols):
+                            continue
+                        table_cluster.label = DocItemLabel.TABLE
 
                     tbl = Table(
                         otsl_seq=otsl_seq,

--- a/docs/usage/advanced_options.md
+++ b/docs/usage/advanced_options.md
@@ -131,6 +131,23 @@ doc_converter = DocumentConverter(
 )
 ```
 
+You can recover tables that the layout model labels as pictures, which happens when a table's rows embed icons or small diagrams. With `try_table_on_picture` enabled, the table structure model also runs on picture regions and keeps the result only when it resolves to a real table. It is disabled by default because it runs the table model on every picture, which increases processing time.
+
+```python
+from docling.datamodel.base_models import InputFormat
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.datamodel.pipeline_options import PdfPipelineOptions
+
+pipeline_options = PdfPipelineOptions(do_table_structure=True)
+pipeline_options.table_structure_options.try_table_on_picture = True  # recover tables misclassified as pictures
+
+doc_converter = DocumentConverter(
+    format_options={
+        InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
+    }
+)
+```
+
 
 ## Impose limits on the document size
 

--- a/tests/test_table_on_picture_option.py
+++ b/tests/test_table_on_picture_option.py
@@ -1,0 +1,47 @@
+"""Unit tests for the ``try_table_on_picture`` table-detection fallback (#3410).
+
+These cover the policy in isolation (which layout regions the table backends
+consider, and when a prediction is kept) so the behaviour is verified without
+downloading or running the table model.
+"""
+
+from docling_core.types.doc import DocItemLabel
+
+from docling.datamodel.pipeline_options import (
+    GraniteVisionTableStructureOptions,
+    TableStructureOptions,
+    TableStructureV2Options,
+)
+from docling.models.base_table_model import is_table_like, table_candidate_labels
+
+
+def test_try_table_on_picture_is_off_by_default_on_every_backend():
+    assert TableStructureOptions().try_table_on_picture is False
+    assert TableStructureV2Options().try_table_on_picture is False
+    assert GraniteVisionTableStructureOptions().try_table_on_picture is False
+
+
+def test_enabling_the_flag_is_preserved():
+    assert TableStructureOptions(try_table_on_picture=True).try_table_on_picture is True
+
+
+def test_candidate_labels_exclude_pictures_by_default():
+    labels = table_candidate_labels(try_table_on_picture=False)
+    assert DocItemLabel.TABLE in labels
+    assert DocItemLabel.DOCUMENT_INDEX in labels
+    assert DocItemLabel.PICTURE not in labels
+
+
+def test_candidate_labels_add_pictures_without_dropping_tables():
+    labels = table_candidate_labels(try_table_on_picture=True)
+    assert DocItemLabel.PICTURE in labels
+    assert DocItemLabel.TABLE in labels
+    assert DocItemLabel.DOCUMENT_INDEX in labels
+
+
+def test_is_table_like_requires_at_least_two_rows_and_columns():
+    assert is_table_like(2, 2) is True
+    assert is_table_like(6, 3) is True
+    assert is_table_like(1, 5) is False
+    assert is_table_like(5, 1) is False
+    assert is_table_like(0, 0) is False


### PR DESCRIPTION
The layout model sometimes labels a real table as a PICTURE, usually when each row embeds an icon or small diagram. The example in #3410 is an operator manual where every row is `number | description | diagram`. Once a region is labeled a picture, the table structure model never runs on it, so the whole table collapses to a single image placeholder and all of its text is lost. Related: #1653, #767.

This adds an opt-in `try_table_on_picture` option on the table structure options. When enabled, the table structure model also runs on picture-classified regions, and keeps the result only when it resolves to a real table (at least two rows and two columns). Otherwise the region stays a picture and the output is unchanged, so the option only ever adds tables that would otherwise be lost.

Notes:

- Off by default. No existing conversion changes, and the cost of running the table model on every picture stays opt-in.
- The flag lives on the table structure options rather than on `PdfPipelineOptions` (which the issue sketched), because the table model only receives `table_structure_options` and the sibling table settings (`do_cell_matching`, `mode`) already live there. Usage: `pipeline_options.table_structure_options.try_table_on_picture = True`.
- The candidate-label selection and the keep-or-discard check are shared helpers, so TableFormer v1, TableFormer v2, and Granite Vision behave the same.

Documented under "Control PDF table extraction options" in the advanced usage page. Added unit tests for the default, the candidate labels, and the threshold; they run without downloading a model.

**Issue resolved by this Pull Request:**
Resolves #3410

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
