### PR TITLE
fix(msword): don't abort conversion on a malformed hyperlink address

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -912,6 +912,21 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         )
 
     def _get_hyperlink_target(self, hyperlink: Hyperlink) -> AnyUrl | Path | None:
+        """Resolve a hyperlink's address to a URL or a local path.
+
+        Addresses without a URL scheme are treated as (relative) filesystem
+        paths. Addresses with a scheme are parsed as URLs.
+
+        Malformed URLs (e.g. an address containing spaces) are handled
+        gracefully: the invalid target is dropped and ``None`` is returned so
+        that the link text is still preserved and conversion of the rest of the
+        document continues. This avoids a single bad hyperlink aborting the
+        whole conversion.
+
+        Returns:
+            An ``AnyUrl`` for a valid URL, a ``Path`` for a scheme-less address,
+            or ``None`` when there is no address or the URL is malformed.
+        """
         if hyperlink.address:
             if not urlparse(hyperlink.address).scheme:
                 return Path(hyperlink.address)

--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -36,7 +36,7 @@ from docx.text.paragraph import Paragraph
 from docx.text.run import Run
 from lxml import etree
 from PIL import Image, UnidentifiedImageError
-from pydantic import AnyUrl
+from pydantic import AnyUrl, ValidationError
 from typing_extensions import override
 
 from docling.backend.abstract_backend import DeclarativeDocumentBackend
@@ -913,11 +913,17 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
 
     def _get_hyperlink_target(self, hyperlink: Hyperlink) -> AnyUrl | Path | None:
         if hyperlink.address:
-            return (
-                AnyUrl(hyperlink.address)
-                if urlparse(hyperlink.address).scheme
-                else Path(hyperlink.address)
-            )
+            if not urlparse(hyperlink.address).scheme:
+                return Path(hyperlink.address)
+            try:
+                return AnyUrl(hyperlink.address)
+            except ValidationError:
+                # A single malformed URL (e.g. containing spaces) must not abort
+                # the whole conversion; drop the link target but keep the text.
+                _log.warning(
+                    "Skipping malformed hyperlink address: %r", hyperlink.address
+                )
+                return None
 
         return None
 

--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -923,6 +923,9 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         document continues. This avoids a single bad hyperlink aborting the
         whole conversion.
 
+        Args:
+            hyperlink: The DOCX hyperlink whose address should be resolved.
+
         Returns:
             An ``AnyUrl`` for a valid URL, a ``Path`` for a scheme-less address,
             or ``None`` when there is no address or the URL is malformed.
@@ -933,8 +936,6 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             try:
                 return AnyUrl(hyperlink.address)
             except ValidationError:
-                # A single malformed URL (e.g. containing spaces) must not abort
-                # the whole conversion; drop the link target but keep the text.
                 _log.warning(
                     "Skipping malformed hyperlink address: %r", hyperlink.address
                 )

--- a/tests/test_backend_msword.py
+++ b/tests/test_backend_msword.py
@@ -908,3 +908,52 @@ def test_invisible_spacer_logic():
     # Test normal, valid graphic
     valid_img = Image.new("RGB", (50, 50), (100, 150, 200))
     assert backend._is_invisible_spacer(valid_img) is False
+
+
+def test_malformed_hyperlink_does_not_abort_conversion(tmp_path):
+    """A single malformed hyperlink address (e.g. containing a space) must not
+    raise a pydantic ValidationError that aborts the whole DOCX conversion.
+
+    Regression test: previously ``_get_hyperlink_target`` called
+    ``AnyUrl(address)`` unguarded, so any address with a scheme but invalid
+    contents crashed the pipeline.
+    """
+    from docx import Document
+    from docx.opc.constants import RELATIONSHIP_TYPE as RT
+    from docx.oxml.ns import qn
+
+    doc = Document()
+    para = doc.add_paragraph("Before link. ")
+    # Ordinary real-world URL that happens to contain a space -> AnyUrl rejects it.
+    r_id = doc.part.relate_to(
+        "http://exa mple.com/bad url", RT.HYPERLINK, is_external=True
+    )
+    hyperlink = etree.SubElement(para._p, qn("w:hyperlink"))
+    hyperlink.set(qn("r:id"), r_id)
+    run = etree.SubElement(hyperlink, qn("w:r"))
+    etree.SubElement(run, qn("w:t")).text = "click me"
+    doc.add_paragraph("After link.")
+
+    docx_path = tmp_path / "malformed_hyperlink.docx"
+    doc.save(docx_path)
+
+    in_doc = InputDocument(
+        path_or_stream=docx_path,
+        format=InputFormat.DOCX,
+        backend=MsWordDocumentBackend,
+    )
+    result = in_doc._backend.convert()
+
+    # Conversion succeeds and the link's visible text is preserved.
+    md = result.export_to_markdown()
+    assert "click me" in md
+    assert "Before link." in md
+    assert "After link." in md
+
+    # The broken link target is dropped rather than crashing the run.
+    hyperlinks = [
+        item.hyperlink
+        for item, _ in result.iterate_items()
+        if isinstance(item, TextItem) and item.hyperlink is not None
+    ]
+    assert hyperlinks == []


### PR DESCRIPTION
Summary
--------------------------
I added guard against a malformed hyperlink address aborting the whole DOCX conversion.
**Issue**
`_get_hyperlink_target` built a `pydantic.AnyUrl` from the raw hyperlink address with no error handling. Any address with a scheme but invalid contents (e.g. a URL containing a space, which is common in real documents) raised a `ValidationError`. Nothing in the call chain (`convert` → `_walk_linear` → `_handle_text_elements` → `_get_paragraph_elements` → `_iter_paragraph_content` → `_get_hyperlink_target`) caught it, so **one bad link aborted the entire document conversion**.


This PR guards the `AnyUrl(...)` construction: when the address has a scheme but fails validation, it logs a warning and drops the link target (returns `None`) instead of propagating the exception. The visible link text is preserved and the
rest of the document converts normally. Valid URLs and scheme-less/relative addresses behave exactly as before.


Testing: added `test_malformed_hyperlink_does_not_abort_conversion`, which builds a DOCX with a space in a hyperlink address and asserts conversion succeeds, the link text is preserved, and the broken target is dropped. Verified it fails on `main` (`ValidationError`) and passes with this fix. Also confirmed valid URLs (`https://example.com/ok`, `mailto:a@b.com`) and relative/scheme-less addresses (`relative/path/file.docx`, `#anchor`) are unchanged. `ruff` clean.

**Issue resolved by this Pull Request:**
Resolves #3743

**Checklist:**

- [x] Documentation has been updated, if necessary. <!-- n/a: no user-facing docs change -->
- [ ] Examples have been added, if necessary. <!-- n/a -->
- [x] Tests have been added, if necessary.
