### PR TITLE
feat(dclx): add DocLang archive input backend

### DIFF
--- a/docling/backend/xml/doclang_archive_backend.py
+++ b/docling/backend/xml/doclang_archive_backend.py
@@ -1,0 +1,77 @@
+import shutil
+import tempfile
+from io import BytesIO
+from pathlib import Path
+from typing import Union
+
+from docling_core.types.doc import DoclingDocument, DocumentOrigin
+from typing_extensions import override
+
+from docling.backend.abstract_backend import DeclarativeDocumentBackend
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.document import InputDocument
+
+_DCLX_MIMETYPE = "application/zip"
+
+
+class DocLangArchiveBackend(DeclarativeDocumentBackend):
+    @override
+    def __init__(
+        self, in_doc: InputDocument, path_or_stream: Union[BytesIO, Path]
+    ) -> None:
+        super().__init__(in_doc, path_or_stream)
+        self._temp_dir: Path | None = None
+        self._doc_or_err = self._get_doc_or_err()
+
+    @override
+    def is_valid(self) -> bool:
+        return isinstance(self._doc_or_err, DoclingDocument)
+
+    @classmethod
+    @override
+    def supports_pagination(cls) -> bool:
+        return False
+
+    @classmethod
+    @override
+    def supported_formats(cls) -> set[InputFormat]:
+        return {InputFormat.DCLX}
+
+    def _get_doc_or_err(self) -> Union[DoclingDocument, Exception]:
+        try:
+            if isinstance(self.path_or_stream, Path):
+                doc = DoclingDocument.load_from_doclang_archive(self.path_or_stream)
+            elif isinstance(self.path_or_stream, BytesIO):
+                self._temp_dir = Path(tempfile.mkdtemp(prefix="docling_dclx_"))
+                archive_path = self._temp_dir / (self.file.name or "document.dclx")
+                archive_path.write_bytes(self.path_or_stream.getvalue())
+                artifacts_dir = self._temp_dir / "artifacts"
+                doc = DoclingDocument.load_from_doclang_archive(
+                    archive_path,
+                    artifacts_dir=artifacts_dir,
+                )
+            else:
+                raise RuntimeError(f"Unexpected: {type(self.path_or_stream)=}")
+
+            doc.origin = DocumentOrigin(
+                filename=self.file.name or "file",
+                mimetype=_DCLX_MIMETYPE,
+                binary_hash=self.document_hash,
+            )
+            return doc
+        except Exception as e:
+            return e
+
+    @override
+    def convert(self) -> DoclingDocument:
+        if isinstance(self._doc_or_err, DoclingDocument):
+            return self._doc_or_err
+
+        raise self._doc_or_err
+
+    @override
+    def unload(self) -> None:
+        if self._temp_dir is not None and self._temp_dir.exists():
+            shutil.rmtree(self._temp_dir)
+            self._temp_dir = None
+        super().unload()

--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -110,6 +110,7 @@ class InputFormat(str, Enum):
     XML_JATS = "xml_jats"
     XML_XBRL = "xml_xbrl"
     XML_DOCLANG = "xml_doclang"
+    DCLX = "dclx"
     METS_GBS = "mets_gbs"
     JSON_DOCLING = "json_docling"
     AUDIO = "audio"
@@ -143,6 +144,7 @@ FormatToExtensions: dict[InputFormat, list[str]] = {
     InputFormat.XML_JATS: ["xml", "nxml"],
     InputFormat.XML_XBRL: ["xml", "xbrl"],
     InputFormat.XML_DOCLANG: ["dclg", "dclg.xml"],
+    InputFormat.DCLX: ["dclx"],
     InputFormat.IMAGE: ["jpg", "jpeg", "png", "tif", "tiff", "bmp", "webp"],
     InputFormat.ASCIIDOC: ["adoc", "asciidoc", "asc"],
     InputFormat.CSV: ["csv"],

--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -746,13 +746,19 @@ class _DocumentConversionInput(BaseModel):
         if isinstance(obj, Path):
             if _DocumentConversionInput._has_doclang_extension(obj.name):
                 return InputFormat.XML_DOCLANG
+            if _DocumentConversionInput._has_dclx_extension(obj.name):
+                return InputFormat.DCLX
             mime = filetype.guess_mime(str(obj))
             obj_ext = obj.suffix[1:] if obj.suffix else ""
             if mime is None:
                 mime = _DocumentConversionInput._mime_from_extension(obj_ext)
-            if mime is None:  # must guess from content
+            needs_content_sniff = mime is None or (
+                mime is not None
+                and mime.lower() in {"application/xml", "application/xhtml+xml"}
+            )
+            if needs_content_sniff:
                 with obj.open("rb") as f:
-                    content = f.read(1024)  # Read first 1KB
+                    content = f.read(1024)
             if mime is not None and mime.lower() == "application/zip":
                 mime_root = "application/vnd.openxmlformats-officedocument"
                 suffix = obj.suffix.lower()
@@ -772,6 +778,8 @@ class _DocumentConversionInput(BaseModel):
         elif isinstance(obj, DocumentStream):
             if _DocumentConversionInput._has_doclang_extension(obj.name):
                 return InputFormat.XML_DOCLANG
+            if _DocumentConversionInput._has_dclx_extension(obj.name):
+                return InputFormat.DCLX
             content = obj.stream.read(8192)
             obj.stream.seek(0)
             mime = filetype.guess_mime(content)
@@ -824,6 +832,10 @@ class _DocumentConversionInput(BaseModel):
         return lower_name.endswith((".dclg", ".dclg.xml"))
 
     @staticmethod
+    def _has_dclx_extension(name: str) -> bool:
+        return name.lower().endswith(".dclx")
+
+    @staticmethod
     def _detect_office_mime_from_zip(
         source: Union[Path, BytesIO],
     ) -> Optional[str]:
@@ -852,6 +864,15 @@ class _DocumentConversionInput(BaseModel):
             if isinstance(source, BytesIO):
                 source.seek(0)
         return None
+
+    @staticmethod
+    def _has_doclang_root_element(content_str: str) -> bool:
+        """Return whether XML content starts with a DocLang root element."""
+        content_str = re.sub(r"<!--(.*?)-->", "", content_str, flags=re.DOTALL)
+        content_str = content_str.lstrip()
+        if re.match(r"<\?xml", content_str):
+            content_str = re.sub(r"<\?xml[^>]*\?>", "", content_str, count=1).lstrip()
+        return re.match(r"<\s*doclang\b", content_str, re.IGNORECASE) is not None
 
     @staticmethod
     def _guess_from_content(
@@ -892,6 +913,13 @@ class _DocumentConversionInput(BaseModel):
                     or "JATS-archive" in xml_doctype
                 ):
                     input_format = InputFormat.XML_JATS
+
+            if (
+                input_format is None
+                and InputFormat.XML_DOCLANG in formats
+                and _DocumentConversionInput._has_doclang_root_element(content_str)
+            ):
+                input_format = InputFormat.XML_DOCLANG
 
         elif mime == "text/plain":
             content_str = content.decode("utf-8", errors="replace")
@@ -987,6 +1015,11 @@ class _DocumentConversionInput(BaseModel):
             r"<!doctype\s+(?P<root>[a-zA-Z_:][a-zA-Z0-9_:.-]*)\s+.*>\s*<(?P=root)\b"
         )
         if p.search(content_str):
+            return "application/xml"
+
+        if _DocumentConversionInput._has_doclang_root_element(
+            content.decode("utf-8", errors="replace")
+        ):
             return "application/xml"
 
         return None

--- a/docling/document_converter.py
+++ b/docling/document_converter.py
@@ -40,6 +40,7 @@ from docling.backend.opendocument_backend import (
     OdtDocumentBackend,
 )
 from docling.backend.webvtt_backend import WebVTTDocumentBackend
+from docling.backend.xml.doclang_archive_backend import DocLangArchiveBackend
 from docling.backend.xml.doclang_backend import DocLangDocumentBackend
 from docling.backend.xml.jats_backend import JatsDocumentBackend
 from docling.backend.xml.uspto_backend import PatentUsptoDocumentBackend
@@ -192,6 +193,11 @@ class XMLDocLangFormatOption(FormatOption):
     backend: Type[AbstractDocumentBackend] = DocLangDocumentBackend
 
 
+class DclxFormatOption(FormatOption):
+    pipeline_cls: Type = SimplePipeline
+    backend: Type[AbstractDocumentBackend] = DocLangArchiveBackend
+
+
 class XBRLFormatOption(FormatOption):
     pipeline_cls: Type = SimplePipeline
     backend: Type[AbstractDocumentBackend] = XBRLDocumentBackend
@@ -255,6 +261,7 @@ def _get_default_option(format: InputFormat) -> FormatOption:
         InputFormat.XML_USPTO: PatentUsptoFormatOption(),
         InputFormat.XML_JATS: XMLJatsFormatOption(),
         InputFormat.XML_DOCLANG: XMLDocLangFormatOption(),
+        InputFormat.DCLX: DclxFormatOption(),
         InputFormat.XML_XBRL: XBRLFormatOption(),
         InputFormat.METS_GBS: FormatOption(
             pipeline_cls=StandardPdfPipeline, backend=MetsGbsDocumentBackend

--- a/docs/usage/supported_formats.md
+++ b/docs/usage/supported_formats.md
@@ -27,7 +27,8 @@ Schema-specific support:
 
 | Format | Description |
 |--------|-------------|
-| DocLang XML | XML format following [DocLang](https://doclang.ai); supported extensions: `.dclg`, `.dclg.xml` |
+| DocLang XML | XML format following [DocLang](https://doclang.ai); supported extensions: `.dclg`, `.dclg.xml`, and generic `.xml` with a `<doclang>` root element |
+| DocLang archive | Zipped DocLang bundle including page images; supported extension: `.dclx` |
 | USPTO XML | XML format followed by [USPTO](https://www.uspto.gov/patents) patents |
 | JATS XML | XML format followed by [JATS](https://jats.nlm.nih.gov/) articles |
 | XBRL XML | XML format for business and financial reporting following [XBRL](https://www.xbrl.org/) standard |

--- a/tests/test_backend_dclx.py
+++ b/tests/test_backend_dclx.py
@@ -1,0 +1,105 @@
+from io import BytesIO
+from pathlib import Path
+
+import pytest
+from docling_core.types.doc import DocItemLabel, DoclingDocument
+
+from docling.datamodel.base_models import DocumentStream, InputFormat
+from docling.datamodel.document import _DocumentConversionInput
+from docling.document_converter import DocumentConverter
+
+DOCLANG_XML = """<doclang>
+  <heading>DocLang Title</heading>
+  <text>Hello world</text>
+  <table>
+    <fcel/><text>H1</text><fcel/><text>H2</text><nl/>
+    <fcel/><text>C1</text><fcel/><text>C2</text><nl/>
+  </table>
+</doclang>
+"""
+
+
+def _write_dclx_archive(path: Path, *, xml: str = DOCLANG_XML) -> None:
+    DocumentConverter(allowed_formats=[InputFormat.XML_DOCLANG]).convert_string(
+        xml,
+        format=InputFormat.XML_DOCLANG,
+        name=f"{path.stem}.dclg.xml",
+    ).document.save_as_doclang_archive(filename=path)
+
+
+def test_dclx_backend_converts_path(tmp_path: Path):
+    archive_path = tmp_path / "sample.dclx"
+    _write_dclx_archive(archive_path)
+
+    result = DocumentConverter(allowed_formats=[InputFormat.DCLX]).convert(archive_path)
+
+    assert result.input.format == InputFormat.DCLX
+    assert result.document.texts[0].label == DocItemLabel.TITLE
+    assert result.document.texts[0].text == "DocLang Title"
+    assert result.document.texts[1].text == "Hello world"
+    assert len(result.document.tables) == 1
+
+
+def test_dclx_backend_converts_stream(tmp_path: Path):
+    archive_path = tmp_path / "sample.dclx"
+    _write_dclx_archive(archive_path)
+    stream = DocumentStream(
+        name="sample.dclx",
+        stream=BytesIO(archive_path.read_bytes()),
+    )
+
+    result = DocumentConverter(allowed_formats=[InputFormat.DCLX]).convert(stream)
+
+    assert result.input.format == InputFormat.DCLX
+    assert result.document.export_to_markdown().startswith("# DocLang Title")
+
+
+def test_dclx_guess_format_by_extension(tmp_path: Path):
+    dci = _DocumentConversionInput(path_or_stream_iterator=[])
+    archive_path = tmp_path / "sample.dclx"
+    _write_dclx_archive(archive_path)
+
+    assert dci._guess_format(archive_path) == InputFormat.DCLX
+
+    stream = DocumentStream(
+        name="sample.dclx",
+        stream=BytesIO(archive_path.read_bytes()),
+    )
+    assert dci._guess_format(stream) == InputFormat.DCLX
+
+
+def test_dclx_not_guessed_without_dclx_extension(tmp_path: Path):
+    dci = _DocumentConversionInput(path_or_stream_iterator=[])
+    archive_path = tmp_path / "sample.dclx"
+    _write_dclx_archive(archive_path)
+
+    zip_path = tmp_path / "archive.zip"
+    zip_path.write_bytes(archive_path.read_bytes())
+    assert dci._guess_format(zip_path) is None
+
+    extensionless_path = tmp_path / "archive_no_ext"
+    extensionless_path.write_bytes(archive_path.read_bytes())
+    assert dci._guess_format(extensionless_path) is None
+
+    stream = DocumentStream(
+        name="archive.zip",
+        stream=BytesIO(zip_path.read_bytes()),
+    )
+    assert dci._guess_format(stream) is None
+
+
+ROUNDTRIP_GT_PATHS = [
+    Path("tests/data/md_deepseek/groundtruth/deepseek_simple.md.json"),
+]
+
+
+@pytest.mark.parametrize("gt_path", ROUNDTRIP_GT_PATHS)
+def test_dclx_roundtrip_from_groundtruth(gt_path: Path, tmp_path: Path):
+    original_doc = DoclingDocument.load_from_json(gt_path)
+    archive_path = tmp_path / f"{gt_path.stem}.dclx"
+    original_doc.save_as_doclang_archive(filename=archive_path)
+
+    result = DocumentConverter(allowed_formats=[InputFormat.DCLX]).convert(archive_path)
+    roundtrip_doc = result.document
+
+    assert roundtrip_doc.export_to_markdown() == original_doc.export_to_markdown()

--- a/tests/test_backend_doclang.py
+++ b/tests/test_backend_doclang.py
@@ -96,7 +96,7 @@ def test_docling_document_doclang_roundtrip_from_groundtruth(gt_path: Path):
     assert len(roundtrip_doc.pictures) == len(original_doc.pictures)
 
 
-@pytest.mark.parametrize("name", ["sample.dclg", "sample.dclg.xml"])
+@pytest.mark.parametrize("name", ["sample.dclg", "sample.dclg.xml", "sample.xml"])
 def test_doclang_guess_format_by_extension(tmp_path: Path, name: str):
     dci = _DocumentConversionInput(path_or_stream_iterator=[])
     doc_path = tmp_path / name
@@ -106,3 +106,15 @@ def test_doclang_guess_format_by_extension(tmp_path: Path, name: str):
 
     stream = DocumentStream(name=name, stream=BytesIO(DOCLANG_XML.encode("utf-8")))
     assert dci._guess_format(stream) == InputFormat.XML_DOCLANG
+
+
+def test_doclang_backend_converts_generic_xml_extension(tmp_path: Path):
+    doc_path = tmp_path / "sample.xml"
+    doc_path.write_text(DOCLANG_XML, encoding="utf-8")
+
+    result = DocumentConverter(allowed_formats=[InputFormat.XML_DOCLANG]).convert(
+        doc_path
+    )
+
+    assert result.input.format == InputFormat.XML_DOCLANG
+    assert result.document.export_to_markdown().startswith("# DocLang Title")

--- a/tests/test_input_doc.py
+++ b/tests/test_input_doc.py
@@ -349,6 +349,18 @@ def test_guess_format(tmp_path):
     stream = DocumentStream(name="docling_test.xml", stream=buf)
     assert dci._guess_format(stream) is None
 
+    # Valid DocLang XML with generic .xml extension
+    doclang_xml = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        "<doclang><heading>DocLang</heading><text>Hello</text></doclang>"
+    )
+    doc_path = temp_dir / "doclang_sample.xml"
+    doc_path.write_text(doclang_xml, encoding="utf-8")
+    assert dci._guess_format(doc_path) == InputFormat.XML_DOCLANG
+    buf = BytesIO(doc_path.read_bytes())
+    stream = DocumentStream(name="doclang_sample.xml", stream=buf)
+    assert dci._guess_format(stream) == InputFormat.XML_DOCLANG
+
     # Plain .txt file (not USPTO) should be detected as Markdown
     stream = DocumentStream(name="pftaps057006474.txt", stream=BytesIO(b"xyz"))
     assert dci._guess_format(stream) == InputFormat.MD


### PR DESCRIPTION
Add read support for `.dclx` zipped DocLang archives, complementing the existing DCLX export path introduced in #3750.

- Introduce `DocLangArchiveBackend` and wire `InputFormat.DCLX` through format detection and `DocumentConverter`
- Recognize DocLang XML in generic `.xml` files via `<doclang>` root sniffing
- Update supported-formats docs and add backend, format-guessing, and roundtrip tests