### PR TITLE
feat(service): Expose GCS, Azure Blob, and Google Drive source/target types

### DIFF
--- a/docling/datamodel/service/__init__.py
+++ b/docling/datamodel/service/__init__.py
@@ -25,6 +25,7 @@ from docling.datamodel.service.options import (
 )
 from docling.datamodel.service.requests import (
     AnyHttpSourceRequest,
+    AzureBlobSourceRequest,
     BaseChunkDocumentsRequest,
     BatchConvertSourcesRequest,
     BatchSourceRequestItem,
@@ -33,6 +34,8 @@ from docling.datamodel.service.requests import (
     ConvertSourcesRequest,
     FileSourceRequest,
     GenericChunkDocumentsRequest,
+    GoogleCloudStorageSourceRequest,
+    GoogleDriveSourceRequest,
     HttpSourceRequest,
     S3SourceRequest,
     SourceRequestItem,
@@ -68,8 +71,20 @@ from docling.datamodel.service.responses import (
     WebsocketMessage,
     ZipArchiveResult,
 )
-from docling.datamodel.service.sources import FileSource, HttpSource, S3Coordinates
+from docling.datamodel.service.sources import (
+    AzureBlobCoordinates,
+    FileSource,
+    GoogleCloudStorageCoordinates,
+    GoogleCloudStorageServiceAccountInfo,
+    GoogleDriveCoordinates,
+    GoogleDriveCredentials,
+    HttpSource,
+    S3Coordinates,
+)
 from docling.datamodel.service.targets import (
+    AzureBlobTarget,
+    GoogleCloudStorageTarget,
+    GoogleDriveTarget,
     InBodyTarget,
     PresignedUrlTarget,
     PutTarget,
@@ -82,6 +97,9 @@ from docling.datamodel.service.tasks import TaskProcessingMeta, TaskType
 __all__ = [
     "AnyHttpSourceRequest",
     "ArtifactRef",
+    "AzureBlobCoordinates",
+    "AzureBlobSourceRequest",
+    "AzureBlobTarget",
     "BaseChunkDocumentsRequest",
     "BaseChunkerOptions",
     "BaseProgress",
@@ -110,6 +128,14 @@ __all__ = [
     "FileSource",
     "FileSourceRequest",
     "GenericChunkDocumentsRequest",
+    "GoogleCloudStorageCoordinates",
+    "GoogleCloudStorageServiceAccountInfo",
+    "GoogleCloudStorageSourceRequest",
+    "GoogleCloudStorageTarget",
+    "GoogleDriveCoordinates",
+    "GoogleDriveCredentials",
+    "GoogleDriveSourceRequest",
+    "GoogleDriveTarget",
     "HealthCheckResponse",
     "HierarchicalChunkerOptions",
     "HttpSource",

--- a/docling/datamodel/service/requests.py
+++ b/docling/datamodel/service/requests.py
@@ -10,8 +10,18 @@ from docling.datamodel.service.chunking import (
     BaseChunkerOptions,
 )
 from docling.datamodel.service.options import ConvertDocumentsOptions
-from docling.datamodel.service.sources import FileSource, HttpSource, S3Coordinates
+from docling.datamodel.service.sources import (
+    AzureBlobCoordinates,
+    FileSource,
+    GoogleCloudStorageCoordinates,
+    GoogleDriveCoordinates,
+    HttpSource,
+    S3Coordinates,
+)
 from docling.datamodel.service.targets import (
+    AzureBlobTarget,
+    GoogleCloudStorageTarget,
+    GoogleDriveTarget,
     InBodyTarget,
     PresignedUrlTarget,
     PutTarget,
@@ -46,6 +56,18 @@ class S3SourceRequest(S3Coordinates):
     kind: Literal["s3"] = "s3"
 
 
+class AzureBlobSourceRequest(AzureBlobCoordinates):
+    kind: Literal["azure_blob"] = "azure_blob"
+
+
+class GoogleCloudStorageSourceRequest(GoogleCloudStorageCoordinates):
+    kind: Literal["google_cloud_storage"] = "google_cloud_storage"
+
+
+class GoogleDriveSourceRequest(GoogleDriveCoordinates):
+    kind: Literal["google_drive"] = "google_drive"
+
+
 ## Multipart targets
 class TargetName(str, enum.Enum):
     INBODY = InBodyTarget().kind
@@ -55,7 +77,11 @@ class TargetName(str, enum.Enum):
 
 ## Aliases
 BatchSourceRequestItem = Annotated[
-    AnyHttpSourceRequest | S3SourceRequest,
+    AnyHttpSourceRequest
+    | S3SourceRequest
+    | AzureBlobSourceRequest
+    | GoogleCloudStorageSourceRequest
+    | GoogleDriveSourceRequest,
     Field(discriminator="kind"),
 ]
 
@@ -64,12 +90,23 @@ SourceRequestItem = Annotated[
 ]
 
 TargetRequest = Annotated[
-    InBodyTarget | ZipTarget | S3Target | PutTarget | PresignedUrlTarget,
+    InBodyTarget
+    | ZipTarget
+    | S3Target
+    | AzureBlobTarget
+    | GoogleCloudStorageTarget
+    | GoogleDriveTarget
+    | PutTarget
+    | PresignedUrlTarget,
     Field(discriminator="kind"),
 ]
 
 BatchTargetRequest = Annotated[
-    S3Target | PresignedUrlTarget,
+    S3Target
+    | AzureBlobTarget
+    | GoogleCloudStorageTarget
+    | GoogleDriveTarget
+    | PresignedUrlTarget,
     Field(discriminator="kind"),
 ]
 

--- a/docling/datamodel/service/sources.py
+++ b/docling/datamodel/service/sources.py
@@ -1,14 +1,23 @@
 import base64
 from io import BytesIO
-from typing import Annotated
+from typing import Annotated, List, Optional
 
-from pydantic import BaseModel, Field, StrictStr
+from pydantic import BaseModel, Field, HttpUrl, SecretStr, StrictStr
 
 # HttpSource lives in the core datamodel so DocumentConverter can accept it as an
 # input source; re-exported here to keep the service-layer import path stable.
 from docling.datamodel.base_models import DocumentStream, HttpSource
 
-__all__ = ["FileSource", "HttpSource", "S3Coordinates"]
+__all__ = [
+    "AzureBlobCoordinates",
+    "FileSource",
+    "GoogleCloudStorageCoordinates",
+    "GoogleCloudStorageServiceAccountInfo",
+    "GoogleDriveCoordinates",
+    "GoogleDriveCredentials",
+    "HttpSource",
+    "S3Coordinates",
+]
 
 
 class FileSource(BaseModel):
@@ -92,3 +101,280 @@ class S3Coordinates(BaseModel):
             ge=1,
         ),
     ] = None
+
+
+class AzureBlobCoordinates(BaseModel):
+    account_name: Annotated[
+        str,
+        Field(description="Azure Storage account name"),
+    ]
+
+    container: Annotated[
+        str,
+        Field(description="Azure Blob container name"),
+    ]
+
+    connection_string: Annotated[
+        str,
+        Field(description="Azure Storage connection string for authentication"),
+    ]
+
+    blob_prefix: Annotated[
+        str,
+        Field(default="", description="Prefix for blob names"),
+    ] = ""
+
+    max_num_elements: Annotated[
+        int | None,
+        Field(default=None, description="Maximum number of blobs to process"),
+    ] = None
+
+
+class GoogleCloudStorageServiceAccountInfo(BaseModel):
+    project_id: Annotated[
+        StrictStr,
+        Field(
+            description="GCP project ID the service account belongs to.",
+            examples=["my-gcp-project"],
+        ),
+    ]
+
+    private_key_id: Annotated[
+        SecretStr,
+        Field(description="Key ID of the private key.", examples=["2aca9ed8..."]),
+    ]
+
+    private_key: Annotated[
+        SecretStr,
+        Field(
+            description="RSA private key in PEM format.",
+            examples=[
+                "-----BEGIN PRIVATE KEY-----\nMIIEv...\n-----END PRIVATE KEY-----\n"
+            ],
+        ),
+    ]
+
+    client_email: Annotated[
+        SecretStr,
+        Field(
+            description="Service account email address.",
+            examples=["my-sa@my-gcp-project.iam.gserviceaccount.com"],
+        ),
+    ]
+
+    client_id: Annotated[
+        SecretStr,
+        Field(
+            description="Numeric client ID of the service account.",
+            examples=["111274397167470984881"],
+        ),
+    ]
+
+    auth_uri: Annotated[
+        StrictStr,
+        Field(
+            description="OAuth 2.0 authorization endpoint.",
+            examples=["https://accounts.google.com/o/oauth2/auth"],
+        ),
+    ]
+
+    token_uri: Annotated[
+        StrictStr,
+        Field(
+            description="OAuth 2.0 token endpoint.",
+            examples=["https://oauth2.googleapis.com/token"],
+        ),
+    ]
+
+    auth_provider_x509_cert_url: Annotated[
+        StrictStr,
+        Field(
+            description="X.509 certificate URL for the auth provider.",
+            examples=["https://www.googleapis.com/oauth2/v1/certs"],
+        ),
+    ]
+
+    client_x509_cert_url: Annotated[
+        SecretStr,
+        Field(
+            description="X.509 certificate URL for the service account.",
+            examples=["https://www.googleapis.com/robot/v1/metadata/x509/my-sa%40..."],
+        ),
+    ]
+
+    universe_domain: Annotated[
+        StrictStr,
+        Field(
+            description="Google Cloud universe domain.",
+            examples=["googleapis.com"],
+        ),
+    ]
+
+
+class GoogleCloudStorageCoordinates(BaseModel):
+    bucket: Annotated[
+        StrictStr,
+        Field(
+            description="GCS bucket name.",
+            examples=["my-docling-bucket"],
+        ),
+    ]
+
+    key_prefix: Annotated[
+        str,
+        Field(
+            description="Object key prefix for traversal (sources) and output (target); defaults to bucket root.",
+            examples=["incoming/docs/", "processed/"],
+        ),
+    ] = ""
+
+    max_num_elements: Annotated[
+        Optional[int],
+        Field(
+            default=None,
+            description=(
+                "Maximum number of GCS objects to iterate for this source"
+                "Optional, defaults to no limit"
+            ),
+            ge=1,
+        ),
+    ]
+
+    project: Annotated[
+        Optional[StrictStr],
+        Field(
+            default=None,
+            description="GCP project ID. Optional (billing / ADC project).",
+            examples=["my-gcp-project"],
+        ),
+    ] = None
+
+    service_account_key: Annotated[
+        Optional[GoogleCloudStorageServiceAccountInfo],
+        Field(
+            default=None,
+            description=(
+                "Service account credentials. Optional; omit to use Application Default "
+                "Credentials / Workload Identity (e.g. on GKE or Cloud Run).To create a key: "
+                "GCP console -> IAM & Admin -> Service Accounts -> Keys -> Add Key -> JSON "
+                "(the 'type' field is omitted as it is always 'service_account')."
+            ),
+        ),
+    ] = None
+
+
+class GoogleDriveCredentials(BaseModel):
+    client_id: Annotated[
+        StrictStr,
+        Field(
+            description="OAuth 2.0 Client ID issued by Google. Required.",
+        ),
+    ]
+
+    project_id: Annotated[
+        StrictStr,
+        Field(
+            description="Google Cloud project ID associated with the OAuth client. Required.",
+            examples=["docling-test-473014"],
+        ),
+    ]
+
+    auth_uri: Annotated[
+        HttpUrl,
+        Field(
+            description="Authorization endpoint URI. Required.",
+            examples=["https://accounts.google.com/o/oauth2/auth"],
+        ),
+    ]
+
+    token_uri: Annotated[
+        HttpUrl,
+        Field(
+            description="Token endpoint URI. Required.",
+            examples=["https://oauth2.googleapis.com/token"],
+        ),
+    ]
+
+    auth_provider_x509_cert_url: Annotated[
+        HttpUrl,
+        Field(
+            description="Certs URL for Google's OAuth provider. Required.",
+            examples=["https://www.googleapis.com/oauth2/v1/certs"],
+        ),
+    ]
+
+    client_secret: Annotated[
+        SecretStr,
+        Field(
+            description="OAuth 2.0 client secret. Required.",
+        ),
+    ]
+
+    redirect_uris: Annotated[
+        List[HttpUrl],
+        Field(
+            description="OAuth 2.0 redirect URIs. Required.",
+            examples=[["http://localhost"]],
+        ),
+    ]
+
+
+class GoogleDriveCoordinates(BaseModel):
+    path_id: Annotated[
+        StrictStr,
+        Field(
+            description=(
+                "Identifier for a file or folder in Google Drive. It can be obtained from the URL as follows:"
+                "Folder: https://drive.google.com/drive/u/0/folders/1yucgL9WGgWZdM1TOuKkeghlPizuzMYb5 -> folder id is 1yucgL9WGgWZdM1TOuKkeghlPizuzMYb5"
+                "File: https://docs.google.com/document/d/1bfaMQ18_i56204VaQDVeAFpqEijJTgvurupdEDiaUQw/edit -> document id is 1bfaMQ18_i56204VaQDVeAFpqEijJTgvurupdEDiaUQw."
+                "Required."
+            ),
+            examples=[
+                "11hgbUnDr-fyX4Hsi3T2q3xvYimvkOrfN",
+            ],
+        ),
+    ]
+
+    token_path: Annotated[
+        Optional[StrictStr],
+        Field(
+            default=None,
+            description=(
+                "Path to save the OAuth 2.0 access token, which is generated on the fly. One of 'token_path' or 'refresh_token' is required."
+            ),
+            examples=[
+                "./dev/google_drive_token.json",
+            ],
+        ),
+    ]
+
+    refresh_token: Annotated[
+        Optional[StrictStr],
+        Field(
+            default=None,
+            description=(
+                "Refresh token for the OAuth 2.0 access, if already pre-generated. One of 'token_path' or 'refresh_token' is required."
+            ),
+        ),
+    ]
+
+    credentials_path: Annotated[
+        Optional[StrictStr],
+        Field(
+            default=None,
+            description=(
+                "Path to the OAuth 2.0 Client ID credentials (available in Google Cloud console). One of 'credentials_path' or 'credentials' is required."
+            ),
+            examples=[
+                "./dev/google_drive_credentials.json",
+            ],
+        ),
+    ]
+
+    credentials: Annotated[
+        Optional[GoogleDriveCredentials],
+        Field(
+            default=None,
+            description="OAuth 2.0 Client ID' credentials (available in Google Cloud console). One of 'credentials_path' or 'credentials' is required.",
+        ),
+    ]

--- a/docling/datamodel/service/sources.py
+++ b/docling/datamodel/service/sources.py
@@ -2,7 +2,7 @@ import base64
 from io import BytesIO
 from typing import Annotated, List, Optional
 
-from pydantic import BaseModel, Field, HttpUrl, SecretStr, StrictStr
+from pydantic import BaseModel, Field, HttpUrl, SecretStr, StrictStr, model_validator
 
 # HttpSource lives in the core datamodel so DocumentConverter can accept it as an
 # input source; re-exported here to keep the service-layer import path stable.
@@ -378,3 +378,11 @@ class GoogleDriveCoordinates(BaseModel):
             description="OAuth 2.0 Client ID' credentials (available in Google Cloud console). One of 'credentials_path' or 'credentials' is required.",
         ),
     ]
+
+    @model_validator(mode="after")
+    def validate_auth_inputs(self) -> "GoogleDriveCoordinates":
+        if not (self.token_path or self.refresh_token):
+            raise ValueError("One of 'token_path' or 'refresh_token' is required.")
+        if not (self.credentials_path or self.credentials):
+            raise ValueError("One of 'credentials_path' or 'credentials' is required.")
+        return self

--- a/docling/datamodel/service/targets.py
+++ b/docling/datamodel/service/targets.py
@@ -2,7 +2,12 @@ from typing import Annotated, Literal
 
 from pydantic import AnyHttpUrl, BaseModel, Field
 
-from docling.datamodel.service.sources import S3Coordinates
+from docling.datamodel.service.sources import (
+    AzureBlobCoordinates,
+    GoogleCloudStorageCoordinates,
+    GoogleDriveCoordinates,
+    S3Coordinates,
+)
 
 
 class InBodyTarget(BaseModel):
@@ -17,6 +22,18 @@ class S3Target(S3Coordinates):
     kind: Literal["s3"] = "s3"
 
 
+class AzureBlobTarget(AzureBlobCoordinates):
+    kind: Literal["azure_blob"] = "azure_blob"
+
+
+class GoogleCloudStorageTarget(GoogleCloudStorageCoordinates):
+    kind: Literal["google_cloud_storage"] = "google_cloud_storage"
+
+
+class GoogleDriveTarget(GoogleDriveCoordinates):
+    kind: Literal["google_drive"] = "google_drive"
+
+
 class PutTarget(BaseModel):
     kind: Literal["put"] = "put"
     url: AnyHttpUrl
@@ -27,6 +44,13 @@ class PresignedUrlTarget(BaseModel):
 
 
 Target = Annotated[
-    InBodyTarget | ZipTarget | S3Target | PutTarget | PresignedUrlTarget,
+    InBodyTarget
+    | ZipTarget
+    | S3Target
+    | AzureBlobTarget
+    | GoogleCloudStorageTarget
+    | GoogleDriveTarget
+    | PutTarget
+    | PresignedUrlTarget,
     Field(discriminator="kind"),
 ]

--- a/docling/service_client/_async_client.py
+++ b/docling/service_client/_async_client.py
@@ -58,7 +58,6 @@ from docling.datamodel.service.responses import (
 from docling.datamodel.service.targets import (
     InBodyTarget,
     PresignedUrlTarget,
-    S3Target,
     ZipTarget,
 )
 from docling.datamodel.settings import DocumentLimits, PageRange
@@ -73,6 +72,7 @@ from docling.service_client.client import (
     StatusWatcherKind,
     SubmitTarget,
     _BaseDoclingServiceClient,
+    _is_storage_target,
     _ResolvedOptions,
     _SourceDescriptor,
 )
@@ -325,7 +325,7 @@ class AsyncDoclingServiceClient(_BaseDoclingServiceClient):
             request_headers=headers,
         )
 
-        if isinstance(target, S3Target):
+        if _is_storage_target(target):
 
             async def fetch_result(
                 task_id: str,
@@ -401,11 +401,16 @@ class AsyncDoclingServiceClient(_BaseDoclingServiceClient):
         max_in_flight: int = DEFAULT_MAX_CONCURRENCY,
         ordered: bool = False,
         *,
-        target: InBodyTarget | PresignedUrlTarget | None = None,
+        target: SubmitTarget | None = None,
     ) -> AsyncGenerator[
         tuple[
             ConversionItem,
-            ConvertDocumentResponse | PresignedUrlConvertResponse | Exception,
+            (
+                ConvertDocumentResponse
+                | PresignedUrlConvertDocumentResponse
+                | PresignedUrlConvertResponse
+                | Exception
+            ),
         ],
         None,
     ]:
@@ -419,7 +424,11 @@ class AsyncDoclingServiceClient(_BaseDoclingServiceClient):
             _idx: int,
             item: ConversionItem,
             async_client: httpx.AsyncClient,
-        ) -> ConvertDocumentResponse | PresignedUrlConvertResponse:
+        ) -> (
+            ConvertDocumentResponse
+            | PresignedUrlConvertDocumentResponse
+            | PresignedUrlConvertResponse
+        ):
             resolved = self._resolve_options(
                 options=item.options,
                 max_num_pages=None,
@@ -484,7 +493,12 @@ class AsyncDoclingServiceClient(_BaseDoclingServiceClient):
             int,
             tuple[
                 ConversionItem,
-                ConvertDocumentResponse | PresignedUrlConvertResponse | Exception,
+                (
+                    ConvertDocumentResponse
+                    | PresignedUrlConvertDocumentResponse
+                    | PresignedUrlConvertResponse
+                    | Exception
+                ),
             ],
         ] = {}
         next_ordered_index = 0
@@ -496,7 +510,10 @@ class AsyncDoclingServiceClient(_BaseDoclingServiceClient):
             max_in_flight=max_in_flight,
         ):
             normalized: (
-                ConvertDocumentResponse | PresignedUrlConvertResponse | Exception
+                ConvertDocumentResponse
+                | PresignedUrlConvertDocumentResponse
+                | PresignedUrlConvertResponse
+                | Exception
             )
             if isinstance(outcome, BaseException):
                 normalized = self._normalize_exception(outcome)
@@ -518,11 +535,16 @@ class AsyncDoclingServiceClient(_BaseDoclingServiceClient):
         max_in_flight: int = DEFAULT_MAX_CONCURRENCY,
         ordered: bool = False,
         *,
-        target: InBodyTarget | PresignedUrlTarget | None = None,
+        target: SubmitTarget | None = None,
     ) -> AsyncGenerator[
         tuple[
             ConversionItem,
-            ConvertDocumentResponse | PresignedUrlConvertResponse | Exception,
+            (
+                ConvertDocumentResponse
+                | PresignedUrlConvertDocumentResponse
+                | PresignedUrlConvertResponse
+                | Exception
+            ),
         ],
         None,
     ]:
@@ -572,6 +594,12 @@ class AsyncDoclingServiceClient(_BaseDoclingServiceClient):
             )
         if isinstance(target, PresignedUrlTarget):
             return lambda task_id, last_status: self._fetch_presigned_result(
+                task_id=task_id,
+                last_status=last_status,
+                async_client=async_client,
+            )
+        if _is_storage_target(target):
+            return lambda task_id, last_status: self._fetch_presigned_document_result(
                 task_id=task_id,
                 last_status=last_status,
                 async_client=async_client,

--- a/docling/service_client/client.py
+++ b/docling/service_client/client.py
@@ -28,7 +28,7 @@ import httpx
 from docling_core.types.doc import DoclingDocument, ImageRef, PictureItem
 from docling_core.types.io import DocumentStream
 from PIL import Image as PILImage
-from pydantic import AnyHttpUrl, TypeAdapter, ValidationError
+from pydantic import AnyHttpUrl, SecretBytes, SecretStr, TypeAdapter, ValidationError
 
 from docling.backend.noop_backend import NoOpBackend
 from docling.datamodel.base_models import (
@@ -68,6 +68,9 @@ from docling.datamodel.service.responses import (
     UsageLimitExceededResponse,
 )
 from docling.datamodel.service.targets import (
+    AzureBlobTarget,
+    GoogleCloudStorageTarget,
+    GoogleDriveTarget,
     InBodyTarget,
     PresignedUrlTarget,
     S3Target,
@@ -101,8 +104,11 @@ if TYPE_CHECKING:
     from docling.service_client._async_client import AsyncDoclingServiceClient
 
 SourceType: TypeAlias = Path | str | DocumentStream | HttpSourceRequest
-SubmitTarget: TypeAlias = InBodyTarget | ZipTarget | PresignedUrlTarget
-BatchSubmitTarget: TypeAlias = S3Target | PresignedUrlTarget
+StorageTarget: TypeAlias = (
+    S3Target | AzureBlobTarget | GoogleCloudStorageTarget | GoogleDriveTarget
+)
+SubmitTarget: TypeAlias = InBodyTarget | ZipTarget | PresignedUrlTarget | StorageTarget
+BatchSubmitTarget: TypeAlias = StorageTarget | PresignedUrlTarget
 logger = logging.getLogger(__name__)
 _T = TypeVar("_T")
 
@@ -119,6 +125,17 @@ TRANSPORT_RETRYABLE_HTTP_METHODS = frozenset({"GET", "HEAD", "OPTIONS"})
 DEFAULT_ARTIFACT_DOWNLOAD_TIMEOUT_SECONDS = 60.0
 DEFAULT_MAX_ARTIFACT_DOWNLOAD_BYTES = 512 * 1024 * 1024
 MAX_ARTIFACT_DOWNLOAD_REDIRECTS = 5
+
+_STORAGE_TARGET_TYPES = (
+    S3Target,
+    AzureBlobTarget,
+    GoogleCloudStorageTarget,
+    GoogleDriveTarget,
+)
+
+
+def _is_storage_target(target: object) -> bool:
+    return isinstance(target, _STORAGE_TARGET_TYPES)
 
 
 def _is_safe_artifact_url(url: str) -> bool:
@@ -300,8 +317,25 @@ class _BaseDoclingServiceClient:
         request: ConvertDocumentsRequest | BatchConvertSourcesRequest,
     ) -> dict[str, Any]:
         payload = request.model_dump(mode="json", exclude_none=True)
+        raw_payload = request.model_dump(mode="python", exclude_none=True)
+        payload = self._restore_secret_values(raw_payload, payload)
         payload["options"] = self._serialize_convert_options(request.options)
         return payload
+
+    def _restore_secret_values(self, raw: Any, dumped: Any) -> Any:
+        if isinstance(raw, (SecretStr, SecretBytes)):
+            return raw.get_secret_value()
+        if isinstance(raw, dict) and isinstance(dumped, dict):
+            return {
+                key: self._restore_secret_values(raw[key], dumped[key])
+                for key in dumped
+            }
+        if isinstance(raw, list) and isinstance(dumped, list):
+            return [
+                self._restore_secret_values(raw_item, dumped_item)
+                for raw_item, dumped_item in zip(raw, dumped)
+            ]
+        return dumped
 
     def _resolve_options(
         self,
@@ -339,7 +373,7 @@ class _BaseDoclingServiceClient:
         self,
         options: ConvertDocumentsRequestOptions,
         output_formats: list[OutputFormat] | None,
-        target: InBodyTarget | ZipTarget | S3Target | PresignedUrlTarget,
+        target: SubmitTarget,
     ) -> ConvertDocumentsRequestOptions:
         effective = options
         if output_formats is not None:
@@ -907,11 +941,16 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
         max_in_flight: int = DEFAULT_MAX_CONCURRENCY,
         ordered: bool = False,
         *,
-        target: InBodyTarget | PresignedUrlTarget | None = None,
+        target: SubmitTarget | None = None,
     ) -> Iterator[
         tuple[
             ConversionItem,
-            ConvertDocumentResponse | PresignedUrlConvertResponse | Exception,
+            (
+                ConvertDocumentResponse
+                | PresignedUrlConvertDocumentResponse
+                | PresignedUrlConvertResponse
+                | Exception
+            ),
         ]
     ]:
         """Yield one outcome per submitted item.
@@ -935,11 +974,16 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
         max_in_flight: int = DEFAULT_MAX_CONCURRENCY,
         ordered: bool = False,
         *,
-        target: InBodyTarget | PresignedUrlTarget | None = None,
+        target: SubmitTarget | None = None,
     ) -> Iterator[
         tuple[
             ConversionItem,
-            ConvertDocumentResponse | PresignedUrlConvertResponse | Exception,
+            (
+                ConvertDocumentResponse
+                | PresignedUrlConvertDocumentResponse
+                | PresignedUrlConvertResponse
+                | Exception
+            ),
         ]
     ]:
         warnings.warn(
@@ -974,6 +1018,7 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
     ) -> (
         ConversionJob[ConversionResult]
         | ConversionJob[RawServiceResult]
+        | ConversionJob[PresignedUrlConvertDocumentResponse]
         | ConversionJob[PresignedUrlConvertResponse]
     ):
         descriptor = self._describe_source(source)
@@ -1120,6 +1165,7 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
     ) -> (
         ConversionJob[ConversionResult]
         | ConversionJob[RawServiceResult]
+        | ConversionJob[PresignedUrlConvertDocumentResponse]
         | ConversionJob[PresignedUrlConvertResponse]
     ):
         descriptor = descriptor or self._describe_source(source)
@@ -1353,6 +1399,11 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
                 task_id=task_id,
                 last_status=last_status,
             )
+        if _is_storage_target(target):
+            return lambda task_id, last_status: self._fetch_presigned_document_result(
+                task_id=task_id,
+                last_status=last_status,
+            )
         return lambda task_id, last_status: self._build_conversion_result(
             payload=self._fetch_convert_result_payload(
                 task_id=task_id,
@@ -1378,7 +1429,7 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
             target=target,
             request_headers=request_headers,
         )
-        if isinstance(target, S3Target):
+        if _is_storage_target(target):
 
             def fetch_result(
                 task_id: str,
@@ -1928,11 +1979,16 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
         item_list: Iterable[ConversionItem],
         max_in_flight: int,
         ordered: bool,
-        target: InBodyTarget | PresignedUrlTarget | None = None,
+        target: SubmitTarget | None = None,
     ) -> Iterator[
         tuple[
             ConversionItem,
-            ConvertDocumentResponse | PresignedUrlConvertResponse | Exception,
+            (
+                ConvertDocumentResponse
+                | PresignedUrlConvertDocumentResponse
+                | PresignedUrlConvertResponse
+                | Exception
+            ),
         ]
     ]:
         self._ensure_sync_bridge_allowed()
@@ -1948,17 +2004,27 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
         item_list: Iterable[ConversionItem],
         max_in_flight: int,
         ordered: bool,
-        target: InBodyTarget | PresignedUrlTarget | None = None,
+        target: SubmitTarget | None = None,
     ) -> Iterator[
         tuple[
             ConversionItem,
-            ConvertDocumentResponse | PresignedUrlConvertResponse | Exception,
+            (
+                ConvertDocumentResponse
+                | PresignedUrlConvertDocumentResponse
+                | PresignedUrlConvertResponse
+                | Exception
+            ),
         ]
     ]:
         async def run() -> AsyncGenerator[
             tuple[
                 ConversionItem,
-                ConvertDocumentResponse | PresignedUrlConvertResponse | Exception,
+                (
+                    ConvertDocumentResponse
+                    | PresignedUrlConvertDocumentResponse
+                    | PresignedUrlConvertResponse
+                    | Exception
+                ),
             ],
             None,
         ]:

--- a/tests/test_service_client_sdk_unit.py
+++ b/tests/test_service_client_sdk_unit.py
@@ -21,6 +21,7 @@ from docling_core.types.doc import (
 )
 from docling_core.types.doc.document import BoundingBox, ProvenanceItem, Size
 from PIL import Image as PILImage
+from pydantic import ValidationError
 
 import docling.service_client._async_client as async_module
 import docling.service_client.client as client_module
@@ -37,6 +38,8 @@ from docling.datamodel.service.options import (
 )
 from docling.datamodel.service.requests import (
     AnyHttpSourceRequest,
+    GoogleCloudStorageSourceRequest,
+    GoogleDriveSourceRequest,
     HttpSourceRequest,
     S3SourceRequest,
 )
@@ -51,7 +54,10 @@ from docling.datamodel.service.responses import (
     TaskStatusResponse,
     WebsocketMessage,
 )
+from docling.datamodel.service.sources import GoogleDriveCoordinates
 from docling.datamodel.service.targets import (
+    AzureBlobTarget,
+    GoogleCloudStorageTarget,
     InBodyTarget,
     PresignedUrlTarget,
     S3Target,
@@ -1931,6 +1937,95 @@ def test_submit_batch_posts_batch_request() -> None:
     )
 
 
+def test_submit_batch_serializes_inline_gcs_secrets_without_redaction() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = request.content.decode("utf-8")
+        return httpx.Response(
+            200, json=_status_response("task-gcs", "pending").model_dump(mode="json")
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        client._http_client.close()
+        client._http_client = httpx.Client(
+            transport=transport,
+            timeout=client._http_client.timeout,
+        )
+        client.submit_batch(
+            sources=[
+                GoogleCloudStorageSourceRequest(
+                    bucket="incoming",
+                    service_account_key={
+                        "project_id": "my-project",
+                        "private_key_id": "kid-123",
+                        "private_key": "private-key-value",
+                        "client_email": "svc@example.com",
+                        "client_id": "client-id-123",
+                        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                        "token_uri": "https://oauth2.googleapis.com/token",
+                        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                        "client_x509_cert_url": "https://example.com/cert",
+                        "universe_domain": "googleapis.com",
+                    },
+                )
+            ],
+            target=PresignedUrlTarget(),
+        )
+
+    payload = json.loads(str(captured["payload"]))
+    creds = payload["sources"][0]["service_account_key"]
+    assert creds["private_key"] == "private-key-value"
+    assert creds["client_email"] == "svc@example.com"
+    assert "**********" not in json.dumps(creds)
+
+
+def test_submit_batch_serializes_inline_drive_secrets_without_redaction() -> None:
+    captured: dict[str, object] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["payload"] = request.content.decode("utf-8")
+        return httpx.Response(
+            200,
+            json=_status_response("task-drive", "pending").model_dump(mode="json"),
+        )
+
+    transport = httpx.MockTransport(handler)
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        client._http_client.close()
+        client._http_client = httpx.Client(
+            transport=transport,
+            timeout=client._http_client.timeout,
+        )
+        client.submit_batch(
+            sources=[
+                GoogleDriveSourceRequest(
+                    path_id="folder-123",
+                    refresh_token="refresh-token-value",
+                    credentials={
+                        "client_id": "client-id",
+                        "project_id": "project-id",
+                        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                        "token_uri": "https://oauth2.googleapis.com/token",
+                        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+                        "client_secret": "client-secret-value",
+                        "redirect_uris": ["http://localhost"],
+                    },
+                )
+            ],
+            target=PresignedUrlTarget(),
+        )
+
+    payload = json.loads(str(captured["payload"]))
+    source = payload["sources"][0]
+    assert source["refresh_token"] == "refresh-token-value"
+    assert source["credentials"]["client_secret"] == "client-secret-value"
+    assert "**********" not in json.dumps(source)
+
+
 def test_submit_batch_returns_presigned_result_for_presigned_target() -> None:
     presigned_result = PresignedUrlConvertResponse(
         num_converted=1,
@@ -2026,6 +2121,53 @@ def test_submit_batch_returns_counts_result_for_s3_target() -> None:
         result = job.result(timeout=1.0)
 
     assert result is s3_result
+
+
+def test_submit_returns_counts_result_for_storage_target() -> None:
+    storage_result = PresignedUrlConvertDocumentResponse(
+        num_converted=1,
+        num_succeeded=1,
+        num_partially_succeeded=0,
+        num_failed=0,
+        processing_time=0.25,
+    )
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        client._submit_convert_task = MethodType(
+            lambda self, source, options, target, request_headers=None: (
+                _status_response("task-storage", "pending")
+            ),
+            client,
+        )
+        client._wait_for_terminal_status = MethodType(
+            lambda self, task_id, timeout: _status_response(task_id, "success"),
+            client,
+        )
+        client._fetch_presigned_document_result = MethodType(
+            lambda self, task_id, last_status: storage_result,
+            client,
+        )
+
+        job = client.submit(
+            source="https://example.org/sample.pdf",
+            target=GoogleCloudStorageTarget(bucket="converted", key_prefix="done/"),
+        )
+        result = job.result(timeout=1.0)
+
+    assert result is storage_result
+
+
+def test_google_drive_coordinates_require_auth_inputs() -> None:
+    with pytest.raises(ValidationError, match="token_path"):
+        GoogleDriveCoordinates(path_id="folder-123")
+
+    valid = GoogleDriveCoordinates(
+        path_id="folder-123",
+        refresh_token="refresh-token",
+        credentials_path="/tmp/client-secret.json",
+    )
+
+    assert valid.refresh_token == "refresh-token"
 
 
 def test_submit_batch_forwards_request_headers() -> None:
@@ -3533,6 +3675,53 @@ async def test_async_submit_batch_returns_counts_result_for_s3_target() -> None:
         result = await job.result(timeout=1.0)
 
     assert result is s3_result
+
+
+@pytest.mark.anyio
+async def test_async_submit_batch_returns_counts_result_for_azure_target() -> None:
+    storage_result = PresignedUrlConvertDocumentResponse(
+        num_converted=1,
+        num_succeeded=1,
+        num_partially_succeeded=0,
+        num_failed=0,
+        processing_time=0.25,
+    )
+
+    async with AsyncDoclingServiceClient(url=TEST_BASE_URL) as client:
+        client._submit_batch_task = MethodType(
+            lambda self, sources, options, target, async_client, request_headers=None: (
+                asyncio.sleep(0, result=_status_response("task-azure", "pending"))
+            ),
+            client,
+        )
+        client._fetch_presigned_document_result = MethodType(
+            lambda self, task_id, last_status, async_client: asyncio.sleep(
+                0, result=storage_result
+            ),
+            client,
+        )
+        client._status_watcher = MethodType(  # type: ignore[method-assign]
+            lambda self: SimpleNamespace(
+                iter_updates=lambda tid, timeout=None: (x async for x in []),
+                wait_for_terminal=lambda tid, timeout=None: asyncio.sleep(
+                    0, result=_status_response(tid, "success")
+                ),
+            ),
+            client,
+        )
+
+        job = await client.submit_batch(
+            sources=[AnyHttpSourceRequest(url="https://example.org/sample.pdf")],
+            target=AzureBlobTarget(
+                account_name="acct",
+                container="converted",
+                connection_string="UseDevelopmentStorage=true",
+                blob_prefix="done/",
+            ),
+        )
+        result = await job.result(timeout=1.0)
+
+    assert result is storage_result
 
 
 # --- submit_chunk ---


### PR DESCRIPTION
The GCS, Azure Blob, and Google Drive coordinate models lived in docling-jobkit, where the docling service-client types and docling-serve endpoints could not reach them. This moves them into `docling/datamodel/service` and wires them into the request/target unions, mirroring the existing `S3Coordinates` / `S3SourceRequest` / `S3Target` pattern.

### Changes
- **sources.py** — new bare coord models: `AzureBlobCoordinates`, `GoogleCloudStorageCoordinates` (+ `GoogleCloudStorageServiceAccountInfo`), `GoogleDriveCoordinates` (+ `GoogleDriveCredentials`).
- **targets.py** — new `AzureBlobTarget`, `GoogleCloudStorageTarget`, `GoogleDriveTarget`; added to the `Target` union.
- **requests.py** — new `AzureBlobSourceRequest`, `GoogleCloudStorageSourceRequest`, `GoogleDriveSourceRequest`. `BatchSourceRequestItem` gains all three sources; `TargetRequest` and `BatchTargetRequest` gain all three targets.
- **__init__.py** — new symbols exported.

### Notes
- `kind` discriminators (`azure_blob`, `google_cloud_storage`, `google_drive`) match the values docling-jobkit already used, so the discriminated unions stay consistent across repos.
- **Google Drive is only in `BatchSourceRequestItem`, not `SourceRequestItem`.** `path_id` is an opaque Drive id — a file id and a folder id are indistinguishable without an API call — so the single-document convert endpoint does not accept Google Drive for now.
- Backward-compat: docling-jobkit keeps a re-export shim at `docling_jobkit.datamodel.google_drive_coords`; the GCS/Azure modules there are removed.

