### PR TITLE
fix: import pypdfium2 lazily in pdf_outline

### DIFF
--- a/docling/utils/pdf_outline.py
+++ b/docling/utils/pdf_outline.py
@@ -13,16 +13,18 @@ extractors are provided so each backend uses its own native capability:
 from __future__ import annotations
 
 import logging
+from functools import cache
 from typing import TYPE_CHECKING
 
-import pypdfium2 as pdfium
-import pypdfium2.raw as pdfium_c
 from pydantic import BaseModel
-from pypdfium2._helpers.misc import PdfiumError
 
 from docling.utils.locks import pypdfium2_lock
 
+# pypdfium2 must only be imported lazily here: ``datamodel.document`` imports this module
+# for ``_PdfOutlineItem``, putting it on the ``docling.service_client`` import chain, which
+# has to stay importable under docling-slim[service-client] (no PDF backend installed).
 if TYPE_CHECKING:
+    import pypdfium2 as pdfium
     from docling_parse.pdf_parser import (
         PdfDocument as DoclingParsePdfDocument,
         PdfTableOfContents,
@@ -49,15 +51,22 @@ class _PdfOutlineItem(BaseModel):
     y_top: float | None = None
 
 
-# Destination view modes whose coordinates carry a usable vertical (top) position, mapped to
-# the index of that coordinate within the position tuple. Coordinates are in PDF space
-# (bottom-left origin). Modes not listed (FIT, FITV, FITB, FITBV, unknown) provide no top.
-_VIEW_TOP_INDEX = {
-    pdfium_c.PDFDEST_VIEW_XYZ: 1,  # [x, y, zoom]
-    pdfium_c.PDFDEST_VIEW_FITH: 0,  # [y]
-    pdfium_c.PDFDEST_VIEW_FITBH: 0,  # [y]
-    pdfium_c.PDFDEST_VIEW_FITR: 3,  # [left, bottom, right, top]
-}
+@cache
+def _view_top_index() -> dict[int, int]:
+    """Destination view modes whose coordinates carry a usable vertical (top) position.
+
+    Maps each mode to the index of that coordinate within the position tuple. Coordinates are
+    in PDF space (bottom-left origin). Modes not listed (FIT, FITV, FITB, FITBV, unknown)
+    provide no top.
+    """
+    import pypdfium2.raw as pdfium_c
+
+    return {
+        pdfium_c.PDFDEST_VIEW_XYZ: 1,  # [x, y, zoom]
+        pdfium_c.PDFDEST_VIEW_FITH: 0,  # [y]
+        pdfium_c.PDFDEST_VIEW_FITBH: 0,  # [y]
+        pdfium_c.PDFDEST_VIEW_FITR: 3,  # [left, bottom, right, top]
+    }
 
 
 def _dest_top_pdf(dest: pdfium.PdfDest) -> tuple[int | None, float | None]:
@@ -67,7 +76,7 @@ def _dest_top_pdf(dest: pdfium.PdfDest) -> tuple[int | None, float | None]:
     """
     page_index = dest.get_index()
     mode, pos = dest.get_view()
-    idx = _VIEW_TOP_INDEX.get(mode)
+    idx = _view_top_index().get(mode)
     y_pdf = pos[idx] if idx is not None and idx < len(pos) else None
     return page_index, y_pdf
 
@@ -79,6 +88,8 @@ def extract_outline_from_pdfium(pdoc: pdfium.PdfDocument) -> list[_PdfOutlineIte
     the target page height. Returns an empty list when the document has no outline or it cannot
     be read.
     """
+    from pypdfium2._helpers.misc import PdfiumError
+
     items: list[_PdfOutlineItem] = []
     page_heights: dict[int, float] = {}
 

--- a/docling/utils/pdf_outline.py
+++ b/docling/utils/pdf_outline.py
@@ -8,6 +8,11 @@ extractors are provided so each backend uses its own native capability:
 * :func:`extract_outline_from_docling_parse` -- for the docling-parse backends, using their native
   ``get_table_of_contents()`` (no pypdfium2 dependency). The native outline carries titles and
   hierarchy only, so page number and position are left unset.
+
+``pypdfium2`` is imported lazily, inside the functions that use it, never at module level:
+``datamodel.document`` imports this module for the ``_PdfOutlineItem`` model, which places it on
+the ``docling.service_client`` import chain. That chain must stay importable on any docling-slim
+install that does not enable the PDF pipeline (and therefore ships no ``pypdfium2``).
 """
 
 from __future__ import annotations
@@ -20,9 +25,6 @@ from pydantic import BaseModel
 
 from docling.utils.locks import pypdfium2_lock
 
-# pypdfium2 must only be imported lazily here: ``datamodel.document`` imports this module
-# for ``_PdfOutlineItem``, putting it on the ``docling.service_client`` import chain, which
-# has to stay importable under docling-slim[service-client] (no PDF backend installed).
 if TYPE_CHECKING:
     import pypdfium2 as pdfium
     from docling_parse.pdf_parser import (
@@ -55,17 +57,26 @@ class _PdfOutlineItem(BaseModel):
 def _view_top_index() -> dict[int, int]:
     """Destination view modes whose coordinates carry a usable vertical (top) position.
 
-    Maps each mode to the index of that coordinate within the position tuple. Coordinates are
-    in PDF space (bottom-left origin). Modes not listed (FIT, FITV, FITB, FITBV, unknown)
-    provide no top.
+    Coordinates are in PDF space (bottom-left origin). Modes not listed (FIT, FITV, FITB,
+    FITBV, unknown) provide no top.
+
+    Returns:
+        A mapping of each supported ``PDFDEST_VIEW_*`` mode to the index of the vertical (top)
+        coordinate within that mode's position tuple:
+
+        * ``PDFDEST_VIEW_XYZ`` -> ``1`` (position is ``[x, y, zoom]``)
+        * ``PDFDEST_VIEW_FITH`` -> ``0`` (position is ``[y]``)
+        * ``PDFDEST_VIEW_FITBH`` -> ``0`` (position is ``[y]``)
+        * ``PDFDEST_VIEW_FITR`` -> ``3`` (position is ``[left, bottom, right, top]``)
     """
+    # lazy import (see module docstring)
     import pypdfium2.raw as pdfium_c
 
     return {
-        pdfium_c.PDFDEST_VIEW_XYZ: 1,  # [x, y, zoom]
-        pdfium_c.PDFDEST_VIEW_FITH: 0,  # [y]
-        pdfium_c.PDFDEST_VIEW_FITBH: 0,  # [y]
-        pdfium_c.PDFDEST_VIEW_FITR: 3,  # [left, bottom, right, top]
+        pdfium_c.PDFDEST_VIEW_XYZ: 1,
+        pdfium_c.PDFDEST_VIEW_FITH: 0,
+        pdfium_c.PDFDEST_VIEW_FITBH: 0,
+        pdfium_c.PDFDEST_VIEW_FITR: 3,
     }
 
 
@@ -88,6 +99,7 @@ def extract_outline_from_pdfium(pdoc: pdfium.PdfDocument) -> list[_PdfOutlineIte
     the target page height. Returns an empty list when the document has no outline or it cannot
     be read.
     """
+    # lazy import (see module docstring)
     from pypdfium2._helpers.misc import PdfiumError
 
     items: list[_PdfOutlineItem] = []

--- a/tests/test_backend_optional_dependencies.py
+++ b/tests/test_backend_optional_dependencies.py
@@ -163,3 +163,16 @@ def test_backend_reports_missing_dependency_with_install_hint(
     result = _run_with_blocked_module(blocked_module, body)
     assert result.returncode == 0, result.stderr
     assert "actionable-error-raised" in result.stdout
+
+
+def test_service_client_imports_without_pdf_pipeline_dependency() -> None:
+    # The service client reaches docling.utils.pdf_outline (via noop_backend ->
+    # datamodel.document, which needs only the _PdfOutlineItem model), so a
+    # module-level pypdfium2 import there breaks `import docling.service_client`
+    # on any slim install that omits the PDF pipeline. Guard the deferred import.
+    result = _run_with_blocked_module(
+        "pypdfium2",
+        "import docling.service_client\n"
+        "from docling.datamodel.service.options import ConvertDocumentsOptions\n",
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_service_client_sdk_unit.py
+++ b/tests/test_service_client_sdk_unit.py
@@ -2,10 +2,7 @@ import asyncio
 import io
 import json
 import queue
-import subprocess
-import sys
 import tempfile
-import textwrap
 import threading
 import time
 import warnings
@@ -3884,46 +3881,3 @@ async def test_async_submit_and_retrieve_each_rejects_invalid_max_in_flight(
                 target=InBodyTarget(),
             ):
                 pass
-
-
-def test_service_client_imports_without_local_conversion_deps() -> None:
-    """The client import chain must resolve under docling-slim[service-client].
-
-    That install profile ships no PDF-backend or local-model packages, so
-    importing ``docling.service_client`` must not touch them at module level.
-    Regression guard: docling-slim 2.109.0 broke this via a module-level
-    ``import pypdfium2`` in ``docling.utils.pdf_outline``, reached through
-    ``noop_backend -> datamodel.document``.
-    """
-    script = textwrap.dedent(
-        """
-        import sys
-
-        BLOCKED = ("pypdfium2", "docling_parse", "torch", "torchvision")
-
-
-        class _BlockLocalConversionDeps:
-            def find_spec(self, fullname, path=None, target=None):
-                if fullname.partition(".")[0] in BLOCKED:
-                    raise ModuleNotFoundError(
-                        f"import of {fullname!r} blocked: not installed under "
-                        "docling-slim[service-client]"
-                    )
-                return None
-
-
-        sys.meta_path.insert(0, _BlockLocalConversionDeps())
-
-        import docling.service_client
-        import docling.datamodel.service.options
-        """
-    )
-    result = subprocess.run(
-        [sys.executable, "-c", script],
-        capture_output=True,
-        text=True,
-        check=False,
-    )
-    assert result.returncode == 0, (
-        f"docling.service_client import requires a blocked package:\n{result.stderr}"
-    )

--- a/tests/test_service_client_sdk_unit.py
+++ b/tests/test_service_client_sdk_unit.py
@@ -2,7 +2,10 @@ import asyncio
 import io
 import json
 import queue
+import subprocess
+import sys
 import tempfile
+import textwrap
 import threading
 import time
 import warnings
@@ -3881,3 +3884,46 @@ async def test_async_submit_and_retrieve_each_rejects_invalid_max_in_flight(
                 target=InBodyTarget(),
             ):
                 pass
+
+
+def test_service_client_imports_without_local_conversion_deps() -> None:
+    """The client import chain must resolve under docling-slim[service-client].
+
+    That install profile ships no PDF-backend or local-model packages, so
+    importing ``docling.service_client`` must not touch them at module level.
+    Regression guard: docling-slim 2.109.0 broke this via a module-level
+    ``import pypdfium2`` in ``docling.utils.pdf_outline``, reached through
+    ``noop_backend -> datamodel.document``.
+    """
+    script = textwrap.dedent(
+        """
+        import sys
+
+        BLOCKED = ("pypdfium2", "docling_parse", "torch", "torchvision")
+
+
+        class _BlockLocalConversionDeps:
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname.partition(".")[0] in BLOCKED:
+                    raise ModuleNotFoundError(
+                        f"import of {fullname!r} blocked: not installed under "
+                        "docling-slim[service-client]"
+                    )
+                return None
+
+
+        sys.meta_path.insert(0, _BlockLocalConversionDeps())
+
+        import docling.service_client
+        import docling.datamodel.service.options
+        """
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, (
+        f"docling.service_client import requires a blocked package:\n{result.stderr}"
+    )


### PR DESCRIPTION
Since 2.109.0, `import docling.service_client` fails with `ModuleNotFoundError: No module named 'pypdfium2'` on `docling-slim[service-client]` installs. `docling/utils/pdf_outline.py` imports pypdfium2 at module level and gets pulled in through `datamodel/document.py`, which only needs the `_PdfOutlineItem` model, so the whole client import chain breaks when no PDF backend is installed. 2.108.0 was fine, and full `docling` installs are unaffected since pypdfium2 is always there.

The fix moves the pypdfium2 imports into the pdfium-only code paths (the view-mode constant table becomes a cached helper, `PdfiumError` is imported inside the extractor) and leaves the rest of the module import-safe. No behavior change for PDF conversion.

Also adds a regression test that blocks pypdfium2/docling-parse/torch in a subprocess and checks the client import surface still resolves, so this can't quietly break again. Verified against a clean `docling-slim[service-client]==2.112.0` venv, plus the service client and heading hierarchy suites.

Replaces #3793 (closed earlier, couldn't be reopened after a force-push).

**Checklist:**

- [x] Documentation has been updated, if necessary. *(not needed)*
- [x] Examples have been added, if necessary. *(not needed)*
- [x] Tests have been added, if necessary.