### PR TITLE
fix(deps): require python-docx>=1.2.0 for DOCX comment extraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ format-pdf = [
 
 # --- Office Formats (office = docx + pptx + xlsx) ---
 format-docx = [
-  'python-docx>=1.1.2,<2.0.0',
+  'python-docx>=1.2.0,<2.0.0',
 ]
 
 format-pptx = [

--- a/uv.lock
+++ b/uv.lock
@@ -1889,7 +1889,7 @@ requires-dist = [
     { name = "pylatexenc", marker = "extra == 'format-latex'", specifier = ">=2.10,<3.0" },
     { name = "pypdfium2", marker = "extra == 'format-pdf-docling'", specifier = ">=4.30.0,!=4.30.1,<6.0.0" },
     { name = "pypdfium2", marker = "extra == 'format-pdf-pypdfium2'", specifier = ">=4.30.0,!=4.30.1,<6.0.0" },
-    { name = "python-docx", marker = "extra == 'format-docx'", specifier = ">=1.1.2,<2.0.0" },
+    { name = "python-docx", marker = "extra == 'format-docx'", specifier = ">=1.2.0,<2.0.0" },
     { name = "python-dotenv", marker = "extra == 'cli'", specifier = "~=1.0" },
     { name = "python-dotenv", marker = "extra == 'service-client'", specifier = "~=1.0" },
     { name = "python-pptx", marker = "extra == 'format-pptx'", specifier = ">=1.0.2,<2.0.0" },


### PR DESCRIPTION
<!-- No tracking issue is resolved; the "Resolves #" section is intentionally removed. -->

DOCX comment extraction in the msword backend depends on python-docx's
`Document.comments` API. `MsWordDocumentBackend._add_comments`
(`docling/backend/msword_backend.py`) reads `docx_obj.comments` and each
comment's `author` / `initials` / `timestamp` / `text` / `comment_id`.

That comments API was first added in **python-docx 1.2.0** (2025-06-16, per the
python-docx release history); it does not exist in 1.1.x. The `format-docx`
extra, however, pinned `python-docx>=1.1.2,<2.0.0`, which still permits
resolving 1.1.x. On such an install the `hasattr(docx_obj, "comments")` guard is
`False`, so comment extraction silently no-ops and DOCX comments are dropped with
no error or warning.

This raises the declared floor to `>=1.2.0` so it matches the runtime
requirement of the feature. It does not change the resolved version (the lockfile
already resolves 1.2.0), only the permitted lower bound; behavior on a
correctly-resolving environment is unchanged.

The comment-extraction feature was introduced in #2834, which added the code path
but left the python-docx floor at `>=1.1.2`; this closes that gap.

**Checklist:**

- [ ] Documentation has been updated, if necessary. (n/a - dependency metadata only)
- [ ] Examples have been added, if necessary. (n/a)
- [ ] Tests have been added, if necessary. (n/a - packaging-metadata correctness;
  see note below)

### Note on tests

This is a dependency-floor (packaging metadata) correction, not a behavior
change. A behavioral regression would require installing python-docx 1.1.x into
the test environment (which no longer provides the comments API), so a
self-contained pytest is not the natural fit and would violate the repo's
guidance against trivial / environment-fragile tests. The existing
`test_comments_extraction` in `tests/test_backend_msword.py` continues to pass on
python-docx 1.2.0, and `uv lock --check` confirms the lockfile stays consistent
with the bumped floor.

## Files changed

- `pyproject.toml` (`format-docx` extra): `python-docx>=1.1.2,<2.0.0`
  -> `python-docx>=1.2.0,<2.0.0`.
- `uv.lock`: the single `requires-dist` specifier for `python-docx`
  (`extra == 'format-docx'`) updated to match.
