### PR TITLE
fix: use generation_config from options in PictureDescriptionVlmEngineModel

### DIFF
--- a/docling/models/stages/picture_description/picture_description_vlm_engine_model.py
+++ b/docling/models/stages/picture_description/picture_description_vlm_engine_model.py
@@ -16,10 +16,10 @@ from docling.datamodel.pipeline_options import (
     PictureDescriptionBaseOptions,
     PictureDescriptionVlmEngineOptions,
 )
-from docling.datamodel.stage_model_specs import EngineModelConfig
 from docling.models.inference_engines.vlm import (
     BaseVlmEngine,
     VlmEngineInput,
+    VlmEngineType,
     create_vlm_engine,
 )
 from docling.models.picture_description_base_model import PictureDescriptionBaseModel
@@ -105,6 +105,51 @@ class PictureDescriptionVlmEngineModel(PictureDescriptionBaseModel):
             # Set provenance from model spec
             self.provenance = f"{self.repo_id} ({engine_type.value})"
 
+    def _resolve_runtime_engine_type(self) -> VlmEngineType:
+        selected_engine_type = getattr(self.engine, "selected_engine_type", None)
+        if selected_engine_type is not None:
+            return selected_engine_type
+        return self.options.engine_options.engine_type
+
+    def _build_engine_inputs(
+        self, image_list: list[Image.Image]
+    ) -> list[VlmEngineInput]:
+        """Build a batch of ``VlmEngineInput`` sharing one generation-config template.
+
+        Generation config is derived from the model spec, but can be overridden by the stage options.
+
+        Args:
+            image_list: list of Images to build Engine Inputs for.
+
+        Returns:
+            List of VlmEngineInput objects for batch prediction.
+        """
+        prompt = self.options.prompt
+        model_spec = self.options.model_spec
+        runtime_engine_type = self._resolve_runtime_engine_type()
+
+        stop_strings = list(model_spec.stop_strings)
+        extra_generation_config = model_spec.get_runtime_input_extra_config(
+            runtime_engine_type
+        )
+
+        # if present generation_config overrides model_spec defaults
+        gen_cfg = self.options.generation_config or {}
+        temperature = gen_cfg.get("temperature", model_spec.temperature)
+        max_new_tokens = gen_cfg.get("max_new_tokens", model_spec.max_new_tokens)
+
+        return [
+            VlmEngineInput(
+                image=image,
+                prompt=prompt,
+                temperature=float(temperature),
+                max_new_tokens=int(max_new_tokens),
+                stop_strings=stop_strings,
+                extra_generation_config=extra_generation_config,
+            )
+            for image in image_list
+        ]
+
     def _annotate_images(self, images: Iterable[Image.Image]) -> Iterable[str]:
         """Generate descriptions for a batch of images.
 
@@ -117,10 +162,8 @@ class PictureDescriptionVlmEngineModel(PictureDescriptionBaseModel):
         if self.engine is None:
             raise RuntimeError("Engine not initialized")
 
-        # Get prompt from options
-        prompt = self.options.prompt
-
         # Convert to list for batch processing
+        # TODO: Consider using chunking here
         image_list = list(images)
 
         if not image_list:
@@ -128,15 +171,7 @@ class PictureDescriptionVlmEngineModel(PictureDescriptionBaseModel):
 
         try:
             # Prepare batch of engine inputs
-            engine_inputs = [
-                VlmEngineInput(
-                    image=image,
-                    prompt=prompt,
-                    temperature=0.0,
-                    max_new_tokens=200,  # Use from options if available
-                )
-                for image in image_list
-            ]
+            engine_inputs = self._build_engine_inputs(image_list)
 
             # Generate descriptions using batch prediction
             outputs = self.engine.predict_batch(engine_inputs)

--- a/tests/test_picture_description_vlm_engine_model.py
+++ b/tests/test_picture_description_vlm_engine_model.py
@@ -5,18 +5,14 @@ from PIL import Image
 
 from docling.datamodel.pipeline_options import PictureDescriptionVlmEngineOptions
 from docling.datamodel.pipeline_options_vlm_model import ResponseFormat
-from docling.datamodel.stage_model_specs import EngineModelConfig, VlmModelSpec
+from docling.datamodel.stage_model_specs import VlmModelSpec
 from docling.datamodel.vlm_engine_options import (
-    AutoInlineVlmEngineOptions,
     TransformersVlmEngineOptions,
-    VlmEngineType,
 )
 from docling.models.inference_engines.vlm import VlmEngineInput, VlmEngineOutput
 from docling.models.stages.picture_description.picture_description_vlm_engine_model import (
     PictureDescriptionVlmEngineModel,
 )
-
-pytestmark = pytest.mark.ml_vlm
 
 
 class _DummyEngine:
@@ -32,6 +28,21 @@ class _DummyEngine:
 
     def cleanup(self):
         pass
+
+
+@pytest.fixture
+def create_dummy_model():
+    def _make(
+        options: PictureDescriptionVlmEngineOptions,
+    ) -> PictureDescriptionVlmEngineModel:
+        model = PictureDescriptionVlmEngineModel.__new__(
+            PictureDescriptionVlmEngineModel
+        )
+        model.options = options
+        model.engine = _DummyEngine()
+        return model
+
+    return _make
 
 
 def _build_options(**model_spec_overrides) -> PictureDescriptionVlmEngineOptions:
@@ -52,11 +63,11 @@ def _build_options(**model_spec_overrides) -> PictureDescriptionVlmEngineOptions
     )
 
 
-def test_engine_picture_description_falls_back_to_model_spec_defaults() -> None:
+def test_engine_picture_description_falls_back_to_model_spec_defaults(
+    create_dummy_model,
+) -> None:
     options = _build_options(temperature=0.1, max_new_tokens=300)
-    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
-    model.options = options
-    model.engine = _DummyEngine()
+    model = create_dummy_model(options)
 
     list(model._annotate_images([Image.new("RGB", (8, 8), "white")]))
 
@@ -65,91 +76,9 @@ def test_engine_picture_description_falls_back_to_model_spec_defaults() -> None:
     assert sent_input.temperature == 0.1
 
 
-def test_engine_picture_description_forwards_stop_strings_and_extra_config() -> None:
-    options = _build_options(
-        stop_strings=["<|im_end|>"],
-        extra_generation_config={"skip_special_tokens": True},
-    )
-    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
-    model.options = options
-    model.engine = _DummyEngine()
-
-    list(model._annotate_images([Image.new("RGB", (8, 8), "white")]))
-
-    sent_input = model.engine.received_inputs[0]
-    assert sent_input.stop_strings == ["<|im_end|>"]
-    assert sent_input.extra_generation_config == {"skip_special_tokens": True}
-
-
-def test_engine_picture_description_resolves_auto_inline_engine_type() -> None:
-    options = _build_options(
-        engine_overrides={
-            VlmEngineType.MLX: EngineModelConfig(extra_config={"mlx_only_key": "x"}),
-        }
-    )
-    options.engine_options = AutoInlineVlmEngineOptions()
-
-    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
-    model.options = options
-    model.engine = _DummyEngine()
-    model.engine.selected_engine_type = (
-        VlmEngineType.MLX
-    )  # Engine hat sich für MLX entschieden
-
-    resolved = model._resolve_runtime_engine_type()
-    assert resolved == VlmEngineType.MLX
-
-
-def test_engine_picture_description_skips_empty_batch() -> None:
-    options = _build_options()
-    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
-    model.options = options
-    model.engine = _DummyEngine()
-
-    assert list(model._annotate_images([])) == []
-    assert model.engine.received_inputs == []
-
-
-def test_engine_picture_description_raises_when_engine_not_initialized() -> None:
-    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
-    model.options = _build_options()
-    model.engine = None
-
-    with pytest.raises(RuntimeError, match="Engine not initialized"):
-        list(model._annotate_images([Image.new("RGB", (8, 8), "white")]))
-
-
-def test_engine_picture_description_yields_empty_strings_on_engine_error() -> None:
-    class _FailingEngine(_DummyEngine):
-        def predict_batch(self, inputs):
-            raise RuntimeError("engine exploded")
-
-    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
-    model.options = _build_options()
-    model.engine = _FailingEngine()
-
-    images = [Image.new("RGB", (8, 8), "white"), Image.new("RGB", (8, 8), "black")]
-    outputs = list(model._annotate_images(images))
-
-    # Batch-Alignment muss erhalten bleiben: gleiche Anzahl wie Input, leere Strings statt Crash
-    assert outputs == ["", ""]
-
-
-def test_engine_picture_description_shares_config_across_batch() -> None:
-    options = _build_options(temperature=0.2, max_new_tokens=500)
-    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
-    model.options = options
-    model.engine = _DummyEngine()
-
-    images = [Image.new("RGB", (8, 8), "white") for _ in range(3)]
-    list(model._annotate_images(images))
-
-    assert len(model.engine.received_inputs) == 3
-    assert all(i.max_new_tokens == 500 for i in model.engine.received_inputs)
-    assert all(i.temperature == 0.2 for i in model.engine.received_inputs)
-
-
-def test_engine_picture_description_forwards_generation_config() -> None:
+def test_engine_picture_description_forwards_generation_config(
+    create_dummy_model,
+) -> None:
     options = PictureDescriptionVlmEngineOptions.from_preset(
         "smolvlm",
         generation_config={
@@ -158,9 +87,7 @@ def test_engine_picture_description_forwards_generation_config() -> None:
             "do_sample": True,
         },
     )
-    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
-    model.options = options
-    model.engine = _DummyEngine()
+    model = create_dummy_model(options)
 
     images = [Image.new("RGB", (8, 8), "white")]
     outputs = list(model._annotate_images(images))

--- a/tests/test_picture_description_vlm_engine_model.py
+++ b/tests/test_picture_description_vlm_engine_model.py
@@ -1,0 +1,171 @@
+from collections.abc import Iterable
+
+import pytest
+from PIL import Image
+
+from docling.datamodel.pipeline_options import PictureDescriptionVlmEngineOptions
+from docling.datamodel.pipeline_options_vlm_model import ResponseFormat
+from docling.datamodel.stage_model_specs import EngineModelConfig, VlmModelSpec
+from docling.datamodel.vlm_engine_options import (
+    AutoInlineVlmEngineOptions,
+    TransformersVlmEngineOptions,
+    VlmEngineType,
+)
+from docling.models.inference_engines.vlm import VlmEngineInput, VlmEngineOutput
+from docling.models.stages.picture_description.picture_description_vlm_engine_model import (
+    PictureDescriptionVlmEngineModel,
+)
+
+pytestmark = pytest.mark.ml_vlm
+
+
+class _DummyEngine:
+    def __init__(self):
+        self.received_inputs: list[VlmEngineInput] = []
+
+    def predict_batch(self, inputs: Iterable[VlmEngineInput]):
+        self.received_inputs = list(inputs)
+        return [
+            VlmEngineOutput(text=f"description {i}", stop_reason="end_of_sequence")
+            for i in range(len(self.received_inputs))
+        ]
+
+    def cleanup(self):
+        pass
+
+
+def _build_options(**model_spec_overrides) -> PictureDescriptionVlmEngineOptions:
+    defaults = dict(
+        name="test-model",
+        default_repo_id="org/test-model",
+        prompt="Describe this image.",
+        response_format=ResponseFormat.PLAINTEXT,
+        temperature=0.1,
+        max_new_tokens=300,
+    )
+    defaults.update(model_spec_overrides)
+    return PictureDescriptionVlmEngineOptions(
+        model_spec=VlmModelSpec(**defaults),
+        engine_options=TransformersVlmEngineOptions(),
+        prompt="Describe this image.",
+        generation_config={},
+    )
+
+
+def test_engine_picture_description_falls_back_to_model_spec_defaults() -> None:
+    options = _build_options(temperature=0.1, max_new_tokens=300)
+    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
+    model.options = options
+    model.engine = _DummyEngine()
+
+    list(model._annotate_images([Image.new("RGB", (8, 8), "white")]))
+
+    sent_input = model.engine.received_inputs[0]
+    assert sent_input.max_new_tokens == 300
+    assert sent_input.temperature == 0.1
+
+
+def test_engine_picture_description_forwards_stop_strings_and_extra_config() -> None:
+    options = _build_options(
+        stop_strings=["<|im_end|>"],
+        extra_generation_config={"skip_special_tokens": True},
+    )
+    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
+    model.options = options
+    model.engine = _DummyEngine()
+
+    list(model._annotate_images([Image.new("RGB", (8, 8), "white")]))
+
+    sent_input = model.engine.received_inputs[0]
+    assert sent_input.stop_strings == ["<|im_end|>"]
+    assert sent_input.extra_generation_config == {"skip_special_tokens": True}
+
+
+def test_engine_picture_description_resolves_auto_inline_engine_type() -> None:
+    options = _build_options(
+        engine_overrides={
+            VlmEngineType.MLX: EngineModelConfig(extra_config={"mlx_only_key": "x"}),
+        }
+    )
+    options.engine_options = AutoInlineVlmEngineOptions()
+
+    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
+    model.options = options
+    model.engine = _DummyEngine()
+    model.engine.selected_engine_type = (
+        VlmEngineType.MLX
+    )  # Engine hat sich für MLX entschieden
+
+    resolved = model._resolve_runtime_engine_type()
+    assert resolved == VlmEngineType.MLX
+
+
+def test_engine_picture_description_skips_empty_batch() -> None:
+    options = _build_options()
+    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
+    model.options = options
+    model.engine = _DummyEngine()
+
+    assert list(model._annotate_images([])) == []
+    assert model.engine.received_inputs == []
+
+
+def test_engine_picture_description_raises_when_engine_not_initialized() -> None:
+    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
+    model.options = _build_options()
+    model.engine = None
+
+    with pytest.raises(RuntimeError, match="Engine not initialized"):
+        list(model._annotate_images([Image.new("RGB", (8, 8), "white")]))
+
+
+def test_engine_picture_description_yields_empty_strings_on_engine_error() -> None:
+    class _FailingEngine(_DummyEngine):
+        def predict_batch(self, inputs):
+            raise RuntimeError("engine exploded")
+
+    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
+    model.options = _build_options()
+    model.engine = _FailingEngine()
+
+    images = [Image.new("RGB", (8, 8), "white"), Image.new("RGB", (8, 8), "black")]
+    outputs = list(model._annotate_images(images))
+
+    # Batch-Alignment muss erhalten bleiben: gleiche Anzahl wie Input, leere Strings statt Crash
+    assert outputs == ["", ""]
+
+
+def test_engine_picture_description_shares_config_across_batch() -> None:
+    options = _build_options(temperature=0.2, max_new_tokens=500)
+    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
+    model.options = options
+    model.engine = _DummyEngine()
+
+    images = [Image.new("RGB", (8, 8), "white") for _ in range(3)]
+    list(model._annotate_images(images))
+
+    assert len(model.engine.received_inputs) == 3
+    assert all(i.max_new_tokens == 500 for i in model.engine.received_inputs)
+    assert all(i.temperature == 0.2 for i in model.engine.received_inputs)
+
+
+def test_engine_picture_description_forwards_generation_config() -> None:
+    options = PictureDescriptionVlmEngineOptions.from_preset(
+        "smolvlm",
+        generation_config={
+            "max_new_tokens": 1234,
+            "temperature": 0.42,
+            "do_sample": True,
+        },
+    )
+    model = PictureDescriptionVlmEngineModel.__new__(PictureDescriptionVlmEngineModel)
+    model.options = options
+    model.engine = _DummyEngine()
+
+    images = [Image.new("RGB", (8, 8), "white")]
+    outputs = list(model._annotate_images(images))
+
+    assert outputs == ["description 0"]
+    sent_input = model.engine.received_inputs[0]
+    assert sent_input.max_new_tokens == 1234
+    assert sent_input.temperature == 0.42


### PR DESCRIPTION
This should fix #3776. PictureDescriptionVlmEngineModel had hard-coded values for `max_new_tokens` and `temperature`.
For VLMConvert this has been fixed in #3322 by @geoHeil, but not for PictureDescriptionVlmEngineModel.

Would also be possible to reuse [_resolve_runtime_engine_type](https://github.com/docling-project/docling/blob/main/docling/models/stages/vlm_convert/vlm_convert_model.py#L95) and adapt [_build_engine_inputs](https://github.com/docling-project/docling/blob/main/docling/models/stages/vlm_convert/vlm_convert_model.py#L101) from VlmConvertModel.

@dolfim-ibm @cau-git 

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #3776

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
