### PR TITLE
fix(md): load embedded base64 images in Markdown backend

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -48,7 +48,7 @@ from typing_extensions import Self, override
 from docling.backend.abstract_backend import (
     DeclarativeDocumentBackend,
 )
-from docling.backend.image_resource_loader import ImageResourceLoader
+from docling.backend.utils.image_resource_loader import ImageResourceLoader
 from docling.datamodel.backend_options import HTMLBackendOptions
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument

--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -1,10 +1,6 @@
-import base64
-import ipaddress
 import logging
 import math
-import os
 import re
-import socket
 import warnings
 from contextlib import contextmanager
 from copy import deepcopy
@@ -12,9 +8,8 @@ from dataclasses import dataclass, field as dataclass_field
 from io import BytesIO
 from pathlib import Path
 from typing import Any, Final, Iterator, Literal, Optional, Union, cast
-from urllib.parse import urljoin, urlparse
+from urllib.parse import urlparse
 
-import requests
 from bs4 import BeautifulSoup, NavigableString, PageElement, Tag
 from bs4.element import PreformattedString
 from docling_core.types.doc import (
@@ -46,17 +41,18 @@ from docling_core.types.doc import (
     TextItem,
 )
 from docling_core.types.doc.document import ContentLayer, Formatting, ImageRef, Script
-from PIL import Image, UnidentifiedImageError
+from PIL import Image
 from pydantic import AnyUrl, BaseModel, ValidationError
 from typing_extensions import Self, override
 
 from docling.backend.abstract_backend import (
     DeclarativeDocumentBackend,
 )
+from docling.backend.image_resource_loader import ImageResourceLoader
 from docling.datamodel.backend_options import HTMLBackendOptions
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
-from docling.exceptions import DocumentLoadError, OperationNotAllowed
+from docling.exceptions import DocumentLoadError
 
 _log = logging.getLogger(__name__)
 
@@ -155,36 +151,6 @@ _FORM_MARKER_ID_RE: Final = re.compile(r"^key(?P<key_id>[A-Za-z0-9]+)_marker$")
 _FORM_VALUE_ID_RE: Final = re.compile(
     r"^key(?P<key_id>[A-Za-z0-9]+)_value(?P<value_id>[A-Za-z0-9]+)$"
 )
-
-
-def _validate_url_safety(url: str) -> None:
-    parsed = urlparse(url)
-    hostname = parsed.hostname
-
-    if not hostname:
-        raise ValueError("URL must contain a valid hostname")
-
-    try:
-        ip = ipaddress.ip_address(hostname)
-    except ValueError:
-        try:
-            ip_str = socket.gethostbyname(hostname)
-            ip = ipaddress.ip_address(ip_str)
-        except (socket.gaierror, socket.herror) as e:
-            raise ValueError(f"Cannot resolve hostname: {hostname}") from e
-
-    if not (
-        ip.is_global
-        and not (
-            ip.is_private
-            or ip.is_loopback
-            or ip.is_link_local
-            or ip.is_reserved
-            or ip.is_multicast
-            or ip.is_unspecified
-        )
-    ):
-        raise ValueError(f"Access to restricted IP address not allowed: {ip}")
 
 
 _CUSTOM_CHECKBOX_CLASSES: Final = {"checkbox", "checkbox-box", "checkbox-input"}
@@ -445,6 +411,14 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         self.base_path: Optional[str] = (
             str(options.source_uri) if options.source_uri is not None else None
         )
+        self._image_loader = ImageResourceLoader(
+            enable_local_fetch=options.enable_local_fetch,
+            enable_remote_fetch=options.enable_remote_fetch,
+            max_image_data_base64_bytes=options.max_image_data_base64_bytes,
+            max_remote_image_bytes=options.max_remote_image_bytes,
+            max_redirects=options.max_redirects,
+            headers=options.headers,
+        )
 
         # Initialize the parents for the hierarchy
         self.max_levels = 10
@@ -589,7 +563,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         return width, height
 
     def _coerce_base_url(self, value: str) -> str:
-        if HTMLDocumentBackend._is_remote_url(value) or value.startswith("file://"):
+        if ImageResourceLoader.is_remote_url(value) or value.startswith("file://"):
             return value
         return Path(value).resolve().as_uri()
 
@@ -599,7 +573,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         if scheme in {"file", "data", "about", "blob"}:
             return None
 
-        if HTMLDocumentBackend._is_remote_url(request_url):
+        if ImageResourceLoader.is_remote_url(request_url):
             if self.options.enable_remote_fetch:
                 return None
             return (
@@ -1327,61 +1301,8 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
             for n in reversed(new_nodes):
                 parent.insert(idx, n)
 
-    @staticmethod
-    def _is_remote_url(value: str) -> bool:
-        parsed = urlparse(value)
-        return parsed.scheme in {"http", "https", "ftp", "s3", "gs"}
-
-    @staticmethod
-    def _is_local_path(value: str) -> bool:
-        """Check if value is a local filesystem path (not a URI)."""
-        parsed = urlparse(value)
-        return not parsed.netloc and (
-            not parsed.scheme
-            or (len(parsed.scheme) == 1 and parsed.scheme.isalpha())  # Windows case
-        )
-
-    def _is_absolute_path(self, loc: str) -> bool:
-        return Path(loc).is_absolute() or (  # Windows-specific absolute paths:
-            len((parsed_loc := urlparse(loc)).scheme) == 1
-            and parsed_loc.scheme.isalpha()
-            and not parsed_loc.netloc
-        )
-
     def _resolve_relative_path(self, loc: str) -> str:
-        loc = loc.strip()
-
-        # Strip file:// prefix for validation as local path
-        if loc.startswith(file_prefix := "file://"):
-            loc = loc[len(file_prefix) :]
-
-        abs_loc = loc
-
-        if self.base_path:
-            if loc.startswith("//"):
-                abs_loc = "https:" + loc
-            elif not loc.startswith(("http://", "https://", "data:", "#")):
-                if HTMLDocumentBackend._is_remote_url(self.base_path):
-                    abs_loc = urljoin(self.base_path, loc)
-                elif HTMLDocumentBackend._is_local_path(self.base_path):
-                    if self._is_absolute_path(loc):
-                        raise ValueError(
-                            f"Absolute paths are not allowed with local base_path: '{loc}'"
-                        )
-
-                    base_dir = Path(self.base_path).parent.resolve()
-                    resolved_path = (base_dir / loc).resolve()
-
-                    if not resolved_path.is_relative_to(base_dir):
-                        raise ValueError(
-                            f"Path traversal blocked: '{loc}' resolves outside base directory"
-                        )
-                    abs_loc = str(resolved_path)
-                else:
-                    raise ValueError(f"Invalid base_path format: '{self.base_path}'")
-
-        _log.debug(f"Resolved location {loc} to {abs_loc}")
-        return abs_loc
+        return self._image_loader.resolve_relative_path(loc, self.base_path)
 
     @staticmethod
     def group_cell_elements(
@@ -4519,112 +4440,10 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         return input_item.get_ref()
 
     def _create_image_ref(self, src_url: str) -> Optional[ImageRef]:
-        try:
-            img_data = self._load_image_data(src_url)
-            if img_data:
-                img = Image.open(BytesIO(img_data))
-                return ImageRef.from_pil(img, dpi=int(img.info.get("dpi", (72,))[0]))
-        except (
-            requests.HTTPError,
-            ValidationError,
-            UnidentifiedImageError,
-            OperationNotAllowed,
-            TypeError,
-            ValueError,
-        ) as e:
-            warnings.warn(f"Could not process an image from {src_url}: {e}")
-
-        return None
+        return self._image_loader.create_image_ref(src_url, self.base_path)
 
     def _load_image_data(self, src_loc: str) -> Optional[bytes]:
-        if src_loc.lower().endswith(".svg"):
-            _log.debug(f"Skipping SVG file: {src_loc}")
-            return None
-
-        if HTMLDocumentBackend._is_remote_url(src_loc):
-            if not self.options.enable_remote_fetch:
-                raise OperationNotAllowed(
-                    "Fetching remote resources is only allowed when set explicitly. "
-                    "Set options.enable_remote_fetch=True."
-                )
-
-            _validate_url_safety(src_loc)
-
-            max_size = self.options.max_remote_image_bytes
-            headers = {"Range": f"bytes=0-{max_size - 1}"}
-
-            # Merge custom headers from options if provided
-            if self.options.headers:
-                headers.update(self.options.headers)
-
-            # Create session with redirect limit
-            session = requests.Session()
-            session.max_redirects = self.options.max_redirects
-
-            # Hook to validate each redirect target
-            def _check_redirect_safety(response, *args, **kwargs):
-                """Validate each redirect target before following it."""
-                if response.is_redirect or response.is_permanent_redirect:
-                    redirect_url = response.headers.get("location")
-                    if redirect_url:
-                        # Handle relative redirects
-                        if not redirect_url.startswith(("http://", "https://")):
-                            from urllib.parse import urljoin
-
-                            redirect_url = urljoin(response.url, redirect_url)
-
-                        # Validate the redirect target
-                        _validate_url_safety(redirect_url)
-
-            session.hooks["response"].append(_check_redirect_safety)
-
-            response = session.get(
-                src_loc, stream=True, headers=headers, timeout=(5, 30)
-            )
-            response.raise_for_status()
-
-            content_length = response.headers.get("content-length")
-            if content_length and int(content_length) > max_size:
-                raise ValueError(f"Resource size exceeds limit: {content_length} bytes")
-
-            chunks = []
-            total_size = 0
-            for chunk in response.iter_content(chunk_size=8192):
-                if chunk:
-                    total_size += len(chunk)
-                    if total_size > max_size:
-                        raise ValueError("Downloaded data exceeds size limit")
-                    chunks.append(chunk)
-
-            return b"".join(chunks)
-        elif src_loc.startswith("data:"):
-            encoded_data = re.sub(r"^data:image/.+;base64,", "", src_loc)
-            decoded_data = base64.b64decode(encoded_data)
-
-            if len(decoded_data) > self.options.max_image_data_base64_bytes:
-                raise ValueError(
-                    f"Decoded image exceeds size limit of {self.options.max_image_data_base64_bytes} bytes."
-                )
-
-            return decoded_data
-
-        if not self.options.enable_local_fetch:
-            raise OperationNotAllowed(
-                "Fetching local resources is only allowed when set explicitly. "
-                "Set options.enable_local_fetch=True."
-            )
-
-        # Require base_path for directory confinement (validation done in _resolve_relative_path)
-        if not self.base_path:
-            raise OperationNotAllowed(
-                f"Local file access requires base_path for directory confinement: '{src_loc}'"
-            )
-
-        if os.path.isfile(src_loc) and os.access(src_loc, os.R_OK):
-            with open(src_loc, "rb") as f:
-                return f.read()
-        else:
-            raise ValueError("File does not exist or it is not readable.")
+        return self._image_loader.load_image_data(src_loc, self.base_path)
 
     @staticmethod
     def get_text(item: PageElement) -> str:

--- a/docling/backend/image_resource_loader.py
+++ b/docling/backend/image_resource_loader.py
@@ -1,0 +1,262 @@
+"""Shared image-resource loading for declarative backends.
+
+Turns an image source (a ``data:`` URI, a local file, or a remote URL) into a
+Docling :class:`~docling_core.types.doc.document.ImageRef`, enforcing the
+relevant safety limits: a path-traversal guard when resolving relative paths,
+the ``enable_local_fetch`` / ``enable_remote_fetch`` toggles, and the base64 and
+remote download size caps.
+
+This logic originated in the HTML backend. It is factored out here so the HTML
+and Markdown backends can share a single implementation instead of duplicating
+it (or constructing one backend from inside the other).
+"""
+
+import base64
+import ipaddress
+import logging
+import os
+import re
+import socket
+import warnings
+from io import BytesIO
+from pathlib import Path
+from typing import Optional
+from urllib.parse import urljoin, urlparse
+
+import requests
+from docling_core.types.doc.document import ImageRef
+from PIL import Image, UnidentifiedImageError
+from pydantic import ValidationError
+
+from docling.exceptions import OperationNotAllowed
+
+_log = logging.getLogger(__name__)
+
+
+def validate_url_safety(url: str) -> None:
+    parsed = urlparse(url)
+    hostname = parsed.hostname
+
+    if not hostname:
+        raise ValueError("URL must contain a valid hostname")
+
+    try:
+        ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        try:
+            ip_str = socket.gethostbyname(hostname)
+            ip = ipaddress.ip_address(ip_str)
+        except (socket.gaierror, socket.herror) as e:
+            raise ValueError(f"Cannot resolve hostname: {hostname}") from e
+
+    if not (
+        ip.is_global
+        and not (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_link_local
+            or ip.is_reserved
+            or ip.is_multicast
+            or ip.is_unspecified
+        )
+    ):
+        raise ValueError(f"Access to restricted IP address not allowed: {ip}")
+
+
+class ImageResourceLoader:
+    """Resolve and load image resources for declarative document backends.
+
+    The ``base_path`` against which relative locations are resolved is supplied
+    per call rather than stored, so a backend that mutates its base path between
+    calls always uses the current value.
+    """
+
+    def __init__(
+        self,
+        *,
+        enable_local_fetch: bool = False,
+        enable_remote_fetch: bool = False,
+        max_image_data_base64_bytes: int = 20 * 1024 * 1024,
+        max_remote_image_bytes: int = 20 * 1024 * 1024,
+        max_redirects: int = 5,
+        headers: Optional[dict[str, str]] = None,
+    ) -> None:
+        self.enable_local_fetch = enable_local_fetch
+        self.enable_remote_fetch = enable_remote_fetch
+        self.max_image_data_base64_bytes = max_image_data_base64_bytes
+        self.max_remote_image_bytes = max_remote_image_bytes
+        self.max_redirects = max_redirects
+        self.headers = headers
+
+    @staticmethod
+    def is_remote_url(value: str) -> bool:
+        parsed = urlparse(value)
+        return parsed.scheme in {"http", "https", "ftp", "s3", "gs"}
+
+    @staticmethod
+    def is_local_path(value: str) -> bool:
+        """Check if value is a local filesystem path (not a URI)."""
+        parsed = urlparse(value)
+        return not parsed.netloc and (
+            not parsed.scheme
+            or (len(parsed.scheme) == 1 and parsed.scheme.isalpha())  # Windows case
+        )
+
+    @staticmethod
+    def is_absolute_path(loc: str) -> bool:
+        return Path(loc).is_absolute() or (  # Windows-specific absolute paths:
+            len((parsed_loc := urlparse(loc)).scheme) == 1
+            and parsed_loc.scheme.isalpha()
+            and not parsed_loc.netloc
+        )
+
+    def resolve_relative_path(self, loc: str, base_path: Optional[str]) -> str:
+        loc = loc.strip()
+
+        # Strip file:// prefix for validation as local path
+        if loc.startswith(file_prefix := "file://"):
+            loc = loc[len(file_prefix) :]
+
+        abs_loc = loc
+
+        if base_path:
+            if loc.startswith("//"):
+                abs_loc = "https:" + loc
+            elif not loc.startswith(("http://", "https://", "data:", "#")):
+                if ImageResourceLoader.is_remote_url(base_path):
+                    abs_loc = urljoin(base_path, loc)
+                elif ImageResourceLoader.is_local_path(base_path):
+                    if ImageResourceLoader.is_absolute_path(loc):
+                        raise ValueError(
+                            f"Absolute paths are not allowed with local base_path: '{loc}'"
+                        )
+
+                    base_dir = Path(base_path).parent.resolve()
+                    resolved_path = (base_dir / loc).resolve()
+
+                    if not resolved_path.is_relative_to(base_dir):
+                        raise ValueError(
+                            f"Path traversal blocked: '{loc}' resolves outside base directory"
+                        )
+                    abs_loc = str(resolved_path)
+                else:
+                    raise ValueError(f"Invalid base_path format: '{base_path}'")
+
+        _log.debug(f"Resolved location {loc} to {abs_loc}")
+        return abs_loc
+
+    def create_image_ref(
+        self, src_url: str, base_path: Optional[str]
+    ) -> Optional[ImageRef]:
+        try:
+            img_data = self.load_image_data(src_url, base_path)
+            if img_data:
+                img = Image.open(BytesIO(img_data))
+                return ImageRef.from_pil(img, dpi=int(img.info.get("dpi", (72,))[0]))
+        except (
+            requests.HTTPError,
+            ValidationError,
+            UnidentifiedImageError,
+            OperationNotAllowed,
+            TypeError,
+            ValueError,
+        ) as e:
+            warnings.warn(f"Could not process an image from {src_url}: {e}")
+
+        return None
+
+    def load_image_ref(self, src: str, base_path: Optional[str]) -> Optional[ImageRef]:
+        """Resolve ``src`` against ``base_path`` and decode it into an ImageRef."""
+        return self.create_image_ref(
+            self.resolve_relative_path(src, base_path), base_path
+        )
+
+    def load_image_data(
+        self, src_loc: str, base_path: Optional[str]
+    ) -> Optional[bytes]:
+        if src_loc.lower().endswith(".svg"):
+            _log.debug(f"Skipping SVG file: {src_loc}")
+            return None
+
+        if ImageResourceLoader.is_remote_url(src_loc):
+            if not self.enable_remote_fetch:
+                raise OperationNotAllowed(
+                    "Fetching remote resources is only allowed when set explicitly. "
+                    "Set options.enable_remote_fetch=True."
+                )
+
+            validate_url_safety(src_loc)
+
+            max_size = self.max_remote_image_bytes
+            headers = {"Range": f"bytes=0-{max_size - 1}"}
+
+            # Merge custom headers from options if provided
+            if self.headers:
+                headers.update(self.headers)
+
+            # Create session with redirect limit
+            session = requests.Session()
+            session.max_redirects = self.max_redirects
+
+            # Hook to validate each redirect target
+            def _check_redirect_safety(response, *args, **kwargs):
+                """Validate each redirect target before following it."""
+                if response.is_redirect or response.is_permanent_redirect:
+                    redirect_url = response.headers.get("location")
+                    if redirect_url:
+                        # Handle relative redirects
+                        if not redirect_url.startswith(("http://", "https://")):
+                            redirect_url = urljoin(response.url, redirect_url)
+
+                        # Validate the redirect target
+                        validate_url_safety(redirect_url)
+
+            session.hooks["response"].append(_check_redirect_safety)
+
+            response = session.get(
+                src_loc, stream=True, headers=headers, timeout=(5, 30)
+            )
+            response.raise_for_status()
+
+            content_length = response.headers.get("content-length")
+            if content_length and int(content_length) > max_size:
+                raise ValueError(f"Resource size exceeds limit: {content_length} bytes")
+
+            chunks = []
+            total_size = 0
+            for chunk in response.iter_content(chunk_size=8192):
+                if chunk:
+                    total_size += len(chunk)
+                    if total_size > max_size:
+                        raise ValueError("Downloaded data exceeds size limit")
+                    chunks.append(chunk)
+
+            return b"".join(chunks)
+        elif src_loc.startswith("data:"):
+            encoded_data = re.sub(r"^data:image/.+;base64,", "", src_loc)
+            decoded_data = base64.b64decode(encoded_data)
+
+            if len(decoded_data) > self.max_image_data_base64_bytes:
+                raise ValueError(
+                    f"Decoded image exceeds size limit of {self.max_image_data_base64_bytes} bytes."
+                )
+
+            return decoded_data
+
+        if not self.enable_local_fetch:
+            raise OperationNotAllowed(
+                "Fetching local resources is only allowed when set explicitly. "
+                "Set options.enable_local_fetch=True."
+            )
+
+        # Require base_path for directory confinement (validation done in resolve_relative_path)
+        if not base_path:
+            raise OperationNotAllowed(
+                f"Local file access requires base_path for directory confinement: '{src_loc}'"
+            )
+
+        if os.path.isfile(src_loc) and os.access(src_loc, os.R_OK):
+            with open(src_loc, "rb") as f:
+                return f.read()
+        else:
+            raise ValueError("File does not exist or it is not readable.")

--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -29,7 +29,7 @@ from docling.backend.abstract_backend import (
     DeclarativeDocumentBackend,
 )
 from docling.backend.html_backend import HTMLDocumentBackend
-from docling.backend.image_resource_loader import ImageResourceLoader
+from docling.backend.utils.image_resource_loader import ImageResourceLoader
 from docling.datamodel.backend_options import (
     HTMLBackendOptions,
     MarkdownBackendOptions,

--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -15,6 +15,7 @@ from docling_core.types.doc import (
     DoclingDocument,
     DocumentOrigin,
     Formatting,
+    ImageRef,
     ListItem,
     NodeItem,
     TableCell,
@@ -169,6 +170,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         self.in_table = False
         self.md_table_buffer: list[str] = []
         self._html_blocks: int = 0
+        self._image_backend: Optional[HTMLDocumentBackend] = None
 
         try:
             if isinstance(self.path_or_stream, BytesIO):
@@ -459,7 +461,8 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                     hyperlink=hyperlink,
                 )
 
-            doc.add_picture(parent=parent_item, caption=fig_caption)
+            image_ref = self._load_image_ref(element.dest)
+            doc.add_picture(parent=parent_item, image=image_ref, caption=fig_caption)
 
         elif isinstance(element, marko.inline.Emphasis):
             _log.debug(" - Emphasis: %s", element.children)
@@ -628,6 +631,51 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                     formatting=formatting,
                     hyperlink=hyperlink,
                 )
+
+    def _get_image_backend(self) -> HTMLDocumentBackend:
+        """Lazily build an HTML backend used only to load image data.
+
+        The HTML backend already implements resolving and decoding image
+        sources (``data:`` URIs, local files, and remote URLs) together with the
+        relevant safety limits, so the Markdown backend reuses it instead of
+        duplicating that logic. The same option mapping is used for embedded
+        HTML blocks (see ``convert``).
+        """
+        if self._image_backend is None:
+            md_options = cast(MarkdownBackendOptions, self.options)
+            html_options = HTMLBackendOptions(
+                enable_local_fetch=md_options.enable_local_fetch,
+                enable_remote_fetch=md_options.enable_remote_fetch,
+                fetch_images=md_options.fetch_images,
+                source_uri=md_options.source_uri,
+                max_image_data_base64_bytes=md_options.max_image_data_base64_bytes,
+            )
+            stream = BytesIO(b"<html><body></body></html>")
+            in_doc = InputDocument(
+                path_or_stream=stream,
+                format=InputFormat.HTML,
+                backend=HTMLDocumentBackend,
+                filename=self.file.name,
+                backend_options=html_options,
+            )
+            self._image_backend = HTMLDocumentBackend(
+                in_doc=in_doc,
+                path_or_stream=stream,
+                options=html_options,
+            )
+        return self._image_backend
+
+    def _load_image_ref(self, dest: str) -> Optional[ImageRef]:
+        """Resolve and decode a Markdown image source into an ``ImageRef``.
+
+        Returns ``None`` when image loading is disabled, the source is empty, or
+        the image cannot be loaded. Loading is delegated to the HTML backend.
+        """
+        if not cast(MarkdownBackendOptions, self.options).fetch_images or not dest:
+            return None
+        backend = self._get_image_backend()
+        src_loc = backend._resolve_relative_path(dest)
+        return backend._create_image_ref(src_loc)
 
     def is_valid(self) -> bool:
         return self.valid

--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -29,6 +29,7 @@ from docling.backend.abstract_backend import (
     DeclarativeDocumentBackend,
 )
 from docling.backend.html_backend import HTMLDocumentBackend
+from docling.backend.image_resource_loader import ImageResourceLoader
 from docling.datamodel.backend_options import (
     HTMLBackendOptions,
     MarkdownBackendOptions,
@@ -170,7 +171,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         self.in_table = False
         self.md_table_buffer: list[str] = []
         self._html_blocks: int = 0
-        self._image_backend: Optional[HTMLDocumentBackend] = None
+        self._image_loader: Optional[ImageResourceLoader] = None
 
         try:
             if isinstance(self.path_or_stream, BytesIO):
@@ -632,50 +633,36 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                     hyperlink=hyperlink,
                 )
 
-    def _get_image_backend(self) -> HTMLDocumentBackend:
-        """Lazily build an HTML backend used only to load image data.
+    def _get_image_loader(self) -> ImageResourceLoader:
+        """Lazily build the shared image-resource loader.
 
-        The HTML backend already implements resolving and decoding image
-        sources (``data:`` URIs, local files, and remote URLs) together with the
-        relevant safety limits, so the Markdown backend reuses it instead of
-        duplicating that logic. The same option mapping is used for embedded
-        HTML blocks (see ``convert``).
+        Resolving and decoding image sources (``data:`` URIs, local files, and
+        remote URLs) together with the relevant safety limits is shared with the
+        HTML backend through :class:`ImageResourceLoader`, so that logic is not
+        duplicated here.
         """
-        if self._image_backend is None:
+        if self._image_loader is None:
             md_options = cast(MarkdownBackendOptions, self.options)
-            html_options = HTMLBackendOptions(
+            self._image_loader = ImageResourceLoader(
                 enable_local_fetch=md_options.enable_local_fetch,
                 enable_remote_fetch=md_options.enable_remote_fetch,
-                fetch_images=md_options.fetch_images,
-                source_uri=md_options.source_uri,
                 max_image_data_base64_bytes=md_options.max_image_data_base64_bytes,
             )
-            stream = BytesIO(b"<html><body></body></html>")
-            in_doc = InputDocument(
-                path_or_stream=stream,
-                format=InputFormat.HTML,
-                backend=HTMLDocumentBackend,
-                filename=self.file.name,
-                backend_options=html_options,
-            )
-            self._image_backend = HTMLDocumentBackend(
-                in_doc=in_doc,
-                path_or_stream=stream,
-                options=html_options,
-            )
-        return self._image_backend
+        return self._image_loader
 
     def _load_image_ref(self, dest: str) -> Optional[ImageRef]:
         """Resolve and decode a Markdown image source into an ``ImageRef``.
 
         Returns ``None`` when image loading is disabled, the source is empty, or
-        the image cannot be loaded. Loading is delegated to the HTML backend.
+        the image cannot be loaded.
         """
-        if not cast(MarkdownBackendOptions, self.options).fetch_images or not dest:
+        md_options = cast(MarkdownBackendOptions, self.options)
+        if not md_options.fetch_images or not dest:
             return None
-        backend = self._get_image_backend()
-        src_loc = backend._resolve_relative_path(dest)
-        return backend._create_image_ref(src_loc)
+        base_path = (
+            str(md_options.source_uri) if md_options.source_uri is not None else None
+        )
+        return self._get_image_loader().load_image_ref(dest, base_path)
 
     def is_valid(self) -> bool:
         return self.valid

--- a/docling/backend/utils/image_resource_loader.py
+++ b/docling/backend/utils/image_resource_loader.py
@@ -34,6 +34,19 @@ _log = logging.getLogger(__name__)
 
 
 def validate_url_safety(url: str) -> None:
+    """Reject URLs that resolve to a non-public IP address.
+
+    Guards against SSRF by requiring the URL's host to resolve to a globally
+    routable address. Private, loopback, link-local, reserved, multicast, and
+    unspecified addresses are refused.
+
+    Args:
+        url: The URL whose host is validated.
+
+    Raises:
+        ValueError: If the URL has no hostname, the hostname cannot be
+            resolved, or it resolves to a restricted (non-global) IP address.
+    """
     parsed = urlparse(url)
     hostname = parsed.hostname
 

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -134,6 +134,10 @@ class MarkdownBackendOptions(BaseBackendOptions):
             "will use it to resolve relative paths in the markdown document."
         ),
     )
+    max_image_data_base64_bytes: PositiveInt = Field(
+        20 * 1024 * 1024,  # 20 MB
+        description="The maximum number of base64 data bytes that the backend will accept.",
+    )
 
 
 class EpubBackendOptions(BaseBackendOptions):

--- a/tests/test_backend_html.py
+++ b/tests/test_backend_html.py
@@ -16,7 +16,9 @@ from pydantic import AnyUrl, ValidationError
 from docling.backend.html_backend import (
     _BR_SENTINEL,
     HTMLDocumentBackend,
-    _validate_url_safety,
+)
+from docling.backend.image_resource_loader import (
+    validate_url_safety as _validate_url_safety,
 )
 from docling.datamodel.backend_options import HTMLBackendOptions
 from docling.datamodel.base_models import InputFormat
@@ -369,8 +371,8 @@ def test_e2e_html_conversions(html_paths):
         assert verify_document(doc, str(gt_path) + ".json", GENERATE)
 
 
-@patch("docling.backend.html_backend.requests.get")
-@patch("docling.backend.html_backend.open", new_callable=mock_open)
+@patch("docling.backend.image_resource_loader.requests.get")
+@patch("docling.backend.image_resource_loader.open", new_callable=mock_open)
 def test_e2e_html_conversion_with_images(mock_local, mock_remote):
     source = "tests/data/html/sources/example_01.html"
     image_path = "tests/data/html/sources/example_image_01.png"
@@ -400,7 +402,7 @@ def test_e2e_html_conversion_with_images(mock_local, mock_remote):
 
     # fetching image remotely - need to mock Session.get instead of requests.get
     with patch(
-        "docling.backend.html_backend.requests.Session.get"
+        "docling.backend.image_resource_loader.requests.Session.get"
     ) as mocked_session_get:
         mock_resp = Mock()
         mock_resp.status_code = 200
@@ -485,7 +487,7 @@ def test_fetch_remote_images(monkeypatch):
     converter = _create_html_converter(
         HTMLBackendOptions(fetch_images=False, source_uri="http://example.com")
     )
-    with patch("docling.backend.html_backend.requests.get") as mocked_get:
+    with patch("docling.backend.image_resource_loader.requests.get") as mocked_get:
         res = converter.convert(source)
         mocked_get.assert_not_called()
     assert res.document
@@ -493,7 +495,7 @@ def test_fetch_remote_images(monkeypatch):
     # no image fetching: the source location is False and enable_local_fetch is False
     converter = _create_html_converter(HTMLBackendOptions(fetch_images=True))
     with (
-        patch("docling.backend.html_backend.requests.get") as mocked_get,
+        patch("docling.backend.image_resource_loader.requests.get") as mocked_get,
         pytest.warns(
             match="Fetching local resources is only allowed when set explicitly"
         ),
@@ -507,7 +509,7 @@ def test_fetch_remote_images(monkeypatch):
         HTMLBackendOptions(fetch_images=True, source_uri="http://example.com")
     )
     with (
-        patch("docling.backend.html_backend.requests.get") as mocked_get,
+        patch("docling.backend.image_resource_loader.requests.get") as mocked_get,
         pytest.warns(
             match="Fetching remote resources is only allowed when set explicitly"
         ),
@@ -523,7 +525,7 @@ def test_fetch_remote_images(monkeypatch):
         )
     )
     with patch(
-        "docling.backend.html_backend.requests.Session.get"
+        "docling.backend.image_resource_loader.requests.Session.get"
     ) as mocked_session_get:
         mocked_session_get.return_value = _create_mock_response()
         res = converter.convert(source)
@@ -537,7 +539,7 @@ def test_fetch_remote_images(monkeypatch):
         )
     )
     with (
-        patch("docling.backend.html_backend.open") as mocked_open,
+        patch("docling.backend.image_resource_loader.open") as mocked_open,
         pytest.warns(match="a bytes-like object is required"),
     ):
         res = converter.convert(source)
@@ -565,7 +567,7 @@ def test_fetch_remote_images_with_custom_headers():
 
     converter = _create_html_converter(backend_options)
     with patch(
-        "docling.backend.html_backend.requests.Session.get"
+        "docling.backend.image_resource_loader.requests.Session.get"
     ) as mocked_session_get:
         mocked_session_get.return_value = _create_mock_response()
         res = converter.convert("./tests/data/html/sources/example_01.html")

--- a/tests/test_backend_html.py
+++ b/tests/test_backend_html.py
@@ -17,7 +17,7 @@ from docling.backend.html_backend import (
     _BR_SENTINEL,
     HTMLDocumentBackend,
 )
-from docling.backend.image_resource_loader import (
+from docling.backend.utils.image_resource_loader import (
     validate_url_safety as _validate_url_safety,
 )
 from docling.datamodel.backend_options import HTMLBackendOptions
@@ -371,8 +371,8 @@ def test_e2e_html_conversions(html_paths):
         assert verify_document(doc, str(gt_path) + ".json", GENERATE)
 
 
-@patch("docling.backend.image_resource_loader.requests.get")
-@patch("docling.backend.image_resource_loader.open", new_callable=mock_open)
+@patch("docling.backend.utils.image_resource_loader.requests.get")
+@patch("docling.backend.utils.image_resource_loader.open", new_callable=mock_open)
 def test_e2e_html_conversion_with_images(mock_local, mock_remote):
     source = "tests/data/html/sources/example_01.html"
     image_path = "tests/data/html/sources/example_image_01.png"
@@ -402,7 +402,7 @@ def test_e2e_html_conversion_with_images(mock_local, mock_remote):
 
     # fetching image remotely - need to mock Session.get instead of requests.get
     with patch(
-        "docling.backend.image_resource_loader.requests.Session.get"
+        "docling.backend.utils.image_resource_loader.requests.Session.get"
     ) as mocked_session_get:
         mock_resp = Mock()
         mock_resp.status_code = 200
@@ -487,7 +487,9 @@ def test_fetch_remote_images(monkeypatch):
     converter = _create_html_converter(
         HTMLBackendOptions(fetch_images=False, source_uri="http://example.com")
     )
-    with patch("docling.backend.image_resource_loader.requests.get") as mocked_get:
+    with patch(
+        "docling.backend.utils.image_resource_loader.requests.get"
+    ) as mocked_get:
         res = converter.convert(source)
         mocked_get.assert_not_called()
     assert res.document
@@ -495,7 +497,7 @@ def test_fetch_remote_images(monkeypatch):
     # no image fetching: the source location is False and enable_local_fetch is False
     converter = _create_html_converter(HTMLBackendOptions(fetch_images=True))
     with (
-        patch("docling.backend.image_resource_loader.requests.get") as mocked_get,
+        patch("docling.backend.utils.image_resource_loader.requests.get") as mocked_get,
         pytest.warns(
             match="Fetching local resources is only allowed when set explicitly"
         ),
@@ -509,7 +511,7 @@ def test_fetch_remote_images(monkeypatch):
         HTMLBackendOptions(fetch_images=True, source_uri="http://example.com")
     )
     with (
-        patch("docling.backend.image_resource_loader.requests.get") as mocked_get,
+        patch("docling.backend.utils.image_resource_loader.requests.get") as mocked_get,
         pytest.warns(
             match="Fetching remote resources is only allowed when set explicitly"
         ),
@@ -525,7 +527,7 @@ def test_fetch_remote_images(monkeypatch):
         )
     )
     with patch(
-        "docling.backend.image_resource_loader.requests.Session.get"
+        "docling.backend.utils.image_resource_loader.requests.Session.get"
     ) as mocked_session_get:
         mocked_session_get.return_value = _create_mock_response()
         res = converter.convert(source)
@@ -539,7 +541,7 @@ def test_fetch_remote_images(monkeypatch):
         )
     )
     with (
-        patch("docling.backend.image_resource_loader.open") as mocked_open,
+        patch("docling.backend.utils.image_resource_loader.open") as mocked_open,
         pytest.warns(match="a bytes-like object is required"),
     ):
         res = converter.convert(source)
@@ -567,7 +569,7 @@ def test_fetch_remote_images_with_custom_headers():
 
     converter = _create_html_converter(backend_options)
     with patch(
-        "docling.backend.image_resource_loader.requests.Session.get"
+        "docling.backend.utils.image_resource_loader.requests.Session.get"
     ) as mocked_session_get:
         mocked_session_get.return_value = _create_mock_response()
         res = converter.convert("./tests/data/html/sources/example_01.html")
@@ -1085,6 +1087,63 @@ def test_path_traversal_blocked_in_resolve_relative_path():
         OperationNotAllowed, match="Local file access requires base_path"
     ):
         html_doc._load_image_data("image.png")
+
+
+def _make_html_backend(options=None):
+    html_path = Path("./tests/data/html/sources/example_01.html")
+    in_doc = InputDocument(
+        path_or_stream=html_path,
+        format=InputFormat.HTML,
+        backend=HTMLDocumentBackend,
+        filename="test",
+    )
+    return HTMLDocumentBackend(
+        in_doc=in_doc,
+        path_or_stream=html_path,
+        options=options or HTMLBackendOptions(),
+    )
+
+
+def test_browser_request_block_reason_policy():
+    """Render-mode request filtering: scheme allow-list plus remote-fetch gating."""
+    backend = _make_html_backend(HTMLBackendOptions(enable_remote_fetch=False))
+
+    # data:/file: schemes are always allowed during rendering
+    assert (
+        backend._get_browser_request_block_reason("data:image/png;base64,AAAA") is None
+    )
+    assert backend._get_browser_request_block_reason("file:///tmp/page.html") is None
+
+    # remote requests are blocked while remote fetch is disabled
+    reason = backend._get_browser_request_block_reason("http://example.com/img.png")
+    assert reason is not None and "remote fetch is disabled" in reason
+
+    # a non-remote, non-allowlisted scheme is refused
+    assert "is not allowed" in (
+        backend._get_browser_request_block_reason("gopher://example.com/x") or ""
+    )
+
+    # remote requests are permitted once remote fetch is enabled
+    backend = _make_html_backend(HTMLBackendOptions(enable_remote_fetch=True))
+    assert (
+        backend._get_browser_request_block_reason("http://example.com/img.png") is None
+    )
+
+
+def test_coerce_base_url():
+    backend = _make_html_backend()
+
+    # Remote and file:// URLs are passed through unchanged
+    assert (
+        backend._coerce_base_url("http://example.com/a.html")
+        == "http://example.com/a.html"
+    )
+    assert backend._coerce_base_url("file:///tmp/a.html") == "file:///tmp/a.html"
+
+    # A local filesystem path is normalized to a file URI
+    assert backend._coerce_base_url(
+        "tests/data/html/sources/example_01.html"
+    ).startswith("file://")
 
 
 def test_valid_local_paths_still_work():

--- a/tests/test_backend_markdown.py
+++ b/tests/test_backend_markdown.py
@@ -1,8 +1,13 @@
+import base64
+from io import BytesIO
 from pathlib import Path
 
 import pytest
+from docling_core.types.doc import PictureItem
+from PIL import Image
 
 from docling.backend.md_backend import MarkdownDocumentBackend
+from docling.datamodel.backend_options import MarkdownBackendOptions
 from docling.datamodel.base_models import ConversionStatus, InputFormat
 from docling.datamodel.document import (
     ConversionResult,
@@ -166,3 +171,81 @@ def test_convert_list_item_codespan_only():
     pred_md = conv_result.document.export_to_markdown()
     assert "- raw\\_ops.Abort" in pred_md
     assert "- raw\\_ops.Abs" in pred_md
+
+
+def _convert_markdown(
+    markdown: str, options: MarkdownBackendOptions
+) -> DoclingDocument:
+    stream = BytesIO(markdown.encode("utf-8"))
+    in_doc = InputDocument(
+        path_or_stream=stream,
+        format=InputFormat.MD,
+        backend=MarkdownDocumentBackend,
+        filename="test.md",
+        backend_options=options,
+    )
+    backend = MarkdownDocumentBackend(
+        in_doc=in_doc,
+        path_or_stream=stream,
+        options=options,
+    )
+    assert backend.is_valid()
+    return backend.convert()
+
+
+def _png_data_uri(width: int, height: int) -> str:
+    buffer = BytesIO()
+    Image.new("RGB", (width, height), color=(255, 0, 0)).save(buffer, format="PNG")
+    encoded = base64.b64encode(buffer.getvalue()).decode()
+    return f"data:image/png;base64,{encoded}"
+
+
+def test_convert_embedded_base64_image():
+    """Embedded base64 image data must be decoded when fetch_images is enabled.
+
+    Regression test for https://github.com/docling-project/docling/issues/1305.
+    """
+    markdown = f"# Title\n\n![alt]({_png_data_uri(7, 5)})\n"
+
+    doc = _convert_markdown(markdown, MarkdownBackendOptions(fetch_images=True))
+
+    pictures = [
+        item for item, _ in doc.iterate_items() if isinstance(item, PictureItem)
+    ]
+    assert len(pictures) == 1
+    picture = pictures[0]
+    assert picture.image is not None
+    image = picture.get_image(doc)
+    assert image is not None
+    assert image.size == (7, 5)
+
+
+def test_convert_embedded_base64_image_disabled_by_default():
+    """Without fetch_images the picture stays a placeholder (default behavior)."""
+    markdown = f"# Title\n\n![alt]({_png_data_uri(7, 5)})\n"
+
+    doc = _convert_markdown(markdown, MarkdownBackendOptions())
+
+    pictures = [
+        item for item, _ in doc.iterate_items() if isinstance(item, PictureItem)
+    ]
+    assert len(pictures) == 1
+    assert pictures[0].image is None
+    assert pictures[0].get_image(doc) is None
+
+
+def test_convert_embedded_base64_image_enforces_size_limit():
+    """Decoded base64 images larger than the configured cap are rejected."""
+    markdown = f"# Title\n\n![alt]({_png_data_uri(7, 5)})\n"
+
+    with pytest.warns(UserWarning, match="exceeds size limit"):
+        doc = _convert_markdown(
+            markdown,
+            MarkdownBackendOptions(fetch_images=True, max_image_data_base64_bytes=8),
+        )
+
+    pictures = [
+        item for item, _ in doc.iterate_items() if isinstance(item, PictureItem)
+    ]
+    assert len(pictures) == 1
+    assert pictures[0].image is None

--- a/tests/test_backend_markdown.py
+++ b/tests/test_backend_markdown.py
@@ -201,10 +201,7 @@ def _png_data_uri(width: int, height: int) -> str:
 
 
 def test_convert_embedded_base64_image():
-    """Embedded base64 image data must be decoded when fetch_images is enabled.
-
-    Regression test for https://github.com/docling-project/docling/issues/1305.
-    """
+    """Embedded base64 image data must be decoded when fetch_images is enabled."""
     markdown = f"# Title\n\n![alt]({_png_data_uri(7, 5)})\n"
 
     doc = _convert_markdown(markdown, MarkdownBackendOptions(fetch_images=True))

--- a/tests/test_image_resource_loader.py
+++ b/tests/test_image_resource_loader.py
@@ -1,0 +1,86 @@
+"""Unit tests for the shared image-resource loader and its safety limits."""
+
+import socket
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+from docling.backend.utils.image_resource_loader import (
+    ImageResourceLoader,
+    validate_url_safety,
+)
+from docling.exceptions import OperationNotAllowed
+
+# A globally routable IP literal (example.com) used so the source URL passes the
+# SSRF check without a DNS lookup, keeping these tests offline.
+_GLOBAL_IP_URL = "http://93.184.216.34/image.png"
+
+
+def test_validate_url_safety_requires_hostname():
+    with pytest.raises(ValueError, match="must contain a valid hostname"):
+        validate_url_safety("https:///no-host")
+
+
+def test_validate_url_safety_rejects_unresolvable_hostname():
+    with patch.object(socket, "gethostbyname", side_effect=socket.gaierror):
+        with pytest.raises(ValueError, match="Cannot resolve hostname"):
+            validate_url_safety("http://does-not-exist.invalid/file")
+
+
+def test_load_image_data_skips_svg():
+    loader = ImageResourceLoader(enable_remote_fetch=True)
+    assert loader.load_image_data("http://example.com/logo.svg", None) is None
+
+
+def test_load_image_data_revalidates_redirect_target():
+    """A redirect to a restricted IP must be blocked, not silently followed."""
+    loader = ImageResourceLoader(enable_remote_fetch=True)
+
+    def fake_get(session, url, **kwargs):
+        # Emulate requests dispatching the response hook on a redirect so the
+        # registered safety check runs against the redirect target. A
+        # protocol-relative location also exercises the relative-redirect join.
+        redirect = Mock()
+        redirect.is_redirect = True
+        redirect.is_permanent_redirect = False
+        redirect.headers = {"location": "//169.254.169.254/latest/meta-data"}
+        redirect.url = url
+        for hook in session.hooks["response"]:
+            hook(redirect)
+        return Mock()
+
+    with patch.object(requests.Session, "get", fake_get):
+        with pytest.raises(ValueError, match="restricted IP address"):
+            loader.load_image_data(_GLOBAL_IP_URL, None)
+
+
+def test_load_image_data_streaming_exceeds_size_limit():
+    """Downloads without a content-length header are still capped while streaming."""
+    loader = ImageResourceLoader(enable_remote_fetch=True, max_remote_image_bytes=10)
+
+    def fake_get(session, url, **kwargs):
+        resp = Mock()
+        resp.headers = {}  # no content-length, so the cap is enforced per chunk
+        resp.raise_for_status = Mock()
+        resp.iter_content = Mock(return_value=[b"x" * 8, b"x" * 8])
+        return resp
+
+    with patch.object(requests.Session, "get", fake_get):
+        with pytest.raises(ValueError, match="Downloaded data exceeds size limit"):
+            loader.load_image_data(_GLOBAL_IP_URL, None)
+
+
+def test_load_image_data_missing_local_file(tmp_path):
+    loader = ImageResourceLoader(enable_local_fetch=True)
+    base_path = str(tmp_path / "doc.html")
+    missing = str(tmp_path / "missing.png")
+
+    with pytest.raises(ValueError, match="File does not exist or it is not readable"):
+        loader.load_image_data(missing, base_path)
+
+
+def test_load_image_data_local_requires_base_path():
+    loader = ImageResourceLoader(enable_local_fetch=True)
+    with pytest.raises(OperationNotAllowed, match="requires base_path"):
+        loader.load_image_data("/some/where/image.png", None)


### PR DESCRIPTION
The Markdown backend created a `PictureItem` for an inline image but never loaded the image bytes, so base64 `data:` URI images ended up with `.image is None` and `picture.get_image(doc)` returning `None`. The embedded image data was silently dropped.

This loads the image source when `fetch_images` is enabled and attaches the resulting `ImageRef` to the picture, mirroring the HTML backend. Loading is delegated to the HTML backend's existing resolver/decoder, which already handles `data:` URIs, local files, and remote URLs together with their safety limits (path-traversal guard, `enable_local_fetch` / `enable_remote_fetch`, base64 size cap), so no image-loading logic is duplicated. A `max_image_data_base64_bytes` cap is added to `MarkdownBackendOptions` to match `HTMLBackendOptions`. The default (`fetch_images=False`) keeps the previous placeholder behavior unchanged, so no reference conversion data changes.

A design note for reviewers: this gates embedded `data:` decoding behind `fetch_images`, mirroring the HTML backend exactly. An alternative would be to always decode embedded `data:` URIs (the bytes are in-document and need no resource access) and gate only local/remote behind the fetch flags, which is a bit friendlier for #1305. Mirroring HTML was chosen for consistency and the smallest behavioral surprise; happy to switch to always-decode if preferred.

**Issue resolved by this Pull Request:**
Resolves #1305

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
