### PR TITLE
feat: add Mistral OCR 4 engine

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -10,6 +10,7 @@ from pydantic import (
     BaseModel,
     ConfigDict,
     Field,
+    SecretStr,
     field_validator,
 )
 from typing_extensions import deprecated
@@ -171,8 +172,8 @@ class OcrOptions(BaseOptions):
     See Also:
         `OcrAutoOptions`: Automatic engine selection based on availability.
         `EasyOcrOptions`, `TesseractCliOcrOptions`, `TesseractOcrOptions`,
-        `RapidOcrOptions`, `OcrMacOptions`, `NemotronOcrOptions`: Engine-specific
-        configurations.
+        `RapidOcrOptions`, `OcrMacOptions`, `NemotronOcrOptions`,
+        `MistralOcrOptions`: Engine-specific configurations.
     """
 
     lang: Annotated[
@@ -373,6 +374,99 @@ class NemotronOcrOptions(OcrOptions):
             )
         ),
     ] = 8
+
+
+class MistralOcrOptions(OcrOptions):
+    """Configuration for Mistral OCR API.
+
+    Notes:
+        This engine calls the Mistral OCR endpoint. Provide `api_key` directly,
+        or set the environment variable named by `api_key_env_var`.
+    """
+
+    kind: ClassVar[Literal["mistral_ocr"]] = "mistral_ocr"
+    lang: Annotated[
+        list[str],
+        Field(
+            description=(
+                "Requested OCR languages. Mistral OCR handles language detection "
+                "server-side; the values are kept for API consistency."
+            )
+        ),
+    ] = []
+    model: Annotated[
+        str,
+        Field(description="Mistral OCR model identifier."),
+    ] = "mistral-ocr-4-0"
+    api_key: Annotated[
+        Optional[SecretStr],
+        Field(
+            default=None,
+            description=(
+                "Mistral API key. If omitted, the engine reads the environment "
+                "variable configured by api_key_env_var."
+            ),
+            exclude=True,
+            repr=False,
+        ),
+    ] = None
+    api_key_env_var: Annotated[
+        str,
+        Field(description="Environment variable used to read the Mistral API key."),
+    ] = "MISTRAL_API_KEY"
+    url: Annotated[
+        str,
+        Field(description="Mistral OCR endpoint URL."),
+    ] = "https://api.mistral.ai/v1/ocr"
+    scale: Annotated[
+        float,
+        Field(
+            description=(
+                "Image scale multiplier for OCR processing. Higher values increase "
+                "resolution before sending page crops to Mistral OCR."
+            ),
+            gt=0.0,
+        ),
+    ] = 2.0
+    timeout: Annotated[
+        float,
+        Field(description="HTTP request timeout in seconds.", gt=0.0),
+    ] = 120.0
+    table_format: Annotated[
+        Literal["html", "markdown"],
+        Field(description="Table format requested from Mistral OCR."),
+    ] = "html"
+    confidence_scores_granularity: Annotated[
+        Literal["page", "word"],
+        Field(description="Confidence score granularity requested from Mistral OCR."),
+    ] = "word"
+    include_image_base64: Annotated[
+        bool,
+        Field(
+            description=(
+                "Request extracted image payloads separately from markdown text. "
+                "This keeps image blocks out of OCR text cells while preserving "
+                "Mistral's image extraction in the API response."
+            )
+        ),
+    ] = True
+    image_limit: Annotated[
+        int | None,
+        Field(
+            default=None,
+            description="Maximum number of images Mistral OCR should extract per page.",
+            ge=0,
+        ),
+    ] = None
+    image_min_size: Annotated[
+        int | None,
+        Field(
+            default=None,
+            description="Minimum image size in pixels for Mistral OCR extraction.",
+            ge=0,
+        ),
+    ] = None
+    model_config = ConfigDict(extra="forbid")
 
 
 class EasyOcrOptions(OcrOptions):

--- a/docling/models/plugins/defaults.py
+++ b/docling/models/plugins/defaults.py
@@ -2,6 +2,7 @@ def ocr_engines():
     from docling.models.stages.ocr.auto_ocr_model import OcrAutoModel
     from docling.models.stages.ocr.easyocr_model import EasyOcrModel
     from docling.models.stages.ocr.kserve_v2_ocr_model import KserveV2OcrModel
+    from docling.models.stages.ocr.mistral_ocr_model import MistralOcrModel
     from docling.models.stages.ocr.nemotron_ocr_model import NemotronOcrModel
     from docling.models.stages.ocr.ocr_mac_model import OcrMacModel
     from docling.models.stages.ocr.rapid_ocr_model import RapidOcrModel
@@ -13,6 +14,7 @@ def ocr_engines():
             OcrAutoModel,
             EasyOcrModel,
             KserveV2OcrModel,
+            MistralOcrModel,
             NemotronOcrModel,
             OcrMacModel,
             RapidOcrModel,

--- a/docling/models/stages/ocr/mistral_ocr_model.py
+++ b/docling/models/stages/ocr/mistral_ocr_model.py
@@ -1,0 +1,305 @@
+"""Mistral OCR API model implementation."""
+
+import base64
+import logging
+import os
+from collections.abc import Iterable
+from io import BytesIO
+from pathlib import Path
+from typing import Any, Type
+
+import requests
+from docling_core.types.doc import BoundingBox, CoordOrigin
+from docling_core.types.doc.page import BoundingRectangle, TextCell
+from PIL import Image
+from pydantic import BaseModel, ConfigDict
+from requests import Response
+
+from docling.datamodel.accelerator_options import AcceleratorOptions
+from docling.datamodel.base_models import (
+    DoclingComponentType,
+    ErrorItem,
+    FailureCategory,
+    Page,
+)
+from docling.datamodel.document import ConversionResult
+from docling.datamodel.pipeline_options import MistralOcrOptions, OcrOptions
+from docling.datamodel.settings import settings
+from docling.models.base_ocr_model import BaseOcrModel
+from docling.utils.profiling import TimeRecorder
+
+_log = logging.getLogger(__name__)
+
+
+class _MistralBlock(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    top_left_x: float
+    top_left_y: float
+    bottom_right_x: float
+    bottom_right_y: float
+    content: str | None = None
+    type: str | None = None
+
+
+class _MistralWordConfidence(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    text: str
+    confidence: float
+    start_index: int
+
+
+class _MistralConfidenceScores(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    word_confidence_scores: list[_MistralWordConfidence] = []
+    average_page_confidence_score: float | None = None
+
+
+class _MistralPage(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    markdown: str = ""
+    blocks: list[_MistralBlock] = []
+    confidence_scores: _MistralConfidenceScores | None = None
+
+
+class _MistralOcrResponse(BaseModel):
+    model_config = ConfigDict(extra="ignore")
+
+    pages: list[_MistralPage] = []
+
+
+class MistralOcrModel(BaseOcrModel):
+    """OCR model using the Mistral OCR API."""
+
+    def __init__(
+        self,
+        enabled: bool,
+        artifacts_path: Path | None,
+        options: MistralOcrOptions,
+        accelerator_options: AcceleratorOptions,
+    ):
+        super().__init__(
+            enabled=enabled,
+            artifacts_path=artifacts_path,
+            options=options,
+            accelerator_options=accelerator_options,
+        )
+        self.options: MistralOcrOptions
+        self.scale = options.scale
+        self._session = requests.Session()
+        self._api_key: str | None = None
+
+        if self.enabled:
+            self._api_key = self._resolve_api_key()
+
+    def _resolve_api_key(self) -> str:
+        if self.options.api_key is not None:
+            return self.options.api_key.get_secret_value()
+
+        api_key = os.getenv(self.options.api_key_env_var)
+        if api_key:
+            return api_key
+
+        raise RuntimeError(
+            "Mistral OCR requires an API key. Set "
+            f"`{self.options.api_key_env_var}` or pass `MistralOcrOptions(api_key=...)`."
+        )
+
+    @staticmethod
+    def _image_data_uri(image: Image.Image) -> str:
+        buffer = BytesIO()
+        image.convert("RGB").save(buffer, format="PNG")
+        image_b64 = base64.b64encode(buffer.getvalue()).decode("ascii")
+        return f"data:image/png;base64,{image_b64}"
+
+    def _request_payload(self, image: Image.Image) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "model": self.options.model,
+            "document": {
+                "type": "image_url",
+                "image_url": self._image_data_uri(image),
+            },
+            "include_blocks": True,
+            "include_image_base64": self.options.include_image_base64,
+            "confidence_scores_granularity": (
+                self.options.confidence_scores_granularity
+            ),
+            "table_format": self.options.table_format,
+        }
+
+        if self.options.image_limit is not None:
+            payload["image_limit"] = self.options.image_limit
+        if self.options.image_min_size is not None:
+            payload["image_min_size"] = self.options.image_min_size
+
+        return payload
+
+    def _request_ocr(self, image: Image.Image) -> _MistralOcrResponse:
+        assert self._api_key is not None
+        response = self._session.post(
+            self.options.url,
+            headers={
+                "Authorization": f"Bearer {self._api_key}",
+                "Content-Type": "application/json",
+            },
+            json=self._request_payload(image),
+            timeout=self.options.timeout,
+        )
+        self._raise_for_response(response)
+        return _MistralOcrResponse.model_validate(response.json())
+
+    @staticmethod
+    def _raise_for_response(response: Response) -> None:
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            detail = response.text[:500]
+            raise requests.HTTPError(
+                f"Mistral OCR request failed with status "
+                f"{response.status_code}: {detail}"
+            ) from exc
+
+    @staticmethod
+    def _block_confidence(block: _MistralBlock, page: _MistralPage) -> float:
+        scores = page.confidence_scores
+        if scores is None:
+            return 1.0
+
+        content = (block.content or "").strip()
+        if content and scores.word_confidence_scores:
+            start = page.markdown.find(content)
+            if start >= 0:
+                end = start + len(content)
+                block_scores = [
+                    word.confidence
+                    for word in scores.word_confidence_scores
+                    if start <= word.start_index < end
+                ]
+                if block_scores:
+                    return sum(block_scores) / len(block_scores)
+
+        if scores.average_page_confidence_score is not None:
+            return scores.average_page_confidence_score
+        return 1.0
+
+    @staticmethod
+    def _block_to_cell(
+        block: _MistralBlock,
+        *,
+        index: int,
+        ocr_rect: BoundingBox,
+        scale: float,
+        confidence: float,
+    ) -> TextCell | None:
+        content = (block.content or "").strip()
+        if not content:
+            return None
+        if block.type is not None and block.type.lower() == "image":
+            return None
+
+        bbox = BoundingBox.from_tuple(
+            coord=(
+                block.top_left_x / scale + ocr_rect.l,
+                block.top_left_y / scale + ocr_rect.t,
+                block.bottom_right_x / scale + ocr_rect.l,
+                block.bottom_right_y / scale + ocr_rect.t,
+            ),
+            origin=CoordOrigin.TOPLEFT,
+        )
+
+        return TextCell(
+            index=index,
+            text=content,
+            orig=content,
+            confidence=confidence,
+            from_ocr=True,
+            rect=BoundingRectangle.from_bounding_box(bbox),
+        )
+
+    def _response_to_cells(
+        self,
+        response: _MistralOcrResponse,
+        *,
+        ocr_rect: BoundingBox,
+        start_index: int,
+    ) -> list[TextCell]:
+        cells: list[TextCell] = []
+        next_index = start_index
+        for page in response.pages:
+            for block in page.blocks:
+                cell = self._block_to_cell(
+                    block,
+                    index=next_index,
+                    ocr_rect=ocr_rect,
+                    scale=self.scale,
+                    confidence=self._block_confidence(block, page),
+                )
+                if cell is None:
+                    continue
+                cells.append(cell)
+                next_index += 1
+        return cells
+
+    def __call__(
+        self, conv_res: ConversionResult, page_batch: Iterable[Page]
+    ) -> Iterable[Page]:
+        if not self.enabled:
+            yield from page_batch
+            return
+
+        for page in page_batch:
+            assert page._backend is not None
+            if not page._backend.is_valid():
+                yield page
+                continue
+
+            with TimeRecorder(conv_res, "ocr"):
+                ocr_rects = self.get_ocr_rects(page)
+                all_ocr_cells: list[TextCell] = []
+                for rect_idx, ocr_rect in enumerate(ocr_rects):
+                    if ocr_rect.area() == 0:
+                        continue
+
+                    high_res_image = page._backend.get_page_image(
+                        scale=self.scale, cropbox=ocr_rect
+                    )
+                    try:
+                        response = self._request_ocr(high_res_image)
+                        cells = self._response_to_cells(
+                            response,
+                            ocr_rect=ocr_rect,
+                            start_index=len(all_ocr_cells),
+                        )
+                        all_ocr_cells.extend(cells)
+                    except Exception as exc:
+                        _log.error(
+                            "Mistral OCR inference failed for page %d rect %d: %s",
+                            page.page_no,
+                            rect_idx,
+                            str(exc),
+                        )
+                        conv_res.errors.append(
+                            ErrorItem(
+                                component_type=DoclingComponentType.MODEL,
+                                module_name=type(self).__name__,
+                                error_message=str(exc) or exc.__class__.__name__,
+                                category=FailureCategory.INFERENCE_FAILURE,
+                                page_no=page.page_no,
+                            )
+                        )
+                    finally:
+                        del high_res_image
+
+                self.post_process_cells(all_ocr_cells, page)
+
+            if settings.debug.visualize_ocr:
+                self.draw_ocr_rects_and_cells(conv_res, page, ocr_rects)
+
+            yield page
+
+    @classmethod
+    def get_options_type(cls) -> Type[OcrOptions]:
+        return MistralOcrOptions

--- a/docs/getting_started/installation.md
+++ b/docs/getting_started/installation.md
@@ -96,6 +96,7 @@ the following engines.
 | ------ | ------------ | ----- |
 | [EasyOCR](https://github.com/JaidedAI/EasyOCR) | `easyocr` extra or via `pip install easyocr`. | `EasyOcrOptions` |
 | [Nemotron OCR](https://huggingface.co/nvidia/nemotron-ocr-v1) | `feat-ocr-nemotron` extra. Supported only on Linux x86_64 with Python 3.12 and CUDA 13.x. See installation note below. | `NemotronOcrOptions` |
+| [Mistral OCR](https://docs.mistral.ai/capabilities/document/) | Built in. Requires a Mistral API key via `MISTRAL_API_KEY` or `MistralOcrOptions(api_key=...)`. | `MistralOcrOptions` |
 | Tesseract | System dependency. See description for Tesseract and Tesserocr below.  | `TesseractOcrOptions` |
 | Tesseract CLI | System dependency. See description below. | `TesseractCliOcrOptions` |
 | OcrMac | System dependency. See description below. | `OcrMacOptions` |

--- a/tach.toml
+++ b/tach.toml
@@ -304,6 +304,11 @@ depends_on = [
 ]
 
 [[modules]]
+path = "docling.models.stages.ocr.mistral_ocr_model"
+layer = "core"
+depends_on = ["docling.datamodel", "docling.models", "docling.utils"]
+
+[[modules]]
 path = "docling.models.stages.page_assemble"
 layer = "models"
 depends_on = [

--- a/tests/test_mistral_ocr_model.py
+++ b/tests/test_mistral_ocr_model.py
@@ -1,0 +1,180 @@
+import os
+
+import pytest
+from docling_core.types.doc import BoundingBox, CoordOrigin
+from PIL import Image, ImageDraw
+
+from docling.datamodel.accelerator_options import AcceleratorOptions
+from docling.datamodel.pipeline_options import MistralOcrOptions
+from docling.models.factories import get_ocr_factory
+from docling.models.stages.ocr.mistral_ocr_model import (
+    MistralOcrModel,
+    _MistralOcrResponse,
+)
+
+pytestmark = pytest.mark.ml_ocr
+
+
+def _make_model(*, enabled: bool = True) -> MistralOcrModel:
+    return MistralOcrModel(
+        enabled=enabled,
+        artifacts_path=None,
+        options=MistralOcrOptions(api_key="test-key", scale=2.0),
+        accelerator_options=AcceleratorOptions(),
+    )
+
+
+def test_mistral_ocr_backend_registration() -> None:
+    factory = get_ocr_factory(allow_external_plugins=False)
+
+    model = factory.create_instance(
+        options=MistralOcrOptions(),
+        enabled=False,
+        artifacts_path=None,
+        accelerator_options=AcceleratorOptions(),
+    )
+
+    assert isinstance(model, MistralOcrModel)
+
+
+def test_mistral_ocr_requires_api_key_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+
+    with pytest.raises(RuntimeError, match="requires an API key"):
+        MistralOcrModel(
+            enabled=True,
+            artifacts_path=None,
+            options=MistralOcrOptions(),
+            accelerator_options=AcceleratorOptions(),
+        )
+
+
+def test_mistral_ocr_reads_api_key_from_configured_env_var(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("DOCLING_TEST_MISTRAL_KEY", "env-key")
+
+    model = MistralOcrModel(
+        enabled=True,
+        artifacts_path=None,
+        options=MistralOcrOptions(api_key_env_var="DOCLING_TEST_MISTRAL_KEY"),
+        accelerator_options=AcceleratorOptions(),
+    )
+
+    assert model._api_key == "env-key"
+
+
+def test_mistral_ocr_payload_requests_blocks_and_separate_images() -> None:
+    model = _make_model()
+    image = Image.new("RGB", (8, 6), "white")
+
+    payload = model._request_payload(image)
+
+    assert payload["model"] == "mistral-ocr-4-0"
+    assert payload["include_blocks"] is True
+    assert payload["include_image_base64"] is True
+    assert payload["confidence_scores_granularity"] == "word"
+    assert payload["table_format"] == "html"
+    assert payload["document"]["type"] == "image_url"
+    assert payload["document"]["image_url"].startswith("data:image/png;base64,")
+
+
+def test_mistral_ocr_blocks_map_to_cells_and_skip_image_blocks() -> None:
+    model = _make_model()
+    response = _MistralOcrResponse.model_validate(
+        {
+            "pages": [
+                {
+                    "markdown": "Invoice 123\n\n![img-0.jpeg](img-0.jpeg)\n\nTotal $42",
+                    "confidence_scores": {
+                        "average_page_confidence_score": 0.7,
+                        "word_confidence_scores": [
+                            {"text": "Invoice", "confidence": 0.9, "start_index": 0},
+                            {"text": " 123", "confidence": 0.8, "start_index": 7},
+                            {"text": "Total", "confidence": 0.6, "start_index": 37},
+                            {"text": " $42", "confidence": 0.5, "start_index": 42},
+                        ],
+                    },
+                    "blocks": [
+                        {
+                            "type": "text",
+                            "content": "Invoice 123",
+                            "top_left_x": 20,
+                            "top_left_y": 30,
+                            "bottom_right_x": 220,
+                            "bottom_right_y": 70,
+                        },
+                        {
+                            "type": "image",
+                            "content": "![img-0.jpeg](img-0.jpeg)",
+                            "top_left_x": 30,
+                            "top_left_y": 90,
+                            "bottom_right_x": 180,
+                            "bottom_right_y": 190,
+                        },
+                        {
+                            "type": "text",
+                            "content": "Total $42",
+                            "top_left_x": 40,
+                            "top_left_y": 220,
+                            "bottom_right_x": 190,
+                            "bottom_right_y": 260,
+                        },
+                    ],
+                }
+            ]
+        }
+    )
+    ocr_rect = BoundingBox(
+        l=10,
+        t=100,
+        r=410,
+        b=500,
+        coord_origin=CoordOrigin.TOPLEFT,
+    )
+
+    cells = model._response_to_cells(response, ocr_rect=ocr_rect, start_index=3)
+
+    assert [cell.text for cell in cells] == ["Invoice 123", "Total $42"]
+    assert [cell.index for cell in cells] == [3, 4]
+    assert cells[0].confidence == pytest.approx(0.85)
+    assert cells[0].rect.to_bounding_box().as_tuple() == pytest.approx(
+        (20.0, 115.0, 120.0, 135.0)
+    )
+    assert cells[1].rect.to_bounding_box().as_tuple() == pytest.approx(
+        (30.0, 210.0, 105.0, 230.0)
+    )
+
+
+@pytest.mark.skipif(
+    not os.getenv("MISTRAL_API_KEY"),
+    reason="Set MISTRAL_API_KEY to run the Mistral OCR integration test.",
+)
+def test_mistral_ocr_live_smoke() -> None:
+    image = Image.new("RGB", (900, 500), "white")
+    draw = ImageDraw.Draw(image)
+    draw.text((80, 90), "Invoice 12345", fill="black")
+    draw.text((80, 170), "Widget $42.00", fill="black")
+
+    model = MistralOcrModel(
+        enabled=True,
+        artifacts_path=None,
+        options=MistralOcrOptions(),
+        accelerator_options=AcceleratorOptions(),
+    )
+    response = model._request_ocr(image)
+    cells = model._response_to_cells(
+        response,
+        ocr_rect=BoundingBox(
+            l=0,
+            t=0,
+            r=image.width,
+            b=image.height,
+            coord_origin=CoordOrigin.TOPLEFT,
+        ),
+        start_index=0,
+    )
+
+    assert any("Invoice 12345" in cell.text for cell in cells)


### PR DESCRIPTION
## Summary

- add `MistralOcrOptions` and a registered `mistral_ocr` OCR engine backed by the Mistral `/v1/ocr` API
- request OCR 4 blocks, word confidence scores, and separate image payloads via `include_image_base64`
- map text blocks with bbox/confidence into Docling `TextCell`s while skipping image blocks as text
- document the new OCR option and add offline tests plus an opt-in live smoke

Closes #2808.
Addresses #1299 for the Mistral OCR path by requesting images separately and keeping image blocks out of OCR text cells.

## Testing

- `uv run pytest tests/test_mistral_ocr_model.py -q`
- `set -a; source /Users/geoheil/.stax/worktrees/jubust/2026-06-26-nemotron/services/data-pipeline-patents/.env; set +a; uv run pytest tests/test_mistral_ocr_model.py::test_mistral_ocr_live_smoke -q`
- `uv run prek run --files docling/datamodel/pipeline_options.py docling/models/plugins/defaults.py docling/models/stages/ocr/mistral_ocr_model.py docs/getting_started/installation.md tests/test_mistral_ocr_model.py`

Note: CI is not expected to have `MISTRAL_API_KEY`; the live smoke is marked `external_service` and skips without that environment variable.
