### PR TITLE
feat(asr): expose and forward native Whisper decoding options

### DIFF
--- a/docling/datamodel/pipeline_options_asr_model.py
+++ b/docling/datamodel/pipeline_options_asr_model.py
@@ -171,6 +171,24 @@ class InlineAsrNativeWhisperOptions(InlineAsrOptions):
             )
         ),
     ] = True
+    beam_size: Annotated[
+        Optional[int],
+        Field(
+            description=(
+                "Number of beams to use for beam search decoding. When unset, "
+                "Whisper uses its default decoding behavior."
+            )
+        ),
+    ] = None
+    condition_on_previous_text: Annotated[
+        bool,
+        Field(
+            description=(
+                "Whether to provide the previous output of the model as a prompt "
+                "for the next window. When unset, Whisper uses its default."
+            )
+        ),
+    ] = None
 
 
 class InlineAsrMlxWhisperOptions(InlineAsrOptions):

--- a/docling/datamodel/pipeline_options_asr_model.py
+++ b/docling/datamodel/pipeline_options_asr_model.py
@@ -175,17 +175,19 @@ class InlineAsrNativeWhisperOptions(InlineAsrOptions):
         Optional[int],
         Field(
             description=(
-                "Number of beams to use for beam search decoding. When unset, "
-                "Whisper uses its default decoding behavior."
+                "Beam size for decoding. Defaults to `1` to enable beam search and "
+                "avoid Whisper's greedy decoding path on long-form audio. Set to `None` "
+                "to use Whisper's greedy decoding default."
             )
         ),
     ] = None
     condition_on_previous_text: Annotated[
-        bool,
+        Optional[bool],
         Field(
             description=(
-                "Whether to provide the previous output of the model as a prompt "
-                "for the next window. When unset, Whisper uses its default."
+                "Whether to feed the model's previous output as a prompt for the next "
+                "window. Defaults to `False` to reduce repetition loops on long or "
+                "difficult audio. Set to `True` to match Whisper's default behavior."
             )
         ),
     ] = None

--- a/docling/datamodel/pipeline_options_asr_model.py
+++ b/docling/datamodel/pipeline_options_asr_model.py
@@ -175,9 +175,9 @@ class InlineAsrNativeWhisperOptions(InlineAsrOptions):
         Optional[int],
         Field(
             description=(
-                "Beam size for decoding. Defaults to `1` to enable beam search and "
-                "avoid Whisper's greedy decoding path on long-form audio. Set to `None` "
-                "to use Whisper's greedy decoding default."
+                "Beam size for beam search decoding. When `None` (the default), "
+                "Whisper uses greedy decoding. Set to a positive integer (e.g. `5`) "
+                "to enable beam search, which can improve accuracy at the cost of speed."
             )
         ),
     ] = None
@@ -186,8 +186,9 @@ class InlineAsrNativeWhisperOptions(InlineAsrOptions):
         Field(
             description=(
                 "Whether to feed the model's previous output as a prompt for the next "
-                "window. Defaults to `False` to reduce repetition loops on long or "
-                "difficult audio. Set to `True` to match Whisper's default behavior."
+                "window. When `None` (the default), Whisper's default of `True` is used. "
+                "Set to `False` to reduce repetition loops on long or difficult audio, "
+                "at the risk of inconsistent text across windows."
             )
         ),
     ] = None

--- a/docling/pipeline/asr_pipeline.py
+++ b/docling/pipeline/asr_pipeline.py
@@ -191,9 +191,6 @@ class _NativeWhisperModel:
 
             self.asr_options = asr_options
             self.max_tokens = asr_options.max_new_tokens
-            self.temperature = asr_options.temperature
-            self.beam_size = asr_options.beam_size
-            self.condition_on_previous_text = asr_options.condition_on_previous_text
 
             self.device = decide_device(
                 accelerator_options.device,
@@ -218,6 +215,7 @@ class _NativeWhisperModel:
             self.verbose = asr_options.verbose
             self.timestamps = asr_options.timestamps
             self.word_timestamps = asr_options.word_timestamps
+            self.language = asr_options.language
             self.beam_size = asr_options.beam_size
             self.condition_on_previous_text = asr_options.condition_on_previous_text
             self.temperature = asr_options.temperature
@@ -280,9 +278,11 @@ class _NativeWhisperModel:
         result = self.model.transcribe(
             str(fpath),
             verbose=self.verbose,
+            language=self.language,
             word_timestamps=self.word_timestamps,
             beam_size=self.beam_size,
             condition_on_previous_text=self.condition_on_previous_text,
+            temperature=self.temperature,
         )
 
         convo: list[_ConversationItem] = []

--- a/docling/pipeline/asr_pipeline.py
+++ b/docling/pipeline/asr_pipeline.py
@@ -192,6 +192,8 @@ class _NativeWhisperModel:
             self.asr_options = asr_options
             self.max_tokens = asr_options.max_new_tokens
             self.temperature = asr_options.temperature
+            self.beam_size = asr_options.beam_size
+            self.condition_on_previous_text = asr_options.condition_on_previous_text
 
             self.device = decide_device(
                 accelerator_options.device,
@@ -216,6 +218,9 @@ class _NativeWhisperModel:
             self.verbose = asr_options.verbose
             self.timestamps = asr_options.timestamps
             self.word_timestamps = asr_options.word_timestamps
+            self.beam_size = asr_options.beam_size
+            self.condition_on_previous_text = asr_options.condition_on_previous_text
+            self.temperature = asr_options.temperature
 
     def run(self, conv_res: ConversionResult) -> ConversionResult:
         # Access the file path from the backend, similar to other pipelines
@@ -273,7 +278,11 @@ class _NativeWhisperModel:
 
     def transcribe(self, fpath: Path) -> list[_ConversationItem]:
         result = self.model.transcribe(
-            str(fpath), verbose=self.verbose, word_timestamps=self.word_timestamps
+            str(fpath),
+            verbose=self.verbose,
+            word_timestamps=self.word_timestamps,
+            beam_size=self.beam_size,
+            condition_on_previous_text=self.condition_on_previous_text,
         )
 
         convo: list[_ConversationItem] = []

--- a/tests/test_asr_pipeline.py
+++ b/tests/test_asr_pipeline.py
@@ -205,6 +205,37 @@ def test_native_and_mlx_transcribe_language_handling(monkeypatch, tmp_path):
         mm.mlx_whisper.transcribe.assert_called()
 
 
+def test_native_whisper_passes_decode_options_to_transcribe(tmp_path):
+    """Native Whisper forwards decoding options to whisper.transcribe."""
+    from docling.pipeline.asr_pipeline import _NativeWhisperModel
+
+    opts = InlineAsrNativeWhisperOptions(
+        repo_id="tiny",
+        word_timestamps=False,
+        beam_size=3,
+        condition_on_previous_text=False,
+    )
+
+    with patch.dict("sys.modules", {"whisper": Mock()}):
+        model = _NativeWhisperModel(
+            enabled=True,
+            artifacts_path=None,
+            accelerator_options=AcceleratorOptions(device=AcceleratorDevice.CPU),
+            asr_options=opts,
+        )
+
+    model.model = Mock()
+    model.model.transcribe.return_value = {"segments": []}
+
+    model.transcribe(tmp_path / "sample.wav")
+
+    model.model.transcribe.assert_called_once()
+    call_kwargs = model.model.transcribe.call_args.kwargs
+
+    assert call_kwargs["beam_size"] == 3
+    assert call_kwargs["condition_on_previous_text"] is False
+
+
 def test_native_init_with_artifacts_path_and_device_logging(tmp_path):
     """Cover _NativeWhisperModel init path with artifacts_path passed."""
     from docling.pipeline.asr_pipeline import _NativeWhisperModel


### PR DESCRIPTION
## Summary

This PR exposes additional decoding options for the native Whisper ASR backend and forwards them to `whisper.transcribe()`.

## Changes

* Added `beam_size` to `InlineAsrNativeWhisperOptions`.
* Added `condition_on_previous_text` to `InlineAsrNativeWhisperOptions`.
* Forwarded `beam_size`, `condition_on_previous_text`, `language`, and `temperature` to the native Whisper `transcribe()` call in `_NativeWhisperModel`.
* This allows users to configure Whisper's decoding behavior through Docling instead of relying solely on Whisper's internal defaults.

Closes #3703.

