### PR TITLE
fix(utils): add request timeout to model download to avoid indefinite hangs

### DIFF
--- a/docling/utils/utils.py
+++ b/docling/utils/utils.py
@@ -46,7 +46,9 @@ def create_hash(string: str):
 
 def download_url_with_progress(url: str, progress: bool = False) -> BytesIO:
     buf = BytesIO()
-    with requests.get(url, stream=True, allow_redirects=True) as response:
+    with requests.get(
+        url, stream=True, allow_redirects=True, timeout=(5, 30)
+    ) as response:
         total_size = int(response.headers.get("content-length", 0))
         progress_bar = tqdm(
             total=total_size,


### PR DESCRIPTION

`download_url_with_progress` in `docling/utils/utils.py` issues its download
with `requests.get(url, stream=True, allow_redirects=True)` but never sets a
`timeout`. Because `requests` does not time out by default, a stalled or
half-open connection to a model-download host blocks the call indefinitely with
no recovery.

This function is on the OCR model-weight download path, so the hang is
user-visible during first-run setup:

- `docling/models/stages/ocr/easyocr_model.py` (EasyOCR weights)
- `docling/models/stages/ocr/rapid_ocr_model.py` (RapidOCR weights)

This is the only `requests`/HTTP call site in the repository that omits a
timeout. Every other one already passes one, so this change closes the gap and
reuses the connect/read tuple already used for the streaming image download in
`docling/backend/utils/image_resource_loader.py` (`timeout=(5, 30)`):

```python
with requests.get(
    url, stream=True, allow_redirects=True, timeout=(5, 30)
) as response:
```

Behavior is unchanged on healthy connections; only the pathological hang is now
bounded. The public signature of `download_url_with_progress` is unchanged.

A regression test (`tests/test_utils.py`) monkeypatches `requests.get`, drives
the function through its real streaming path, and asserts a non-None `timeout`
is passed. It is network-free and needs no `ml_*` marker.

**Checklist:**

- [ ] Documentation has been updated, if necessary. (n/a - no user-facing API or behavior change)
- [ ] Examples have been added, if necessary. (n/a)
- [x] Tests have been added, if necessary.
