### PR TITLE
fix(service_client): handle Retry-After HTTP-date with unknown timezone

### DIFF
--- a/docling/service_client/client.py
+++ b/docling/service_client/client.py
@@ -615,7 +615,13 @@ class _BaseDoclingServiceClient:
         except (TypeError, ValueError, IndexError, OverflowError):
             return None
 
-        now = datetime.now(tz=retry_at.tzinfo or timezone.utc)
+        # parsedate_to_datetime returns a naive datetime for HTTP-dates carrying
+        # an unknown timezone (e.g. "-0000"); assume UTC so the subtraction below
+        # does not mix naive and aware datetimes.
+        if retry_at.tzinfo is None:
+            retry_at = retry_at.replace(tzinfo=timezone.utc)
+
+        now = datetime.now(tz=timezone.utc)
         return max(0.0, (retry_at - now).total_seconds())
 
     def _raise_for_result_404(

--- a/tests/test_service_client_sdk_unit.py
+++ b/tests/test_service_client_sdk_unit.py
@@ -7,7 +7,8 @@ import threading
 import time
 import warnings
 import zipfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
 from pathlib import Path, PurePath
 from types import MethodType, SimpleNamespace
 
@@ -2258,6 +2259,35 @@ def test_429_without_retry_after_header_does_not_retry() -> None:
             )
 
     assert call_count == 1
+
+
+def test_retry_after_http_date_with_unknown_timezone_does_not_crash() -> None:
+    # RFC 7231 mandates GMT, but non-conformant servers/proxies emit dates with
+    # an unknown timezone ("-0000"), which email.utils parses to a naive
+    # datetime. The backoff computation must not raise when mixing that with an
+    # aware "now".
+    response = httpx.Response(
+        503, headers={"Retry-After": "Sun, 06 Nov 1994 08:49:37 -0000"}
+    )
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        delay = client._retry_after_delay_seconds(response)
+
+    assert isinstance(delay, float)
+    assert delay == 0.0  # a date in the past clamps to zero
+
+
+def test_retry_after_future_http_date_returns_positive_delay() -> None:
+    future = datetime.now(tz=timezone.utc) + timedelta(seconds=120)
+    response = httpx.Response(
+        503, headers={"Retry-After": format_datetime(future, usegmt=True)}
+    )
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        delay = client._retry_after_delay_seconds(response)
+
+    assert isinstance(delay, float)
+    assert 0.0 < delay <= 120.0
 
 
 def test_402_usage_limit_exceeded_raises_explicit_exception() -> None:


### PR DESCRIPTION

The service client's retry backoff crashes with a `TypeError` when a `429`/`503`
response carries a `Retry-After` HTTP-date whose timezone is unknown (for example
`-0000`).

`_BaseDoclingServiceClient._retry_after_delay_seconds` parses date-formatted
`Retry-After` values with `email.utils.parsedate_to_datetime`. For a spec-compliant
value ending in `GMT` this returns an aware datetime and works. But `email.utils`
maps an unknown/zoneless timezone (`-0000`) to a **naive** datetime. The code then
computed `now = datetime.now(tz=retry_at.tzinfo or timezone.utc)`, which is aware,
so `retry_at - now` subtracted a naive datetime from an aware one and raised:

```
TypeError: can't subtract offset-naive and offset-aware datetimes
```

The `try/except` around the parse did not cover the subtraction, so instead of
retrying, the client crashed. RFC 7231 mandates `GMT`, but non-conformant servers
and proxies do emit `-0000`, and the code already anticipates HTTP-date values
(it calls `parsedate_to_datetime`), so this is a genuine handling gap.

**Fix:** normalize the parsed datetime to UTC when it is naive, then compute the
delta between two aware datetimes:

```python
if retry_at.tzinfo is None:
    retry_at = retry_at.replace(tzinfo=timezone.utc)
now = datetime.now(tz=timezone.utc)
```

The fix lives in the shared base class, so it covers both `DoclingServiceClient`
and `AsyncDoclingServiceClient` (the async client inherits
`_retry_after_delay_seconds`).

Added two regression tests in `tests/test_service_client_sdk_unit.py`:
- a `Retry-After` HTTP-date with an unknown timezone (`-0000`) no longer raises and
  clamps a past date to `0.0` (RED before the fix: `TypeError`),
- a future GMT HTTP-date still yields a correct positive delay.

`tests/test_service_client_sdk_unit.py` passes (133 passed), and `ruff`, the
formatter, and `ty` are clean.

**Checklist:**

- [ ] Documentation has been updated, if necessary. (N/A - internal behavior fix)
- [ ] Examples have been added, if necessary. (N/A)
- [x] Tests have been added, if necessary.

> Note: no `Resolves #` line - there is no upstream tracking issue for this crash.
> Per the template, that section is omitted.
