### PR TITLE
fix(md): stop duplicating table cells in the Markdown backend

### DIFF
--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -251,9 +251,6 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
             table_data = TableData(
                 num_rows=num_rows, num_cols=num_cols, table_cells=tcells
             )
-            # Populate
-            for tcell in tcells:
-                table_data.table_cells.append(tcell)
             if len(tcells) > 0:
                 doc.add_table(data=table_data)
         return

--- a/tests/test_backend_markdown.py
+++ b/tests/test_backend_markdown.py
@@ -273,3 +273,31 @@ def test_code_block_language_detection():
         CodeLanguageLabel.SQL,
         CodeLanguageLabel.UNKNOWN,
     ]
+
+
+def test_convert_table_has_no_duplicate_cells():
+    """
+    Regression test:
+    A parsed Markdown table must expose each cell exactly once. The backend used
+    to append every cell a second time after passing it to the TableData
+    constructor, so table.data.table_cells contained twice the real cell count
+    (each grid position appeared twice) in export_to_dict/JSON and anything
+    iterating the cells directly.
+    """
+    markdown = """| Region | Q1 | Q2 |
+| --- | --- | --- |
+| North | 10 | 20 |
+| South | 30 | 40 |
+"""
+    conv_result = get_converter().convert_string(markdown, format=InputFormat.MD)
+    assert conv_result.status == ConversionStatus.SUCCESS
+
+    table = conv_result.document.tables[0]
+    table_data = table.data
+    assert len(table_data.table_cells) == table_data.num_rows * table_data.num_cols
+
+    positions = [
+        (cell.start_row_offset_idx, cell.start_col_offset_idx)
+        for cell in table_data.table_cells
+    ]
+    assert len(positions) == len(set(positions))


### PR DESCRIPTION
```markdown
Every table parsed from a Markdown file exposes each cell twice.

In `MarkdownDocumentBackend._close_table` the cells are passed to the
`TableData` constructor via `table_cells=tcells`, which already stores every
cell. Immediately afterwards the same list is re-appended in a loop:

```python
table_data = TableData(
    num_rows=num_rows, num_cols=num_cols, table_cells=tcells
)
# Populate
for tcell in tcells:
    table_data.table_cells.append(tcell)
```

So `table.data.table_cells` ends up with twice the real cell count: every grid
position appears twice. This is visible in `export_to_dict` / JSON and in any
code that iterates `table.data.table_cells` directly. A 3x3 table
(header + 2 rows) yields 18 cells instead of 9.

The Markdown and dataframe exports looked correct only because they
de-duplicate by grid position, which hid the doubled underlying data.

This removes the redundant re-population loop so the cells populated by the
`TableData` constructor are the only ones kept.

**Testing**

- Added `tests/test_backend_markdown.py::test_convert_table_has_no_duplicate_cells`,
  which converts a small table and asserts it has exactly
  `num_rows * num_cols` cells with no duplicated `(start_row, start_col)`
  positions. It fails on the current code (18 != 9) and passes with the fix.
- `pytest tests/test_backend_markdown.py` -> 8 passed, 1 skipped.
- `pytest tests/test_backend_html.py` -> 36 passed (the Markdown backend
  delegates to the HTML backend when a document mixes Markdown and raw HTML).
- Reference groundtruth data is unchanged: the only Markdown JSON groundtruth
  that contains a table already stores the correct (non-doubled) cell count,
  because that source also contains a raw HTML block, which routes the whole
  document through the HTML backend. No reference-data regeneration was needed.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
```

Notes on the checklist: no docs or examples change (internal data-shape bug
fix, no user-facing API change). Tests box is checked (regression test added).
