### PR TITLE
fix(msword): keep paragraph formatting when a trailing run is whitespace-only

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -1186,12 +1186,9 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         ] = []
         group_text = ""
         previous_format = None
-        last_format = None
 
         # Iterate over the runs of the paragraph and group them by format
         for text, format, hyperlink in self._iter_paragraph_content(paragraph):
-            last_format = format
-
             if (len(text.strip()) and format != previous_format) or (
                 hyperlink is not None
             ):
@@ -1213,7 +1210,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
 
         # Format the last group
         if len(group_text.strip()) > 0:
-            paragraph_elements.append((group_text.strip(), last_format, None))
+            paragraph_elements.append((group_text.strip(), previous_format, None))
 
         return paragraph_elements
 

--- a/tests/test_backend_msword.py
+++ b/tests/test_backend_msword.py
@@ -1190,3 +1190,43 @@ def test_malformed_hyperlink_does_not_abort_conversion(tmp_path):
         if isinstance(item, TextItem) and item.hyperlink is not None
     ]
     assert hyperlinks == []
+
+
+def test_trailing_whitespace_run_keeps_paragraph_formatting(tmp_path):
+    """A whitespace-only trailing run must not overwrite the paragraph's formatting.
+
+    Regression test: the final run group was flushed with the format of the last
+    run *seen* rather than the format of the run that opened the group. Word
+    routinely emits a trailing plain run holding just spaces, which silently
+    stripped bold/italic from the whole preceding text.
+    """
+    from docx import Document
+
+    doc = Document()
+
+    para = doc.add_paragraph()
+    para.add_run("All bold text").bold = True
+    para.add_run("   ")
+
+    para = doc.add_paragraph()
+    para.add_run("All italic text").italic = True
+    para.add_run(" ")
+
+    # A bold whitespace-only run must not make the plain text bold either.
+    para = doc.add_paragraph()
+    para.add_run("Plain text")
+    para.add_run("   ").bold = True
+
+    docx_path = tmp_path / "trailing_whitespace_run.docx"
+    doc.save(docx_path)
+
+    doc = _convert(docx_path)
+    formatting = {
+        item.text: item.formatting
+        for item, _ in doc.iterate_items()
+        if isinstance(item, TextItem)
+    }
+
+    assert formatting["All bold text"].bold is True
+    assert formatting["All italic text"].italic is True
+    assert formatting["Plain text"].bold is False


### PR DESCRIPTION
**Summary**
--------------------------------------------
Word routinely ends a paragraph with a run containing nothing but spaces. In `MsWordDocumentBackend._get_paragraph_elements`, that trailing run silently stripped bold/italic/underline/strikethrough from all the text before it, so a fully-bold heading exported as `bold=False`.

The grouping loop tracked formatting in two variables:

- `previous_format` — the format of the run that *opened* the current group. Guarded by `len(text.strip())`, so whitespace-only runs never change it.
- `last_format` — reassigned on *every* run, whitespace-only ones included.

Intermediate groups were flushed with `previous_format`, but the final group was flushed with `last_format`. The two only diverge when the last run is whitespace-only — exactly the common case — and the final flush then took the whitespace run's format instead of the group's.

This drops `last_format` and flushes the final group with `previous_format`, matching how every other group is already emitted. The `len(text.strip())` guard means `previous_format` is by construction the format of the run that opened the group, so no separate tracking is needed.

The fix is symmetric: a *bold* whitespace-only trailing run no longer makes plain text come out bold either.

**Issue resolved by this Pull Request:**
Resolves #3798

**Checklist:**

- [X] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
