### PR TITLE
fix(docling-parse): render threaded backend page images with pypdfium2 (#3512)

### DIFF
--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -79,6 +79,47 @@ def _make_docling_parse_page_content_config(
     )
 
 
+def _render_page_image_via_pdfium(
+    ppage: PdfPage,
+    page_size: Size,
+    scale: float,
+    cropbox: Optional[BoundingBox],
+) -> Image.Image:
+    """Render a page raster with pypdfium2.
+
+    Shared by the serial and threaded docling-parse page backends so both feed
+    the downstream layout model an identical raster. Diverging renderers (e.g.
+    the docling-parse rasterizer) produce subtly different images and can flip
+    layout detection (see issue #3512).
+    """
+    if not cropbox:
+        cropbox = BoundingBox(
+            l=0,
+            r=page_size.width,
+            t=0,
+            b=page_size.height,
+            coord_origin=CoordOrigin.TOPLEFT,
+        )
+        padbox = BoundingBox(l=0, r=0, t=0, b=0, coord_origin=CoordOrigin.BOTTOMLEFT)
+    else:
+        padbox = cropbox.to_bottom_left_origin(page_size.height).model_copy()
+        padbox.r = page_size.width - padbox.r
+        padbox.t = page_size.height - padbox.t
+
+    with pypdfium2_lock:
+        bitmap = ppage.render(
+            scale=scale * 1.5,
+            rotation=0,  # no additional rotation
+            crop=padbox.as_tuple(),
+        )
+        image = bitmap.to_pil().copy()
+        bitmap.close()
+    # We resize the image from 1.5x the given scale to make it sharper.
+    return image.resize(
+        size=(round(cropbox.width * scale), round(cropbox.height * scale))
+    )
+
+
 class DoclingParsePageBackend(ManagedPdfiumPageBackend):
     def __init__(
         self,
@@ -203,38 +244,9 @@ class DoclingParsePageBackend(ManagedPdfiumPageBackend):
     def get_page_image(
         self, scale: float = 1, cropbox: Optional[BoundingBox] = None
     ) -> Image.Image:
-        page_size = self.get_size()
-
-        if not cropbox:
-            cropbox = BoundingBox(
-                l=0,
-                r=page_size.width,
-                t=0,
-                b=page_size.height,
-                coord_origin=CoordOrigin.TOPLEFT,
-            )
-            padbox = BoundingBox(
-                l=0, r=0, t=0, b=0, coord_origin=CoordOrigin.BOTTOMLEFT
-            )
-        else:
-            padbox = cropbox.to_bottom_left_origin(page_size.height).model_copy()
-            padbox.r = page_size.width - padbox.r
-            padbox.t = page_size.height - padbox.t
-
-        with pypdfium2_lock:
-            bitmap = self._ppage.render(
-                scale=scale * 1.5,
-                rotation=0,  # no additional rotation
-                crop=padbox.as_tuple(),
-            )
-            image = bitmap.to_pil().copy()
-            bitmap.close()
-        # We resize the image from 1.5x the given scale to make it sharper.
-        image = image.resize(
-            size=(round(cropbox.width * scale), round(cropbox.height * scale))
+        return _render_page_image_via_pdfium(
+            self._require_page(), self.get_size(), scale, cropbox
         )
-
-        return image
 
     def get_size(self) -> Size:
         with pypdfium2_lock:
@@ -380,9 +392,18 @@ def _resolve_threaded_page_numbers(
 
 
 class ThreadedDoclingParsePageBackend(PdfPageBackend):
-    def __init__(self, result: PageParseResult):
+    def __init__(
+        self,
+        result: PageParseResult,
+        doc_backend: Optional["ThreadedDoclingParseDocumentBackend"] = None,
+    ):
         self._result = result
         self._seg_page: Optional[SegmentedPdfPage] = None
+        # The owning document backend lazily provides a shared pypdfium2 document
+        # used to render page rasters with the same engine as the serial backend,
+        # so the downstream layout model sees an identical image (issue #3512).
+        self._doc_backend = doc_backend
+        self._ppage: Optional[PdfPage] = None
 
     @property
     def page_no(self) -> int:
@@ -446,13 +467,25 @@ class ThreadedDoclingParsePageBackend(PdfPageBackend):
     def get_page_image(
         self, scale: float = 1, cropbox: Optional[BoundingBox] = None
     ) -> Image.Image:
+        if self._doc_backend is not None:
+            pdoc = self._doc_backend._ensure_pdoc()
+            with pypdfium2_lock:
+                if self._ppage is None:
+                    self._ppage = pdoc[self._result.page_number - 1]
+            return _render_page_image_via_pdfium(
+                self._ppage, self.get_size(), scale, cropbox
+            ).convert("RGB")
+        # Fallback: docling-parse rasterizer (renders a slightly different image).
         return self._result.get_image(scale=scale, cropbox=cropbox).convert("RGB")
 
     def get_size(self) -> Size:
         return Size(width=self._result.page_width, height=self._result.page_height)
 
     def unload(self) -> None:
-        return None
+        if self._ppage is not None:
+            with pypdfium2_lock:
+                self._ppage.close()
+            self._ppage = None
 
 
 class ThreadedDoclingParseDocumentBackend(PdfDocumentBackend):
@@ -516,6 +549,25 @@ class ThreadedDoclingParseDocumentBackend(PdfDocumentBackend):
             page_numbers=requested_page_numbers,
         )
 
+        self._password = password
+        # pypdfium2 document, opened lazily on the first page render. Page rasters
+        # are rendered with pypdfium2 (same engine as the serial backend) so the
+        # downstream layout model receives an identical image; the docling-parse
+        # rasterizer produces a subtly different image that can change layout
+        # detection and drop tables (issue #3512). Kept lazy so that documents
+        # whose pages are never rendered incur no pypdfium2 load.
+        self._pdoc: Optional[pdfium.PdfDocument] = None
+
+    def _ensure_pdoc(self) -> pdfium.PdfDocument:
+        with pypdfium2_lock:
+            if self._pdoc is None:
+                if isinstance(self.path_or_stream, BytesIO):
+                    self.path_or_stream.seek(0)
+                self._pdoc = pdfium.PdfDocument(
+                    self.path_or_stream, password=self._password
+                )
+            return self._pdoc
+
     def is_valid(self) -> bool:
         return not self._closed and self.page_count() > 0
 
@@ -523,10 +575,12 @@ class ThreadedDoclingParseDocumentBackend(PdfDocumentBackend):
         return self.parser.page_count(self.doc_key)
 
     def get_document_outline(self) -> list[_PdfOutlineItem]:
-        """Extract the outline via docling-parse (this backend holds no pypdfium2 handle).
+        """Extract the outline via docling-parse.
 
         The threaded parser exposes no table-of-contents accessor, so a lightweight lazy
         docling-parse document is loaded purely to read the (cheap, structure-only) outline.
+        The pypdfium2 document used for page rendering has no outline accessor either, so it
+        is not reused here.
         """
         password = (
             self.options.password.get_secret_value() if self.options.password else None
@@ -550,11 +604,15 @@ class ThreadedDoclingParseDocumentBackend(PdfDocumentBackend):
 
     def iter_pages(self) -> Iterator[ThreadedDoclingParsePageBackend]:
         for result in self.parser.iterate_results():
-            yield ThreadedDoclingParsePageBackend(result)
+            yield ThreadedDoclingParsePageBackend(result, self)
 
     def unload(self) -> None:
         if self._closed:
             return
         self._closed = True
         self.parser.unload(self.doc_key)
+        if self._pdoc is not None:
+            with pypdfium2_lock:
+                self._pdoc.close()
+            self._pdoc = None
         super().unload()

--- a/tests/test_backend_docling_parse.py
+++ b/tests/test_backend_docling_parse.py
@@ -5,7 +5,7 @@ from typing import Any
 import pytest
 from docling_core.types.doc import CoordOrigin
 from docling_parse.pdf_parser import ContentLevel
-from PIL import Image, ImageDraw, ImageStat
+from PIL import Image, ImageChops, ImageDraw, ImageStat
 
 import docling.backend.docling_parse_backend as docling_parse_backend_module
 from docling.backend.docling_parse_backend import (
@@ -95,6 +95,48 @@ def test_crop_page_image(test_doc_path):
     # Explicitly clean up resources
     page_backend.unload()
     doc_backend.unload()
+
+
+def test_threaded_backend_renders_same_image_as_serial(test_doc_path):
+    """Both docling-parse backends must feed the layout model an identical raster.
+
+    The threaded backend previously rendered via the docling-parse rasterizer,
+    producing a subtly different image than the serial (pypdfium2) backend. That
+    divergence changed layout detection and dropped tables (issue #3512).
+    """
+    serial_backend = _get_backend(test_doc_path)
+    serial_page = serial_backend.load_page(0)
+    try:
+        serial_image = serial_page.get_page_image(scale=1.0)
+    finally:
+        serial_page.unload()
+        serial_backend.unload()
+
+    in_doc = InputDocument(
+        path_or_stream=test_doc_path,
+        format=InputFormat.PDF,
+        backend=ThreadedDoclingParseDocumentBackend,
+    )
+    threaded_backend = in_doc._backend
+    threaded_image = None
+    page_backends = []
+    try:
+        for page_backend in threaded_backend.iter_pages():
+            page_backends.append(page_backend)
+            if page_backend.page_no == 1:
+                threaded_image = page_backend.get_page_image(scale=1.0)
+    finally:
+        for page_backend in page_backends:
+            page_backend.unload()
+        threaded_backend.unload()
+
+    assert threaded_image is not None
+
+    assert threaded_image.size == serial_image.size
+    diff = ImageChops.difference(
+        serial_image.convert("RGB"), threaded_image.convert("RGB")
+    )
+    assert diff.getbbox() is None
 
 
 def test_num_pages(test_doc_path):


### PR DESCRIPTION
## Problem

Fixes #3512. Switching only the PDF backend from `DoclingParseDocumentBackend` to `ThreadedDoclingParseDocumentBackend` — same pipeline options, same `StandardPdfPipeline` — causes tables to be dropped. The serial backend extracts a table; the threaded backend emits its cell content as loose text and produces zero tables. Persists at `parser_threads=1`, so not a concurrency bug.

## Root cause

The two backends rasterize the page for the layout model with **different engines**:

- `DoclingParsePageBackend.get_page_image` (serial) — pypdfium2 (`ppage.render`)
- `ThreadedDoclingParsePageBackend.get_page_image` (threaded) — the docling-parse rasterizer (`result.get_image`)

The rasters differ (e.g. 595×842 vs 595×841, ~3% of pixels). The layout vision model is sensitive to this: on the docling-parse raster it emits extra spurious overlapping clusters, and `LayoutPostprocessor` then evicts the real table cluster and demotes its cells to loose text.

It is **not** the cells (byte-identical across backends), **not** concurrency, and **not** TableFormer.

Verified: forcing the threaded pipeline to use the serial (pypdfium2) raster restores `tables=1`; after the fix the layout-input images are byte-identical (max pixel diff = 0).

## Fix

- Extract the serial rendering into a shared `_render_page_image_via_pdfium` helper.
- Route the threaded backend through it too, via a **lazily-opened** shared `pdfium.PdfDocument` (opened only on first page render, so the existing no-page-count-probe / lazy-load contract is preserved).

The serial path is a pure refactor (behavior unchanged), so reference test data is unaffected (default backend is the serial one).

## Tests

- New `test_threaded_backend_renders_same_image_as_serial` — asserts raster parity between the two backends (no ML model required).
- Repro from the issue now returns `tables=1 texts=1` for serial, threaded, and `threaded(parser_threads=1)`.
- `tests/test_backend_docling_parse.py`: 24 passed. `prek run --all-files`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
