### PR TITLE
chore(video): add ffmpeg-based video frame samplers

### DIFF
--- a/docling/utils/video_frame_sampling.py
+++ b/docling/utils/video_frame_sampling.py
@@ -1,0 +1,260 @@
+"""Video frame sampling utilities.
+
+This module is intentionally free of any docling imports. It provides two
+frame samplers over a video file, using ffmpeg as the only hard runtime
+dependency (ffmpeg is already required by the ASR path).
+
+- ``FixedIntervalFrameSampler`` extracts one frame every N seconds.
+- ``SimpleSceneChangeFrameSampler`` probes low-resolution frames and emits a
+  representative frame per detected scene using a mean-absolute-difference
+  heuristic.
+
+Both return ``VideoFrame`` objects carrying the frame image and its timestamp.
+"""
+
+import logging
+import shutil
+import subprocess
+from io import BytesIO
+from pathlib import Path
+from typing import Final
+
+import numpy as np
+from PIL import Image
+from pydantic import BaseModel, ConfigDict, Field
+
+_log = logging.getLogger(__name__)
+
+MISSING_FFMPEG_MESSAGE: Final[str] = (
+    "FFmpeg is required for video processing but was not found on PATH. "
+    "Install it with your system package manager (e.g., 'brew install ffmpeg' "
+    "on macOS, 'apt-get install ffmpeg' on Linux, 'winget install ffmpeg' on "
+    "Windows)."
+)
+
+
+class VideoFrame(BaseModel):
+    """A single sampled video frame with its timestamp."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    timestamp: float = Field(..., ge=0, description="Seconds from video start.")
+    image: Image.Image = Field(..., description="The decoded frame image.")
+    scene_id: int | None = Field(
+        None, description="Scene index if produced by a scene sampler."
+    )
+
+
+class VideoScene(BaseModel):
+    """A contiguous time window treated as one scene."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    scene_id: int
+    start_time: float = Field(..., ge=0)
+    end_time: float = Field(..., ge=0)
+    representative_frame: VideoFrame | None = None
+
+
+def _require_ffmpeg() -> None:
+    if shutil.which("ffmpeg") is None:
+        raise RuntimeError(MISSING_FFMPEG_MESSAGE)
+
+
+def _probe_duration(video_path: Path) -> float:
+    """Return the video duration in seconds using ffprobe, or 0.0 on failure."""
+    if shutil.which("ffprobe") is None:
+        return 0.0
+    try:
+        out = subprocess.run(
+            [
+                "ffprobe",
+                "-v",
+                "error",
+                "-show_entries",
+                "format=duration",
+                "-of",
+                "default=noprint_wrappers=1:nokey=1",
+                str(video_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return float(out.stdout.strip())
+    except (subprocess.CalledProcessError, ValueError):
+        return 0.0
+
+
+def _extract_frame(video_path: Path, timestamp: float) -> Image.Image | None:
+    """Extract a single frame at ``timestamp`` as a PIL image via ffmpeg.
+
+    Returns None if ffmpeg produced no output (e.g. timestamp past end).
+    """
+    proc = subprocess.run(
+        [
+            "ffmpeg",
+            "-nostdin",
+            "-ss",
+            f"{timestamp:.3f}",
+            "-i",
+            str(video_path),
+            "-frames:v",
+            "1",
+            "-f",
+            "image2pipe",
+            "-vcodec",
+            "png",
+            "-",
+        ],
+        capture_output=True,
+        check=False,
+    )
+    if proc.returncode != 0 or not proc.stdout:
+        _log.debug(
+            "Frame extraction at %.3fs produced no output (rc=%s): %s",
+            timestamp,
+            proc.returncode,
+            proc.stderr.decode("utf-8", "replace")[-200:],
+        )
+        return None
+    try:
+        return Image.open(BytesIO(proc.stdout)).convert("RGB")
+    except Exception as exc:  # pragma: no cover - defensive
+        _log.debug("Failed to decode extracted frame at %.3fs: %s", timestamp, exc)
+        return None
+
+
+class FixedIntervalFrameSampler:
+    """Sample one frame every ``interval_seconds`` from time zero."""
+
+    def __init__(
+        self,
+        interval_seconds: float = 10.0,
+        max_frames: int | None = None,
+    ):
+        if interval_seconds <= 0:
+            raise ValueError("interval_seconds must be > 0")
+        if max_frames is not None and max_frames <= 0:
+            raise ValueError("max_frames must be > 0 when set")
+        self.interval_seconds = interval_seconds
+        self.max_frames = max_frames
+
+    def sample(self, video_path: Path) -> list[VideoFrame]:
+        _require_ffmpeg()
+        duration = _probe_duration(video_path)
+
+        frames: list[VideoFrame] = []
+        t = 0.0
+        # If duration is unknown (0.0), rely on extraction returning None at EOF.
+        while duration == 0.0 or t < duration:
+            if self.max_frames is not None and len(frames) >= self.max_frames:
+                break
+            image = _extract_frame(video_path, t)
+            if image is None:
+                break
+            frames.append(VideoFrame(timestamp=t, image=image))
+            t += self.interval_seconds
+        return frames
+
+
+class SimpleSceneChangeFrameSampler:
+    """Detect scenes via mean-absolute pixel difference of probe frames.
+
+    Probes the video at ``probe_fps`` (downscaled RGB), starts a new scene when
+    the normalized frame difference exceeds ``threshold`` and enough time has
+    elapsed since the last boundary, and emits one representative frame per
+    scene (taken at the scene midpoint).
+    """
+
+    def __init__(
+        self,
+        threshold: float = 0.35,
+        probe_fps: float = 1.0,
+        min_scene_duration_seconds: float = 2.0,
+        max_frames: int | None = None,
+        probe_size: int = 64,
+    ):
+        if threshold < 0:
+            raise ValueError("threshold must be >= 0")
+        if probe_fps <= 0:
+            raise ValueError("probe_fps must be > 0")
+        if min_scene_duration_seconds < 0:
+            raise ValueError("min_scene_duration_seconds must be >= 0")
+        if max_frames is not None and max_frames <= 0:
+            raise ValueError("max_frames must be > 0 when set")
+        self.threshold = threshold
+        self.probe_fps = probe_fps
+        self.min_scene_duration_seconds = min_scene_duration_seconds
+        self.max_frames = max_frames
+        self.probe_size = probe_size
+
+    def _probe_frames(self, video_path: Path) -> list[tuple[float, Image.Image]]:
+        """Extract downscaled RGB probe frames at probe_fps."""
+        duration = _probe_duration(video_path)
+        step = 1.0 / self.probe_fps
+        probes: list[tuple[float, Image.Image]] = []
+        t = 0.0
+        while duration == 0.0 or t < duration:
+            image = _extract_frame(video_path, t)
+            if image is None:
+                break
+            small = image.convert("RGB").resize((self.probe_size, self.probe_size))
+            probes.append((t, small))
+            t += step
+            # Safety bound if duration is unknown.
+            if duration == 0.0 and len(probes) > 100000:
+                break
+        return probes
+
+    @staticmethod
+    def _mean_abs_diff(a: Image.Image, b: Image.Image) -> float:
+        """Normalized mean absolute difference of two images in [0, 1]."""
+        arr_a = np.asarray(a, dtype=np.int16)
+        arr_b = np.asarray(b, dtype=np.int16)
+        if arr_a.shape != arr_b.shape or arr_a.size == 0:
+            return 0.0
+        return float(np.abs(arr_a - arr_b).mean()) / 255.0
+
+    def detect_scenes(self, video_path: Path) -> list[VideoScene]:
+        _require_ffmpeg()
+        probes = self._probe_frames(video_path)
+        if not probes:
+            return []
+
+        boundaries: list[float] = [probes[0][0]]
+        last_boundary = probes[0][0]
+        prev = probes[0][1]
+        for ts, frame in probes[1:]:
+            diff = self._mean_abs_diff(prev, frame)
+            if (
+                diff >= self.threshold
+                and (ts - last_boundary) >= self.min_scene_duration_seconds
+            ):
+                boundaries.append(ts)
+                last_boundary = ts
+            prev = frame
+
+        end_time = probes[-1][0]
+        scenes: list[VideoScene] = []
+        for idx, start in enumerate(boundaries):
+            stop = boundaries[idx + 1] if idx + 1 < len(boundaries) else end_time
+            scenes.append(VideoScene(scene_id=idx, start_time=start, end_time=stop))
+        return scenes
+
+    def sample(self, video_path: Path) -> list[VideoFrame]:
+        scenes = self.detect_scenes(video_path)
+        frames: list[VideoFrame] = []
+        for scene in scenes:
+            if self.max_frames is not None and len(frames) >= self.max_frames:
+                break
+            midpoint = (scene.start_time + scene.end_time) / 2.0
+            image = _extract_frame(video_path, midpoint)
+            if image is None:
+                image = _extract_frame(video_path, scene.start_time)
+            if image is None:
+                continue
+            frame = VideoFrame(timestamp=midpoint, image=image, scene_id=scene.scene_id)
+            scene.representative_frame = frame
+            frames.append(frame)
+        return frames

--- a/tests/test_video_frame_sampling.py
+++ b/tests/test_video_frame_sampling.py
@@ -1,0 +1,204 @@
+"""Tests for docling.utils.video_frame_sampling.
+
+The scene/frame extraction tests build a tiny synthetic video with ffmpeg when
+it is available on PATH; those are skipped otherwise. The validation and
+pixel-diff tests run without ffmpeg using synthetic PIL images.
+"""
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from docling.utils.video_frame_sampling import (
+    FixedIntervalFrameSampler,
+    SimpleSceneChangeFrameSampler,
+    VideoFrame,
+    VideoScene,
+)
+
+_HAS_FFMPEG = shutil.which("ffmpeg") is not None
+
+
+def _make_three_scene_video(path: Path) -> None:
+    """Render a 12s video: 4s red, 4s green, 4s blue (three hard cuts)."""
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-y",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=red:s=160x120:d=4",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=green:s=160x120:d=4",
+            "-f",
+            "lavfi",
+            "-i",
+            "color=c=blue:s=160x120:d=4",
+            "-filter_complex",
+            "[0:v][1:v][2:v]concat=n=3:v=1:a=0",
+            str(path),
+        ],
+        capture_output=True,
+        check=True,
+    )
+
+
+@pytest.fixture
+def three_scene_video(tmp_path: Path) -> Path:
+    if not _HAS_FFMPEG:
+        pytest.skip("ffmpeg not available")
+    out = tmp_path / "scenes.mp4"
+    _make_three_scene_video(out)
+    return out
+
+
+# --------------------------------------------------------------------------- #
+# Model tests (no ffmpeg)
+# --------------------------------------------------------------------------- #
+
+
+def test_video_frame_model_holds_image():
+    img = Image.new("RGB", (4, 4))
+    f = VideoFrame(timestamp=1.5, image=img, scene_id=2)
+    assert f.timestamp == 1.5
+    assert f.scene_id == 2
+    assert f.image.size == (4, 4)
+
+
+def test_video_scene_model():
+    s = VideoScene(scene_id=0, start_time=0.0, end_time=4.0)
+    assert s.end_time == 4.0
+    assert s.representative_frame is None
+
+
+# --------------------------------------------------------------------------- #
+# Validation guards (no ffmpeg)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"interval_seconds": 0},
+        {"interval_seconds": -1},
+        {"interval_seconds": 5, "max_frames": 0},
+    ],
+)
+def test_fixed_interval_rejects_bad_args(kwargs):
+    with pytest.raises(ValueError):
+        FixedIntervalFrameSampler(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"threshold": -1},
+        {"probe_fps": 0},
+        {"min_scene_duration_seconds": -1},
+        {"max_frames": 0},
+    ],
+)
+def test_scene_sampler_rejects_bad_args(kwargs):
+    with pytest.raises(ValueError):
+        SimpleSceneChangeFrameSampler(**kwargs)
+
+
+# --------------------------------------------------------------------------- #
+# Pixel-diff heuristic (no ffmpeg)
+# --------------------------------------------------------------------------- #
+
+
+def test_mean_abs_diff_identical_is_zero():
+    a = Image.new("RGB", (8, 8), (100, 100, 100))
+    b = Image.new("RGB", (8, 8), (100, 100, 100))
+    assert SimpleSceneChangeFrameSampler._mean_abs_diff(a, b) == 0.0
+
+
+def test_mean_abs_diff_black_vs_white_is_one():
+    a = Image.new("RGB", (8, 8), (0, 0, 0))
+    b = Image.new("RGB", (8, 8), (255, 255, 255))
+    assert SimpleSceneChangeFrameSampler._mean_abs_diff(a, b) == pytest.approx(1.0)
+
+
+def test_mean_abs_diff_red_vs_green_is_significant():
+    a = Image.new("RGB", (8, 8), (255, 0, 0))
+    b = Image.new("RGB", (8, 8), (0, 255, 0))
+    # red->green differs on two channels: mean over RGB = (255+255+0)/3/255
+    assert SimpleSceneChangeFrameSampler._mean_abs_diff(a, b) == pytest.approx(
+        2 / 3, abs=1e-6
+    )
+
+
+# --------------------------------------------------------------------------- #
+# End-to-end sampling (requires ffmpeg)
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.skipif(not _HAS_FFMPEG, reason="ffmpeg not available")
+def test_fixed_interval_timestamps(three_scene_video: Path):
+    frames = FixedIntervalFrameSampler(interval_seconds=3.0).sample(three_scene_video)
+    ts = [round(f.timestamp, 1) for f in frames]
+    assert ts == [0.0, 3.0, 6.0, 9.0]
+    for f in frames:
+        assert f.image.mode == "RGB"
+        assert f.image.size == (160, 120)
+
+
+@pytest.mark.skipif(not _HAS_FFMPEG, reason="ffmpeg not available")
+def test_fixed_interval_respects_max_frames(three_scene_video: Path):
+    frames = FixedIntervalFrameSampler(interval_seconds=1.0, max_frames=2).sample(
+        three_scene_video
+    )
+    assert len(frames) == 2
+
+
+@pytest.mark.skipif(not _HAS_FFMPEG, reason="ffmpeg not available")
+def test_scene_change_detects_three_scenes(three_scene_video: Path):
+    sampler = SimpleSceneChangeFrameSampler(
+        threshold=0.2, probe_fps=2.0, min_scene_duration_seconds=1.0
+    )
+    scenes = sampler.detect_scenes(three_scene_video)
+    assert len(scenes) == 3
+    # boundaries near 0, 4, 8
+    starts = [round(s.start_time) for s in scenes]
+    assert starts == [0, 4, 8]
+
+
+@pytest.mark.skipif(not _HAS_FFMPEG, reason="ffmpeg not available")
+def test_scene_change_representative_frames_are_correct_colors(
+    three_scene_video: Path,
+):
+    sampler = SimpleSceneChangeFrameSampler(
+        threshold=0.2, probe_fps=2.0, min_scene_duration_seconds=1.0
+    )
+    frames = sampler.sample(three_scene_video)
+    assert len(frames) == 3
+    colors = []
+    for f in frames:
+        cx, cy = f.image.size[0] // 2, f.image.size[1] // 2
+        r, g, b = f.image.getpixel((cx, cy))[:3]
+        if r > 100:
+            colors.append("red")
+        elif g > 100:
+            colors.append("green")
+        elif b > 100:
+            colors.append("blue")
+        else:
+            colors.append("?")
+    assert colors == ["red", "green", "blue"]
+
+
+@pytest.mark.skipif(not _HAS_FFMPEG, reason="ffmpeg not available")
+def test_scene_change_respects_min_duration(three_scene_video: Path):
+    # A very large min duration collapses everything into one scene.
+    sampler = SimpleSceneChangeFrameSampler(
+        threshold=0.2, probe_fps=2.0, min_scene_duration_seconds=100.0
+    )
+    scenes = sampler.detect_scenes(three_scene_video)
+    assert len(scenes) == 1


### PR DESCRIPTION
Add docling/utils/video_frame_sampling.py with FixedIntervalFrameSampler and SimpleSceneChangeFrameSampler over a video file, using ffmpeg as the only hard runtime dependency. Frames are returned as VideoFrame models carrying image + timestamp; scenes as VideoScene time windows.

Docling-agnostic (PIL + numpy + pydantic only). Tests cover validation, the pixel-diff heuristic, and end-to-end sampling against a synthetic three-scene video (skipped when ffmpeg is absent).

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
