### PR TITLE
feat: allow overriding same-font enforcement

### DIFF
--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -47,9 +47,10 @@ _log = logging.getLogger(__name__)
 
 def _make_docling_parse_decode_config(
     *,
+    enforce_same_font: bool = True,
     release_native_memory_every_n_pages: int | None = None,
 ) -> DecodeConfig:
-    config = DecodeConfig(enforce_same_font=True)
+    config = DecodeConfig(enforce_same_font=enforce_same_font)
 
     if release_native_memory_every_n_pages is not None:
         config.release_native_memory_every_n_pages = release_native_memory_every_n_pages
@@ -279,7 +280,9 @@ class DoclingParseDocumentBackend(ManagedPdfiumDocumentBackend):
             with pypdfium2_lock:
                 self._pdoc = pdfium.PdfDocument(self.path_or_stream, password=password)
             self.parser = DoclingPdfParser(loglevel="fatal")
-            decode_config = _make_docling_parse_decode_config()
+            decode_config = _make_docling_parse_decode_config(
+                enforce_same_font=self.options.enforce_same_font,
+            )
             self.dp_doc = self.parser.load(
                 path_or_stream=self.path_or_stream,
                 password=password,
@@ -490,6 +493,7 @@ class ThreadedDoclingParseDocumentBackend(PdfDocumentBackend):
             else 128
         )
         decode_config = _make_docling_parse_decode_config(
+            enforce_same_font=self.options.enforce_same_font,
             release_native_memory_every_n_pages=native_memory_release_interval,
         )
         content_config = _make_docling_parse_page_content_config(

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -169,6 +169,14 @@ class PdfBackendOptions(BaseBackendOptions):
 
     kind: Literal["pdf"] = Field("pdf", exclude=True, repr=False)
     password: Optional[SecretStr] = None
+    enforce_same_font: bool = Field(
+        True,
+        description=(
+            "Whether docling-parse should split text cells at font boundaries. "
+            "Disable this when PDFs use separate fonts for base glyphs and "
+            "diacritics that should remain in the same text cell."
+        ),
+    )
 
 
 class ThreadedDoclingParseBackendOptions(PdfBackendOptions):


### PR DESCRIPTION
## Summary

- Add `PdfBackendOptions.enforce_same_font` so callers can control docling-parse font-boundary splitting.
- Pass the option into `DecodeConfig` for both `DoclingParseDocumentBackend` and `ThreadedDoclingParseDocumentBackend`.
- Add focused tests covering the default behavior and disabling the setting for both backends.

## Why

`docling-parse` defaults to `enforce_same_font=True`, which splits text cells at font boundaries. Some PDFs render base glyphs and diacritics with separate fonts, so this can split a single visible word into multiple cells and later produce text with unwanted spaces, e.g. `Zwierz ą t` instead of `Zwierząt`.

This exposes the setting through `PdfBackendOptions` so callers can disable font-boundary splitting without subclassing `DoclingParseDocumentBackend` or depending on docling-parse internals.