### PR TITLE
fix(html): parse tables nested inside list items (#3508)

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -2223,6 +2223,9 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
             elif elem.name == "table":
                 # Dispatch nested tables to the block handler so they are parsed
                 # as tables instead of being flattened into the list item text.
+                # No _has_list_ancestor-style guard is needed here (unlike the
+                # list branch): _handle_block consumes the whole table, so its
+                # descendants are never re-walked by _process_nested_element.
                 self._handle_block(elem, doc)
                 self.parents[self.level + 1] = None
             else:

--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -1865,7 +1865,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
             return AnnotatedTextList()
         if self._is_checkbox_label_tag(tag):
             return AnnotatedTextList()
-        if not ignore_list or (tag.name not in ["ul", "ol", "dl"]):
+        if not ignore_list or (tag.name not in ["ul", "ol", "dl", "table"]):
             for child in tag:
                 if isinstance(child, Tag) and child.name in _FORMAT_TAG_MAP:
                     with self._use_format([child.name]):
@@ -2220,6 +2220,11 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
                 if not self._has_list_ancestor(elem, li):
                     self._handle_block(elem, doc)
                     self.parents[self.level + 1] = None
+            elif elem.name == "table":
+                # Dispatch nested tables to the block handler so they are parsed
+                # as tables instead of being flattened into the list item text.
+                self._handle_block(elem, doc)
+                self.parents[self.level + 1] = None
             else:
                 # Recursively process children for other elements (like divs)
                 for child in elem.children:

--- a/tests/test_backend_html.py
+++ b/tests/test_backend_html.py
@@ -267,6 +267,49 @@ def test_nested_table_in_list_item():
     assert md.count("Fault type.") == 1
 
 
+@pytest.mark.parametrize(
+    "inner",
+    [
+        # table as a direct child of <li>
+        b"<li>Step:<table><tbody><tr><td>A</td><td>B</td></tr></tbody></table></li>",
+        # table wrapped in a <div> inside <li> (reaches the table branch via the
+        # generic else-recursion path)
+        b"<li>Step:<div><table><tbody><tr><td>A</td><td>B</td></tr></tbody>"
+        b"</table></div></li>",
+    ],
+)
+def test_nested_table_in_list_item_wrappers(inner):
+    """#3508: the nested table is parsed regardless of an intermediate wrapper."""
+    html = b"<html><body><ol>" + inner + b"</ol></body></html>"
+    in_doc = InputDocument(
+        path_or_stream=BytesIO(html),
+        format=InputFormat.HTML,
+        backend=HTMLDocumentBackend,
+        filename="test",
+    )
+    backend = HTMLDocumentBackend(in_doc=in_doc, path_or_stream=BytesIO(html))
+    doc = backend.convert()
+    assert len(doc.tables) == 1
+
+
+def test_nested_table_in_description_list_item():
+    """#3508: same fix applies to a <table> nested in a <dl>/<dd>."""
+    html = (
+        b"<html><body><dl><dt>Term</dt>"
+        b"<dd>Def:<table><tbody><tr><td>A</td><td>B</td></tr></tbody></table></dd>"
+        b"</dl></body></html>"
+    )
+    in_doc = InputDocument(
+        path_or_stream=BytesIO(html),
+        format=InputFormat.HTML,
+        backend=HTMLDocumentBackend,
+        filename="test",
+    )
+    backend = HTMLDocumentBackend(in_doc=in_doc, path_or_stream=BytesIO(html))
+    doc = backend.convert()
+    assert len(doc.tables) == 1
+
+
 def test_description_lists():
     """Test that HTML description lists (<dl>, <dt>, <dd>) are properly parsed."""
     test_set: list[tuple[bytes, str]] = []

--- a/tests/test_backend_html.py
+++ b/tests/test_backend_html.py
@@ -224,6 +224,49 @@ def test_ordered_lists():
         assert doc.export_to_markdown() == pair[1], f"Error in case {idx}"
 
 
+def test_nested_table_in_list_item():
+    """Regression for #3508: a <table> nested inside an <ol>/<li> must be parsed
+    as a table instead of being flattened into the list item's text.
+
+    Previously the nested table was recursed into as flow content, so its cells
+    collapsed into the list item text and the cells' inner <ul> items were hoisted
+    into the ordered list (breaking the numbering).
+    """
+    html = (
+        b"<html><body><ol>"
+        b"<li>First step.</li>"
+        b"<li>Second step:"
+        b"<table><thead><tr><th>Name</th><th>Desc</th></tr></thead>"
+        b"<tbody><tr><td>Type</td>"
+        b"<td>Fault type.<ul><li>Alpha</li><li>Beta</li></ul></td></tr>"
+        b"</tbody></table></li>"
+        b"<li>Third step.</li>"
+        b"</ol></body></html>"
+    )
+    in_doc = InputDocument(
+        path_or_stream=BytesIO(html),
+        format=InputFormat.HTML,
+        backend=HTMLDocumentBackend,
+        filename="test",
+    )
+    backend = HTMLDocumentBackend(in_doc=in_doc, path_or_stream=BytesIO(html))
+    doc: DoclingDocument = backend.convert()
+    assert doc
+
+    # The nested table must be parsed as a table (was 0 before the fix).
+    assert len(doc.tables) == 1
+    assert doc.tables[0].data.num_rows == 2
+    assert doc.tables[0].data.num_cols == 2
+
+    md = doc.export_to_markdown()
+    # Ordered-list numbering stays 1..3; the cell's inner <ul> is not hoisted.
+    assert "1. First step." in md
+    assert "2. Second step" in md
+    assert "3. Third step." in md
+    # Cell text lives in the table, not duplicated into the list item text.
+    assert md.count("Fault type.") == 1
+
+
 def test_description_lists():
     """Test that HTML description lists (<dl>, <dt>, <dd>) are properly parsed."""
     test_set: list[tuple[bytes, str]] = []


### PR DESCRIPTION
Fixes #3508

### Problem

When a `<table>` is nested inside an ordered/unordered list item (`<ol>`/`<li>`), the table is lost on conversion: it is **not** emitted as a table, its cell text collapses into the list item's text, and any `<ul>` inside a cell is hoisted up into the outer ordered list — which also breaks the list numbering (the reporter saw `1, 2, 3, 5, 6, 8`).

For the document in #3508, `len(doc.tables) == 0` — the whole table structure disappears.

### Root cause

In `HTMLDocumentBackend`, list-item nested content is processed by `_process_nested_element`, which only dispatches `img` and `ul`/`ol`/`dl` to real handlers; everything else falls into an `else` branch that recurses into children as generic flow content. A nested `<table>` hits that `else` branch, so it never reaches `_handle_block` (which would parse it via `parse_table_data`). Its `<td>`/`<th>` text is emitted as flat text and its cell `<ul>`s are picked up as list items.

Separately, `_extract_text_and_hyperlink_recursively` (which builds the list item's inline text with `ignore_list=True`) skips `<ul>/<ol>/<dl>` but not `<table>`, so cell text is pulled into the item text.

### Fix

Treat a nested `<table>` the same way nested lists are already treated — as a block that is rendered separately:

1. `_process_nested_element`: dispatch `<table>` to `_handle_block`.
2. `_extract_text_and_hyperlink_recursively`: also skip `<table>` when `ignore_list` is set, so cell text is not duplicated into the list item text.

Two lines of behavior change; no new parameters.

### Before / after (issue document)

| | `len(doc.tables)` | list numbering | cell value-ranges |
|---|---|---|---|
| before | `0` (flattened to text) | `1,2,3,5,6,8` | lost / scrambled |
| after | `1` (`4×2` table) | `1..6` | preserved inside cells |

### Test

Adds `test_nested_table_in_list_item` (regression for #3508): a `<table>` inside an `<ol>/<li>` with an inner `<ul>` in a cell. Asserts the table is parsed (`len(doc.tables) == 1`, `2×2`), the ordered-list numbering stays `1..3`, and cell text is not duplicated into the item text. Fails before the fix (`0 tables`), passes after. Full `tests/test_backend_html.py` suite stays green.
