### PR TITLE
fix(msword): preserve cells in table rows starting late with gridBefore

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -2118,18 +2118,25 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
 
                 spanned_idx = row_idx
                 spanned_tc: CT_Tc | None = cell._tc
+                # Absolute grid column of the current cell. `_Row.cells` is indexed
+                # from the first cell actually present, so in a row that starts late
+                # via `w:gridBefore` the positional index is offset from the grid
+                # column by `grid_cols_before`.
+                grid_col = row.grid_cols_before + col_idx
                 while spanned_tc == cell._tc:
                     spanned_idx += 1
                     if spanned_idx < num_rows:
-                        # A later row may be shorter than the current one (e.g. it
-                        # starts late via `w:gridBefore` or ends early via
-                        # `w:gridAfter`), so `_Row.cells` returns fewer entries.
-                        # Guard the positional lookup to avoid an IndexError that
-                        # would abort parsing of the whole table.
-                        spanned_cells = table.rows[spanned_idx].cells
+                        # Map the grid column back to a positional index in the
+                        # later row, which may start late (`w:gridBefore`) or end
+                        # early (`w:gridAfter`) and therefore not contain this grid
+                        # column at all. Bounds-checking also avoids an IndexError
+                        # that would otherwise abort parsing of the whole table.
+                        spanned_row = table.rows[spanned_idx]
+                        spanned_cells = spanned_row.cells
+                        spanned_col = grid_col - spanned_row.grid_cols_before
                         spanned_tc = (
-                            spanned_cells[col_idx]._tc
-                            if col_idx < len(spanned_cells)
+                            spanned_cells[spanned_col]._tc
+                            if 0 <= spanned_col < len(spanned_cells)
                             else None
                         )
                     else:

--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -2120,11 +2120,20 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                 spanned_tc: CT_Tc | None = cell._tc
                 while spanned_tc == cell._tc:
                     spanned_idx += 1
-                    spanned_tc = (
-                        table.rows[spanned_idx].cells[col_idx]._tc
-                        if spanned_idx < num_rows
-                        else None
-                    )
+                    if spanned_idx < num_rows:
+                        # A later row may be shorter than the current one (e.g. it
+                        # starts late via `w:gridBefore` or ends early via
+                        # `w:gridAfter`), so `_Row.cells` returns fewer entries.
+                        # Guard the positional lookup to avoid an IndexError that
+                        # would abort parsing of the whole table.
+                        spanned_cells = table.rows[spanned_idx].cells
+                        spanned_tc = (
+                            spanned_cells[col_idx]._tc
+                            if col_idx < len(spanned_cells)
+                            else None
+                        )
+                    else:
+                        spanned_tc = None
                 _log.debug(f"  spanned before row {spanned_idx}")
 
                 # Detect equations in cell text
@@ -2147,7 +2156,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                 if len(provs_in_cell) > 0:
                     # Cell has multiple elements, we need to group them
                     rich_table_cell = True
-                    group_name = f"rich_cell_group_{len(doc.tables)}_{col_idx}_{row.grid_cols_before + row_idx}"
+                    group_name = f"rich_cell_group_{len(doc.tables)}_{row.grid_cols_before + col_idx}_{row_idx}"
                     ref_for_rich_cell = MsWordDocumentBackend._group_cell_elements(
                         group_name,
                         doc,
@@ -2161,11 +2170,13 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                         text=text,
                         row_span=spanned_idx - row_idx,
                         col_span=cell.grid_span,
-                        start_row_offset_idx=row.grid_cols_before + row_idx,
-                        end_row_offset_idx=row.grid_cols_before + spanned_idx,
-                        start_col_offset_idx=col_idx,
-                        end_col_offset_idx=col_idx + cell.grid_span,
-                        column_header=row.grid_cols_before + row_idx == 0,
+                        start_row_offset_idx=row_idx,
+                        end_row_offset_idx=spanned_idx,
+                        start_col_offset_idx=row.grid_cols_before + col_idx,
+                        end_col_offset_idx=row.grid_cols_before
+                        + col_idx
+                        + cell.grid_span,
+                        column_header=row_idx == 0,
                         row_header=False,
                         ref=ref_for_rich_cell,  # points to an artificial group around children
                     )
@@ -2176,11 +2187,13 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                         text=text,
                         row_span=spanned_idx - row_idx,
                         col_span=cell.grid_span,
-                        start_row_offset_idx=row.grid_cols_before + row_idx,
-                        end_row_offset_idx=row.grid_cols_before + spanned_idx,
-                        start_col_offset_idx=col_idx,
-                        end_col_offset_idx=col_idx + cell.grid_span,
-                        column_header=row.grid_cols_before + row_idx == 0,
+                        start_row_offset_idx=row_idx,
+                        end_row_offset_idx=spanned_idx,
+                        start_col_offset_idx=row.grid_cols_before + col_idx,
+                        end_col_offset_idx=row.grid_cols_before
+                        + col_idx
+                        + cell.grid_span,
+                        column_header=row_idx == 0,
                         row_header=False,
                     )
                     doc.add_table_cell(table_item=docling_table, cell=simple_cell)

--- a/tests/test_backend_msword.py
+++ b/tests/test_backend_msword.py
@@ -607,6 +607,57 @@ def test_table_row_with_grid_before_is_preserved(tmp_path):
     assert b2.start_row_offset_idx == 1
 
 
+def test_vertical_merge_across_grid_before_row_keeps_row_span(tmp_path):
+    """A vertical merge must keep its row span across a row that starts late.
+
+    ``_Row.cells`` is indexed from the first cell present, so the same grid
+    column maps to different positional indices in rows with different
+    ``grid_cols_before``. The vertical-merge scan must map by grid column, not
+    by raw position, or a cell merged down a column loses its span when the row
+    below starts late.
+
+    See: https://github.com/docling-project/docling/issues/3739
+    """
+    from docx import Document
+    from docx.oxml.ns import qn
+
+    # 3-column table; grid column 2 is merged across rows 0-1, and row 1 starts
+    # late (gridBefore=2):
+    #   grid col:   0    1    2
+    #   row 0:    [A ] [B ] [M ]   (M spans rows 0-1)
+    #   row 1:     .    .   [M ]   (gridBefore=2)
+    docx_path = tmp_path / "vmerge_grid_before.docx"
+    doc = Document()
+    table = doc.add_table(rows=2, cols=3)
+    table.style = "Table Grid"
+    table.cell(0, 0).text = "A"
+    table.cell(0, 1).text = "B"
+    table.cell(0, 2).text = "M"
+    table.cell(1, 0).text = "x0"
+    table.cell(1, 1).text = "x1"
+    table.cell(1, 2).text = "y2"
+    table.cell(0, 2).merge(table.cell(1, 2))  # vertical merge, grid column 2
+    tr = table.rows[1]._tr
+    tr.get_or_add_trPr().append(tr.makeelement(qn("w:gridBefore"), {qn("w:val"): "2"}))
+    for tc in tr.findall(qn("w:tc"))[:2]:
+        tr.remove(tc)  # drop the two leading cells -> row starts late
+    doc.save(docx_path)
+
+    in_doc = InputDocument(
+        path_or_stream=docx_path,
+        format=InputFormat.DOCX,
+        backend=MsWordDocumentBackend,
+    )
+    table_item = in_doc._backend.convert().tables[0]
+
+    merged = next(
+        cell for cell in table_item.data.table_cells if cell.text.startswith("M")
+    )
+    assert merged.start_col_offset_idx == 2
+    assert merged.start_row_offset_idx == 0
+    assert merged.row_span == 2
+
+
 def test_list_counter_and_enum_marker(docx_paths):
     """Test list counter increment, sub-level reset, marker building, and sequence reset."""
     docx_path = docx_paths[0]

--- a/tests/test_backend_msword.py
+++ b/tests/test_backend_msword.py
@@ -552,6 +552,61 @@ def test_block_sdt_tables_are_extracted():
     assert phase_2_idx < table_idxs[1]
 
 
+def test_table_row_with_grid_before_is_preserved(tmp_path):
+    """Rows that start late via ``w:gridBefore`` must not drop cells.
+
+    python-docx's ``_Row.cells`` returns only the cells actually present, so a
+    ``gridBefore`` row is shorter than the grid width. The vertical-merge scan
+    used to index that shorter row positionally and raise ``IndexError``, which
+    ``_walk_linear`` swallowed at DEBUG level, aborting the whole table. In
+    addition, ``grid_cols_before`` (a column count) was applied as a row offset,
+    shifting late-starting cells down instead of right.
+
+    See: https://github.com/docling-project/docling/issues/3739
+    """
+    from docx import Document
+    from docx.oxml.ns import qn
+
+    # Build a 2x2 table whose 2nd row starts late (gridBefore=1):
+    #   grid col:   0    1
+    #   row 0:    [A1] [B1]
+    #   row 1:     .   [B2]   <- gridBefore=1, leading cell removed
+    docx_path = tmp_path / "grid_before.docx"
+    doc = Document()
+    table = doc.add_table(rows=2, cols=2)
+    table.style = "Table Grid"
+    for (r, c), txt in {
+        (0, 0): "A1",
+        (0, 1): "B1",
+        (1, 0): "A2",
+        (1, 1): "B2",
+    }.items():
+        table.cell(r, c).text = txt
+    tr = table.rows[1]._tr
+    tr.get_or_add_trPr().append(tr.makeelement(qn("w:gridBefore"), {qn("w:val"): "1"}))
+    tr.remove(tr.findall(qn("w:tc"))[0])  # drop leading cell -> row starts late
+    doc.save(docx_path)
+
+    in_doc = InputDocument(
+        path_or_stream=docx_path,
+        format=InputFormat.DOCX,
+        backend=MsWordDocumentBackend,
+    )
+    result = in_doc._backend.convert()
+
+    assert len(result.tables) == 1
+    table_item = result.tables[0]
+
+    # The table must not be aborted: all populated cells survive.
+    cell_texts = {cell.text for cell in table_item.data.table_cells}
+    assert {"A1", "B1", "B2"}.issubset(cell_texts)
+
+    # B2 belongs at grid column 1 (grid_cols_before shifts it right, not down).
+    b2 = next(cell for cell in table_item.data.table_cells if cell.text == "B2")
+    assert b2.start_col_offset_idx == 1
+    assert b2.start_row_offset_idx == 1
+
+
 def test_list_counter_and_enum_marker(docx_paths):
     """Test list counter increment, sub-level reset, marker building, and sequence reset."""
     docx_path = docx_paths[0]


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #3739

### Problem

DOCX table rows that start late via `w:gridBefore` (Word writes this when leading cells are deleted or merged away) silently lose cells, and in the worst case the whole table is dropped.

python-docx's `_Row.cells` returns *only the cells actually present*, so a `gridBefore` row is shorter than the grid width. Two defects follow from that:

1. **`IndexError` aborts the table.** The vertical-merge scan indexes a later, shorter row positionally (`table.rows[spanned_idx].cells[col_idx]`) with no bounds check. When the later row is shorter, this raises `IndexError`, which `_walk_linear` catches and logs only at `DEBUG` ("could not parse a table, broken docx table"), silently discarding the rest of the table. The main column loop already guards this exact case (added in a prior fix); the merge scan was never updated to match.

2. **`grid_cols_before` misused as a row offset.** `grid_cols_before` is a *column* count, but it was added to `row_idx` in `start_row_offset_idx`, `end_row_offset_idx`, and the `column_header` test. Even when parsing doesn't crash, a late-starting row's cells are shifted **down** into the wrong grid row (and mislabeled as non-headers) instead of **right** into the correct grid column.

### Fix

1. Bounds-check the positional lookup in the vertical-merge scan, mirroring the existing guard in the main column loop.
2. Apply `grid_cols_before` to the **column** offset (`start_col_offset_idx` / `end_col_offset_idx`) rather than the row offset.

### Before / After

For a 2×2 table whose second row starts late (`gridBefore=1`):

Before — three of four cells dropped:
```
| A1 |    |
|    |    |
```

After — all populated cells preserved and correctly placed:
```
| A1 | B1 |
|    | B2 |
```

### Verification

- Added a regression test (`test_table_row_with_grid_before_is_preserved`) that builds a table with a late-starting row and asserts all populated cells survive and land in the correct column. It fails on `main` (only `A1` survives) and passes with this change.
- Converted the full existing `tests/data/docx/sources/*.docx` corpus through `MsWordDocumentBackend` before and after the change: output is byte-identical for every file (the change is a no-op when no row uses `gridBefore`/`gridAfter`).
- `ruff check` and `ruff format --check` pass on the changed files.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.