### PR TITLE
perf(docx): dedup textbox elements with sets instead of lists

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -249,7 +249,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         self.numbered_headers: dict[int, int] = {}
         self.equation_bookends: str = "<eq>{EQ}</eq>"
         # Track processed textbox elements to avoid duplication
-        self.processed_textbox_elements: list[int] = []
+        self.processed_textbox_elements: set[int] = set()
         self.docx_to_pdf_converter: Callable | None = None
         self.docx_to_pdf_converter_init = False
         self.display_drawingml_warning = True
@@ -574,10 +574,10 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
 
                 if textbox_elements:
                     # Mark the parent element as processed
-                    self.processed_textbox_elements.append(element_id)
+                    self.processed_textbox_elements.add(element_id)
                     # Also mark all found textbox elements as processed
                     for tb_element in textbox_elements:
-                        self.processed_textbox_elements.append(id(tb_element))
+                        self.processed_textbox_elements.add(id(tb_element))
 
                     _log.debug(
                         f"Found textbox content with {len(textbox_elements)} elements"
@@ -1370,7 +1370,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
 
     def _collect_textbox_paragraphs(self, textbox_elements):
         """Collect and organize paragraphs from textbox elements."""
-        processed_paragraphs = []
+        processed_paragraphs: set[int] = set()
         container_paragraphs = {}
 
         for element in textbox_elements:
@@ -1380,7 +1380,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                 continue
 
             tag_name = etree.QName(element).localname
-            processed_paragraphs.append(element_id)
+            processed_paragraphs.add(element_id)
 
             # Handle paragraphs directly found (VML textboxes)
             if tag_name == "p":
@@ -1407,7 +1407,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                 for p in paragraphs:
                     p_id = id(p)
                     if p_id not in processed_paragraphs:
-                        processed_paragraphs.append(p_id)
+                        processed_paragraphs.add(p_id)
                         container_paragraphs[container_id].append(
                             (p, self._get_paragraph_position(p))
                         )
@@ -1421,7 +1421,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                 for p in paragraphs:
                     p_id = id(p)
                     if p_id not in processed_paragraphs:
-                        processed_paragraphs.append(p_id)
+                        processed_paragraphs.add(p_id)
                         container_paragraphs[container_id].append(
                             (p, self._get_paragraph_position(p))
                         )

--- a/tests/test_backend_msword.py
+++ b/tests/test_backend_msword.py
@@ -145,6 +145,30 @@ def test_textbox_extraction(documents):
     assert textbox_found
 
 
+def test_processed_textbox_elements_is_a_set():
+    """The textbox dedup tracker must stay a set for O(1) membership.
+
+    ``_walk_linear`` membership-checks ``processed_textbox_elements`` once per
+    body element, so backing it with a list makes textbox-heavy DOCX conversion
+    quadratic in the number of textbox elements. Convert a document that
+    actually contains textboxes and assert the tracker was populated and remains
+    a set, so a regression back to a list is caught here rather than only in
+    conversion timing.
+    """
+    docx_path = Path("./tests/data/docx/sources/textbox.docx")
+    in_doc = InputDocument(
+        path_or_stream=docx_path,
+        format=InputFormat.DOCX,
+        backend=MsWordDocumentBackend,
+    )
+    backend = in_doc._backend
+    backend.convert()
+
+    assert isinstance(backend.processed_textbox_elements, set)
+    # The fixture has textboxes, so the dedup path ran and marked elements.
+    assert backend.processed_textbox_elements
+
+
 def test_heading_levels(documents):
     name = "word_sample.docx"
     doc = next(item[1] for item in documents if item[0].name == name)


### PR DESCRIPTION

The MS Word backend tracks already-seen textbox elements in Python lists that are
only ever membership-checked. In `_walk_linear` (the main DOCX body traversal) the
instance attribute `processed_textbox_elements` is checked with `not in` once per
body element, so as textbox elements accumulate the per-element check grows to
`O(T)` and traversing `N` body elements becomes `O(N*T)`, i.e. quadratic for
textbox-heavy documents (flyer/slide-like DOCX, or forms built entirely from text
boxes). `_collect_textbox_paragraphs` has the same pattern in a local list.

This switches both structures to `set`, so membership is `O(1)` and conversion is
linear again. They are used purely for deduplication (never indexed, sliced, or
iterated for ordering), so conversion output is unchanged; paragraph order still
comes from `container_paragraphs` insertion order plus `_get_paragraph_position`
sorting. This also aligns them with the `set` already used for the same purpose in
the sibling `_handle_textbox_content`.

A regression test converts the existing `textbox.docx` fixture and asserts the
tracker stays a `set`; reverting it to a list fails the test.

**Checklist:**

- [ ] Documentation has been updated, if necessary. (n/a: internal perf change,
  no user-facing behavior change)
- [ ] Examples have been added, if necessary. (n/a)
- [x] Tests have been added, if necessary.
