### PR TITLE
fix(asciidoc): drop phantom cell from trailing-pipe table rows

### DIFF
--- a/docling/backend/asciidoc_backend.py
+++ b/docling/backend/asciidoc_backend.py
@@ -371,6 +371,12 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
         line = re.sub(rf"(^|\s){_CELL_SPEC}(?=\|)", r"\1", line)
         # Split by "|" and remove the leading empty string from the first "|"
         cells = line.split("|")[1:]
+        # A "|" that terminates the line (trailing-pipe row style, e.g.
+        # "|A|B|") marks the end of the row, not the start of a new cell, so it
+        # must not yield a phantom empty cell that would inflate the column
+        # count. Mid-row empty cells (e.g. "|A||B") are kept.
+        if cells and line.rstrip().endswith("|"):
+            cells = cells[:-1]
         # Strip whitespace from each cell (empty cells become empty strings)
         return [cell.strip() for cell in cells]
 

--- a/tests/data/asciidoc/groundtruth/asciidoc_01.asciidoc.md
+++ b/tests/data/asciidoc/groundtruth/asciidoc_01.asciidoc.md
@@ -21,7 +21,7 @@ This is some introductory text in section 1.1.
 
 This is some text in section 2.
 
-| Header 1 | Header 2 |  |
-| - | - | - |
-| Value 1 | Value 2 |  |
-| Value 3 | Value 4 |  |
+| Header 1 | Header 2 |
+| - | - |
+| Value 1 | Value 2 |
+| Value 3 | Value 4 |

--- a/tests/data/asciidoc/groundtruth/asciidoc_02.asciidoc.md
+++ b/tests/data/asciidoc/groundtruth/asciidoc_02.asciidoc.md
@@ -27,10 +27,10 @@ bla bla bla bli bla ble
 
 ## Section 4: test tables
 
-| Header 1 | Header 2 |  |
-| - | - | - |
-| Value 1 | Value 2 |  |
-| Value 3 | Value 4 |  |
+| Header 1 | Header 2 |
+| - | - |
+| Value 1 | Value 2 |
+| Value 3 | Value 4 |
 
 Caption for the table 1
 
@@ -63,15 +63,15 @@ Caption for the table 4
 
 Table 5 with multiple empty cells
 
-| Column 1 Heading | Column 2 Heading | Column 3 Heading |  |
-| - | - | - | - |
-| Cell 1 |  | Cell 3 |  |
-| Cell 4 |  |  |  |
-| Cell 7 |  |  |  |
-| Cell 10 | Cell 11 | Cell 12 |  |
-|  | Cell 14 | Cell 15 |  |
-|  |  |  |  |
-| Cell 19 | Cell 20 | Cell 21 |  |
+| Column 1 Heading | Column 2 Heading | Column 3 Heading |
+| - | - | - |
+| Cell 1 |  | Cell 3 |
+| Cell 4 |  |  |
+| Cell 7 |  |  |
+| Cell 10 | Cell 11 | Cell 12 |
+|  | Cell 14 | Cell 15 |
+|  |  |  |
+| Cell 19 | Cell 20 | Cell 21 |
 
 #### SubSubSection 2.1.1
 

--- a/tests/test_backend_asciidoc.py
+++ b/tests/test_backend_asciidoc.py
@@ -78,6 +78,31 @@ def test_table_cell_content_preserved():
     ]
 
 
+def test_table_trailing_pipe_no_phantom_cell():
+    # A "|" that terminates a row (trailing-pipe style) must not add a phantom
+    # empty cell, which would inflate the table's column count.
+    assert AsciiDocBackend._parse_table_line("|Header 1|Header 2|") == [
+        "Header 1",
+        "Header 2",
+    ]
+    assert AsciiDocBackend._parse_table_line("|Cell 10|Cell 11|Cell 12|") == [
+        "Cell 10",
+        "Cell 11",
+        "Cell 12",
+    ]
+    # Leading and mid-row empty cells must still be preserved.
+    assert AsciiDocBackend._parse_table_line("|Cell 1 | | Cell 3") == [
+        "Cell 1",
+        "",
+        "Cell 3",
+    ]
+    assert AsciiDocBackend._parse_table_line("|| Cell 14 | Cell 15 |") == [
+        "",
+        "Cell 14",
+        "Cell 15",
+    ]
+
+
 def test_empty_table_does_not_crash():
     # An empty table must yield an empty grid rather than raising.
     data = AsciiDocBackend._populate_table_as_grid([])


### PR DESCRIPTION

AsciiDoc table rows written in the common trailing-pipe style (each row ends with a
`|`, e.g. `|Cell 1|Cell 2|`) were parsed with one extra, empty cell. Because a
table's column count is derived from the widest row
(`num_cols = max(len(row) for row in rows)` in `_populate_table_as_grid`), a single
trailing-pipe row inflated the whole table by one spurious empty column: `num_cols`
is wrong and an empty column is appended to every row in every export that reads
`TableData` (Markdown, HTML, JSON, dataframe).

### Reproduce

```python
from docling.backend.asciidoc_backend import AsciiDocBackend

AsciiDocBackend._parse_table_line("|Header 1|Header 2|")
# before: ['Header 1', 'Header 2', '']   <- phantom trailing cell
# after:  ['Header 1', 'Header 2']
```

End to end, a two-column table authored as

```
|===
|Header 1|Header 2|
|Value 1|Value 2|
|===
```

converts to a table with `num_cols == 3` on `main` (should be `2`).

### Root cause

This is a regression from #3664 (empty-cell handling). `_parse_table_line` splits on
`|` and takes `[1:]` to drop the leading empty string. Before #3664, the trailing
`|` produced an empty string that was silently dropped by the old
`[c.strip() for c in ... if c.strip()]` filter, but that same filter also dropped
legitimate mid-row empty cells, which is exactly the bug #3664 fixed. Removing the
filter fixed mid-row empties but un-masked the trailing empty, so trailing-pipe rows
now over-count.

### Fix

In `_parse_table_line`, after `cells = line.split("|")[1:]`, drop a single trailing
empty cell only when the line actually ends with a row-terminating `|`. This matches
AsciiDoc's semantics, where a `|` starts a cell and a row-terminating `|` closes the
row rather than opening a new one (https://docs.asciidoctor.org/asciidoc/latest/tables/data-format/).
Leading empty cells (`|| Cell 14 | Cell 15 |`) and mid-row empty cells
(`|Cell 1 | | Cell 3`) are untouched.

### Tests

- Added `test_table_trailing_pipe_no_phantom_cell` to `tests/test_backend_asciidoc.py`
  (mirrors the existing `test_table_cell_content_preserved`): trailing-pipe rows no
  longer yield a phantom cell, and leading/mid-row empties are preserved. This test
  is red on `main` and green with the fix.
- Regenerated the two affected groundtruth fixtures
  (`tests/data/asciidoc/groundtruth/asciidoc_01.asciidoc.md` and
  `asciidoc_02.asciidoc.md`) with `DOCLING_GEN_TEST_DATA=1`. The diff only removes
  the spurious trailing empty column; every real (mid-row) empty cell is preserved.

Note for reviewers: this changes default conversion output for AsciiDoc tables, so
the two regenerated groundtruth files fall under the reference-data review. The diff
is limited to dropping the phantom column, so the change is worth a quick look at
`git diff -- tests/data/asciidoc/groundtruth/`. Correcting the output is the point
of the fix (the current default output is the bug), so an opt-in flag would not
address the regression.

**Checklist:**

- [ ] Documentation has been updated, if necessary. (n/a - no user-facing docs change)
- [ ] Examples have been added, if necessary. (n/a)
- [x] Tests have been added, if necessary.

(Remove the "Resolves #" section from the template: there is no open tracking issue;
the PR is framed as a regression fix for #3664.)

---

## Files changed (4)

```
docling/backend/asciidoc_backend.py                     | 6 +++++    (the fix: 6-line guard + comment)
tests/test_backend_asciidoc.py                          | 25 +++++++  (new regression test)
tests/data/asciidoc/groundtruth/asciidoc_01.asciidoc.md | 8 ++--      (regenerated; drops phantom column)
tests/data/asciidoc/groundtruth/asciidoc_02.asciidoc.md | 26 +++---   (regenerated; drops phantom column)
```

Total: 48 insertions, 17 deletions.
