### PR TITLE
fix: guard backend imports to prevent ImportError on slim installs

### DIFF
--- a/docling/backend/docx/drawingml/utils.py
+++ b/docling/backend/docx/drawingml/utils.py
@@ -1,13 +1,17 @@
+from __future__ import annotations
+
 import os
 import shutil
 import subprocess
 from pathlib import Path
 from tempfile import mkdtemp
-from typing import Callable, Optional
+from typing import TYPE_CHECKING, Callable, Optional
 
 import pypdfium2
-from docx.document import Document
 from PIL import Image, ImageChops
+
+if TYPE_CHECKING:
+    from docx.document import Document
 
 
 def get_libreoffice_cmd(raise_if_unavailable: bool = False) -> Optional[str]:

--- a/docling/backend/docx/latex/omml.py
+++ b/docling/backend/docx/latex/omml.py
@@ -8,12 +8,18 @@ special characters.
 Adapted from https://github.com/xiilei/dwml/blob/master/dwml/omml.py on 23/01/2025.
 """
 
+from __future__ import annotations
+
 import logging
 from typing import Any, Iterator
 
 import lxml.etree as ET
 from lxml.etree import _Element
-from pylatexenc.latexencode import UnicodeToLatexEncoder
+
+try:  # pragma: no cover - import-time guard
+    from pylatexenc.latexencode import UnicodeToLatexEncoder
+except ImportError:
+    pass
 
 from docling.backend.docx.latex.latex_dict import (
     ALN,
@@ -295,11 +301,6 @@ class oMath2Latex(Tag2Method):
 
     _t_dict: dict[str, str] = T
     __direct_tags: tuple[str, ...] = ("box", "num", "den", "deg", "e")
-    u: UnicodeToLatexEncoder = UnicodeToLatexEncoder(
-        replacement_latex_protection="braces-all",
-        unknown_char_policy="keep",
-        unknown_char_warning=False,
-    )
 
     def __init__(self, element: _Element):
         """Initialize OMML to LaTeX converter.
@@ -307,6 +308,11 @@ class oMath2Latex(Tag2Method):
         Args:
             element: Root oMath XML element to convert.
         """
+        self.u: UnicodeToLatexEncoder = UnicodeToLatexEncoder(
+            replacement_latex_protection="braces-all",
+            unknown_char_policy="keep",
+            unknown_char_warning=False,
+        )
         self._latex = self.process_children(element)
 
     def __str__(self) -> str:

--- a/docling/backend/docx/latex/omml.py
+++ b/docling/backend/docx/latex/omml.py
@@ -19,7 +19,7 @@ from lxml.etree import _Element
 try:  # pragma: no cover - import-time guard
     from pylatexenc.latexencode import UnicodeToLatexEncoder
 except ImportError:
-    pass
+    pass  # guarded by MsWordDocumentBackend.__init__
 
 from docling.backend.docx.latex.latex_dict import (
     ALN,

--- a/docling/backend/email_backend.py
+++ b/docling/backend/email_backend.py
@@ -34,7 +34,7 @@ _log = logging.getLogger(__name__)
 
 _INSTALL_HINT = (
     "The 'mail-parser' package is required to process email files. "
-    "Install it with `pip install 'docling[format-email]'`."
+    "Install it with `pip install 'docling-slim[format-email]'`."
 )
 
 

--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import math
 import re
@@ -10,8 +12,6 @@ from pathlib import Path
 from typing import Any, Final, Iterator, Literal, Optional, Union, cast
 from urllib.parse import urlparse
 
-from bs4 import BeautifulSoup, NavigableString, PageElement, Tag
-from bs4.element import PreformattedString
 from docling_core.types.doc import (
     BoundingBox,
     CodeLanguageLabel,
@@ -58,6 +58,21 @@ from docling.utils.code_language import (
     _HINT_PREFIXES,
     detect_code_language,
     normalize_code_language,
+)
+
+_BS4_AVAILABLE: bool = False
+_BS4_IMPORT_ERROR: ImportError | None = None
+try:  # pragma: no cover - import-time guard
+    from bs4 import BeautifulSoup, NavigableString, PageElement, Tag
+    from bs4.element import PreformattedString
+
+    _BS4_AVAILABLE = True
+except ImportError as e:  # pragma: no cover - import-time guard
+    _BS4_IMPORT_ERROR = e
+
+_INSTALL_HINT = (
+    "The 'beautifulsoup4' package is required to process HTML files. "
+    "Install it with `pip install 'docling-slim[format-html]'`."
 )
 
 _log = logging.getLogger(__name__)
@@ -312,7 +327,7 @@ class AnnotatedTextList(list):
             source_tag_id=current_source_tag_id,
         )
 
-    def simplify_text_elements(self) -> "AnnotatedTextList":
+    def simplify_text_elements(self) -> AnnotatedTextList:
         simplified = AnnotatedTextList()
         if not self:
             return self
@@ -408,6 +423,8 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         path_or_stream: Union[BytesIO, Path],
         options: Optional[HTMLBackendOptions] = None,
     ):
+        if not _BS4_AVAILABLE:
+            raise ImportError(_INSTALL_HINT) from _BS4_IMPORT_ERROR
         if options is None:
             options = HTMLBackendOptions()
         super().__init__(in_doc, path_or_stream, options)

--- a/docling/backend/latex/backend.py
+++ b/docling/backend/latex/backend.py
@@ -7,14 +7,6 @@ from typing import TYPE_CHECKING, Optional, Union, cast
 
 from docling_core.types.doc import DocItemLabel, DoclingDocument, NodeItem
 from docling_core.types.doc.document import Formatting
-from pylatexenc.latexwalker import (
-    LatexCharsNode,
-    LatexEnvironmentNode,
-    LatexGroupNode,
-    LatexMacroNode,
-    LatexMathNode,
-    LatexWalker,
-)
 
 from docling.backend.abstract_backend import DeclarativeDocumentBackend
 from docling.backend.latex.handlers.environments import EnvironmentHandlerMixin
@@ -28,6 +20,27 @@ from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
 
 _log = logging.getLogger(__name__)
+
+_PYLATEXENC_AVAILABLE: bool = False
+_PYLATEXENC_IMPORT_ERROR: ImportError | None = None
+try:  # pragma: no cover - import-time guard
+    from pylatexenc.latexwalker import (
+        LatexCharsNode,
+        LatexEnvironmentNode,
+        LatexGroupNode,
+        LatexMacroNode,
+        LatexMathNode,
+        LatexWalker,
+    )
+
+    _PYLATEXENC_AVAILABLE = True
+except ImportError as e:  # pragma: no cover - import-time guard
+    _PYLATEXENC_IMPORT_ERROR = e
+
+_INSTALL_HINT = (
+    "The 'pylatexenc' package is required to process LaTeX files. "
+    "Install it with `pip install 'docling-slim[format-latex]'`."
+)
 
 if TYPE_CHECKING:
     import concurrent.futures
@@ -49,6 +62,8 @@ class LatexDocumentBackend(
         path_or_stream: Union[BytesIO, Path],
         options: Optional[LatexBackendOptions] = None,
     ):
+        if not _PYLATEXENC_AVAILABLE:
+            raise ImportError(_INSTALL_HINT) from _PYLATEXENC_IMPORT_ERROR
         if options is None:
             options = LatexBackendOptions()
         super().__init__(in_doc, path_or_stream, options)

--- a/docling/backend/latex/handlers/environments.py
+++ b/docling/backend/latex/handlers/environments.py
@@ -1,17 +1,10 @@
+from __future__ import annotations
+
 import logging
 import re
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, cast
 
-if TYPE_CHECKING:
-    from concurrent.futures import Future, ThreadPoolExecutor
-    from typing import Any
-
-    from docling.backend.latex.engines.tectonic import TectonicEngine
-    from docling.datamodel.backend_options import (
-        BaseBackendOptions,
-        LatexBackendOptions,
-    )
 from docling_core.types.doc import CodeLanguageLabel
 from docling_core.types.doc.document import (
     CodeMetaField,
@@ -22,9 +15,23 @@ from docling_core.types.doc.document import (
     NodeItem,
     PictureMeta,
 )
-from pylatexenc.latexwalker import LatexEnvironmentNode, LatexMacroNode
 
 from docling.backend.latex.constants import ENV_LIST, ENV_MATH, ENV_QUOTE, ENV_THEOREM
+
+if TYPE_CHECKING:
+    from concurrent.futures import Future, ThreadPoolExecutor
+    from typing import Any
+
+    from docling.backend.latex.engines.tectonic import TectonicEngine
+    from docling.datamodel.backend_options import (
+        BaseBackendOptions,
+        LatexBackendOptions,
+    )
+
+try:  # pragma: no cover - import-time guard
+    from pylatexenc.latexwalker import LatexEnvironmentNode, LatexMacroNode
+except ImportError:
+    pass
 
 _log = logging.getLogger(__name__)
 _TIKZ_END_PATTERN = re.compile(r"\\end\s*\{\s*tikzpicture\s*\}")
@@ -32,25 +39,25 @@ _TIKZ_END_PATTERN = re.compile(r"\\end\s*\{\s*tikzpicture\s*\}")
 
 class EnvironmentHandlerMixin:
     if TYPE_CHECKING:
-        options: "BaseBackendOptions"
+        options: BaseBackendOptions
         latex_preamble: str
-        path_or_stream: "Any"
-        _tectonic_engine: "TectonicEngine | None"
-        _tikz_executor: "ThreadPoolExecutor | None"
-        _tikz_futures: list["Future[Any]"]
+        path_or_stream: Any
+        _tectonic_engine: TectonicEngine | None
+        _tikz_executor: ThreadPoolExecutor | None
+        _tikz_futures: list[Future[Any]]
 
         def _process_nodes(
             self,
-            nodes: "Any",
-            doc: "Any",
-            parent: "Any" = ...,
-            formatting: "Any" = ...,
-            text_label: "Any" = ...,
+            nodes: Any,
+            doc: Any,
+            parent: Any = ...,
+            formatting: Any = ...,
+            text_label: Any = ...,
         ) -> None: ...
         def _clean_math(self, latex_str: str, env_name: str) -> str: ...
-        def _parse_table(self, node: "Any") -> "Any": ...
+        def _parse_table(self, node: Any) -> Any: ...
         def _extract_verbatim_content(self, latex_str: str, env_name: str) -> str: ...
-        def _extract_macro_arg(self, node: "Any") -> str: ...
+        def _extract_macro_arg(self, node: Any) -> str: ...
 
     def _find_document_env(self, nodes, depth: int = 0):
         if nodes is None or depth > 10:

--- a/docling/backend/latex/handlers/environments.py
+++ b/docling/backend/latex/handlers/environments.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 try:  # pragma: no cover - import-time guard
     from pylatexenc.latexwalker import LatexEnvironmentNode, LatexMacroNode
 except ImportError:
-    pass
+    pass  # guarded by LatexDocumentBackend.__init__
 
 _log = logging.getLogger(__name__)
 _TIKZ_END_PATTERN = re.compile(r"\\end\s*\{\s*tikzpicture\s*\}")

--- a/docling/backend/latex/handlers/macros.py
+++ b/docling/backend/latex/handlers/macros.py
@@ -1,12 +1,10 @@
+from __future__ import annotations
+
 import logging
 import re
+from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Callable
-
-if TYPE_CHECKING:
-    from io import BytesIO
-    from pathlib import Path
-    from typing import Any
 
 import pypdfium2
 from docling_core.types.doc.document import (
@@ -17,14 +15,6 @@ from docling_core.types.doc.document import (
     NodeItem,
 )
 from PIL import Image
-from pylatexenc.latexwalker import (
-    LatexCharsNode,
-    LatexEnvironmentNode,
-    LatexGroupNode,
-    LatexMacroNode,
-    LatexWalker,
-    LatexWalkerParseError,
-)
 
 from docling.backend.latex.constants import (
     MACROS_ACCENTS,
@@ -44,12 +34,27 @@ from docling.backend.latex.constants import (
     MACROS_TEXT_STYLE,
 )
 
+if TYPE_CHECKING:
+    from typing import Any
+
+try:  # pragma: no cover - import-time guard
+    from pylatexenc.latexwalker import (
+        LatexCharsNode,
+        LatexEnvironmentNode,
+        LatexGroupNode,
+        LatexMacroNode,
+        LatexWalker,
+        LatexWalkerParseError,
+    )
+except ImportError:
+    pass
+
 _log = logging.getLogger(__name__)
 
 
 class MacroHandlerMixin:
     if TYPE_CHECKING:
-        path_or_stream: "BytesIO | Path"
+        path_or_stream: BytesIO | Path
         _input_stack: set[str]
         _custom_macros: dict[str, str]
         _custom_macro_num_args: dict[str, int]
@@ -57,13 +62,13 @@ class MacroHandlerMixin:
 
         def _process_nodes(
             self,
-            nodes: "Any",
-            doc: "Any",
-            parent: "Any" = ...,
-            formatting: "Any" = ...,
-            text_label: "Any" = ...,
+            nodes: Any,
+            doc: Any,
+            parent: Any = ...,
+            formatting: Any = ...,
+            text_label: Any = ...,
         ) -> None: ...
-        def _nodes_to_text(self, nodes: "Any") -> str: ...
+        def _nodes_to_text(self, nodes: Any) -> str: ...
 
     def _preprocess_custom_macros(self, latex_text: str) -> str:
         latex_text = re.sub(r"\\be\b", r"\\begin{equation}", latex_text)

--- a/docling/backend/latex/handlers/macros.py
+++ b/docling/backend/latex/handlers/macros.py
@@ -47,7 +47,7 @@ try:  # pragma: no cover - import-time guard
         LatexWalkerParseError,
     )
 except ImportError:
-    pass
+    pass  # guarded by LatexDocumentBackend.__init__
 
 _log = logging.getLogger(__name__)
 

--- a/docling/backend/latex/handlers/math.py
+++ b/docling/backend/latex/handlers/math.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 try:  # pragma: no cover - import-time guard
     from pylatexenc.latexwalker import LatexMathNode
 except ImportError:
-    pass
+    pass  # guarded by LatexDocumentBackend.__init__
 
 
 class MathHandlerMixin:

--- a/docling/backend/latex/handlers/math.py
+++ b/docling/backend/latex/handlers/math.py
@@ -1,13 +1,19 @@
+from __future__ import annotations
+
 import re
 from typing import TYPE_CHECKING, Callable, List, Optional
+
+from docling_core.types.doc.document import DocItemLabel, DoclingDocument, NodeItem
+
+from docling.backend.latex.constants import ENV_MATH_CLEAN, ENV_MATH_DISPLAY_PREFIXES
 
 if TYPE_CHECKING:
     from typing import Any
 
-from docling_core.types.doc.document import DocItemLabel, DoclingDocument, NodeItem
-from pylatexenc.latexwalker import LatexMathNode
-
-from docling.backend.latex.constants import ENV_MATH_CLEAN, ENV_MATH_DISPLAY_PREFIXES
+try:  # pragma: no cover - import-time guard
+    from pylatexenc.latexwalker import LatexMathNode
+except ImportError:
+    pass
 
 
 class MathHandlerMixin:

--- a/docling/backend/latex/utils/table.py
+++ b/docling/backend/latex/utils/table.py
@@ -1,16 +1,8 @@
+from __future__ import annotations
+
 from typing import TYPE_CHECKING, Callable, List, Optional
 
-if TYPE_CHECKING:
-    from typing import Any
-
 from docling_core.types.doc.document import TableCell, TableData
-from pylatexenc.latexwalker import (
-    LatexCharsNode,
-    LatexEnvironmentNode,
-    LatexMacroNode,
-    LatexWalker,
-    LatexWalkerParseError,
-)
 
 from docling.backend.latex.constants import (
     MACROS_ESCAPED,
@@ -18,11 +10,25 @@ from docling.backend.latex.constants import (
     TABLE_MACROS_RULE,
 )
 
+if TYPE_CHECKING:
+    from typing import Any
+
+try:  # pragma: no cover - import-time guard
+    from pylatexenc.latexwalker import (
+        LatexCharsNode,
+        LatexEnvironmentNode,
+        LatexMacroNode,
+        LatexWalker,
+        LatexWalkerParseError,
+    )
+except ImportError:
+    pass
+
 
 class TableHelperMixin:
     if TYPE_CHECKING:
 
-        def _nodes_to_text(self, nodes: "Any") -> str: ...
+        def _nodes_to_text(self, nodes: Any) -> str: ...
 
     def _process_table_macro_node(
         self,

--- a/docling/backend/latex/utils/table.py
+++ b/docling/backend/latex/utils/table.py
@@ -22,7 +22,7 @@ try:  # pragma: no cover - import-time guard
         LatexWalkerParseError,
     )
 except ImportError:
-    pass
+    pass  # guarded by LatexDocumentBackend.__init__
 
 
 class TableHelperMixin:

--- a/docling/backend/latex/utils/text.py
+++ b/docling/backend/latex/utils/text.py
@@ -33,7 +33,7 @@ try:  # pragma: no cover - import-time guard
         LatexMathNode,
     )
 except ImportError:
-    pass
+    pass  # guarded by LatexDocumentBackend.__init__
 
 
 class TextHelperMixin:

--- a/docling/backend/latex/utils/text.py
+++ b/docling/backend/latex/utils/text.py
@@ -1,21 +1,13 @@
+from __future__ import annotations
+
 import re
 from typing import TYPE_CHECKING, Callable, List, Optional
-
-if TYPE_CHECKING:
-    from typing import Any
 
 from docling_core.types.doc.document import (
     DocItemLabel,
     DoclingDocument,
     Formatting,
     NodeItem,
-)
-from pylatexenc.latexwalker import (
-    LatexCharsNode,
-    LatexEnvironmentNode,
-    LatexGroupNode,
-    LatexMacroNode,
-    LatexMathNode,
 )
 
 from docling.backend.latex.constants import (
@@ -29,6 +21,20 @@ from docling.backend.latex.constants import (
     MACROS_TEXT_STYLE,
 )
 
+if TYPE_CHECKING:
+    from typing import Any
+
+try:  # pragma: no cover - import-time guard
+    from pylatexenc.latexwalker import (
+        LatexCharsNode,
+        LatexEnvironmentNode,
+        LatexGroupNode,
+        LatexMacroNode,
+        LatexMathNode,
+    )
+except ImportError:
+    pass
+
 
 class TextHelperMixin:
     if TYPE_CHECKING:
@@ -37,16 +43,16 @@ class TextHelperMixin:
 
         def _process_nodes(
             self,
-            nodes: "Any",
-            doc: "Any",
-            parent: "Any" = ...,
-            formatting: "Any" = ...,
-            text_label: "Any" = ...,
+            nodes: Any,
+            doc: Any,
+            parent: Any = ...,
+            formatting: Any = ...,
+            text_label: Any = ...,
         ) -> None: ...
-        def _extract_macro_arg(self, node: "Any") -> str: ...
+        def _extract_macro_arg(self, node: Any) -> str: ...
         def _expand_macros(self, latex_str: str) -> str: ...
         def _expand_custom_macro_invocation(
-            self, node: "Any", following_nodes: "Any"
+            self, node: Any, following_nodes: Any
         ) -> tuple[str, int]: ...
         def _parse_latex_fragment_to_text(self, latex_fragment: str) -> str: ...
 

--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -61,7 +61,7 @@ _log = logging.getLogger(__name__)
 
 _INSTALL_HINT = (
     "The 'marko' package is required to process Markdown files. "
-    "Install it with `pip install 'docling[format-markdown]'`."
+    "Install it with `pip install 'docling-slim[format-markdown]'`."
 )
 
 _MARKER_BODY = "DOCLING_DOC_MD_HTML_EXPORT"

--- a/docling/backend/msexcel_backend.py
+++ b/docling/backend/msexcel_backend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import collections
 import logging
 import posixpath
@@ -29,18 +31,6 @@ from docling_core.types.doc import (
     TableData,
 )
 from lxml import etree
-from openpyxl import load_workbook
-from openpyxl.chartsheet.chartsheet import Chartsheet
-from openpyxl.drawing.image import Image
-from openpyxl.drawing.spreadsheet_drawing import (
-    OneCellAnchor,
-    SpreadsheetDrawing,
-    TwoCellAnchor,
-)
-from openpyxl.packaging.relationship import get_dependents, get_rels_path
-from openpyxl.styles import PatternFill
-from openpyxl.worksheet.worksheet import Worksheet
-from openpyxl.xml.constants import IMAGE_NS
 from PIL import Image as PILImage, UnidentifiedImageError
 from pydantic import BaseModel, Field, NonNegativeInt, PositiveInt
 from pydantic.dataclasses import dataclass
@@ -60,6 +50,31 @@ from docling.datamodel.document import InputDocument
 from docling.exceptions import DocumentLoadError
 
 _log = logging.getLogger(__name__)
+
+_OPENPYXL_AVAILABLE: bool = False
+_OPENPYXL_IMPORT_ERROR: ImportError | None = None
+try:  # pragma: no cover - import-time guard
+    from openpyxl import load_workbook
+    from openpyxl.chartsheet.chartsheet import Chartsheet
+    from openpyxl.drawing.image import Image
+    from openpyxl.drawing.spreadsheet_drawing import (
+        OneCellAnchor,
+        SpreadsheetDrawing,
+        TwoCellAnchor,
+    )
+    from openpyxl.packaging.relationship import get_dependents, get_rels_path
+    from openpyxl.styles import PatternFill
+    from openpyxl.worksheet.worksheet import Worksheet
+    from openpyxl.xml.constants import IMAGE_NS
+
+    _OPENPYXL_AVAILABLE = True
+except ImportError as e:  # pragma: no cover - import-time guard
+    _OPENPYXL_IMPORT_ERROR = e
+
+_INSTALL_HINT = (
+    "The 'openpyxl' package is required to process Excel files. "
+    "Install it with `pip install 'docling-slim[format-xlsx]'`."
+)
 
 
 # Safe XML parser — prevents XXE, DTD-over-network, and entity-expansion attacks.
@@ -172,7 +187,7 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
     @override
     def __init__(
         self,
-        in_doc: "InputDocument",
+        in_doc: InputDocument,
         path_or_stream: BytesIO | Path,
         options: MsExcelBackendOptions | None = None,
     ) -> None:
@@ -186,6 +201,8 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         Raises:
             RuntimeError: An error occurred parsing the file.
         """
+        if not _OPENPYXL_AVAILABLE:
+            raise ImportError(_INSTALL_HINT) from _OPENPYXL_IMPORT_ERROR
         if options is None:
             options = MsExcelBackendOptions()
         super().__init__(in_doc, path_or_stream, options)

--- a/docling/backend/mspowerpoint_backend.py
+++ b/docling/backend/mspowerpoint_backend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import warnings
 from io import BytesIO
@@ -20,10 +22,6 @@ from docling_core.types.doc import (
 from docling_core.types.doc.document import ContentLayer
 from lxml import etree
 from PIL import Image, UnidentifiedImageError
-from pptx import Presentation, presentation
-from pptx.enum.shapes import MSO_SHAPE_TYPE, PP_PLACEHOLDER
-from pptx.exc import InvalidXmlError
-from pptx.oxml.text import CT_TextLineBreak
 from typing_extensions import override
 
 from docling.backend.abstract_backend import (
@@ -35,6 +33,23 @@ from docling.datamodel.document import InputDocument
 from docling.exceptions import DocumentLoadError
 
 _log = logging.getLogger(__name__)
+
+_PPTX_AVAILABLE: bool = False
+_PPTX_IMPORT_ERROR: ImportError | None = None
+try:  # pragma: no cover - import-time guard
+    from pptx import Presentation, presentation
+    from pptx.enum.shapes import MSO_SHAPE_TYPE, PP_PLACEHOLDER
+    from pptx.exc import InvalidXmlError
+    from pptx.oxml.text import CT_TextLineBreak
+
+    _PPTX_AVAILABLE = True
+except ImportError as e:  # pragma: no cover - import-time guard
+    _PPTX_IMPORT_ERROR = e
+
+_INSTALL_HINT = (
+    "The 'python-pptx' package is required to process PowerPoint files. "
+    "Install it with `pip install 'docling-slim[format-pptx]'`."
+)
 
 
 class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBackend):
@@ -66,8 +81,10 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
     )
 
     def __init__(
-        self, in_doc: "InputDocument", path_or_stream: Union[BytesIO, Path]
+        self, in_doc: InputDocument, path_or_stream: Union[BytesIO, Path]
     ) -> None:
+        if not _PPTX_AVAILABLE:
+            raise ImportError(_INSTALL_HINT) from _PPTX_IMPORT_ERROR
         super().__init__(in_doc, path_or_stream)
         self.path_or_stream: Union[BytesIO, Path] = path_or_stream
         self.page_range = in_doc.limits.page_range

--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import re
 import warnings
@@ -26,15 +28,6 @@ from docling_core.types.doc import (
     TableItem,
 )
 from docling_core.types.doc.document import FineRef, Formatting, Script
-from docx import Document
-from docx.document import Document as DocxDocument
-from docx.oxml.table import CT_Tc
-from docx.oxml.xmlchemy import BaseOxmlElement
-from docx.styles.style import ParagraphStyle
-from docx.table import Table, _Cell
-from docx.text.hyperlink import Hyperlink
-from docx.text.paragraph import Paragraph
-from docx.text.run import Run
 from lxml import etree
 from PIL import Image, UnidentifiedImageError
 from pydantic import AnyUrl, ValidationError
@@ -51,6 +44,28 @@ from docling.datamodel.document import InputDocument
 from docling.exceptions import DocumentLoadError, SecurityError
 
 _log = logging.getLogger(__name__)
+
+_DOCX_AVAILABLE: bool = False
+_DOCX_IMPORT_ERROR: ImportError | None = None
+try:  # pragma: no cover - import-time guard
+    from docx import Document
+    from docx.document import Document as DocxDocument
+    from docx.oxml.table import CT_Tc
+    from docx.oxml.xmlchemy import BaseOxmlElement
+    from docx.styles.style import ParagraphStyle
+    from docx.table import Table, _Cell
+    from docx.text.hyperlink import Hyperlink
+    from docx.text.paragraph import Paragraph
+    from docx.text.run import Run
+
+    _DOCX_AVAILABLE = True
+except ImportError as e:  # pragma: no cover - import-time guard
+    _DOCX_IMPORT_ERROR = e
+
+_INSTALL_HINT = (
+    "The 'python-docx' package is required to process Word files. "
+    "Install it with `pip install 'docling-slim[format-docx]'`."
+)
 
 _STRICT_OOXML_NS_PREFIX: Final[str] = "http://purl.oclc.org/ooxml/"
 _TRANSITIONAL_NS_HOST: Final[str] = "http://schemas.openxmlformats.org/"
@@ -197,7 +212,9 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
     """Images with an area (w*h) below this are dropped as layout artifacts."""
 
     @override
-    def __init__(self, in_doc: "InputDocument", path_or_stream: BytesIO | Path) -> None:
+    def __init__(self, in_doc: InputDocument, path_or_stream: BytesIO | Path) -> None:
+        if not _DOCX_AVAILABLE:
+            raise ImportError(_INSTALL_HINT) from _DOCX_IMPORT_ERROR
         super().__init__(in_doc, path_or_stream)
         self.XML_KEY = f"{self._W_NS_CLARK}val"
         self.xml_namespaces = {

--- a/docling/backend/opendocument_backend.py
+++ b/docling/backend/opendocument_backend.py
@@ -80,7 +80,7 @@ _log = logging.getLogger(__name__)
 
 _INSTALL_HINT = (
     "The 'odfdo' package is required to process OpenDocument files. "
-    "Install it with `pip install 'docling[opendocument]'`."
+    "Install it with `pip install 'docling-slim[format-opendocument]'`."
 )
 
 _ODF_CHART_CLASS_TO_PICTURE_CLASSIFICATION = {

--- a/docling/backend/xml/jats_backend.py
+++ b/docling/backend/xml/jats_backend.py
@@ -17,13 +17,14 @@ Security Note:
     external entity fetching and preventing XXE attacks.
 """
 
+from __future__ import annotations
+
 import logging
 import traceback
 from io import BytesIO
 from pathlib import Path
 from typing import Final, cast
 
-from bs4 import BeautifulSoup, NavigableString, Tag
 from docling_core.types.doc import (
     DocItemLabel,
     DoclingDocument,
@@ -35,7 +36,6 @@ from docling_core.types.doc import (
     TableData,
     TextItem,
 )
-from lxml import etree
 from typing_extensions import TypedDict, override
 
 from docling.backend.abstract_backend import DeclarativeDocumentBackend
@@ -43,6 +43,21 @@ from docling.backend.html_backend import HTMLDocumentBackend
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
 from docling.exceptions import DocumentLoadError
+
+_BS4_AVAILABLE: bool = False
+_BS4_IMPORT_ERROR: ImportError | None = None
+try:  # pragma: no cover - import-time guard
+    from bs4 import BeautifulSoup, NavigableString, Tag
+    from lxml import etree
+
+    _BS4_AVAILABLE = True
+except ImportError as e:  # pragma: no cover - import-time guard
+    _BS4_IMPORT_ERROR = e
+
+_INSTALL_HINT = (
+    "The 'beautifulsoup4' and 'lxml' packages are required to process JATS files. "
+    "Install them with `pip install 'docling-slim[format-xml-jats]'`."
+)
 
 _log = logging.getLogger(__name__)
 
@@ -108,7 +123,9 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
     """
 
     @override
-    def __init__(self, in_doc: "InputDocument", path_or_stream: BytesIO | Path) -> None:
+    def __init__(self, in_doc: InputDocument, path_or_stream: BytesIO | Path) -> None:
+        if not _BS4_AVAILABLE:
+            raise ImportError(_INSTALL_HINT) from _BS4_IMPORT_ERROR
         super().__init__(in_doc, path_or_stream)
         self.path_or_stream = path_or_stream
 

--- a/docling/backend/xml/uspto_backend.py
+++ b/docling/backend/xml/uspto_backend.py
@@ -36,6 +36,8 @@ Security Note:
     the required DTD structure.
 """
 
+from __future__ import annotations
+
 import html
 import logging
 import re
@@ -48,9 +50,6 @@ from xml.sax import SAXParseException
 from xml.sax.handler import ContentHandler, feature_external_ges, feature_external_pes
 from xml.sax.xmlreader import AttributesImpl
 
-from bs4 import BeautifulSoup, Tag
-from defusedxml.common import DefusedXmlException
-from defusedxml.sax import make_parser
 from docling_core.types.doc import (
     DocItem,
     DocItemLabel,
@@ -68,6 +67,22 @@ from docling.backend.abstract_backend import DeclarativeDocumentBackend
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
 from docling.exceptions import DocumentLoadError
+
+_BS4_AVAILABLE: bool = False
+_BS4_IMPORT_ERROR: ImportError | None = None
+try:  # pragma: no cover - import-time guard
+    from bs4 import BeautifulSoup, Tag
+    from defusedxml.common import DefusedXmlException
+    from defusedxml.sax import make_parser
+
+    _BS4_AVAILABLE = True
+except ImportError as e:  # pragma: no cover - import-time guard
+    _BS4_IMPORT_ERROR = e
+
+_INSTALL_HINT = (
+    "The 'beautifulsoup4' and 'defusedxml' packages are required to process USPTO patent files. "
+    "Install them with `pip install 'docling-slim[format-xml-uspto]'`."
+)
 
 _log = logging.getLogger(__name__)
 
@@ -95,6 +110,8 @@ class PatentHeading(Enum):
 class PatentUsptoDocumentBackend(DeclarativeDocumentBackend):
     @override
     def __init__(self, in_doc: InputDocument, path_or_stream: BytesIO | Path) -> None:
+        if not _BS4_AVAILABLE:
+            raise ImportError(_INSTALL_HINT) from _BS4_IMPORT_ERROR
         super().__init__(in_doc, path_or_stream)
 
         self.patent_content: str = ""

--- a/docling/backend/xml/xbrl_backend.py
+++ b/docling/backend/xml/xbrl_backend.py
@@ -92,7 +92,7 @@ class XBRLDocumentBackend(DeclarativeDocumentBackend):
         if not _XBRL_AVAILABLE:
             raise ImportError(
                 "The 'arelle-release' package is required to process XBRL documents. "
-                "Please install it using `pip install 'docling[xbrl]'`"
+                "Please install it using `pip install 'docling-slim[format-xml-xbrl]'`"
             ) from _XBRL_IMPORT_ERROR
 
         super().__init__(in_doc, path_or_stream)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,6 @@ format-opendocument = [
 # --- Web Formats (web = html + markdown) ---
 format-html = [
   'beautifulsoup4>=4.12.3,<5.0.0',
-  'lxml>=4.0.0,<7.0.0',
 ]
 
 format-markdown = [
@@ -148,6 +147,16 @@ format-latex = [
 format-email = [
   'docling-slim[format-html]',
   'mail-parser>=4.1.4,<5.0.0',
+]
+
+format-xml-jats = [
+  'docling-slim[format-html]',
+  'lxml>=4.0.0,<7.0.0',
+]
+
+format-xml-uspto = [
+  'docling-slim[format-html]',
+  'defusedxml>=0.7.1,<0.8.0',
 ]
 
 format-xml-xbrl = [
@@ -265,7 +274,7 @@ standard = [
 ]
 
 all = [
-  'docling-slim[standard,models-vlm-inline,format-audio,format-html-render,format-xml-xbrl,models-remote,models-onnxruntime,feat-ocr-easyocr,feat-ocr-tesserocr,feat-ocr-mac]',
+  'docling-slim[standard,models-vlm-inline,format-audio,format-html-render,format-xml-jats,format-xml-uspto,format-xml-xbrl,models-remote,models-onnxruntime,feat-ocr-easyocr,feat-ocr-tesserocr,feat-ocr-mac]',
 ]
 
 [dependency-groups]

--- a/tests/test_backend_optional_dependencies.py
+++ b/tests/test_backend_optional_dependencies.py
@@ -16,6 +16,15 @@ from pathlib import Path
 import pytest
 
 _EML_SAMPLE = Path(__file__).parent / "data" / "email" / "sources" / "eml_simple.eml"
+_MD_SAMPLE = Path(__file__).parent / "data" / "md" / "sources" / "mixed.md"
+_DOCX_SAMPLE = Path(__file__).parent / "data" / "docx" / "sources" / "word_tables.docx"
+_PPTX_SAMPLE = (
+    Path(__file__).parent / "data" / "pptx" / "sources" / "powerpoint_sample.pptx"
+)
+_XLSX_SAMPLE = Path(__file__).parent / "data" / "xlsx" / "sources" / "xlsx_01.xlsx"
+_TEX_SAMPLE = (
+    Path(__file__).parent / "data" / "latex" / "sources" / "1706.03762" / "main.tex"
+)
 
 
 def _run_with_blocked_module(
@@ -34,7 +43,7 @@ def _run_with_blocked_module(
 
 @pytest.mark.parametrize(
     "blocked_module",
-    ["mailparser", "marko"],
+    ["mailparser", "marko", "docx", "pptx", "openpyxl", "pylatexenc"],
 )
 def test_converter_constructs_without_optional_backend_dependency(
     blocked_module: str,
@@ -70,5 +79,85 @@ def test_email_backend_reports_missing_dependency_with_install_hint() -> None:
         "    raise AssertionError('expected ImportError when mail-parser is missing')\n"
     )
     result = _run_with_blocked_module("mailparser", body)
+    assert result.returncode == 0, result.stderr
+    assert "actionable-error-raised" in result.stdout
+
+
+@pytest.mark.parametrize(
+    ("blocked_module", "backend_import", "backend_class", "sample", "fmt", "extra"),
+    [
+        (
+            "mailparser",
+            "docling.backend.email_backend",
+            "EmailDocumentBackend",
+            _EML_SAMPLE,
+            "EMAIL",
+            "format-email",
+        ),
+        (
+            "marko",
+            "docling.backend.md_backend",
+            "MarkdownDocumentBackend",
+            _MD_SAMPLE,
+            "MD",
+            "format-markdown",
+        ),
+        (
+            "docx",
+            "docling.backend.msword_backend",
+            "MsWordDocumentBackend",
+            _DOCX_SAMPLE,
+            "DOCX",
+            "format-docx",
+        ),
+        (
+            "pptx",
+            "docling.backend.mspowerpoint_backend",
+            "MsPowerpointDocumentBackend",
+            _PPTX_SAMPLE,
+            "PPTX",
+            "format-pptx",
+        ),
+        (
+            "openpyxl",
+            "docling.backend.msexcel_backend",
+            "MsExcelDocumentBackend",
+            _XLSX_SAMPLE,
+            "XLSX",
+            "format-xlsx",
+        ),
+        (
+            "pylatexenc",
+            "docling.backend.latex_backend",
+            "LatexDocumentBackend",
+            _TEX_SAMPLE,
+            "LATEX",
+            "format-latex",
+        ),
+    ],
+)
+def test_backend_reports_missing_dependency_with_install_hint(
+    blocked_module: str,
+    backend_import: str,
+    backend_class: str,
+    sample: Path,
+    fmt: str,
+    extra: str,
+) -> None:
+    body = (
+        "from pathlib import Path\n"
+        f"from {backend_import} import {backend_class}\n"
+        "from docling.datamodel.base_models import InputFormat\n"
+        "from docling.datamodel.document import InputDocument\n"
+        f"path = Path({str(sample)!r})\n"
+        "try:\n"
+        f"    InputDocument(path_or_stream=path, format=InputFormat.{fmt}, backend={backend_class})\n"
+        "except ImportError as exc:\n"
+        f"    assert {extra!r} in str(exc), str(exc)\n"
+        "    print('actionable-error-raised')\n"
+        "else:\n"
+        f"    raise AssertionError('expected ImportError when {blocked_module} is missing')\n"
+    )
+    result = _run_with_blocked_module(blocked_module, body)
     assert result.returncode == 0, result.stderr
     assert "actionable-error-raised" in result.stdout

--- a/tests/test_backend_optional_dependencies.py
+++ b/tests/test_backend_optional_dependencies.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 _EML_SAMPLE = Path(__file__).parent / "data" / "email" / "sources" / "eml_simple.eml"
+_HTML_SAMPLE = Path(__file__).parent / "data" / "html" / "sources" / "hyperlink_01.html"
 _MD_SAMPLE = Path(__file__).parent / "data" / "md" / "sources" / "mixed.md"
 _DOCX_SAMPLE = Path(__file__).parent / "data" / "docx" / "sources" / "word_tables.docx"
 _PPTX_SAMPLE = (
@@ -25,6 +26,8 @@ _XLSX_SAMPLE = Path(__file__).parent / "data" / "xlsx" / "sources" / "xlsx_01.xl
 _TEX_SAMPLE = (
     Path(__file__).parent / "data" / "latex" / "sources" / "1706.03762" / "main.tex"
 )
+_JATS_SAMPLE = Path(__file__).parent / "data" / "jats" / "sources" / "pone.0234687.nxml"
+_USPTO_SAMPLE = Path(__file__).parent / "data" / "uspto" / "sources" / "ipg08672134.xml"
 
 
 def _run_with_blocked_module(
@@ -43,7 +46,7 @@ def _run_with_blocked_module(
 
 @pytest.mark.parametrize(
     "blocked_module",
-    ["mailparser", "marko", "docx", "pptx", "openpyxl", "pylatexenc"],
+    ["mailparser", "marko", "docx", "pptx", "openpyxl", "pylatexenc", "bs4"],
 )
 def test_converter_constructs_without_optional_backend_dependency(
     blocked_module: str,
@@ -68,6 +71,14 @@ def test_converter_constructs_without_optional_backend_dependency(
             _EML_SAMPLE,
             "EMAIL",
             "format-email",
+        ),
+        (
+            "bs4",
+            "docling.backend.html_backend",
+            "HTMLDocumentBackend",
+            _HTML_SAMPLE,
+            "HTML",
+            "format-html",
         ),
         (
             "marko",
@@ -108,6 +119,22 @@ def test_converter_constructs_without_optional_backend_dependency(
             _TEX_SAMPLE,
             "LATEX",
             "format-latex",
+        ),
+        (
+            "bs4",
+            "docling.backend.xml.jats_backend",
+            "JatsDocumentBackend",
+            _JATS_SAMPLE,
+            "XML_JATS",
+            "format-xml-jats",
+        ),
+        (
+            "bs4",
+            "docling.backend.xml.uspto_backend",
+            "PatentUsptoDocumentBackend",
+            _USPTO_SAMPLE,
+            "XML_USPTO",
+            "format-xml-uspto",
         ),
     ],
 )

--- a/tests/test_backend_optional_dependencies.py
+++ b/tests/test_backend_optional_dependencies.py
@@ -58,31 +58,6 @@ def test_converter_constructs_without_optional_backend_dependency(
     assert result.returncode == 0, result.stderr
 
 
-def test_email_backend_reports_missing_dependency_with_install_hint() -> None:
-    # Using a backend whose optional dependency is absent must fail with an
-    # actionable ImportError that names the extra to install, not a NameError or
-    # an error mislabeled as a corrupt-document failure.
-    body = (
-        "from pathlib import Path\n"
-        "from docling.backend.email_backend import EmailDocumentBackend\n"
-        "from docling.datamodel.base_models import InputFormat\n"
-        "from docling.datamodel.document import InputDocument\n"
-        f"path = Path({str(_EML_SAMPLE)!r})\n"
-        "try:\n"
-        "    InputDocument(\n"
-        "        path_or_stream=path, format=InputFormat.EMAIL, backend=EmailDocumentBackend\n"
-        "    )\n"
-        "except ImportError as exc:\n"
-        "    assert 'format-email' in str(exc), str(exc)\n"
-        "    print('actionable-error-raised')\n"
-        "else:\n"
-        "    raise AssertionError('expected ImportError when mail-parser is missing')\n"
-    )
-    result = _run_with_blocked_module("mailparser", body)
-    assert result.returncode == 0, result.stderr
-    assert "actionable-error-raised" in result.stdout
-
-
 @pytest.mark.parametrize(
     ("blocked_module", "backend_import", "backend_class", "sample", "fmt", "extra"),
     [

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'darwin'",
@@ -1638,14 +1638,10 @@ format-docx = [
 ]
 format-email = [
     { name = "beautifulsoup4" },
-    { name = "lxml", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "mail-parser" },
 ]
 format-html = [
     { name = "beautifulsoup4" },
-    { name = "lxml", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
 ]
 format-html-render = [
     { name = "playwright" },
@@ -1680,12 +1676,19 @@ format-pptx = [
 ]
 format-web = [
     { name = "beautifulsoup4" },
-    { name = "lxml", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "marko" },
 ]
 format-xlsx = [
     { name = "openpyxl" },
+]
+format-xml-jats = [
+    { name = "beautifulsoup4" },
+    { name = "lxml", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+format-xml-uspto = [
+    { name = "beautifulsoup4" },
+    { name = "defusedxml" },
 ]
 format-xml-xbrl = [
     { name = "arelle-release" },
@@ -1730,8 +1733,6 @@ standard = [
     { name = "docling-parse" },
     { name = "httpx" },
     { name = "huggingface-hub" },
-    { name = "lxml", version = "5.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "lxml", version = "6.1.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "mail-parser" },
     { name = "marko" },
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -1843,6 +1844,7 @@ requires-dist = [
     { name = "arelle-release", marker = "extra == 'format-xml-xbrl'", specifier = ">=2.38.17,<3.0.0" },
     { name = "beautifulsoup4", marker = "extra == 'format-html'", specifier = ">=4.12.3,<5.0.0" },
     { name = "certifi", specifier = ">=2024.7.4" },
+    { name = "defusedxml", marker = "extra == 'format-xml-uspto'", specifier = ">=0.7.1,<0.8.0" },
     { name = "defusedxml", marker = "extra == 'models-local'", specifier = ">=0.7.1,<0.8.0" },
     { name = "docling-core", specifier = ">=2.86.0,<3.0.0" },
     { name = "docling-core", extras = ["chunking"], marker = "extra == 'feat-chunking'", specifier = ">=2.73.0,<3.0.0" },
@@ -1851,15 +1853,17 @@ requires-dist = [
     { name = "docling-slim", extras = ["convert-core"], marker = "extra == 'extract-core'" },
     { name = "docling-slim", extras = ["format-docx", "format-pptx", "format-xlsx"], marker = "extra == 'format-office'" },
     { name = "docling-slim", extras = ["format-html"], marker = "extra == 'format-email'" },
+    { name = "docling-slim", extras = ["format-html"], marker = "extra == 'format-xml-jats'" },
+    { name = "docling-slim", extras = ["format-html"], marker = "extra == 'format-xml-uspto'" },
     { name = "docling-slim", extras = ["format-html", "format-markdown"], marker = "extra == 'format-web'" },
     { name = "docling-slim", extras = ["format-pdf", "models-local", "feat-ocr-rapidocr", "format-office", "format-web", "format-latex", "format-email", "feat-chunking", "extract-core", "service-client", "cli"], marker = "extra == 'standard'" },
     { name = "docling-slim", extras = ["format-pdf-pypdfium2", "format-pdf-docling"], marker = "extra == 'format-pdf'" },
-    { name = "docling-slim", extras = ["standard", "models-vlm-inline", "format-audio", "format-html-render", "format-xml-xbrl", "models-remote", "models-onnxruntime", "feat-ocr-easyocr", "feat-ocr-tesserocr", "feat-ocr-mac"], marker = "extra == 'all'" },
+    { name = "docling-slim", extras = ["standard", "models-vlm-inline", "format-audio", "format-html-render", "format-xml-jats", "format-xml-uspto", "format-xml-xbrl", "models-remote", "models-onnxruntime", "feat-ocr-easyocr", "feat-ocr-tesserocr", "feat-ocr-mac"], marker = "extra == 'all'" },
     { name = "easyocr", marker = "extra == 'feat-ocr-easyocr'", specifier = ">=1.7,<2.0" },
     { name = "filetype", specifier = ">=1.2.0,<2.0.0" },
     { name = "httpx", marker = "extra == 'service-client'", specifier = ">=0.28,<1.0.0" },
     { name = "huggingface-hub", marker = "extra == 'models-local'", specifier = ">=0.23,<2" },
-    { name = "lxml", marker = "extra == 'format-html'", specifier = ">=4.0.0,<7.0.0" },
+    { name = "lxml", marker = "extra == 'format-xml-jats'", specifier = ">=4.0.0,<7.0.0" },
     { name = "mail-parser", marker = "extra == 'format-email'", specifier = ">=4.1.4,<5.0.0" },
     { name = "marko", marker = "extra == 'format-markdown'", specifier = ">=2.1.2,<3.0.0" },
     { name = "mlx-vlm", marker = "python_full_version >= '3.10' and platform_machine == 'arm64' and sys_platform == 'darwin' and extra == 'models-vlm-inline'", specifier = ">=0.4.3,<1.0.0" },
@@ -1910,7 +1914,7 @@ requires-dist = [
     { name = "websockets", marker = "extra == 'service-client'", specifier = ">=14.0,<17.0" },
     { name = "whisper-s2t-reborn", marker = "(platform_machine != 'arm64' and extra == 'format-audio') or (sys_platform != 'darwin' and extra == 'format-audio')", specifier = ">=1.6.3,<2" },
 ]
-provides-extras = ["convert-core", "extract-core", "format-pdf-pypdfium2", "format-pdf-docling", "format-pdf", "format-docx", "format-pptx", "format-xlsx", "format-office", "format-opendocument", "format-html", "format-markdown", "format-web", "format-latex", "format-email", "format-xml-xbrl", "format-html-render", "format-audio", "feat-ocr-rapidocr", "feat-ocr-rapidocr-onnx", "feat-ocr-easyocr", "feat-ocr-tesserocr", "feat-ocr-mac", "feat-ocr-nemotron", "models-local", "models-remote", "models-onnxruntime", "models-vlm-inline", "feat-chunking", "service-client", "cli", "standard", "all"]
+provides-extras = ["convert-core", "extract-core", "format-pdf-pypdfium2", "format-pdf-docling", "format-pdf", "format-docx", "format-pptx", "format-xlsx", "format-office", "format-opendocument", "format-html", "format-markdown", "format-web", "format-latex", "format-email", "format-xml-jats", "format-xml-uspto", "format-xml-xbrl", "format-html-render", "format-audio", "feat-ocr-rapidocr", "feat-ocr-rapidocr-onnx", "feat-ocr-easyocr", "feat-ocr-tesserocr", "feat-ocr-mac", "feat-ocr-nemotron", "models-local", "models-remote", "models-onnxruntime", "models-vlm-inline", "feat-chunking", "service-client", "cli", "standard", "all"]
 
 [package.metadata.requires-dev]
 constraints = [


### PR DESCRIPTION
## Problem

`DocumentConverter` imports every format backend eagerly at module load time. Backends that referenced optional third-party packages (`pylatexenc`, `python-docx`, `python-pptx`, `openpyxl`) at the top level caused an `ImportError` at `import docling` time on any install that omits the corresponding extra — including all `docling-slim` variants.

PR #3702 introduced conditional import guards for the `email` and `markdown` backends but explicitly deferred the remaining backends to a follow-up.

## Solution

Apply the same deferred-error pattern to all remaining backends that depend on optional extras:


| Backend | Optional package | Extra |
|---|---|---|
| `html_backend.py` | `beautifulsoup4` | `format-html` |
| `latex/backend.py` (and sub-modules) | `pylatexenc` | `format-latex` |
| `msword_backend.py` | `python-docx` | `format-docx` |
| `mspowerpoint_backend.py` | `python-pptx` | `format-pptx` |
| `msexcel_backend.py` | `openpyxl` | `format-xlsx` |
| `xml/jats_backend.py` | `beautifulsoup4`, `lxml` | `format-xml-jats` (new) |
| `xml/uspto_backend.py` | `beautifulsoup4`, `defusedxml` | `format-xml-uspto` (new) |

The pattern is the same in each case:
1. Module-level `try/except ImportError` guard after all unconditional imports,
   setting `_*_AVAILABLE: bool` and `_*_IMPORT_ERROR`.
2. Check `if not _*_AVAILABLE: raise ImportError(_INSTALL_HINT)` at the top of
   `__init__`, before `super().__init__()`, so a missing dependency surfaces as
   an actionable message rather than a `NameError` or a misleading
   document-load failure.
3. `from __future__ import annotations` added to files where optional types
   appear in class-body method signatures, to prevent `NameError` at class
   definition time.

### New optional extras

Two new extras are introduced for the XML format backends that were previously
undeclared:

```toml
format-xml-jats = [
  'docling-slim[format-html]',   # bs4
  'lxml>=4.0.0,<7.0.0',
]

format-xml-uspto = [
  'docling-slim[format-html]',   # bs4
  'defusedxml>=0.7.1,<0.8.0',
]
```

Both are included in the all convenience bundle.

#### Dependency correction: lxml moved out of format-html

`lxml` was previously listed under `format-html` but `html_backend.py` does
not import it. `lxml` is needed only by `jats_backend.py`, so it is now
correctly declared as a direct dependency of `format-xml-jats`. Backends that
use `lxml` through Office packages (`format-docx`, `format-pptx`) already get
it transitively via `python-docx` and `python-pptx`.

### Additional fixes

- `docling/backend/docx/drawingml/utils.py`: `from docx.document import
  Document` moved to `TYPE_CHECKING` (it is only used as a type annotation).
- `docling/backend/docx/latex/omml.py`: `UnicodeToLatexEncoder` class-variable
  initialisation moved from class body into `__init__` so the class can be
  defined without `pylatexenc` installed; import guarded.
- All `_INSTALL_HINT` strings updated to reference `docling-slim[format-X]`
  rather than `docling[format-X]`, matching the slim-package install surface.
- Import ordering in `latex/handlers/` and `latex/utils/` cleaned up: all
  unconditional imports appear before `if TYPE_CHECKING` and the optional
  `try/except` guard; removed a duplicate `from pathlib import Path` inside a
  `TYPE_CHECKING` block in `macros.py`.

## Testing

`tests/test_backend_optional_dependencies.py` now contains exactly two
parametrised test functions (the old standalone
`test_email_backend_reports_missing_dependency_with_install_hint` has been
merged into the second):

- `test_converter_constructs_without_optional_backend_dependency` — 6 cases
  (`mailparser`, `marko`, `docx`, `pptx`, `openpyxl`, `pylatexenc`): asserts
  that `DocumentConverter()` can be constructed with the dependency blocked.
- `test_backend_reports_missing_dependency_with_install_hint` — 6 cases (one
  per optional backend): asserts that instantiating the backend without its
  dependency raises an `ImportError` whose message contains the correct
  `docling-slim[format-X]` extra name.

Fixes #3740 (follow-up to #3702).