### PR TITLE
fix(docx): clean up DrawingML temp dir on conversion error

### DIFF
--- a/docling/backend/docx/drawingml/utils.py
+++ b/docling/backend/docx/drawingml/utils.py
@@ -114,22 +114,23 @@ def get_pil_from_dml_docx(
         return None
 
     temp_dir = Path(mkdtemp())
-    temp_docx = Path(temp_dir / "drawing_only.docx")
-    temp_pdf = Path(temp_dir / "drawing_only.pdf")
+    try:
+        temp_docx = Path(temp_dir / "drawing_only.docx")
+        temp_pdf = Path(temp_dir / "drawing_only.pdf")
 
-    # 1) Save docx temporarily
-    docx.save(str(temp_docx))
+        # 1) Save docx temporarily
+        docx.save(str(temp_docx))
 
-    # 2) Export to PDF
-    converter(temp_docx, temp_pdf)
+        # 2) Export to PDF
+        converter(temp_docx, temp_pdf)
 
-    # 3) Load PDF as PNG
-    pdf = pypdfium2.PdfDocument(temp_pdf)
-    page = pdf[0]
-    image = crop_whitespace(page.render(scale=2).to_pil())
-    page.close()
-    pdf.close()
-
-    shutil.rmtree(temp_dir, ignore_errors=True)
+        # 3) Load PDF as PNG
+        pdf = pypdfium2.PdfDocument(temp_pdf)
+        page = pdf[0]
+        image = crop_whitespace(page.render(scale=2).to_pil())
+        page.close()
+        pdf.close()
+    finally:
+        shutil.rmtree(temp_dir, ignore_errors=True)
 
     return image


### PR DESCRIPTION
<!-- No "Resolves #" section: this is a standalone robustness fix with no
     tracking issue, and the template says to remove that section in that case. -->

`get_pil_from_dml_docx` (`docling/backend/docx/drawingml/utils.py`) creates a
temporary directory with `mkdtemp()` but only removes it with a trailing
`shutil.rmtree` that has no `try`/`finally` guard. Any exception raised in
between (in `docx.save`, the DOCX->PDF `converter`, which is a LibreOffice
subprocess, or the `pypdfium2` render) propagates before the cleanup line is
reached, so the `mkdtemp` directory (and the `drawing_only.docx` /
`drawing_only.pdf` written into it) is left behind in the system temp location.
Over a batch that converts many DOCX files whose DrawingML export fails, these
directories accumulate until the OS temp cleaner runs.

This wraps the work block in `try` / `finally` so the temp directory is always
removed, mirroring the existing pattern already used for the same
`mkdtemp` -> LibreOffice-convert -> `rmtree` flow in
`MsExcelDocumentBackend._convert_emf_wmf_to_pil`
(`docling/backend/msexcel_backend.py`). The exception still propagates unchanged
to the caller, so behavior is otherwise identical: the sole caller
`MsWordDocumentBackend._convert_elements_to_image_via_docx` already wraps this
call in `try/except Exception -> return None`. No conversion output changes, so
no reference/groundtruth data is affected.

A regression test (`test_get_pil_from_dml_docx_cleans_temp_dir_on_error`) drives
the failure path: it points the helper's `mkdtemp` at a temp subdir, passes a
`converter` that raises, and asserts both that the exception still propagates
and that the temp directory is no longer left behind. It fails on the pre-fix
code (temp dir survives) and passes with the fix.

**Checklist:**

- [x] Documentation has been updated, if necessary. (not necessary: no
  user-facing/API change)
- [x] Examples have been added, if necessary. (not necessary)
- [x] Tests have been added, if necessary.
