### PR TITLE
docs(deepseekocr): fix parse_deepseekocr_markdown Args docstring

### DIFF
--- a/docling/utils/deepseekocr_utils.py
+++ b/docling/utils/deepseekocr_utils.py
@@ -252,9 +252,10 @@ def parse_deepseekocr_markdown(
 
     Args:
         content: The annotated markdown content string
-        page_image: Optional PIL Image of the page
-        page_no: Page number (default: 1)
-        filename: Source filename (default: "file")
+        original_page_size: Physical page dimensions (points).
+        page_no: Page number (1-based).
+        filename: Source filename.
+        page_image: Optional PIL image of the page.
 
     Returns:
         DoclingDocument with parsed content


### PR DESCRIPTION

The `Args` section of `parse_deepseekocr_markdown` in
`docling/utils/deepseekocr_utils.py` does not match the function signature:

```python
def parse_deepseekocr_markdown(
    content: str,
    original_page_size: Size,
    page_no: int,
    filename: str = "file",
    page_image: Optional[PILImage.Image] = None,
) -> DoclingDocument:
```

The docstring documented `page_no` as `Page number (default: 1)`, but `page_no`
is a required positional parameter with no default: calling without it raises
`TypeError: parse_deepseekocr_markdown() missing 1 required positional argument:
'page_no'`. It also documented `filename` with a redundant default, listed the
parameters out of signature order, and omitted `original_page_size` entirely.

This aligns the `Args` block with the signature and with the two sibling OCR
parsers that share the same signature and already document it correctly:
`parse_chandra_html` (`docling/utils/chandra_utils.py`) and `parse_dots_json`
(`docling/utils/dots_utils.py`). Parameters are now listed in signature order,
`page_no` is described as a 1-based page number, and `original_page_size` is
documented.

Documentation only; no behavior change, and conversion output is unaffected.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary. (n/a - docstring-only)
- [ ] Tests have been added, if necessary. (n/a - no behavior change; repo
      guidance discourages trivial/self-validating tests)

> Note: remove the `Resolves #` section from the template - there is no tracking
> issue for this.

## The diff (1 file, +4/-3)

```diff
diff --git a/docling/utils/deepseekocr_utils.py b/docling/utils/deepseekocr_utils.py
index 4d87299..1d3fdff 100644
--- a/docling/utils/deepseekocr_utils.py
+++ b/docling/utils/deepseekocr_utils.py
@@ -252,9 +252,10 @@ def parse_deepseekocr_markdown(

     Args:
         content: The annotated markdown content string
-        page_image: Optional PIL Image of the page
-        page_no: Page number (default: 1)
-        filename: Source filename (default: "file")
+        original_page_size: Physical page dimensions (points).
+        page_no: Page number (1-based).
+        filename: Source filename.
+        page_image: Optional PIL image of the page.

     Returns:
         DoclingDocument with parsed content
```
