### PR TITLE
fix: import pypdfium2 lazily to keep service client importable on slim installs

### DIFF
--- a/docling/utils/pdf_outline.py
+++ b/docling/utils/pdf_outline.py
@@ -13,16 +13,18 @@ extractors are provided so each backend uses its own native capability:
 from __future__ import annotations
 
 import logging
+from functools import cache
 from typing import TYPE_CHECKING
 
-import pypdfium2 as pdfium
-import pypdfium2.raw as pdfium_c
 from pydantic import BaseModel
-from pypdfium2._helpers.misc import PdfiumError
 
 from docling.utils.locks import pypdfium2_lock
 
+# pypdfium2 must only be imported lazily here: ``datamodel.document`` imports this module
+# for ``_PdfOutlineItem``, putting it on the ``docling.service_client`` import chain, which
+# has to stay importable under docling-slim[service-client] (no PDF backend installed).
 if TYPE_CHECKING:
+    import pypdfium2 as pdfium
     from docling_parse.pdf_parser import (
         PdfDocument as DoclingParsePdfDocument,
         PdfTableOfContents,
@@ -49,15 +51,22 @@ class _PdfOutlineItem(BaseModel):
     y_top: float | None = None
 
 
-# Destination view modes whose coordinates carry a usable vertical (top) position, mapped to
-# the index of that coordinate within the position tuple. Coordinates are in PDF space
-# (bottom-left origin). Modes not listed (FIT, FITV, FITB, FITBV, unknown) provide no top.
-_VIEW_TOP_INDEX = {
-    pdfium_c.PDFDEST_VIEW_XYZ: 1,  # [x, y, zoom]
-    pdfium_c.PDFDEST_VIEW_FITH: 0,  # [y]
-    pdfium_c.PDFDEST_VIEW_FITBH: 0,  # [y]
-    pdfium_c.PDFDEST_VIEW_FITR: 3,  # [left, bottom, right, top]
-}
+@cache
+def _view_top_index() -> dict[int, int]:
+    """Destination view modes whose coordinates carry a usable vertical (top) position.
+
+    Maps each mode to the index of that coordinate within the position tuple. Coordinates are
+    in PDF space (bottom-left origin). Modes not listed (FIT, FITV, FITB, FITBV, unknown)
+    provide no top.
+    """
+    import pypdfium2.raw as pdfium_c
+
+    return {
+        pdfium_c.PDFDEST_VIEW_XYZ: 1,  # [x, y, zoom]
+        pdfium_c.PDFDEST_VIEW_FITH: 0,  # [y]
+        pdfium_c.PDFDEST_VIEW_FITBH: 0,  # [y]
+        pdfium_c.PDFDEST_VIEW_FITR: 3,  # [left, bottom, right, top]
+    }
 
 
 def _dest_top_pdf(dest: pdfium.PdfDest) -> tuple[int | None, float | None]:
@@ -67,7 +76,7 @@ def _dest_top_pdf(dest: pdfium.PdfDest) -> tuple[int | None, float | None]:
     """
     page_index = dest.get_index()
     mode, pos = dest.get_view()
-    idx = _VIEW_TOP_INDEX.get(mode)
+    idx = _view_top_index().get(mode)
     y_pdf = pos[idx] if idx is not None and idx < len(pos) else None
     return page_index, y_pdf
 
@@ -79,6 +88,8 @@ def extract_outline_from_pdfium(pdoc: pdfium.PdfDocument) -> list[_PdfOutlineIte
     the target page height. Returns an empty list when the document has no outline or it cannot
     be read.
     """
+    from pypdfium2._helpers.misc import PdfiumError
+
     items: list[_PdfOutlineItem] = []
     page_heights: dict[int, float] = {}
 

--- a/tests/test_service_client_sdk_unit.py
+++ b/tests/test_service_client_sdk_unit.py
@@ -2,7 +2,10 @@ import asyncio
 import io
 import json
 import queue
+import subprocess
+import sys
 import tempfile
+import textwrap
 import threading
 import time
 import warnings
@@ -3881,3 +3884,46 @@ async def test_async_submit_and_retrieve_each_rejects_invalid_max_in_flight(
                 target=InBodyTarget(),
             ):
                 pass
+
+
+def test_service_client_imports_without_local_conversion_deps() -> None:
+    """The client import chain must resolve under docling-slim[service-client].
+
+    That install profile ships no PDF-backend or local-model packages, so
+    importing ``docling.service_client`` must not touch them at module level.
+    Regression guard: docling-slim 2.109.0 broke this via a module-level
+    ``import pypdfium2`` in ``docling.utils.pdf_outline``, reached through
+    ``noop_backend -> datamodel.document``.
+    """
+    script = textwrap.dedent(
+        """
+        import sys
+
+        BLOCKED = ("pypdfium2", "docling_parse", "torch", "torchvision")
+
+
+        class _BlockLocalConversionDeps:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname.partition(".")[0] in BLOCKED:
+                    raise ModuleNotFoundError(
+                        f"import of {fullname!r} blocked: not installed under "
+                        "docling-slim[service-client]"
+                    )
+                return None
+
+
+        sys.meta_path.insert(0, _BlockLocalConversionDeps())
+
+        import docling.service_client
+        import docling.datamodel.service.options
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"docling.service_client import requires a blocked package:\n{result.stderr}"
+    )


### PR DESCRIPTION
Since 2.109.0, `import docling.service_client` fails with `ModuleNotFoundError: No module named 'pypdfium2'` under a `docling-slim[service-client]` install (the documented light profile for remote-only use — httpx + websockets, no PDF backend).

Root cause: `docling.utils.pdf_outline` imports pypdfium2 at module level, and the module sits on the service-client import chain — `docling.service_client` → `_async_client` → `backend.noop_backend` → `datamodel.document`, which imports it only for the `_PdfOutlineItem` model. 2.108.0 (before `pdf_outline` existed) imports fine; 2.109.0–2.112.0 are broken. Full `docling` installs are unaffected (pypdfium2 is always present there).

This PR defers the pypdfium2 imports into the pdfium-specific extractor paths (`_view_top_index()` helper + function-level `PdfiumError` import) and leaves the shared `_PdfOutlineItem` model import-safe. No behavior change for PDF conversion.

Verification:
- New regression test blocks `pypdfium2`/`docling_parse`/`torch` imports in a subprocess and asserts the client import surface resolves (fails on current `main`, passes with the fix).
- Fixed file dropped into a clean `docling-slim[service-client]==2.112.0` venv: `DoclingServiceClient`, exceptions, and `ConvertDocumentsOptions` all import.
- `tests/test_service_client_sdk_unit.py` (140) and `tests/test_heading_hierarchy_bookmarks.py` (11 passed, 2 pre-existing reportlab skips) pass locally.

**Checklist:**

- [x] Documentation has been updated, if necessary. *(not necessary — restores documented behavior)*
- [x] Examples have been added, if necessary. *(not necessary)*
- [x] Tests have been added, if necessary.