### PR TITLE
feat: add HTML pre-heading content layer option

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -569,11 +569,12 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         if len(clean_headers):
             header = clean_headers[0]
         # Set starting content layer
-        self.content_layer = (
-            ContentLayer.BODY
-            if (not self.options.infer_furniture) or (header is None)
-            else ContentLayer.FURNITURE
-        )
+        if (not self.options.infer_furniture) or (header is None):
+            self.content_layer = ContentLayer.BODY
+        elif self.options.pre_heading_content_layer is not None:
+            self.content_layer = self.options.pre_heading_content_layer
+        else:
+            self.content_layer = ContentLayer.FURNITURE
         # reset context
         self.ctx = _Context()
         self._render_visibility_cache.clear()

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -1,6 +1,7 @@
 from pathlib import Path, PurePath
 from typing import Annotated, Literal, Optional, Union
 
+from docling_core.types.doc.document import ContentLayer
 from pydantic import AnyUrl, BaseModel, Field, PositiveInt, SecretStr, conint
 
 
@@ -101,6 +102,13 @@ class HTMLBackendOptions(BaseBackendOptions):
     )
     infer_furniture: bool = Field(
         True, description="Infer all the content before the first header as furniture."
+    )
+    pre_heading_content_layer: Optional[ContentLayer] = Field(
+        None,
+        description=(
+            "Content layer assigned to content before the first heading. "
+            "When unset, the backend keeps the inferred furniture behavior."
+        ),
     )
     max_image_data_base64_bytes: PositiveInt = Field(
         20 * 1024 * 1024,  # 20 MB

--- a/tests/test_backend_html_content_layer.py
+++ b/tests/test_backend_html_content_layer.py
@@ -1,0 +1,61 @@
+from io import BytesIO
+
+from docling_core.types.doc.document import ContentLayer
+
+from docling.backend.html_backend import HTMLDocumentBackend
+from docling.datamodel.backend_options import HTMLBackendOptions
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.document import DoclingDocument, InputDocument
+
+
+def _convert_html(
+    raw_html: bytes, options: HTMLBackendOptions | None = None
+) -> DoclingDocument:
+    in_doc = InputDocument(
+        path_or_stream=BytesIO(raw_html),
+        format=InputFormat.HTML,
+        backend=HTMLDocumentBackend,
+        filename="test.html",
+    )
+    backend = HTMLDocumentBackend(
+        in_doc=in_doc,
+        path_or_stream=BytesIO(raw_html),
+        options=options,
+    )
+    return backend.convert()
+
+
+def test_html_pre_heading_content_layer_defaults_to_furniture():
+    raw_html = (
+        b"<html><body><p>Intro before heading</p>"
+        b"<h1>Main Heading</h1>"
+        b"<p>Body content</p></body></html>"
+    )
+
+    doc = _convert_html(raw_html)
+
+    assert doc.export_to_markdown() == "# Main Heading\n\nBody content"
+    assert (
+        doc.export_to_markdown(
+            included_content_layers={ContentLayer.BODY, ContentLayer.FURNITURE}
+        )
+        == "Intro before heading\n\n# Main Heading\n\nBody content"
+    )
+
+
+def test_html_pre_heading_content_layer_can_be_body():
+    raw_html = (
+        b"<html><body><p>Intro before heading</p>"
+        b"<h1>Main Heading</h1>"
+        b"<p>Body content</p>"
+        b"<footer><p>Footer content</p></footer></body></html>"
+    )
+
+    doc = _convert_html(
+        raw_html,
+        options=HTMLBackendOptions(pre_heading_content_layer=ContentLayer.BODY),
+    )
+
+    assert doc.export_to_markdown() == (
+        "Intro before heading\n\n# Main Heading\n\nBody content"
+    )


### PR DESCRIPTION
﻿## Summary

- Add `HTMLBackendOptions.pre_heading_content_layer` so callers can choose the content layer assigned to HTML content before the first heading.
- Keep the existing inferred furniture behavior as the default when the option is unset.
- Add lightweight HTML backend tests covering the default behavior and explicit `ContentLayer.BODY` override.

## Why

For HTML fragments used in RAG pipelines, content before the first heading may be semantically part of the body. The new option lets callers preserve that content as body text without disabling the existing default furniture inference for everyone.

Fixes #2487.

## Checks

- `python -m pytest tests/test_backend_html_content_layer.py -q`
- `python -m ruff check docling/datamodel/backend_options.py docling/backend/html_backend.py tests/test_backend_html_content_layer.py`
- `python -m ruff format --check docling/datamodel/backend_options.py docling/backend/html_backend.py tests/test_backend_html_content_layer.py`
