### PR TITLE
feat(boxnote): add a BoxNote document backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Docling simplifies document processing by parsing diverse formats — including 
 
 ## Features
 
-- 🗂️ Parsing of [multiple document formats][supported_formats] including PDF, DOCX, PPTX, XLSX, HTML, EPUB, WAV, MP3, WebVTT, email formats (EML, MSG), images (PNG, TIFF, JPEG, ...), LaTeX, DocLang, plain text, and more
+- 🗂️ Parsing of [multiple document formats][supported_formats] including PDF, DOCX, PPTX, XLSX, HTML, EPUB, WAV, MP3, WebVTT, Box Notes, email formats (EML, MSG), images (PNG, TIFF, JPEG, ...), LaTeX, DocLang, plain text, and more
 - 📑 Advanced PDF understanding incl. page layout, reading order, table structure, code, formulas, image classification, and more
 - 🧬 A unified, expressive [DoclingDocument][docling_document] representation format
 - ↪️ Various [export formats][supported_formats] and options, including Markdown, HTML, WebVTT, DocLang, [DocTags](https://arxiv.org/abs/2503.11576) and lossless JSON

--- a/docling/backend/boxnote_backend.py
+++ b/docling/backend/boxnote_backend.py
@@ -95,10 +95,7 @@ class BoxNoteDocumentBackend(DeclarativeDocumentBackend):
 
         origin = DocumentOrigin(
             filename=self.file.name or "file.boxnote",
-            # DocumentOrigin only accepts MIME types registered in docling-core.
-            # Until application/vnd.box.boxnote is added there, use the JSON type
-            # it already accepts (a Box Note is JSON).
-            mimetype="application/json",
+            mimetype="application/vnd.box.boxnote",
             binary_hash=self.document_hash,
         )
         doc = DoclingDocument(name=self.file.stem or "file", origin=origin)

--- a/docling/backend/boxnote_backend.py
+++ b/docling/backend/boxnote_backend.py
@@ -1,0 +1,426 @@
+import json
+import logging
+from io import BytesIO
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+from docling_core.types.doc import (
+    DocItemLabel,
+    DoclingDocument,
+    DocumentOrigin,
+    Formatting,
+    GroupLabel,
+    NodeItem,
+    RichTableCell,
+    TableCell,
+    TableData,
+)
+from pydantic import AnyUrl, TypeAdapter, ValidationError
+from typing_extensions import override
+
+from docling.backend.abstract_backend import DeclarativeDocumentBackend
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.document import InputDocument
+from docling.exceptions import DocumentLoadError
+
+_log = logging.getLogger(__name__)
+
+_HYPERLINK = TypeAdapter(AnyUrl)
+
+# Box Note link marks carry web URLs, so only these schemes become hyperlinks. A
+# stray "javascript:" or a bare string is dropped rather than mis-read as a link.
+_SAFE_LINK_SCHEMES = frozenset({"http", "https", "mailto"})
+
+# (text, inline formatting, hyperlink) for one styled span of a block.
+_Run = tuple[str, Formatting | None, AnyUrl | None]
+
+
+class BoxNoteDocumentBackend(DeclarativeDocumentBackend):
+    """Declarative backend for Box Notes (.boxnote files).
+
+    Box Notes are JSON. This reads the current (post-August 2022) schema, a
+    ProseMirror-style "doc" node tree, and maps it onto a DoclingDocument.
+    Notes saved before that release use the older "atext"/"pool" model and are
+    reported as unsupported rather than silently mis-parsed.
+    """
+
+    @override
+    def __init__(self, in_doc: InputDocument, path_or_stream: BytesIO | Path):
+        super().__init__(in_doc, path_or_stream)
+
+        self.data: dict[str, Any] = {}
+        try:
+            raw = ""
+            if isinstance(self.path_or_stream, BytesIO):
+                raw = self.path_or_stream.getvalue().decode("utf-8")
+            elif isinstance(self.path_or_stream, Path):
+                raw = self.path_or_stream.read_text(encoding="utf-8")
+            if raw.strip():
+                loaded = json.loads(raw)
+                if isinstance(loaded, dict):
+                    self.data = loaded
+        except (json.JSONDecodeError, UnicodeDecodeError, OSError) as e:
+            raise DocumentLoadError(
+                f"Could not load Box Note document with hash {self.document_hash}."
+            ) from e
+
+        if "atext" in self.data and not self.is_valid():
+            raise DocumentLoadError(
+                "Legacy Box Notes (the pre-August-2022 atext/pool format) are not "
+                "supported yet; only the current Box Note format can be converted."
+            )
+
+    @override
+    def is_valid(self) -> bool:
+        return isinstance(self.data.get("doc"), dict)
+
+    @classmethod
+    @override
+    def supports_pagination(cls) -> bool:
+        return False
+
+    @classmethod
+    @override
+    def supported_formats(cls) -> set[InputFormat]:
+        return {InputFormat.BOXNOTE}
+
+    @override
+    def convert(self) -> DoclingDocument:
+        if not self.is_valid():
+            raise RuntimeError(
+                f"Cannot convert Box Note with hash {self.document_hash}: "
+                "no 'doc' node found."
+            )
+
+        origin = DocumentOrigin(
+            filename=self.file.name or "file.boxnote",
+            # DocumentOrigin only accepts MIME types registered in docling-core.
+            # Until application/vnd.box.boxnote is added there, use the JSON type
+            # it already accepts (a Box Note is JSON).
+            mimetype="application/json",
+            binary_hash=self.document_hash,
+        )
+        doc = DoclingDocument(name=self.file.stem or "file", origin=origin)
+
+        self._add_blocks(self.data["doc"].get("content", []), doc, None)
+        return doc
+
+    def _add_blocks(
+        self, nodes: list[dict], doc: DoclingDocument, parent: NodeItem | None
+    ) -> None:
+        for node in nodes:
+            self._add_block(node, doc, parent)
+
+    def _add_block(
+        self, node: dict[str, Any], doc: DoclingDocument, parent: NodeItem | None
+    ) -> None:
+        node_type = node.get("type")
+        content = node.get("content", [])
+
+        if node_type == "heading":
+            text, formatting, hyperlink = self._collapse(content)
+            if text:
+                level = node.get("attrs", {}).get("level") or 1
+                if level <= 1:
+                    doc.add_title(
+                        text=text,
+                        parent=parent,
+                        formatting=formatting,
+                        hyperlink=hyperlink,
+                    )
+                else:
+                    doc.add_heading(
+                        text=text,
+                        level=level - 1,
+                        parent=parent,
+                        formatting=formatting,
+                        hyperlink=hyperlink,
+                    )
+        elif node_type == "paragraph":
+            self._add_paragraph(content, doc, parent)
+        elif node_type in ("bullet_list", "ordered_list", "check_list"):
+            self._add_list(node_type, content, doc, parent)
+        elif node_type == "code_block":
+            code = self._plain_text(content)
+            if code:
+                doc.add_code(text=code, parent=parent)
+        elif node_type == "table":
+            self._add_table(content, doc, parent)
+        elif node_type == "image":
+            self._add_image(node.get("attrs", {}), doc, parent)
+        elif content:
+            # blockquote, call_out_box and other wrappers have no dedicated item;
+            # keep their inner blocks rather than dropping the text.
+            self._add_blocks(content, doc, parent)
+
+    def _add_paragraph(
+        self, content: list[dict], doc: DoclingDocument, parent: NodeItem | None
+    ) -> None:
+        runs = self._runs(content)
+        if not runs:
+            return
+        if len(runs) == 1:
+            text, formatting, hyperlink = runs[0]
+            doc.add_text(
+                label=DocItemLabel.TEXT,
+                text=text,
+                parent=parent,
+                formatting=formatting,
+                hyperlink=hyperlink,
+            )
+            return
+        group = doc.add_inline_group(parent=parent)
+        for text, formatting, hyperlink in runs:
+            doc.add_text(
+                label=DocItemLabel.TEXT,
+                text=text,
+                parent=group,
+                formatting=formatting,
+                hyperlink=hyperlink,
+            )
+
+    def _add_list(
+        self,
+        list_type: str,
+        items: list[dict],
+        doc: DoclingDocument,
+        parent: NodeItem | None,
+    ) -> None:
+        enumerated = list_type == "ordered_list"
+        group = doc.add_group(
+            label=GroupLabel.ORDERED_LIST if enumerated else GroupLabel.LIST,
+            name="list",
+            parent=parent,
+        )
+        for item in items:
+            if item.get("type") == "check_list_item":
+                self._add_check_item(item, doc, group)
+            else:
+                self._add_list_item(item, doc, group, enumerated)
+
+    def _add_list_item(
+        self,
+        item: dict[str, Any],
+        doc: DoclingDocument,
+        group: NodeItem,
+        enumerated: bool,
+    ) -> None:
+        text, formatting, hyperlink, nested = self._split_item(item)
+        list_item = doc.add_list_item(
+            text=text,
+            enumerated=enumerated,
+            parent=group,
+            formatting=formatting,
+            hyperlink=hyperlink,
+        )
+        if nested:
+            self._add_blocks(nested, doc, list_item)
+
+    def _add_check_item(
+        self, item: dict[str, Any], doc: DoclingDocument, group: NodeItem
+    ) -> None:
+        text, formatting, hyperlink, nested = self._split_item(item)
+        label = (
+            DocItemLabel.CHECKBOX_SELECTED
+            if item.get("attrs", {}).get("checked")
+            else DocItemLabel.CHECKBOX_UNSELECTED
+        )
+        check_item = doc.add_text(
+            label=label,
+            text=text,
+            parent=group,
+            formatting=formatting,
+            hyperlink=hyperlink,
+        )
+        if nested:
+            self._add_blocks(nested, doc, check_item)
+
+    def _split_item(
+        self, item: dict[str, Any]
+    ) -> tuple[str, Formatting | None, AnyUrl | None, list[dict]]:
+        """Split a list item into its own text and any nested blocks.
+
+        The leading paragraph becomes the item text; everything else (nested
+        lists, extra paragraphs) is returned to be added as children.
+        """
+        text, formatting, hyperlink = "", None, None
+        nested: list[dict] = []
+        for child in item.get("content", []):
+            if not text and child.get("type") == "paragraph":
+                text, formatting, hyperlink = self._collapse(child.get("content", []))
+            else:
+                nested.append(child)
+        return text, formatting, hyperlink, nested
+
+    def _add_table(
+        self, rows: list[dict], doc: DoclingDocument, parent: NodeItem | None
+    ) -> None:
+        rows = [row for row in rows if row.get("type") == "table_row"]
+        if not rows:
+            return
+
+        data = TableData(num_rows=len(rows), num_cols=0, table_cells=[])
+        table = doc.add_table(data=data, parent=parent)
+
+        occupied: set[tuple[int, int]] = set()
+        num_cols = 0
+        for row_idx, row in enumerate(rows):
+            col_idx = 0
+            for cell in row.get("content", []):
+                cell_type = cell.get("type")
+                if cell_type not in ("table_cell", "table_header"):
+                    continue
+                while (row_idx, col_idx) in occupied:
+                    col_idx += 1
+                attrs = cell.get("attrs", {})
+                row_span = attrs.get("rowspan") or 1
+                col_span = attrs.get("colspan") or 1
+                end_row = row_idx + row_span
+                end_col = col_idx + col_span
+                blocks = cell.get("content", [])
+                is_header = cell_type == "table_header"
+
+                if self._cell_is_rich(blocks):
+                    group = doc.add_group(
+                        label=GroupLabel.UNSPECIFIED, name="table_cell", parent=table
+                    )
+                    self._add_blocks(blocks, doc, group)
+                    table_cell: TableCell = RichTableCell(
+                        text=self._cell_text(blocks),
+                        row_span=row_span,
+                        col_span=col_span,
+                        start_row_offset_idx=row_idx,
+                        end_row_offset_idx=end_row,
+                        start_col_offset_idx=col_idx,
+                        end_col_offset_idx=end_col,
+                        column_header=is_header,
+                        ref=group.get_ref(),
+                    )
+                else:
+                    table_cell = TableCell(
+                        text=self._cell_text(blocks),
+                        row_span=row_span,
+                        col_span=col_span,
+                        start_row_offset_idx=row_idx,
+                        end_row_offset_idx=end_row,
+                        start_col_offset_idx=col_idx,
+                        end_col_offset_idx=end_col,
+                        column_header=is_header,
+                    )
+                doc.add_table_cell(table_item=table, cell=table_cell)
+
+                for span_row in range(row_idx, row_idx + row_span):
+                    for span_col in range(col_idx, col_idx + col_span):
+                        occupied.add((span_row, span_col))
+                col_idx += col_span
+                num_cols = max(num_cols, col_idx)
+
+        table.data.num_cols = num_cols
+
+    def _cell_is_rich(self, blocks: list[dict]) -> bool:
+        """A cell is rich when it cannot be one plain-text TableCell.
+
+        That covers images, multiple blocks, any non-paragraph block (lists,
+        code, nested tables), and a lone paragraph carrying a link or formatting:
+        a plain TableCell has no hyperlink field, so a flattened link would be
+        lost.
+        """
+        meaningful = [
+            block
+            for block in blocks
+            if block.get("type") != "paragraph" or self._runs(block.get("content", []))
+        ]
+        if len(meaningful) > 1:
+            return True
+        if any(block.get("type") != "paragraph" for block in meaningful):
+            return True
+        return any(
+            formatting or hyperlink
+            for block in meaningful
+            for _, formatting, hyperlink in self._runs(block.get("content", []))
+        )
+
+    def _add_image(
+        self, attrs: dict[str, Any], doc: DoclingDocument, parent: NodeItem | None
+    ) -> None:
+        caption = None
+        label = attrs.get("alt") or attrs.get("fileName")
+        if label:
+            caption = doc.add_text(label=DocItemLabel.CAPTION, text=label)
+        doc.add_picture(caption=caption, parent=parent)
+
+    def _collapse(self, content: list[dict]) -> _Run:
+        """Reduce inline content to a single run.
+
+        Headings and list items take one formatting and one hyperlink, so a
+        single styled span keeps its style and a mixed span falls back to plain
+        joined text.
+        """
+        runs = self._runs(content)
+        if len(runs) == 1:
+            return runs[0]
+        return "".join(text for text, _, _ in runs), None, None
+
+    def _runs(self, content: list[dict]) -> list[_Run]:
+        runs: list[_Run] = []
+        for node in content or []:
+            node_type = node.get("type")
+            if node_type == "text":
+                text = node.get("text", "")
+                if text:
+                    formatting, hyperlink = self._marks(node.get("marks", []))
+                    runs.append((text, formatting, hyperlink))
+            elif node_type == "hard_break":
+                runs.append((" ", None, None))
+        return runs
+
+    def _marks(self, marks: list[dict]) -> tuple[Formatting | None, AnyUrl | None]:
+        formatting: Formatting | None = None
+        hyperlink: AnyUrl | None = None
+        for mark in marks or []:
+            mark_type = mark.get("type")
+            if mark_type == "strong":
+                formatting = formatting or Formatting()
+                formatting.bold = True
+            elif mark_type == "em":
+                formatting = formatting or Formatting()
+                formatting.italic = True
+            elif mark_type == "underline":
+                formatting = formatting or Formatting()
+                formatting.underline = True
+            elif mark_type == "strikethrough":
+                formatting = formatting or Formatting()
+                formatting.strikethrough = True
+            elif mark_type == "link":
+                href = mark.get("attrs", {}).get("href")
+                if isinstance(href, str) and href:
+                    hyperlink = self._as_url(href)
+        return formatting, hyperlink
+
+    def _plain_text(self, nodes: list[dict]) -> str:
+        parts: list[str] = []
+        for node in nodes or []:
+            node_type = node.get("type")
+            if node_type == "text":
+                parts.append(node.get("text", ""))
+            elif node_type == "hard_break":
+                parts.append("\n")
+            elif node.get("content"):
+                parts.append(self._plain_text(node["content"]))
+        return "".join(parts)
+
+    def _cell_text(self, blocks: list[dict]) -> str:
+        texts = (self._plain_text(block.get("content", [])).strip() for block in blocks)
+        return " ".join(text for text in texts if text)
+
+    @staticmethod
+    def _as_url(href: str) -> AnyUrl | None:
+        try:
+            if urlparse(href).scheme not in _SAFE_LINK_SCHEMES:
+                return None
+            return _HYPERLINK.validate_python(href)
+        except (ValueError, ValidationError):
+            # urlparse raises on malformed input (e.g. unbalanced IPv6 brackets);
+            # drop the link rather than failing the whole conversion.
+            return None

--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -117,6 +117,7 @@ class InputFormat(str, Enum):
     LATEX = "latex"
     EMAIL = "email"
     EPUB = "epub"
+    BOXNOTE = "boxnote"
 
 
 class OutputFormat(str, Enum):
@@ -157,6 +158,7 @@ FormatToExtensions: dict[InputFormat, list[str]] = {
     InputFormat.LATEX: ["tex", "latex"],
     InputFormat.EMAIL: ["eml"],
     InputFormat.EPUB: ["epub"],
+    InputFormat.BOXNOTE: ["boxnote"],
 }
 
 FormatToMimeType: dict[InputFormat, list[str]] = {
@@ -223,6 +225,7 @@ FormatToMimeType: dict[InputFormat, list[str]] = {
     InputFormat.LATEX: ["text/x-tex", "application/x-tex", "text/x-latex"],
     InputFormat.EMAIL: ["message/rfc822"],
     InputFormat.EPUB: ["application/epub+zip"],
+    InputFormat.BOXNOTE: ["application/vnd.box.boxnote"],
 }
 
 MimeTypeToFormat: dict[str, list[InputFormat]] = {

--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -928,6 +928,8 @@ class _DocumentConversionInput(BaseModel):
             mime = FormatToMimeType[InputFormat.CSV][0]
         elif ext in FormatToExtensions[InputFormat.JSON_DOCLING]:
             mime = FormatToMimeType[InputFormat.JSON_DOCLING][0]
+        elif ext in FormatToExtensions[InputFormat.BOXNOTE]:
+            mime = FormatToMimeType[InputFormat.BOXNOTE][0]
         elif ext in FormatToExtensions[InputFormat.PDF]:
             mime = FormatToMimeType[InputFormat.PDF][0]
         elif ext in FormatToExtensions[InputFormat.DOCX]:

--- a/docling/document_converter.py
+++ b/docling/document_converter.py
@@ -19,6 +19,7 @@ from docling.backend.abstract_backend import (
     AbstractDocumentBackend,
 )
 from docling.backend.asciidoc_backend import AsciiDocBackend
+from docling.backend.boxnote_backend import BoxNoteDocumentBackend
 from docling.backend.csv_backend import CsvDocumentBackend
 from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
 from docling.backend.email_backend import EmailDocumentBackend
@@ -102,6 +103,11 @@ class FormatOption(BaseFormatOption):
             self.pipeline_options = self.pipeline_cls.get_default_options()
 
         return self
+
+
+class BoxNoteFormatOption(FormatOption):
+    pipeline_cls: Type = SimplePipeline
+    backend: Type[AbstractDocumentBackend] = BoxNoteDocumentBackend
 
 
 class CsvFormatOption(FormatOption):
@@ -236,6 +242,7 @@ class EpubFormatOption(FormatOption):
 def _get_default_option(format: InputFormat) -> FormatOption:
     format_to_default_options = {
         InputFormat.CSV: CsvFormatOption(),
+        InputFormat.BOXNOTE: BoxNoteFormatOption(),
         InputFormat.XLSX: ExcelFormatOption(),
         InputFormat.DOCX: WordFormatOption(),
         InputFormat.PPTX: PowerpointFormatOption(),

--- a/docs/index.md
+++ b/docs/index.md
@@ -35,7 +35,7 @@ Docling simplifies document processing by parsing diverse formats — including 
 
 ## Features
 
-- 🗂️ Parsing of [multiple document formats][supported_formats] including PDF, DOCX, PPTX, XLSX, HTML, EPUB, WAV, MP3, WebVTT, email formats (EML, MSG), images (PNG, TIFF, JPEG, ...), LaTeX, DocLang, plain text, and more
+- 🗂️ Parsing of [multiple document formats][supported_formats] including PDF, DOCX, PPTX, XLSX, HTML, EPUB, WAV, MP3, WebVTT, Box Notes, email formats (EML, MSG), images (PNG, TIFF, JPEG, ...), LaTeX, DocLang, plain text, and more
 - 📑 Advanced PDF understanding incl. page layout, reading order, table structure, code, formulas, image classification, and more
 - 🧬 A unified, expressive [DoclingDocument][docling_document] representation format
 - ↪️ Various [export formats][supported_formats] and options, including Markdown, HTML, WebVTT, DocLang, [DocTags](https://arxiv.org/abs/2503.11576) and lossless JSON

--- a/docs/usage/supported_formats.md
+++ b/docs/usage/supported_formats.md
@@ -22,6 +22,7 @@ Below you can find a listing of all supported input and output formats.
 | MP4, AVI, MOV | Video formats — audio track is extracted and transcribed (requires `asr` extra and `ffmpeg`) |
 | WebVTT | Web Video Text Tracks format for displaying timed text |
 | Chunks (JSONL) | Chunked document output for RAG pipelines; configurable via `--chunks-type`, `--chunks-max-tokens`, `--chunks-tokenizer` |
+| BoxNote | Box Notes collaborative note format |
 
 Schema-specific support:
 

--- a/tests/data/boxnote/groundtruth/sample.boxnote.itxt
+++ b/tests/data/boxnote/groundtruth/sample.boxnote.itxt
@@ -1,0 +1,31 @@
+item-0 at level 0: unspecified: group _root_
+  item-1 at level 1: title: Release notes
+  item-2 at level 1: inline: group group
+    item-3 at level 2: text: We shipped a 
+    item-4 at level 2: text: new
+    item-5 at level 2: text:  parser. See the 
+    item-6 at level 2: text: docs
+    item-7 at level 2: text:  for details.
+  item-8 at level 1: section_header: Highlights
+  item-9 at level 1: list: group list
+    item-10 at level 2: list_item: Faster conversion
+    item-11 at level 2: list_item: Fewer allocations
+      item-12 at level 3: list: group list
+        item-13 at level 4: list_item: Nested detail
+  item-14 at level 1: list: group list
+    item-15 at level 2: list_item: First step
+    item-16 at level 2: list_item: Second step
+  item-17 at level 1: list: group list
+    item-18 at level 2: checkbox_selected: Write tests
+    item-19 at level 2: checkbox_unselected: Ship it
+  item-20 at level 1: text: Old caveat
+  item-21 at level 1: code: print("hello")
+  item-22 at level 1: table with [2x2]
+    item-23 at level 2: unspecified: group table_cell
+      item-24 at level 3: text: alpha
+    item-25 at level 2: unspecified: group table_cell
+      item-26 at level 3: text: 1
+      item-27 at level 3: text: primary
+  item-28 at level 1: caption: Architecture diagram
+  item-29 at level 1: picture
+    item-29 at level 2: caption: Architecture diagram

--- a/tests/data/boxnote/groundtruth/sample.boxnote.json
+++ b/tests/data/boxnote/groundtruth/sample.boxnote.json
@@ -1,0 +1,635 @@
+{
+  "schema_name": "DoclingDocument",
+  "version": "1.10.0",
+  "name": "sample",
+  "origin": {
+    "mimetype": "application/json",
+    "binary_hash": 17703658933025322390,
+    "filename": "sample.boxnote"
+  },
+  "furniture": {
+    "self_ref": "#/furniture",
+    "children": [],
+    "content_layer": "furniture",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "body": {
+    "self_ref": "#/body",
+    "children": [
+      {
+        "$ref": "#/texts/0"
+      },
+      {
+        "$ref": "#/groups/0"
+      },
+      {
+        "$ref": "#/texts/6"
+      },
+      {
+        "$ref": "#/groups/1"
+      },
+      {
+        "$ref": "#/groups/3"
+      },
+      {
+        "$ref": "#/groups/4"
+      },
+      {
+        "$ref": "#/texts/14"
+      },
+      {
+        "$ref": "#/texts/15"
+      },
+      {
+        "$ref": "#/tables/0"
+      },
+      {
+        "$ref": "#/texts/19"
+      },
+      {
+        "$ref": "#/pictures/0"
+      }
+    ],
+    "content_layer": "body",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "groups": [
+    {
+      "self_ref": "#/groups/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/1"
+        },
+        {
+          "$ref": "#/texts/2"
+        },
+        {
+          "$ref": "#/texts/3"
+        },
+        {
+          "$ref": "#/texts/4"
+        },
+        {
+          "$ref": "#/texts/5"
+        }
+      ],
+      "content_layer": "body",
+      "name": "group",
+      "label": "inline"
+    },
+    {
+      "self_ref": "#/groups/1",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/7"
+        },
+        {
+          "$ref": "#/texts/8"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/2",
+      "parent": {
+        "$ref": "#/texts/8"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/9"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/3",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/10"
+        },
+        {
+          "$ref": "#/texts/11"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/4",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/12"
+        },
+        {
+          "$ref": "#/texts/13"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/5",
+      "parent": {
+        "$ref": "#/tables/0"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/16"
+        }
+      ],
+      "content_layer": "body",
+      "name": "table_cell",
+      "label": "unspecified"
+    },
+    {
+      "self_ref": "#/groups/6",
+      "parent": {
+        "$ref": "#/tables/0"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/17"
+        },
+        {
+          "$ref": "#/texts/18"
+        }
+      ],
+      "content_layer": "body",
+      "name": "table_cell",
+      "label": "unspecified"
+    }
+  ],
+  "texts": [
+    {
+      "self_ref": "#/texts/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "title",
+      "prov": [],
+      "orig": "Release notes",
+      "text": "Release notes"
+    },
+    {
+      "self_ref": "#/texts/1",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "We shipped a ",
+      "text": "We shipped a "
+    },
+    {
+      "self_ref": "#/texts/2",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "new",
+      "text": "new",
+      "formatting": {
+        "bold": true,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "script": "baseline"
+      }
+    },
+    {
+      "self_ref": "#/texts/3",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": " parser. See the ",
+      "text": " parser. See the "
+    },
+    {
+      "self_ref": "#/texts/4",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "docs",
+      "text": "docs",
+      "hyperlink": "https://example.com/docs"
+    },
+    {
+      "self_ref": "#/texts/5",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": " for details.",
+      "text": " for details."
+    },
+    {
+      "self_ref": "#/texts/6",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [],
+      "orig": "Highlights",
+      "text": "Highlights",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/7",
+      "parent": {
+        "$ref": "#/groups/1"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Faster conversion",
+      "text": "Faster conversion",
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/8",
+      "parent": {
+        "$ref": "#/groups/1"
+      },
+      "children": [
+        {
+          "$ref": "#/groups/2"
+        }
+      ],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Fewer allocations",
+      "text": "Fewer allocations",
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/9",
+      "parent": {
+        "$ref": "#/groups/2"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Nested detail",
+      "text": "Nested detail",
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/10",
+      "parent": {
+        "$ref": "#/groups/3"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "First step",
+      "text": "First step",
+      "enumerated": true,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/11",
+      "parent": {
+        "$ref": "#/groups/3"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Second step",
+      "text": "Second step",
+      "enumerated": true,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/12",
+      "parent": {
+        "$ref": "#/groups/4"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "checkbox_selected",
+      "prov": [],
+      "orig": "Write tests",
+      "text": "Write tests"
+    },
+    {
+      "self_ref": "#/texts/13",
+      "parent": {
+        "$ref": "#/groups/4"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "checkbox_unselected",
+      "prov": [],
+      "orig": "Ship it",
+      "text": "Ship it"
+    },
+    {
+      "self_ref": "#/texts/14",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Old caveat",
+      "text": "Old caveat",
+      "formatting": {
+        "bold": false,
+        "italic": false,
+        "underline": false,
+        "strikethrough": true,
+        "script": "baseline"
+      }
+    },
+    {
+      "self_ref": "#/texts/15",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "code",
+      "prov": [],
+      "orig": "print(\"hello\")",
+      "text": "print(\"hello\")",
+      "captions": [],
+      "references": [],
+      "footnotes": [],
+      "code_language": "unknown"
+    },
+    {
+      "self_ref": "#/texts/16",
+      "parent": {
+        "$ref": "#/groups/5"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "alpha",
+      "text": "alpha",
+      "hyperlink": "https://example.com/alpha"
+    },
+    {
+      "self_ref": "#/texts/17",
+      "parent": {
+        "$ref": "#/groups/6"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "1",
+      "text": "1"
+    },
+    {
+      "self_ref": "#/texts/18",
+      "parent": {
+        "$ref": "#/groups/6"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "primary",
+      "text": "primary",
+      "formatting": {
+        "bold": false,
+        "italic": true,
+        "underline": false,
+        "strikethrough": false,
+        "script": "baseline"
+      }
+    },
+    {
+      "self_ref": "#/texts/19",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "caption",
+      "prov": [],
+      "orig": "Architecture diagram",
+      "text": "Architecture diagram"
+    }
+  ],
+  "pictures": [
+    {
+      "self_ref": "#/pictures/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "picture",
+      "prov": [],
+      "captions": [
+        {
+          "$ref": "#/texts/19"
+        }
+      ],
+      "references": [],
+      "footnotes": [],
+      "annotations": []
+    }
+  ],
+  "tables": [
+    {
+      "self_ref": "#/tables/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/groups/5"
+        },
+        {
+          "$ref": "#/groups/6"
+        }
+      ],
+      "content_layer": "body",
+      "label": "table",
+      "prov": [],
+      "captions": [],
+      "references": [],
+      "footnotes": [],
+      "data": {
+        "table_cells": [
+          {
+            "row_span": 1,
+            "col_span": 1,
+            "start_row_offset_idx": 0,
+            "end_row_offset_idx": 1,
+            "start_col_offset_idx": 0,
+            "end_col_offset_idx": 1,
+            "text": "Name",
+            "column_header": true,
+            "row_header": false,
+            "row_section": false,
+            "fillable": false
+          },
+          {
+            "row_span": 1,
+            "col_span": 1,
+            "start_row_offset_idx": 0,
+            "end_row_offset_idx": 1,
+            "start_col_offset_idx": 1,
+            "end_col_offset_idx": 2,
+            "text": "Value",
+            "column_header": true,
+            "row_header": false,
+            "row_section": false,
+            "fillable": false
+          },
+          {
+            "row_span": 1,
+            "col_span": 1,
+            "start_row_offset_idx": 1,
+            "end_row_offset_idx": 2,
+            "start_col_offset_idx": 0,
+            "end_col_offset_idx": 1,
+            "text": "alpha",
+            "column_header": false,
+            "row_header": false,
+            "row_section": false,
+            "fillable": false,
+            "ref": {
+              "$ref": "#/groups/5"
+            }
+          },
+          {
+            "row_span": 1,
+            "col_span": 1,
+            "start_row_offset_idx": 1,
+            "end_row_offset_idx": 2,
+            "start_col_offset_idx": 1,
+            "end_col_offset_idx": 2,
+            "text": "1 primary",
+            "column_header": false,
+            "row_header": false,
+            "row_section": false,
+            "fillable": false,
+            "ref": {
+              "$ref": "#/groups/6"
+            }
+          }
+        ],
+        "num_rows": 2,
+        "num_cols": 2,
+        "orientation": "rot_0",
+        "grid": [
+          [
+            {
+              "row_span": 1,
+              "col_span": 1,
+              "start_row_offset_idx": 0,
+              "end_row_offset_idx": 1,
+              "start_col_offset_idx": 0,
+              "end_col_offset_idx": 1,
+              "text": "Name",
+              "column_header": true,
+              "row_header": false,
+              "row_section": false,
+              "fillable": false
+            },
+            {
+              "row_span": 1,
+              "col_span": 1,
+              "start_row_offset_idx": 0,
+              "end_row_offset_idx": 1,
+              "start_col_offset_idx": 1,
+              "end_col_offset_idx": 2,
+              "text": "Value",
+              "column_header": true,
+              "row_header": false,
+              "row_section": false,
+              "fillable": false
+            }
+          ],
+          [
+            {
+              "row_span": 1,
+              "col_span": 1,
+              "start_row_offset_idx": 1,
+              "end_row_offset_idx": 2,
+              "start_col_offset_idx": 0,
+              "end_col_offset_idx": 1,
+              "text": "alpha",
+              "column_header": false,
+              "row_header": false,
+              "row_section": false,
+              "fillable": false
+            },
+            {
+              "row_span": 1,
+              "col_span": 1,
+              "start_row_offset_idx": 1,
+              "end_row_offset_idx": 2,
+              "start_col_offset_idx": 1,
+              "end_col_offset_idx": 2,
+              "text": "1 primary",
+              "column_header": false,
+              "row_header": false,
+              "row_section": false,
+              "fillable": false
+            }
+          ]
+        ]
+      },
+      "annotations": []
+    }
+  ],
+  "key_value_items": [],
+  "form_items": [],
+  "pages": {}
+}

--- a/tests/data/boxnote/groundtruth/sample.boxnote.json
+++ b/tests/data/boxnote/groundtruth/sample.boxnote.json
@@ -3,7 +3,7 @@
   "version": "1.10.0",
   "name": "sample",
   "origin": {
-    "mimetype": "application/json",
+    "mimetype": "application/vnd.box.boxnote",
     "binary_hash": 17703658933025322390,
     "filename": "sample.boxnote"
   },

--- a/tests/data/boxnote/groundtruth/sample.boxnote.md
+++ b/tests/data/boxnote/groundtruth/sample.boxnote.md
@@ -1,0 +1,29 @@
+# Release notes
+
+We shipped a  **new**  parser. See the  [docs](https://example.com/docs)  for details.
+
+## Highlights
+
+- Faster conversion
+- Fewer allocations
+    - Nested detail
+
+1. First step
+2. Second step
+
+- [x] Write tests
+- [ ] Ship it
+
+~~Old caveat~~
+
+```
+print("hello")
+```
+
+| Name | Value |
+| - | - |
+| [alpha](https://example.com/alpha) | 1  *primary* |
+
+Architecture diagram
+
+<!-- image -->

--- a/tests/data/boxnote/sources/sample.boxnote
+++ b/tests/data/boxnote/sources/sample.boxnote
@@ -1,0 +1,185 @@
+{
+  "version": 1,
+  "schema_version": 1,
+  "last_edit_timestamp": 1700000000000,
+  "doc": {
+    "type": "doc",
+    "attrs": {
+      "table_of_contents": {
+        "enabled": false,
+        "allowedLevels": [1, 2, 3]
+      }
+    },
+    "content": [
+      {
+        "type": "heading",
+        "attrs": {"level": 1},
+        "content": [{"type": "text", "text": "Release notes"}]
+      },
+      {
+        "type": "paragraph",
+        "content": [
+          {"type": "text", "text": "We shipped a "},
+          {"type": "text", "marks": [{"type": "strong"}], "text": "new"},
+          {"type": "text", "text": " parser. See the "},
+          {
+            "type": "text",
+            "marks": [{"type": "link", "attrs": {"href": "https://example.com/docs"}}],
+            "text": "docs"
+          },
+          {"type": "text", "text": " for details."}
+        ]
+      },
+      {
+        "type": "heading",
+        "attrs": {"level": 2},
+        "content": [{"type": "text", "text": "Highlights"}]
+      },
+      {
+        "type": "bullet_list",
+        "content": [
+          {
+            "type": "list_item",
+            "content": [
+              {"type": "paragraph", "content": [{"type": "text", "text": "Faster conversion"}]}
+            ]
+          },
+          {
+            "type": "list_item",
+            "content": [
+              {
+                "type": "paragraph",
+                "content": [
+                  {"type": "text", "marks": [{"type": "em"}], "text": "Fewer"},
+                  {"type": "text", "text": " allocations"}
+                ]
+              },
+              {
+                "type": "bullet_list",
+                "content": [
+                  {
+                    "type": "list_item",
+                    "content": [
+                      {"type": "paragraph", "content": [{"type": "text", "text": "Nested detail"}]}
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "ordered_list",
+        "attrs": {"order": 1},
+        "content": [
+          {
+            "type": "list_item",
+            "content": [
+              {"type": "paragraph", "content": [{"type": "text", "text": "First step"}]}
+            ]
+          },
+          {
+            "type": "list_item",
+            "content": [
+              {"type": "paragraph", "content": [{"type": "text", "text": "Second step"}]}
+            ]
+          }
+        ]
+      },
+      {
+        "type": "check_list",
+        "content": [
+          {
+            "type": "check_list_item",
+            "attrs": {"checked": true},
+            "content": [
+              {"type": "paragraph", "content": [{"type": "text", "text": "Write tests"}]}
+            ]
+          },
+          {
+            "type": "check_list_item",
+            "attrs": {"checked": false},
+            "content": [
+              {"type": "paragraph", "content": [{"type": "text", "text": "Ship it"}]}
+            ]
+          }
+        ]
+      },
+      {
+        "type": "blockquote",
+        "content": [
+          {
+            "type": "paragraph",
+            "content": [{"type": "text", "marks": [{"type": "strikethrough"}], "text": "Old caveat"}]
+          }
+        ]
+      },
+      {
+        "type": "code_block",
+        "attrs": {"language": "python"},
+        "content": [{"type": "text", "text": "print(\"hello\")"}]
+      },
+      {
+        "type": "table",
+        "content": [
+          {
+            "type": "table_row",
+            "content": [
+              {
+                "type": "table_header",
+                "attrs": {"colspan": 1, "rowspan": 1},
+                "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Name"}]}]
+              },
+              {
+                "type": "table_header",
+                "attrs": {"colspan": 1, "rowspan": 1},
+                "content": [{"type": "paragraph", "content": [{"type": "text", "text": "Value"}]}]
+              }
+            ]
+          },
+          {
+            "type": "table_row",
+            "content": [
+              {
+                "type": "table_cell",
+                "attrs": {"colspan": 1, "rowspan": 1},
+                "content": [
+                  {
+                    "type": "paragraph",
+                    "content": [
+                      {
+                        "type": "text",
+                        "marks": [{"type": "link", "attrs": {"href": "https://example.com/alpha"}}],
+                        "text": "alpha"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "type": "table_cell",
+                "attrs": {"colspan": 1, "rowspan": 1},
+                "content": [
+                  {"type": "paragraph", "content": [{"type": "text", "text": "1"}]},
+                  {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "marks": [{"type": "em"}], "text": "primary"}]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "type": "image",
+        "attrs": {
+          "fileName": "diagram.png",
+          "alt": "Architecture diagram",
+          "boxSharedLink": "https://app.box.com/s/example"
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_backend_boxnote.py
+++ b/tests/test_backend_boxnote.py
@@ -1,0 +1,142 @@
+import json
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+
+from docling.datamodel.base_models import (
+    ConversionStatus,
+    DocumentStream,
+    InputFormat,
+)
+from docling.datamodel.document import (
+    ConversionResult,
+    DoclingDocument,
+    _DocumentConversionInput,
+)
+from docling.document_converter import DocumentConverter
+
+from .test_data_gen_flag import GEN_TEST_DATA
+from .verify_utils import verify_document, verify_export
+
+GENERATE = GEN_TEST_DATA
+pytestmark = pytest.mark.cross_platform
+
+
+def get_converter() -> DocumentConverter:
+    return DocumentConverter(allowed_formats=[InputFormat.BOXNOTE])
+
+
+def _boxnote_stream(payload: dict, name: str = "test.boxnote") -> DocumentStream:
+    raw = json.dumps(payload).encode("utf-8")
+    return DocumentStream(name=name, stream=BytesIO(raw))
+
+
+def test_e2e_boxnote_conversions():
+    directory = Path("./tests/data/boxnote/sources/")
+    boxnote_paths = sorted(directory.rglob("*.boxnote"))
+    converter = get_converter()
+
+    for boxnote_path in boxnote_paths:
+        gt_path = boxnote_path.parent.parent / "groundtruth" / boxnote_path.name
+
+        conv_result: ConversionResult = converter.convert(boxnote_path)
+        doc: DoclingDocument = conv_result.document
+
+        pred_md: str = doc.export_to_markdown(compact_tables=True)
+        assert verify_export(pred_md, str(gt_path) + ".md", GENERATE), "export to md"
+
+        pred_itxt: str = doc._export_to_indented_text(
+            max_text_len=70, explicit_tables=False
+        )
+        assert verify_export(pred_itxt, str(gt_path) + ".itxt", GENERATE), (
+            "export to indented-text"
+        )
+
+        assert verify_document(doc, str(gt_path) + ".json", GENERATE), "export to json"
+
+
+def test_boxnote_format_detection():
+    payload = {"doc": {"type": "doc", "content": []}}
+    stream = _boxnote_stream(payload)
+    dci = _DocumentConversionInput(path_or_stream_iterator=[])
+
+    assert dci._guess_format(stream) == InputFormat.BOXNOTE
+
+
+def test_legacy_boxnote_reports_unsupported():
+    legacy = {
+        "atext": {"text": "Hello, World!\n", "attribs": "*0+d|1+1"},
+        "pool": {"numToAttrib": {"0": ["author", "1"]}, "nextNum": 1},
+    }
+    conv_result = get_converter().convert(
+        _boxnote_stream(legacy, name="legacy.boxnote"), raises_on_error=False
+    )
+
+    assert conv_result.status == ConversionStatus.FAILURE
+    assert any("legacy" in err.error_message.lower() for err in conv_result.errors)
+
+
+def test_empty_boxnote_fails_cleanly():
+    conv_result = get_converter().convert(
+        DocumentStream(name="empty.boxnote", stream=BytesIO(b"")),
+        raises_on_error=False,
+    )
+
+    assert conv_result.status == ConversionStatus.FAILURE
+
+
+@pytest.mark.parametrize("payload", [b"[1, 2, 3]", b"42", b"null", b'"hello"'])
+def test_non_object_boxnote_fails_cleanly(payload: bytes):
+    conv_result = get_converter().convert(
+        DocumentStream(name="scalar.boxnote", stream=BytesIO(payload)),
+        raises_on_error=False,
+    )
+
+    assert conv_result.status == ConversionStatus.FAILURE
+
+
+def _linked_paragraph(href) -> dict:
+    return {
+        "doc": {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {
+                            "type": "text",
+                            "marks": [{"type": "link", "attrs": {"href": href}}],
+                            "text": "click",
+                        }
+                    ],
+                }
+            ],
+        }
+    }
+
+
+def test_safe_hyperlink_is_kept():
+    doc = (
+        get_converter()
+        .convert(_boxnote_stream(_linked_paragraph("https://x.com")))
+        .document
+    )
+
+    assert str(doc.texts[0].hyperlink) == "https://x.com/"
+
+
+@pytest.mark.parametrize(
+    "href", ["javascript:alert(1)", "hello", "", "http://[::1", "//cdn.example.com/x"]
+)
+def test_unsafe_hyperlink_is_dropped(href: str):
+    doc = get_converter().convert(_boxnote_stream(_linked_paragraph(href))).document
+
+    assert doc.texts[0].hyperlink is None
+
+
+@pytest.mark.parametrize("href", [42, True, ["http://x.com"], {"href": "http://x.com"}])
+def test_non_string_hyperlink_is_dropped(href):
+    doc = get_converter().convert(_boxnote_stream(_linked_paragraph(href))).document
+
+    assert doc.texts[0].hyperlink is None


### PR DESCRIPTION
## Description

Adds a backend for Box Notes (`.boxnote`), modeled on the existing `csv` and `webvtt` backends.

`.boxnote` files are JSON, but Box has two incompatible schemas. The older `atext`/`pool` model (what [boxnotes2html](https://github.com/alexwennerberg/boxnotes2html) parses) predates a 2022 change; the current one is a ProseMirror-style `doc` tree, which is what the app exports now. This handles the current format and maps its nodes onto a `DoclingDocument`: headings, paragraphs (with bold/italic/underline/strikethrough and links), lists, tables, code and images.

The decode is pure Python, so there's no new dependency. A legacy `atext`/`pool` note is detected and rejected with a clear `DocumentLoadError` rather than mis-parsed. I left legacy out to keep this focused; it's an easy follow-up if you'd want it here.

## Changes

- `docling/backend/boxnote_backend.py`: new `BoxNoteDocumentBackend`.
- `docling/datamodel/base_models.py`: register `InputFormat.BOXNOTE`, the `.boxnote` extension, and a mime type.
- `docling/datamodel/document.py`: resolve `.boxnote` to its mime in format detection.
- `docling/document_converter.py`: `BoxNoteFormatOption` on the `SimplePipeline`, plus its default option.
- `docs/usage/supported_formats.md`: list BoxNote.

## Tests

`tests/test_backend_boxnote.py` covers a sample `.boxnote` end to end (Markdown, indented-text and JSON ground truth), format detection, the legacy-unsupported path, and empty input.

Resolves #481

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
