### PR TITLE
feat(msexcel): render native Excel charts as images

### DIFF
--- a/docling/backend/msexcel_backend.py
+++ b/docling/backend/msexcel_backend.py
@@ -6,6 +6,7 @@ import posixpath
 import shutil
 import subprocess
 import warnings
+from copy import deepcopy
 from datetime import datetime
 from io import BytesIO
 from pathlib import Path
@@ -1589,7 +1590,9 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         if not any(copied):
             return None
 
-        chart_sheet.add_chart(chart, "A1")
+        # ``add_chart`` overwrites ``chart.anchor``; copy so the workbook's own
+        # chart keeps the anchor its provenance bbox is derived from.
+        chart_sheet.add_chart(deepcopy(chart), "A1")
         return standalone
 
     def _copy_reference_into(self, target: Workbook, ref: str) -> bool:

--- a/docling/backend/msexcel_backend.py
+++ b/docling/backend/msexcel_backend.py
@@ -59,7 +59,7 @@ _log = logging.getLogger(__name__)
 _OPENPYXL_AVAILABLE: bool = False
 _OPENPYXL_IMPORT_ERROR: ImportError | None = None
 try:  # pragma: no cover - import-time guard
-    from openpyxl import load_workbook
+    from openpyxl import Workbook, load_workbook
     from openpyxl.chartsheet.chartsheet import Chartsheet
     from openpyxl.drawing.image import Image
     from openpyxl.drawing.spreadsheet_drawing import (
@@ -89,6 +89,13 @@ _SAFE_XML_PARSER: Final = etree.XMLParser(
     load_dtd=False,
     no_network=True,
     dtd_validation=False,
+)
+
+_CHART_RENDER_HINT = (
+    "LibreOffice is required to render Excel charts as images "
+    "(render_chart_images=True). Install LibreOffice and make sure `soffice` is "
+    "on PATH. Charts still keep their classification and reconstructed tabular "
+    "data without it."
 )
 
 # Maps an openpyxl chart object's ``tagname`` (the DrawingML element name, e.g.
@@ -1272,7 +1279,17 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
             return doc
         content_layer = self._get_sheet_content_layer(sheet)
 
-        for chart in sheet._charts:  # type: ignore[attr-defined]
+        charts = sheet._charts  # type: ignore[attr-defined]
+        if not charts:
+            return doc
+
+        # Rendering a chart to an actual image is opt-in and needs LibreOffice.
+        render_charts = self.options.render_chart_images
+        if render_charts and self._get_libreoffice_converter() is None:
+            _log.warning(_CHART_RENDER_HINT)
+            render_charts = False
+
+        for chart in charts:
             try:
                 classification = _CHART_TAGNAME_TO_CLASSIFICATION.get(
                     chart.tagname, PictureClassificationLabel.OTHER_CHART
@@ -1284,6 +1301,21 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
                     self._anchor_to_tuple(chart.anchor),
                     origin=CoordOrigin.TOPLEFT,
                 )
+
+                # On any rendering failure fall back to the no-image behavior:
+                # the picture still carries its classification and chart data.
+                image_ref = None
+                if render_charts:
+                    try:
+                        chart_image = self._render_chart_image(chart)
+                        if chart_image is not None:
+                            image_ref = ImageRef.from_pil(image=chart_image, dpi=72)
+                    except Exception:
+                        _log.warning(
+                            "could not render a chart image; keeping chart data "
+                            "without image",
+                            exc_info=True,
+                        )
 
                 caption_item = (
                     doc.add_text(
@@ -1297,6 +1329,7 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
 
                 picture = doc.add_picture(
                     parent=self.parent,
+                    image=image_ref,
                     caption=caption_item,
                     prov=ProvenanceItem(
                         page_no=page_no,
@@ -1450,6 +1483,168 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
                 )
 
         return TableData(num_rows=num_rows, num_cols=num_cols, table_cells=cells)
+
+    @staticmethod
+    def _to_float(text: str) -> float | None:
+        """Parse a cell string into a float, or None if it is not numeric.
+
+        Cached values arrive as strings; a chart plots them only when they are
+        written back as numbers. Non-numeric cells (blank, labels) return None
+        so the caller can leave them as text.
+        """
+        try:
+            return float(text)
+        except (TypeError, ValueError):
+            return None
+
+    def _render_chart_image(self, chart: Any) -> PILImage.Image | None:
+        """Render a native chart to an image via LibreOffice.
+
+        XLSX stores charts as vector definitions with no embedded raster.  To
+        obtain a picture we isolate the chart into a throwaway single-chart
+        workbook (its data copied onto hidden sheets so the series still
+        resolve), convert that to PDF with LibreOffice — the same external tool
+        already used for EMF/WMF images — and rasterize the first page with
+        pypdfium2, trimming the surrounding whitespace.
+
+        Args:
+            chart: An openpyxl chart object.
+
+        Returns:
+            A PIL Image, or None when LibreOffice is unavailable, the chart has
+            no resolvable data, or the conversion fails.
+        """
+        converter = self._get_libreoffice_converter()
+        if converter is None:
+            return None
+
+        standalone = self._build_standalone_chart_workbook(chart)
+        if standalone is None:
+            return None
+
+        temp_dir = Path(mkdtemp())
+        try:
+            input_path = temp_dir / "chart.xlsx"
+            output_path = temp_dir / "chart.pdf"
+            standalone.save(input_path)
+            converter(input_path, output_path)
+            if not output_path.exists():
+                _log.debug("LibreOffice produced no PDF output for a chart")
+                return None
+            pdf = pypdfium2.PdfDocument(str(output_path))
+            page = pdf[0]
+            pil_image = crop_whitespace(page.render(scale=2).to_pil())
+            page.close()
+            pdf.close()
+            return pil_image
+        except Exception as exc:
+            _log.debug("Chart rendering via LibreOffice failed: %s", exc)
+            return None
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def _build_standalone_chart_workbook(self, chart: Any) -> Workbook | None:
+        """Build a one-chart workbook with the chart's data on hidden sheets.
+
+        A chart references its data by sheet-qualified ranges (e.g.
+        ``"'Sheet1'!$B$2:$B$7"``).  Every referenced range is recreated here —
+        same sheet name, same cell coordinates, cached values — on hidden
+        sheets, and the chart is anchored alone on a single visible sheet.
+        LibreOffice prints only the visible sheet, so the resulting PDF holds
+        just the chart.
+
+        Args:
+            chart: An openpyxl chart object.
+
+        Returns:
+            A populated Workbook, or None when the chart exposes no resolvable
+            data references.
+        """
+        if self.workbook is None:
+            return None
+
+        references: list[str] = []
+        for series in chart.series:
+            for data_source in (
+                series.cat,
+                series.xVal,
+                series.val,
+                series.yVal,
+                series.tx,
+            ):
+                formula = self._ref_formula(data_source)
+                if formula:
+                    references.append(formula)
+        if not references:
+            return None
+
+        standalone = Workbook()
+        # A fresh Workbook always holds exactly one worksheet; take it directly
+        # rather than via ``.active``, which is typed as optional.
+        chart_sheet = standalone.worksheets[0]
+        chart_sheet.title = "chart_render"
+
+        # Every reference must be copied, so this cannot short-circuit.
+        copied = [self._copy_reference_into(standalone, ref) for ref in references]
+        if not any(copied):
+            return None
+
+        chart_sheet.add_chart(chart, "A1")
+        return standalone
+
+    def _copy_reference_into(self, target: Workbook, ref: str) -> bool:
+        """Copy one chart data range into ``target`` on a hidden sheet.
+
+        Recreates the referenced sheet by name if needed, hides it, and writes
+        the cached cell values at their original coordinates.  Numeric-looking
+        text is coerced to numbers so the chart plots it as values rather than
+        labels.
+
+        Args:
+            target: The standalone Workbook being assembled.
+            ref: A sheet-qualified range reference, e.g. "'Sheet1'!$B$2:$B$7".
+
+        Returns:
+            True when the referenced range was resolved and copied.
+        """
+        if self.workbook is None or "!" not in ref:
+            return False
+
+        sheet_part, cell_range = ref.rsplit("!", 1)
+        sheet_part = sheet_part.strip()
+        if sheet_part.startswith("'") and sheet_part.endswith("'"):
+            sheet_part = sheet_part[1:-1].replace("''", "'")
+        if sheet_part not in self.workbook.sheetnames:
+            _log.debug("Chart references unknown sheet %r", sheet_part)
+            return False
+
+        try:
+            bounds = range_boundaries(cell_range)
+        except Exception:
+            _log.debug("Could not parse chart range %r", cell_range)
+            return False
+        if any(bound is None for bound in bounds):
+            # Open-ended ranges (e.g. "B:B") carry no usable row bounds.
+            _log.debug("Chart range %r is not fully bounded", cell_range)
+            return False
+        min_col, min_row, max_col, max_row = cast(tuple[int, int, int, int], bounds)
+
+        source_sheet = self.workbook[sheet_part]
+        if sheet_part in target.sheetnames:
+            dest_sheet = target[sheet_part]
+        else:
+            dest_sheet = target.create_sheet(sheet_part)
+            dest_sheet.sheet_state = "hidden"
+
+        for row in range(min_row, max_row + 1):
+            for col in range(min_col, max_col + 1):
+                value = source_sheet.cell(row=row, column=col).value
+                if isinstance(value, str):
+                    numeric = self._to_float(value)
+                    if numeric is not None:
+                        value = numeric
+                dest_sheet.cell(row=row, column=col, value=value)
+        return True
 
     @staticmethod
     def _ref_formula(data_source: Any) -> str | None:

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -245,6 +245,18 @@ class MsExcelBackendOptions(BaseBackendOptions):
         ),
     )
 
+    render_chart_images: bool = Field(
+        False,
+        description=(
+            "Whether to render an image for each native chart and attach it to "
+            "the chart PictureItem. The chart is isolated into a temporary "
+            "workbook and rasterized with LibreOffice, the same external tool "
+            "used for EMF/WMF images. Opt-in (default False) because it "
+            "requires a LibreOffice installation and inflates the output size. "
+            "Only takes effect when parse_charts is True."
+        ),
+    )
+
     gap_tolerance: int = Field(
         0,
         description=(

--- a/tests/test_backend_msexcel.py
+++ b/tests/test_backend_msexcel.py
@@ -395,6 +395,62 @@ def test_chart_parsing_disabled() -> None:
     assert doc.pages[2].size.height == 0
 
 
+def test_chart_image_rendering_disabled_by_default(documents) -> None:
+    """Test that charts carry no rendered image unless the option is enabled.
+
+    The default converter (used by the ``documents`` fixture) leaves
+    render_chart_images=False, so the xlsx_03 chart picture keeps its
+    classification and tabular data but no pixels. This guards the promise that
+    the feature does not change default output for existing users.
+    """
+    doc = next(item for path, item in documents if path.stem == "xlsx_03_chartsheet")
+
+    pictures = list(doc.pictures)
+    assert len(pictures) == 1
+    assert pictures[0].image is None, (
+        "chart picture should have no image when render_chart_images is off"
+    )
+
+
+def test_chart_image_rendering(libreoffice_available) -> None:
+    """Test that render_chart_images=True attaches a LibreOffice-rendered image.
+
+    LibreOffice output is not byte-stable, and the cropped image size depends on
+    the LibreOffice version and page setup, so the pixels are not compared
+    against groundtruth. We assert the picture gains a non-trivial image while
+    keeping the classification and tabular data extracted from the chart.
+
+    Requires LibreOffice; skipped when it is not installed.
+    """
+    if not libreoffice_available:
+        pytest.skip("LibreOffice is not installed — chart rendering cannot be tested")
+
+    path = next(item for item in get_excel_paths() if item.stem == "xlsx_03_chartsheet")
+
+    options = MsExcelBackendOptions(render_chart_images=True)
+    format_options = {InputFormat.XLSX: ExcelFormatOption(backend_options=options)}
+    converter = DocumentConverter(
+        allowed_formats=[InputFormat.XLSX], format_options=format_options
+    )
+    doc = converter.convert(path).document
+
+    pictures = list(doc.pictures)
+    assert len(pictures) == 1, f"Expected one chart picture, got {len(pictures)}"
+
+    picture = pictures[0]
+    assert (
+        picture.meta.classification.predictions[0].class_name
+        == PictureClassificationLabel.BAR_CHART
+    )
+    assert picture.meta.tabular_chart is not None
+
+    image = picture.get_image(doc=doc)
+    assert image is not None, "chart picture should carry a rendered image"
+    assert image.width > 50 and image.height > 50, (
+        f"rendered chart image is implausibly small: {image.size}"
+    )
+
+
 def test_inflated_rows_handling(documents) -> None:
     """Test that files with inflated max_row are handled correctly.
 

--- a/tests/test_backend_msexcel.py
+++ b/tests/test_backend_msexcel.py
@@ -451,6 +451,42 @@ def test_chart_image_rendering(libreoffice_available) -> None:
     )
 
 
+def test_chart_render_does_not_mutate_source_chart() -> None:
+    """Test that assembling the render workbook leaves the source chart intact.
+
+    ``Worksheet.add_chart`` overwrites ``chart.anchor``. Were the backend to
+    hand its own chart object to the temporary render workbook, the source
+    chart's anchor would be replaced by a plain "A1" string and every later
+    provenance bbox would silently collapse to (0, 0, 0, 0). Only the workbook
+    assembly is exercised, so this runs without LibreOffice.
+    """
+    path = next(item for item in get_excel_paths() if item.stem == "xlsx_03_chartsheet")
+    in_doc = InputDocument(
+        path_or_stream=path,
+        format=InputFormat.XLSX,
+        filename=path.stem,
+        backend=MsExcelDocumentBackend,
+    )
+    backend = MsExcelDocumentBackend(
+        in_doc=in_doc,
+        path_or_stream=path,
+        options=MsExcelBackendOptions(render_chart_images=True),
+    )
+    chart = next(
+        chart
+        for name in backend.workbook.sheetnames
+        for chart in backend.workbook[name]._charts
+    )
+    bbox_before = backend._anchor_to_tuple(chart.anchor)
+    assert bbox_before != (0, 0, 0, 0), "test fixture should have a real anchor"
+
+    assert backend._build_standalone_chart_workbook(chart) is not None
+
+    assert backend._anchor_to_tuple(chart.anchor) == bbox_before, (
+        "assembling the render workbook must not overwrite the source anchor"
+    )
+
+
 def test_inflated_rows_handling(documents) -> None:
     """Test that files with inflated max_row are handled correctly.
 


### PR DESCRIPTION
Hi maintainers, this PR is a follow up with #3756 to get the actual chart image. Thank you Dr @PeterStaar-IBM for your guidance on this PR.

**Summary**
---------------------------
This PR is focus on chart on Excel first. Native charts in XLSX are stored as vector definitions with no embedded raster, so the chart `PictureItem` emitted by #3756 carried a classification and the reconstructed `tabular_chart` data, but `picture.image` was always `None`, unlike the embedded-image and EMF/WMF paths, which attach real pixels.

This adds an opt-in `MsExcelBackendOptions.render_chart_images` (default `False`). When enabled, each chart is rendered and attached as an `ImageRef` alongside the data it already carried.

### How it works

XLSX has no chart bitmap to extract, so the chart is rendered:

1. The chart is isolated into a temporary single-chart workbook. Every range it references (`cat`/`xVal`, `val`/`yVal`, `tx`) is recreated on **hidden** sheets under the original sheet names and coordinates, using cached values, so the series still resolve.
2. LibreOffice converts that workbook to PDF. Only the one visible sheet prints,so the page contains just the chart.
3. The page is rasterized with `pypdfium2` and whitespace-cropped.

Steps 2–3 reuse the exact chain already used for EMF/WMF images (#3714).

### Behavior and safety

- **Opt-in.** Default `False`, so existing output is unchanged and no reference data was regenerated. Only takes effect when `parse_charts` is `True`.
- **Graceful degradation.** If LibreOffice is missing, a hint is logged once per chart-bearing sheet and rendering is skipped; the picture keeps its classification and `tabular_chart`. Any rendering failure is caught and falls back to the same no-image behavior, never a failed conversion.
- **Cost.** One LibreOffice subprocess per chart (bounded by the existing `LIBREOFFICE_TIMEOUT_S`). This is why the option is opt-in; batching charts into a single conversion would be a reasonable follow-up.

### Tests

- `test_chart_image_rendering`: asserts the picture gains a non-trivial image while keeping its classification and tabular data. LibreOffice output is not byte-stable and its cropped size varies by version/page setup, so pixels are not compared against groundtruth. Skipped when LibreOffice is unavailable, mirroring `test_emf_images_in_xlsx`.
- `test_chart_image_rendering_disabled_by_default`: guards that the default path still produces `picture.image is None`.
- `test_chart_render_does_not_mutate_source_chart`: guards that assembling the temporary render workbook does not overwrite the source chart's anchor, which would silently zero the provenance bbox. Runs without LibreOffice.


**Checklist:**

- [x] Documentation has been updated, if necessary. 
- [x] Examples have been added, if necessary. 
- [x] Tests have been added, if necessary.
