### PR TITLE
fix(tests): correct XBRL source path to point to 'sources/' subdirectory

### DIFF
--- a/tests/test_backend_xbrl.py
+++ b/tests/test_backend_xbrl.py
@@ -25,7 +25,7 @@ GENERATE = GEN_TEST_DATA
 
 @pytest.fixture(scope="module")
 def xbrl_paths() -> list[tuple[Path, Path]]:
-    directory = Path(os.path.dirname(__file__) + "/data/xbrl/")
+    directory = Path(os.path.dirname(__file__) + "/data/xbrl/sources/")
     xml_files = sorted(
         [
             item


### PR DESCRIPTION
## Summary

Fix a silent regression in the XBRL backend test: the `xbrl_paths` fixture was scanning the wrong directory, causing the test to run zero conversions while still passing.

## Root cause

Commit 011469074f (`chore: restructure the tests and its regression
data (#3690)`) reorganised the XBRL test data into subdirectories:

```
tests/data/xbrl/
├── sources/          ← XBRL input files and taxonomy dirs
│   ├── grve_10q_htm.xml
│   ├── grve-taxonomy/
│   ├── mlac-20251231.xml
│   └── mlac-taxonomy/
└── groundtruth/      ← expected conversion outputs
```

That commit updated the `gt_path` line in the test to reflect the new
layout, but forgot to update the `directory =` line in the `xbrl_paths`
fixture. As a result the fixture kept pointing at `tests/data/xbrl/`
instead of `tests/data/xbrl/sources/`.

Because `directory.iterdir()` found only two subdirectories and no
`.xml`/`.xbrl` files, `xml_files` was always empty. The guard assertion
`assert len(xml_files) == len(taxonomy_dir)` passed vacuously (0 == 0),
and the test loop executed zero iterations — silently succeeding without
exercising any real conversion.

## Fix

One-line change: point the fixture at the correct `sources/`
subdirectory so the test actually runs.