### PR TITLE
refactor: Decouple ground-truth path construction from verification

### DIFF
--- a/tests/groundtruth_paths.py
+++ b/tests/groundtruth_paths.py
@@ -1,0 +1,72 @@
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+# The four ground-truth artifacts produced per converted document
+_PAGES_META_SUFFIX = ".pages.meta.json"
+_JSON_SUFFIX = ".json"
+_MD_SUFFIX = ".md"
+_DOCTAGS_SUFFIX = ".doctags.txt"
+
+
+class GroundTruthPaths(BaseModel):
+    """Locations of the ground-truth files for a single converted document"""
+
+    model_config = ConfigDict(frozen=True)
+
+    pages_meta: Path
+    doc_json: Path
+    md: Path
+    doctags: Path
+
+
+def get_regular_groundtruth_paths(
+    input_path: Path,
+    *,
+    gt_dir: Optional[Path] = None,
+    tag: Optional[str] = None,
+) -> GroundTruthPaths:
+    """Build the GT paths for ``input_path``.
+
+    Returns:
+        The four GT file locations as a :class:`GroundTruthPaths`.
+    """
+    base_dir = (
+        gt_dir if gt_dir is not None else input_path.parent.parent / "groundtruth"
+    )
+    base = base_dir / input_path.name
+    prefix = "" if tag is None else f".{tag}"
+
+    gt_paths = GroundTruthPaths(
+        pages_meta=base.with_suffix(f"{prefix}{_PAGES_META_SUFFIX}"),
+        doc_json=base.with_suffix(f"{prefix}{_JSON_SUFFIX}"),
+        md=base.with_suffix(f"{prefix}{_MD_SUFFIX}"),
+        doctags=base.with_suffix(f"{prefix}{_DOCTAGS_SUFFIX}"),
+    )
+    return gt_paths
+
+
+def get_ocr_groundtruth_paths(
+    input_path: Path,
+    *,
+    engine: Optional[str] = None,
+    mode: Optional[str] = None,
+    gt_dir: Optional[Path] = None,
+) -> GroundTruthPaths:
+    """Build GT paths for an OCR conversion, tagged by engine and (optional) mode.
+
+    Returns:
+        The four GT file locations as a :class:`GroundTruthPaths`.
+    """
+    if engine is None and mode is None:
+        tag: Optional[str] = None
+    elif mode is None:
+        tag = engine
+    elif engine is None:
+        tag = mode
+    else:
+        tag = f"{engine}.{mode}"
+
+    gt_paths = get_regular_groundtruth_paths(input_path, gt_dir=gt_dir, tag=tag)
+    return gt_paths

--- a/tests/test_backend_webp.py
+++ b/tests/test_backend_webp.py
@@ -16,6 +16,7 @@ from docling.datamodel.pipeline_options import (
     TesseractOcrOptions,
 )
 from docling.document_converter import DocumentConverter, ImageFormatOption
+from tests.groundtruth_paths import get_regular_groundtruth_paths
 from tests.verify_utils import verify_conversion_result_v2
 
 from .test_data_gen_flag import GEN_TEST_DATA
@@ -81,7 +82,7 @@ def test_e2e_webp_conversions():
             )
 
             verify_conversion_result_v2(
-                input_path=webp_path,
+                gt=get_regular_groundtruth_paths(webp_path),
                 doc_result=doc_result,
                 generate=GENERATE,
                 fuzzy=True,

--- a/tests/test_e2e_conversion.py
+++ b/tests/test_e2e_conversion.py
@@ -8,6 +8,7 @@ from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import PdfPipelineOptions
 from docling.document_converter import DocumentConverter, PdfFormatOption
 
+from .groundtruth_paths import get_regular_groundtruth_paths
 from .test_data_gen_flag import GEN_TEST_DATA
 from .verify_utils import verify_conversion_result_v2
 
@@ -65,7 +66,7 @@ def test_e2e_pdfs_conversions():
         verify_doctags = pdf_path.name not in SKIP_DOCTAGS_COMPARISON
 
         verify_conversion_result_v2(
-            input_path=pdf_path,
+            gt=get_regular_groundtruth_paths(pdf_path),
             doc_result=doc_result,
             generate=GENERATE_V2,
             verify_doctags=verify_doctags,

--- a/tests/test_e2e_nemotron_ocr_conversion.py
+++ b/tests/test_e2e_nemotron_ocr_conversion.py
@@ -22,6 +22,7 @@ from docling.models.stages.ocr.nemotron_ocr_model import (
     resolve_nemotronocr_language,
 )
 
+from .groundtruth_paths import get_ocr_groundtruth_paths
 from .test_data_gen_flag import GEN_TEST_DATA
 from .verify_utils import verify_conversion_result_v2
 
@@ -144,10 +145,9 @@ def test_e2e_nemotron_ocr_conversions():
             doc_result: ConversionResult = converter.convert(pdf_path)
 
             verify_conversion_result_v2(
-                input_path=pdf_path,
+                gt=get_ocr_groundtruth_paths(pdf_path, engine=engine_suffix),
                 doc_result=doc_result,
                 generate=GENERATE_V2,
-                ocr_engine=engine_suffix,
                 fuzzy=True,
             )
 
@@ -178,9 +178,8 @@ def test_e2e_nemotron_ocr_multipage_batching():
         doc_result: ConversionResult = converter.convert(pdf_path)
 
         verify_conversion_result_v2(
-            input_path=pdf_path,
+            gt=get_ocr_groundtruth_paths(pdf_path, engine=engine_suffix),
             doc_result=doc_result,
             generate=GENERATE_V2,
-            ocr_engine=engine_suffix,
             fuzzy=True,
         )

--- a/tests/test_e2e_ocr_conversion.py
+++ b/tests/test_e2e_ocr_conversion.py
@@ -20,6 +20,7 @@ from docling.datamodel.pipeline_options import (
 )
 from docling.document_converter import DocumentConverter, PdfFormatOption
 
+from .groundtruth_paths import get_regular_groundtruth_paths
 from .test_data_gen_flag import GEN_TEST_DATA
 from .verify_utils import verify_conversion_result_v2
 
@@ -111,7 +112,7 @@ def test_e2e_conversions():
             doc_result: ConversionResult = converter.convert(pdf_path)
 
             verify_conversion_result_v2(
-                input_path=pdf_path,
+                gt=get_regular_groundtruth_paths(pdf_path),
                 doc_result=doc_result,
                 generate=GENERATE_V2,
                 fuzzy=True,

--- a/tests/test_groundtruth_paths.py
+++ b/tests/test_groundtruth_paths.py
@@ -1,0 +1,49 @@
+from pathlib import Path
+
+import pytest
+
+from tests.groundtruth_paths import (
+    get_ocr_groundtruth_paths,
+    get_regular_groundtruth_paths,
+)
+
+
+def test_default_paths_cover_dir_suffixes_and_dotted_stem():
+    # Dotted stem (arXiv id) exercises "only the extension is replaced".
+    # Default GT dir is the `groundtruth` sibling of the source's parent.
+    gt = get_regular_groundtruth_paths(Path("tests/data/pdf/sources/2206.01062.pdf"))
+
+    gt_dir = Path("tests/data/pdf/groundtruth")
+    assert gt.pages_meta == gt_dir / "2206.01062.pages.meta.json"
+    assert gt.doc_json == gt_dir / "2206.01062.json"
+    assert gt.md == gt_dir / "2206.01062.md"
+    assert gt.doctags == gt_dir / "2206.01062.doctags.txt"
+
+
+def test_gt_dir_override_and_tag_before_format_suffix():
+    override = Path("some/other/groundtruth")
+    gt = get_regular_groundtruth_paths(
+        Path("tests/data/pdf/sources/report.pdf"),
+        gt_dir=override,
+        tag="nemotron-ocr.full-page",
+    )
+
+    assert gt.doc_json == override / "report.nemotron-ocr.full-page.json"
+    assert gt.doctags == override / "report.nemotron-ocr.full-page.doctags.txt"
+
+
+@pytest.mark.parametrize(
+    ("engine", "mode", "expected_tag"),
+    [
+        (None, None, None),
+        ("nemotron-ocr", None, "nemotron-ocr"),
+        (None, "force_full_page_ocr", "force_full_page_ocr"),
+        ("nemotron-ocr", "full-page", "nemotron-ocr.full-page"),
+    ],
+)
+def test_ocr_tag_composition(engine, mode, expected_tag):
+    input_path = Path("tests/data/scanned/sources/ocr_test.pdf")
+
+    # ocr_groundtruth_paths is a thin tag-composer over groundtruth_paths.
+    ocr_gt = get_ocr_groundtruth_paths(input_path, engine=engine, mode=mode)
+    assert ocr_gt == get_regular_groundtruth_paths(input_path, tag=expected_tag)

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -15,6 +15,7 @@ from docling.datamodel.pipeline_options_vlm_model import (
 from docling.document_converter import DocumentConverter, PdfFormatOption
 from docling.models.base_model import BaseVlmPageModel
 
+from .groundtruth_paths import get_regular_groundtruth_paths
 from .test_data_gen_flag import GEN_TEST_DATA
 from .verify_utils import verify_conversion_result_v2
 
@@ -56,7 +57,9 @@ def test_convert_path(converter: DocumentConverter):
     # Avoid heavy torch-dependent models by not instantiating layout models here in coverage run
     doc_result = converter.convert(pdf_path)
     verify_conversion_result_v2(
-        input_path=pdf_path, doc_result=doc_result, generate=GENERATE
+        gt=get_regular_groundtruth_paths(pdf_path),
+        doc_result=doc_result,
+        generate=GENERATE,
     )
 
 
@@ -69,7 +72,9 @@ def test_convert_stream(converter: DocumentConverter):
 
     doc_result = converter.convert(stream)
     verify_conversion_result_v2(
-        input_path=pdf_path, doc_result=doc_result, generate=GENERATE
+        gt=get_regular_groundtruth_paths(pdf_path),
+        doc_result=doc_result,
+        generate=GENERATE,
     )
 
 

--- a/tests/test_kserve_v2_ocr_integration.py
+++ b/tests/test_kserve_v2_ocr_integration.py
@@ -13,6 +13,7 @@ from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import KserveV2OcrOptions, PdfPipelineOptions
 from docling.document_converter import DocumentConverter, PdfFormatOption
 
+from .groundtruth_paths import get_ocr_groundtruth_paths
 from .test_data_gen_flag import GEN_TEST_DATA
 from .verify_utils import verify_conversion_result_v2
 
@@ -69,10 +70,9 @@ def test_kserve_v2_ocr_conversion() -> None:
             doc_result: ConversionResult = converter.convert(input_path)
 
             verify_conversion_result_v2(
-                input_path=input_path,
+                gt=get_ocr_groundtruth_paths(input_path, engine="kserve_v2_ocr"),
                 doc_result=doc_result,
                 generate=GEN_TEST_DATA,
-                ocr_engine="kserve_v2_ocr",
                 fuzzy=True,
             )
 

--- a/tests/verify_utils.py
+++ b/tests/verify_utils.py
@@ -20,6 +20,8 @@ from pydantic import BaseModel, TypeAdapter
 from docling.datamodel.base_models import ConversionStatus, Page
 from docling.datamodel.document import ConversionResult
 
+from .groundtruth_paths import GroundTruthPaths
+
 COORD_PREC = 2  # decimal places for coordinates
 CONFID_PREC = 3  # decimal places for confidence
 STRICT_BBOX_TOL_RATIO = 0.0025  # allow minor cross-platform layout variance
@@ -353,15 +355,16 @@ def verify_dt(doc_pred_dt: str, doc_true_dt: str, fuzzy: bool):
 
 
 def verify_conversion_result_v2(
-    input_path: Path,
+    gt: GroundTruthPaths,
     doc_result: ConversionResult,
     generate: bool = False,
-    ocr_engine: Optional[str] = None,
     fuzzy: bool = False,
     verify_doctags: bool = True,
     indent: int = 2,
 ):
     PageMetaList = TypeAdapter(list[_TestPagesMeta])
+
+    input_path = doc_result.input.file
 
     assert doc_result.status == ConversionStatus.SUCCESS, (
         f"Doc {input_path} did not convert successfully."
@@ -375,26 +378,24 @@ def verify_conversion_result_v2(
     doc_pred_md = doc_result.document.export_to_markdown(compact_tables=True)
     doc_pred_dt = doc_result.document.export_to_doctags()
 
-    engine_suffix = "" if ocr_engine is None else f".{ocr_engine}"
+    pages_path = gt.pages_meta
+    json_path = gt.doc_json
+    md_path = gt.md
+    dt_path = gt.doctags
 
-    gt_subpath = input_path.parent.parent / "groundtruth" / input_path.name
-
-    pages_path = gt_subpath.with_suffix(f"{engine_suffix}.pages.meta.json")
-    json_path = gt_subpath.with_suffix(f"{engine_suffix}.json")
-    md_path = gt_subpath.with_suffix(f"{engine_suffix}.md")
-    dt_path = gt_subpath.with_suffix(f"{engine_suffix}.doctags.txt")
-
-    # print("generate: ", generate)
     if generate:  # only used when re-generating truth
         pages_path.parent.mkdir(parents=True, exist_ok=True)
 
-        pages_data = PageMetaList.dump_json(doc_pred_pages_meta, indent=2)
+        pages_data = PageMetaList.dump_json(doc_pred_pages_meta, indent=indent)
         with open(pages_path, mode="w", encoding="utf-8") as fw:
             fw.write(pages_data.decode())
 
         json_path.parent.mkdir(parents=True, exist_ok=True)
         doc_pred.save_as_json(
-            json_path, coord_precision=COORD_PREC, confid_precision=CONFID_PREC
+            json_path,
+            indent=indent,
+            coord_precision=COORD_PREC,
+            confid_precision=CONFID_PREC,
         )
 
         md_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
Decouple ground-truth path construction from verification

- Introduce `tests/groundtruth_paths.py`, which owns the naming and location of ground-truth files
- Refactor `verify_conversion_result_v2()` to accept a `GroundTruthPaths` object and be responsible only for loading and validating the tests

This separation keeps the verifier model-agnostic and makes it easy to add test-specific ground-truth path schemes without touching verification logic.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
