### PR TITLE
fix(visualization): scale top y-edge by scale_y in draw_clusters

### DIFF
--- a/docling/utils/visualization.py
+++ b/docling/utils/visualization.py
@@ -28,7 +28,7 @@ def draw_clusters(
                 cx0, cy0, cx1, cy1 = tc.rect.to_bounding_box().as_tuple()
                 cx0 *= scale_x
                 cx1 *= scale_x
-                cy0 *= scale_x
+                cy0 *= scale_y
                 cy1 *= scale_y
 
                 draw.rectangle(
@@ -40,7 +40,7 @@ def draw_clusters(
             x0, y0, x1, y1 = c.bbox.as_tuple()
             x0 *= scale_x
             x1 *= scale_x
-            y0 *= scale_x
+            y0 *= scale_y
             y1 *= scale_y
 
             if y1 <= y0:


### PR DESCRIPTION

In `draw_clusters` the top y-coordinate of debug cluster boxes and their cells
was multiplied by `scale_x`, while the matching bottom y-coordinate on the next
line correctly used `scale_y`:

```python
cx0 *= scale_x
cx1 *= scale_x
cy0 *= scale_x   # top edge - wrong axis
cy1 *= scale_y   # bottom edge
```

`scale_x = image.width / page.size.width` and
`scale_y = image.height / page.size.height` differ whenever the rasterized image
aspect ratio does not match the page aspect ratio (for example rendering/OCR at a
DPI that does not preserve aspect). In that case the top edge of every drawn box
is misplaced, distorting the overlay (and for a box whose scaled top passes its
bottom it can invert).

This changes the two top-edge lines to use `scale_y`, so both y-edges scale by
`scale_y`. That matches the pattern already used consistently elsewhere in the
repo (`table_structure_model.py`, `table_structure_model_v2.py`,
`layout_object_detection_model.py`) and the earlier fix for the same axis bug in
the table model (#2287).

The change only affects debug visualization overlays gated behind the debug
settings (`visualize_cells` / `visualize_raw_layout` / `visualize_layout`); the
`DoclingDocument` conversion output is unchanged, and it is a no-op under uniform
scaling (`scale_x == scale_y`), so no reference data is regenerated.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
