### PR TITLE
feat: optional deps handling for ONNX runtime

### DIFF
--- a/docling/models/inference_engines/common/hf_vision_base.py
+++ b/docling/models/inference_engines/common/hf_vision_base.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
 import logging
 from numbers import Integral, Real
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import numpy as np
+from PIL import Image
 
 from docling.datamodel.accelerator_options import AcceleratorOptions
 from docling.models.inference_engines.vlm._utils import resolve_model_artifacts_path
@@ -19,6 +21,86 @@ if TYPE_CHECKING:
     from docling.datamodel.stage_model_specs import EngineModelConfig
 
 _log = logging.getLogger(__name__)
+
+
+class NumpyImageProcessor:
+    """Dependency-light, torch-free stand-in for a transformers image processor.
+
+    Reproduces the resize/rescale/normalize preprocessing described by a
+    ``preprocessor_config.json`` using only numpy + Pillow and returns
+    ``{"pixel_values": np.ndarray}`` shaped ``(N, C, H, W)``. It exists so the ONNX
+    Runtime object-detection engine can preprocess inputs in environments without
+    torch/torchvision: transformers >= 5 gates its image-processor classes behind
+    those backends, so ``AutoImageProcessor.from_pretrained`` is unavailable there.
+
+    For the default docling layout presets (RT-DETR: resize to a fixed square, no
+    rescale/normalize) the output is byte-identical to the transformers slow image
+    processor.
+    """
+
+    # PIL resampling filter for the integer codes stored by transformers/PIL.
+    _RESAMPLE = {
+        0: Image.Resampling.NEAREST,
+        1: Image.Resampling.LANCZOS,
+        2: Image.Resampling.BILINEAR,
+        3: Image.Resampling.BICUBIC,
+        4: Image.Resampling.BOX,
+        5: Image.Resampling.HAMMING,
+    }
+
+    def __init__(self, config: Dict[str, Any]) -> None:
+        self.size: Optional[Dict[str, int]] = config.get("size")
+        self.do_resize: bool = bool(config.get("do_resize", False))
+        self.do_rescale: bool = bool(config.get("do_rescale", False))
+        self.do_normalize: bool = bool(config.get("do_normalize", False))
+        self.rescale_factor: float = float(config.get("rescale_factor", 1.0 / 255.0))
+        self.image_mean: Optional[List[float]] = config.get("image_mean")
+        self.image_std: Optional[List[float]] = config.get("image_std")
+        self.resample = self._RESAMPLE.get(
+            int(config.get("resample", 2)), Image.Resampling.BILINEAR
+        )
+
+    @classmethod
+    def from_config_file(cls, path: Path) -> NumpyImageProcessor:
+        with path.open(encoding="utf-8") as handle:
+            return cls(json.load(handle))
+
+    def _target_hw(self) -> Optional[Tuple[int, int]]:
+        size = self.size or {}
+        if "height" in size and "width" in size:
+            return int(size["height"]), int(size["width"])
+        edge = size.get("shortest_edge") or size.get("longest_edge")
+        if edge is not None:
+            return int(edge), int(edge)
+        return None
+
+    def __call__(
+        self, images: Any, return_tensors: str = "np", **_: Any
+    ) -> Dict[str, np.ndarray]:
+        if not isinstance(images, (list, tuple)):
+            images = [images]
+        target = self._target_hw()
+        frames: List[np.ndarray] = []
+        for image in images:
+            pil = image.convert("RGB")
+            if self.do_resize and target is not None:
+                pil = pil.resize((target[1], target[0]), resample=self.resample)
+            frames.append(np.asarray(pil))
+        batch = np.stack(frames, axis=0)  # (N, H, W, C), uint8
+        if self.do_rescale or self.do_normalize:
+            batch = batch.astype(np.float32)
+        if self.do_rescale:
+            batch = batch * self.rescale_factor
+        if (
+            self.do_normalize
+            and self.image_mean is not None
+            and self.image_std is not None
+        ):
+            mean = np.asarray(self.image_mean, dtype=np.float32)
+            std = np.asarray(self.image_std, dtype=np.float32)
+            batch = (batch - mean) / std
+        pixel_values = np.ascontiguousarray(batch.transpose(0, 3, 1, 2))
+        return {"pixel_values": pixel_values}
 
 
 class HfVisionModelMixin(HuggingFaceModelDownloadMixin):
@@ -85,6 +167,17 @@ class HfVisionModelMixin(HuggingFaceModelDownloadMixin):
 
             _log.debug("Loading image processor from %s", model_folder)
             return AutoImageProcessor.from_pretrained(str(model_folder))
+        except ImportError:
+            # transformers >= 5 gates its image-processor classes behind the
+            # torch/torchvision backends. In a torch-free environment the ONNX
+            # object-detection engine still needs preprocessing, so fall back to a
+            # dependency-light numpy processor built from preprocessor_config.json.
+            _log.info(
+                "transformers image processor unavailable (torch-free environment); "
+                "using numpy preprocessing fallback for %s",
+                model_folder,
+            )
+            return NumpyImageProcessor.from_config_file(preprocessor_config)
         except Exception as exc:
             raise RuntimeError(
                 f"Failed to load image processor from {model_folder}: {exc}"

--- a/docling/models/plugins/defaults.py
+++ b/docling/models/plugins/defaults.py
@@ -1,4 +1,21 @@
-def ocr_engines():
+from __future__ import annotations
+
+from contextlib import suppress
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    # Experimental table crops layout models
+    from docling.experimental.models.table_crops_layout_model import (
+        TableCropsLayoutModel,
+    )
+
+    # Layout models
+    from docling.models.stages.layout.layout_model import LayoutModel
+    from docling.models.stages.layout.layout_object_detection_model import (
+        LayoutObjectDetectionModel,
+    )
+
+    # OCR models
     from docling.models.stages.ocr.auto_ocr_model import OcrAutoModel
     from docling.models.stages.ocr.easyocr_model import EasyOcrModel
     from docling.models.stages.ocr.kserve_v2_ocr_model import KserveV2OcrModel
@@ -7,25 +24,11 @@ def ocr_engines():
     from docling.models.stages.ocr.rapid_ocr_model import RapidOcrModel
     from docling.models.stages.ocr.tesseract_ocr_cli_model import TesseractOcrCliModel
     from docling.models.stages.ocr.tesseract_ocr_model import TesseractOcrModel
-
-    return {
-        "ocr_engines": [
-            OcrAutoModel,
-            EasyOcrModel,
-            KserveV2OcrModel,
-            NemotronOcrModel,
-            OcrMacModel,
-            RapidOcrModel,
-            TesseractOcrModel,
-            TesseractOcrCliModel,
-        ]
-    }
-
-
-def picture_description():
     from docling.models.stages.picture_description.picture_description_api_model import (
         PictureDescriptionApiModel,
     )
+
+    # Picture description models
     from docling.models.stages.picture_description.picture_description_vlm_engine_model import (
         PictureDescriptionVlmEngineModel,
     )
@@ -33,34 +36,7 @@ def picture_description():
         PictureDescriptionVlmModel,
     )
 
-    return {
-        "picture_description": [
-            PictureDescriptionVlmEngineModel,  # New engine-based (preferred)
-            PictureDescriptionVlmModel,  # Legacy direct transformers
-            PictureDescriptionApiModel,  # API-based
-        ]
-    }
-
-
-def layout_engines():
-    from docling.experimental.models.table_crops_layout_model import (
-        TableCropsLayoutModel,
-    )
-    from docling.models.stages.layout.layout_model import LayoutModel
-    from docling.models.stages.layout.layout_object_detection_model import (
-        LayoutObjectDetectionModel,
-    )
-
-    return {
-        "layout_engines": [
-            LayoutObjectDetectionModel,
-            LayoutModel,
-            TableCropsLayoutModel,
-        ]
-    }
-
-
-def table_structure_engines():
+    # Table structure models
     from docling.models.stages.table_structure.table_structure_model import (
         TableStructureModel,
     )
@@ -71,10 +47,137 @@ def table_structure_engines():
         TableStructureModelV2,
     )
 
-    return {
-        "table_structure_engines": [
+
+def ocr_engines():
+    engines: list[
+        type[OcrAutoModel]
+        | type[EasyOcrModel]
+        | type[KserveV2OcrModel]
+        | type[NemotronOcrModel]
+        | type[OcrMacModel]
+        | type[RapidOcrModel]
+        | type[TesseractOcrModel]
+        | type[TesseractOcrCliModel]
+    ] = []
+
+    with suppress(ImportError):
+        from docling.models.stages.ocr.auto_ocr_model import OcrAutoModel
+
+        engines.append(OcrAutoModel)
+    with suppress(ImportError):
+        from docling.models.stages.ocr.easyocr_model import EasyOcrModel
+
+        engines.append(EasyOcrModel)
+    with suppress(ImportError):
+        from docling.models.stages.ocr.kserve_v2_ocr_model import KserveV2OcrModel
+
+        engines.append(KserveV2OcrModel)
+    with suppress(ImportError):
+        from docling.models.stages.ocr.nemotron_ocr_model import NemotronOcrModel
+
+        engines.append(NemotronOcrModel)
+    with suppress(ImportError):
+        from docling.models.stages.ocr.ocr_mac_model import OcrMacModel
+
+        engines.append(OcrMacModel)
+    with suppress(ImportError):
+        from docling.models.stages.ocr.rapid_ocr_model import RapidOcrModel
+
+        engines.append(RapidOcrModel)
+    with suppress(ImportError):
+        from docling.models.stages.ocr.tesseract_ocr_model import TesseractOcrModel
+
+        engines.append(TesseractOcrModel)
+    with suppress(ImportError):
+        from docling.models.stages.ocr.tesseract_ocr_cli_model import (
+            TesseractOcrCliModel,
+        )
+
+        engines.append(TesseractOcrCliModel)
+
+    return {"ocr_engines": engines}
+
+
+def picture_description():
+    engines: list[
+        type[PictureDescriptionVlmEngineModel]
+        | type[PictureDescriptionVlmModel]
+        | type[PictureDescriptionApiModel]
+    ] = []
+
+    with suppress(ImportError):
+        from docling.models.stages.picture_description.picture_description_vlm_engine_model import (
+            PictureDescriptionVlmEngineModel,
+        )
+
+        engines.append(PictureDescriptionVlmEngineModel)  # New engine-based (preferred)
+    with suppress(ImportError):
+        from docling.models.stages.picture_description.picture_description_vlm_model import (
+            PictureDescriptionVlmModel,
+        )
+
+        engines.append(PictureDescriptionVlmModel)  # Legacy direct transformers
+    with suppress(ImportError):
+        from docling.models.stages.picture_description.picture_description_api_model import (
+            PictureDescriptionApiModel,
+        )
+
+        engines.append(PictureDescriptionApiModel)  # API-based
+
+    return {"picture_description": engines}
+
+
+def layout_engines():
+    engines: list[
+        type[LayoutObjectDetectionModel]
+        | type[LayoutModel]
+        | type[TableCropsLayoutModel]
+    ] = []
+
+    with suppress(ImportError):
+        from docling.models.stages.layout.layout_object_detection_model import (
+            LayoutObjectDetectionModel,
+        )
+
+        engines.append(LayoutObjectDetectionModel)
+    with suppress(ImportError):
+        from docling.models.stages.layout.layout_model import LayoutModel
+
+        engines.append(LayoutModel)
+    with suppress(ImportError):
+        from docling.experimental.models.table_crops_layout_model import (
+            TableCropsLayoutModel,
+        )
+
+        engines.append(TableCropsLayoutModel)
+
+    return {"layout_engines": engines}
+
+
+def table_structure_engines():
+    engines: list[
+        type[TableStructureModel]
+        | type[TableStructureModelV2]
+        | type[GraniteVisionTableStructureModel]
+    ] = []
+
+    with suppress(ImportError):
+        from docling.models.stages.table_structure.table_structure_model import (
             TableStructureModel,
+        )
+
+        engines.append(TableStructureModel)
+    with suppress(ImportError):
+        from docling.models.stages.table_structure.table_structure_model_v2 import (
             TableStructureModelV2,
+        )
+
+        engines.append(TableStructureModelV2)
+    with suppress(ImportError):
+        from docling.models.stages.table_structure.table_structure_model_granite_vision import (
             GraniteVisionTableStructureModel,
-        ]
-    }
+        )
+
+        engines.append(GraniteVisionTableStructureModel)
+
+    return {"table_structure_engines": engines}

--- a/docling/models/stages/chart_extraction/granite_vision.py
+++ b/docling/models/stages/chart_extraction/granite_vision.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Any, List, Literal, Optional, cast
 
 import pandas as pd
-import torch
 from docling_core.types.doc import (
     CodeLanguageLabel,
     DescriptionMetaField,
@@ -24,7 +23,6 @@ from docling_core.types.doc import (
 from docling_core.types.doc.document import CodeMetaField
 from PIL import Image
 from pydantic import BaseModel
-from transformers import AutoModelForImageTextToText, AutoProcessor
 
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
 from docling.datamodel.base_models import ItemAndImageEnrichmentElement
@@ -200,6 +198,8 @@ class ChartExtractionModelGraniteVision(_BaseChartExtractionModelGraniteVision):
     _model_repo_revision = "6e1fbaae4604ecc85f4f371416d82154ca49ad67"
 
     def _load_model(self, artifacts_path: Path) -> None:
+        from transformers import AutoModelForImageTextToText, AutoProcessor
+
         self._processor = AutoProcessor.from_pretrained(
             artifacts_path,
             trust_remote_code=True,
@@ -346,6 +346,9 @@ class ChartExtractionModelGraniteVisionV4(_BaseChartExtractionModelGraniteVision
     _model_repo_revision = "dd48e97503de471803850df70843cf9eb5da8712"
 
     def _load_model(self, artifacts_path: Path) -> None:
+        import torch
+        from transformers import AutoModelForImageTextToText, AutoProcessor
+
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -12,14 +12,76 @@ from docling_core.types.doc import (
     TableData,
 )
 from docling_core.types.doc.document import ContentLayer
-from docling_ibm_models.list_item_normalizer.list_marker_processor import (
-    ListItemMarkerProcessor,
-)
-from docling_ibm_models.reading_order.reading_order_rb import (
-    PageElement as ReadingOrderPageElement,
-    ReadingOrderPredictor,
-)
 from pydantic import BaseModel, ConfigDict
+
+try:
+    from docling_ibm_models.list_item_normalizer.list_marker_processor import (
+        ListItemMarkerProcessor,
+    )
+    from docling_ibm_models.reading_order.reading_order_rb import (
+        PageElement as ReadingOrderPageElement,
+        ReadingOrderPredictor,
+    )
+except ImportError:
+    # The rule-based reading-order model and list-marker normalization are absent,
+    # the reading order falls back to a geometric sort (top-to-bottom, left-to-right — the same
+    # ordering the rule-based PageElement uses as its primitive) and list items are left
+    # unchanged. Caption/footnote/merge association is skipped.
+    import logging as _logging
+
+    from docling_core.types.doc.base import BoundingBox, Size
+    from docling_core.types.doc.document import RefItem
+    from docling_core.types.doc.labels import DocItemLabel
+
+    _logging.getLogger(__name__).warning(
+        "docling-ibm-models is not installed; using a torch-free geometric reading-order "
+        "fallback (rule-based reading order + list-item normalization disabled)."
+    )
+
+    class ReadingOrderPageElement(
+        BoundingBox
+    ):  # torch-free stand-in for the rule-based PageElement
+        eps: float = 1.0e-3
+        cid: int
+        # Always supplied at construction, so no default is needed.
+        ref: RefItem
+        text: str = ""
+        page_no: int
+        page_size: Size
+        label: DocItemLabel
+
+        def __lt__(self, other: "ReadingOrderPageElement") -> bool:
+            if self.page_no == other.page_no:
+                if self.overlaps_horizontally(other):
+                    return self.b > other.b
+                return self.l < other.l
+            return self.page_no < other.page_no
+
+    class ReadingOrderPredictor:  # torch-free geometric fallback
+        def predict_reading_order(
+            self, page_elements: list["ReadingOrderPageElement"]
+        ) -> list["ReadingOrderPageElement"]:
+            return sorted(page_elements)
+
+        def predict_to_captions(
+            self, sorted_elements: list["ReadingOrderPageElement"]
+        ) -> dict[int, list[int]]:
+            return {}
+
+        def predict_to_footnotes(
+            self, sorted_elements: list["ReadingOrderPageElement"]
+        ) -> dict[int, list[int]]:
+            return {}
+
+        def predict_merges(
+            self, sorted_elements: list["ReadingOrderPageElement"]
+        ) -> dict[int, list[int]]:
+            return {}
+
+    class ListItemMarkerProcessor:  # torch-free no-op
+        def process_list_item(self, list_item):
+            return list_item
+
 
 from docling.datamodel.base_models import (
     BasePageElement,

--- a/docling/utils/accelerator_utils.py
+++ b/docling/utils/accelerator_utils.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import suppress
 from typing import List, Optional
 
 from docling.datamodel.accelerator_options import AcceleratorDevice
@@ -17,13 +18,20 @@ def decide_device(
     1. AUTO: Check for the best available device on the system.
     2. User-defined: Check if the device actually exists, otherwise fall-back to CPU
     """
-    import torch
+    has_torch = False
+    with suppress(ImportError):
+        import torch
+
+        has_torch = True
 
     device = "cpu"
 
-    has_cuda = torch.backends.cuda.is_built() and torch.cuda.is_available()
-    has_mps = torch.backends.mps.is_built() and torch.backends.mps.is_available()
-    has_xpu = hasattr(torch, "xpu") and torch.xpu.is_available()
+    if has_torch:
+        has_cuda = torch.backends.cuda.is_built() and torch.cuda.is_available()
+        has_mps = torch.backends.mps.is_built() and torch.backends.mps.is_available()
+        has_xpu = hasattr(torch, "xpu") and torch.xpu.is_available()
+    else:
+        has_cuda = has_mps = has_xpu = False
 
     if supported_devices is not None:
         if has_cuda and AcceleratorDevice.CUDA not in supported_devices:

--- a/tests/test_numpy_image_processor.py
+++ b/tests/test_numpy_image_processor.py
@@ -1,0 +1,191 @@
+"""Unit tests for the torch-free ``NumpyImageProcessor`` preprocessing fallback."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from docling.models.inference_engines.common.hf_vision_base import NumpyImageProcessor
+
+# Default rescale factor used by transformers image processors (1/255).
+_DEFAULT_RESCALE = 1.0 / 255.0
+
+
+def _uniform_rgb(width: int, height: int, color: tuple[int, int, int]) -> Image.Image:
+    return Image.new("RGB", (width, height), color)
+
+
+def test_call_returns_channel_first_batch_and_resizes() -> None:
+    """A single image is resized and returned as a (N, C, H, W) float/uint batch."""
+    proc = NumpyImageProcessor({"do_resize": True, "size": {"height": 32, "width": 48}})
+    # PIL size is (width, height); start from a non-target shape.
+    out = proc(_uniform_rgb(20, 10, (10, 20, 30)))
+
+    pixel_values = out["pixel_values"]
+    assert pixel_values.shape == (1, 3, 32, 48)
+    assert pixel_values.dtype == np.uint8
+    # Uniform input stays uniform through resize; channels preserved per-plane.
+    assert np.array_equal(np.unique(pixel_values[0, 0]), np.array([10]))
+    assert np.array_equal(np.unique(pixel_values[0, 1]), np.array([20]))
+    assert np.array_equal(np.unique(pixel_values[0, 2]), np.array([30]))
+
+
+def test_call_without_resize_preserves_dimensions() -> None:
+    proc = NumpyImageProcessor({"do_resize": False})
+    out = proc(_uniform_rgb(20, 10, (1, 2, 3)))
+    # (width=20, height=10) -> (N, C, H, W) = (1, 3, 10, 20)
+    assert out["pixel_values"].shape == (1, 3, 10, 20)
+
+
+def test_do_resize_without_size_is_noop() -> None:
+    """do_resize is honored only when a resolvable target size is present."""
+    proc = NumpyImageProcessor({"do_resize": True})
+    out = proc(_uniform_rgb(16, 8, (0, 0, 0)))
+    assert out["pixel_values"].shape == (1, 3, 8, 16)
+
+
+def test_list_and_tuple_inputs_are_stacked_into_batch() -> None:
+    proc = NumpyImageProcessor({"do_resize": True, "size": {"height": 4, "width": 4}})
+    images = [_uniform_rgb(6, 6, (5, 5, 5)) for _ in range(3)]
+    assert proc(images)["pixel_values"].shape == (3, 3, 4, 4)
+    assert proc(tuple(images))["pixel_values"].shape == (3, 3, 4, 4)
+
+
+@pytest.mark.parametrize("mode", ["L", "RGBA", "P", "CMYK"])
+def test_non_rgb_inputs_are_converted_to_three_channels(mode: str) -> None:
+    proc = NumpyImageProcessor({"do_resize": False})
+    out = proc(Image.new(mode, (4, 3)))
+    assert out["pixel_values"].shape == (1, 3, 3, 4)
+
+
+def test_rescale_produces_float32_and_scales_values() -> None:
+    proc = NumpyImageProcessor({"do_rescale": True, "rescale_factor": _DEFAULT_RESCALE})
+    out = proc(_uniform_rgb(4, 4, (255, 255, 255)))
+    pixel_values = out["pixel_values"]
+    assert pixel_values.dtype == np.float32
+    np.testing.assert_allclose(pixel_values, 1.0, rtol=0, atol=1e-6)
+
+
+def test_normalize_applies_mean_and_std_per_channel() -> None:
+    proc = NumpyImageProcessor(
+        {
+            "do_rescale": True,
+            "rescale_factor": _DEFAULT_RESCALE,
+            "do_normalize": True,
+            "image_mean": [0.5, 0.5, 0.5],
+            "image_std": [0.5, 0.5, 0.5],
+        }
+    )
+    # 255 -> rescale 1.0 -> normalize (1.0 - 0.5) / 0.5 = 1.0
+    white = proc(_uniform_rgb(2, 2, (255, 255, 255)))["pixel_values"]
+    np.testing.assert_allclose(white, 1.0, rtol=0, atol=1e-6)
+    # 0 -> rescale 0.0 -> normalize (0.0 - 0.5) / 0.5 = -1.0
+    black = proc(_uniform_rgb(2, 2, (0, 0, 0)))["pixel_values"]
+    np.testing.assert_allclose(black, -1.0, rtol=0, atol=1e-6)
+
+
+def test_normalize_uses_distinct_per_channel_statistics() -> None:
+    proc = NumpyImageProcessor(
+        {
+            "do_rescale": False,
+            "do_normalize": True,
+            "image_mean": [10.0, 20.0, 30.0],
+            "image_std": [2.0, 4.0, 5.0],
+        }
+    )
+    out = proc(_uniform_rgb(2, 2, (10, 40, 5)))["pixel_values"]
+    # channel 0: (10-10)/2 = 0 ; channel 1: (40-20)/4 = 5 ; channel 2: (5-30)/5 = -5
+    np.testing.assert_allclose(out[0, 0], 0.0, atol=1e-6)
+    np.testing.assert_allclose(out[0, 1], 5.0, atol=1e-6)
+    np.testing.assert_allclose(out[0, 2], -5.0, atol=1e-6)
+
+
+def test_normalize_skipped_when_mean_or_std_missing() -> None:
+    """Normalization requires both mean and std; otherwise it is skipped."""
+    proc = NumpyImageProcessor(
+        {"do_rescale": True, "do_normalize": True, "image_mean": [0.5, 0.5, 0.5]}
+    )
+    out = proc(_uniform_rgb(2, 2, (255, 255, 255)))["pixel_values"]
+    # Only rescale applied (1.0), no normalization since image_std is absent.
+    np.testing.assert_allclose(out, 1.0, atol=1e-6)
+
+
+def test_no_rescale_or_normalize_keeps_uint8_original_values() -> None:
+    proc = NumpyImageProcessor({"do_resize": False})
+    out = proc(_uniform_rgb(3, 3, (7, 8, 9)))["pixel_values"]
+    assert out.dtype == np.uint8
+    assert out[0, 0].tolist() == [[7, 7, 7], [7, 7, 7], [7, 7, 7]]
+    assert out[0, 1].tolist() == [[8, 8, 8], [8, 8, 8], [8, 8, 8]]
+    assert out[0, 2].tolist() == [[9, 9, 9], [9, 9, 9], [9, 9, 9]]
+
+
+def test_pixel_values_are_contiguous() -> None:
+    proc = NumpyImageProcessor({"do_resize": False})
+    out = proc(_uniform_rgb(4, 5, (1, 1, 1)))["pixel_values"]
+    assert out.flags["C_CONTIGUOUS"]
+
+
+@pytest.mark.parametrize(
+    ("size", "expected"),
+    [
+        ({"height": 32, "width": 48}, (32, 48)),
+        ({"shortest_edge": 64}, (64, 64)),
+        ({"longest_edge": 100}, (100, 100)),
+        ({"shortest_edge": 64, "longest_edge": 100}, (64, 64)),
+        ({}, None),
+        (None, None),
+    ],
+)
+def test_target_hw_resolution(
+    size: dict[str, int] | None, expected: tuple[int, int] | None
+) -> None:
+    proc = NumpyImageProcessor({"size": size} if size is not None else {})
+    assert proc._target_hw() == expected
+
+
+def test_defaults_when_config_is_empty() -> None:
+    proc = NumpyImageProcessor({})
+    assert proc.do_resize is False
+    assert proc.do_rescale is False
+    assert proc.do_normalize is False
+    assert proc.rescale_factor == pytest.approx(_DEFAULT_RESCALE)
+    assert proc.resample is Image.Resampling.BILINEAR
+
+
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [
+        (0, Image.Resampling.NEAREST),
+        (1, Image.Resampling.LANCZOS),
+        (2, Image.Resampling.BILINEAR),
+        (3, Image.Resampling.BICUBIC),
+        (4, Image.Resampling.BOX),
+        (5, Image.Resampling.HAMMING),
+        (99, Image.Resampling.BILINEAR),  # unknown code falls back to bilinear
+    ],
+)
+def test_resample_code_mapping(code: int, expected: Image.Resampling) -> None:
+    assert NumpyImageProcessor({"resample": code}).resample is expected
+
+
+def test_from_config_file_reads_json(tmp_path: Path) -> None:
+    config: dict[str, Any] = {
+        "do_resize": True,
+        "size": {"height": 640, "width": 640},
+        "do_rescale": True,
+        "rescale_factor": _DEFAULT_RESCALE,
+        "resample": 3,
+    }
+    config_path = tmp_path / "preprocessor_config.json"
+    config_path.write_text(json.dumps(config), encoding="utf-8")
+
+    proc = NumpyImageProcessor.from_config_file(config_path)
+    assert proc.do_resize is True
+    assert proc._target_hw() == (640, 640)
+    assert proc.do_rescale is True
+    assert proc.resample is Image.Resampling.BICUBIC

--- a/tests/test_reading_order_fallback.py
+++ b/tests/test_reading_order_fallback.py
@@ -1,0 +1,116 @@
+"""Unit tests for the torch-free reading-order fallback (used when docling-ibm-models is absent)."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from collections.abc import Iterator
+from types import ModuleType
+from typing import Any
+
+import pytest
+from docling_core.types.doc import DocItemLabel
+from docling_core.types.doc.base import CoordOrigin, Size
+from docling_core.types.doc.document import RefItem
+
+_MODULE = "docling.models.stages.reading_order.readingorder_model"
+
+
+@pytest.fixture
+def fallback_module(monkeypatch: pytest.MonkeyPatch) -> Iterator[ModuleType]:
+    """Reimport the reading-order module with docling-ibm-models unavailable.
+
+    Setting the package (and any loaded submodules) to ``None`` in ``sys.modules`` makes
+    ``import docling_ibm_models...`` raise ``ImportError``, so the module binds its torch-free
+    fallbacks (geometric reading order + no-op list processing). The original module object is
+    restored on teardown so other tests keep the real implementation.
+    """
+    original = sys.modules.get(_MODULE)
+    blocked = [
+        name
+        for name in list(sys.modules)
+        if name == "docling_ibm_models" or name.startswith("docling_ibm_models.")
+    ]
+    for name in blocked:
+        monkeypatch.setitem(sys.modules, name, None)
+    monkeypatch.setitem(sys.modules, "docling_ibm_models", None)
+    monkeypatch.delitem(sys.modules, _MODULE, raising=False)
+
+    module = importlib.import_module(_MODULE)
+    yield module
+
+    if original is not None:
+        sys.modules[_MODULE] = original
+    else:
+        sys.modules.pop(_MODULE, None)
+
+
+def _element(
+    module: ModuleType,
+    *,
+    cid: int,
+    left: float,
+    right: float,
+    bottom: float,
+    top: float,
+    page_no: int = 0,
+) -> Any:
+    return module.ReadingOrderPageElement(
+        cid=cid,
+        ref=RefItem.model_validate({"$ref": f"#/{cid}"}),
+        text="",
+        page_no=page_no,
+        page_size=Size(width=100.0, height=100.0),
+        label=DocItemLabel.TEXT,
+        l=left,
+        r=right,
+        b=bottom,
+        t=top,
+        coord_origin=CoordOrigin.BOTTOMLEFT,
+    )
+
+
+def test_fallback_orders_top_to_bottom(fallback_module: ModuleType) -> None:
+    """Horizontally overlapping elements sort top-first (higher bottom-left ``b``)."""
+    upper = _element(fallback_module, cid=0, left=0, right=50, bottom=80, top=90)
+    lower = _element(fallback_module, cid=1, left=0, right=50, bottom=10, top=20)
+    ordered = fallback_module.ReadingOrderPredictor().predict_reading_order(
+        [lower, upper]
+    )
+    assert [element.cid for element in ordered] == [0, 1]
+
+
+def test_fallback_orders_left_to_right(fallback_module: ModuleType) -> None:
+    """Horizontally disjoint elements sort left-first."""
+    left = _element(fallback_module, cid=0, left=0, right=40, bottom=10, top=20)
+    right = _element(fallback_module, cid=1, left=60, right=100, bottom=10, top=20)
+    ordered = fallback_module.ReadingOrderPredictor().predict_reading_order(
+        [right, left]
+    )
+    assert [element.cid for element in ordered] == [0, 1]
+
+
+def test_fallback_association_maps_are_empty(fallback_module: ModuleType) -> None:
+    """Caption/footnote/merge association is skipped in the torch-free fallback."""
+    predictor = fallback_module.ReadingOrderPredictor()
+    elements = [_element(fallback_module, cid=0, left=0, right=10, bottom=0, top=10)]
+    assert predictor.predict_to_captions(elements) == {}
+    assert predictor.predict_to_footnotes(elements) == {}
+    assert predictor.predict_merges(elements) == {}
+
+
+def test_fallback_list_item_processor_is_noop(fallback_module: ModuleType) -> None:
+    sentinel = object()
+    assert (
+        fallback_module.ListItemMarkerProcessor().process_list_item(sentinel)
+        is sentinel
+    )
+
+
+def test_fallback_is_active_without_docling_ibm_models(
+    fallback_module: ModuleType,
+) -> None:
+    """The fixture blocks docling-ibm-models, so the bound classes are the local stand-ins."""
+    assert sys.modules["docling_ibm_models"] is None
+    assert type(fallback_module.ReadingOrderPredictor()).__module__ == _MODULE
+    assert fallback_module.ReadingOrderPageElement.__module__ == _MODULE


### PR DESCRIPTION
This makes it possible to load docling with ONNX without needing torch/transformer deps:

- Moved the module-level torch and transformers imports down into the load methods.
- Fixed device selection to gracefully fall back to CPU when torch isn't around
- Wrapped engine registration in a guarded loader. If an optional backend (like TableFormer v2) is missing, we just skip it now instead of crashing the factory setup.
- Added a numpy image processor fallback for ONNX. This handles the RT-DETR layout presets without needing torch. Output is identical to the transformers version.


**Checklist:**

- [ ] Documentation has been updated, if necessary.  N/A
- [ ] Examples have been added, if necessary. N/A
- [x] Tests have been added, if necessary. 
