### PR TITLE
revert: fix(asciidoc): drop phantom cell from trailing-pipe table rows

### DIFF
--- a/docling/backend/asciidoc_backend.py
+++ b/docling/backend/asciidoc_backend.py
@@ -371,12 +371,6 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
         line = re.sub(rf"(^|\s){_CELL_SPEC}(?=\|)", r"\1", line)
         # Split by "|" and remove the leading empty string from the first "|"
         cells = line.split("|")[1:]
-        # A "|" that terminates the line (trailing-pipe row style, e.g.
-        # "|A|B|") marks the end of the row, not the start of a new cell, so it
-        # must not yield a phantom empty cell that would inflate the column
-        # count. Mid-row empty cells (e.g. "|A||B") are kept.
-        if cells and line.rstrip().endswith("|"):
-            cells = cells[:-1]
         # Strip whitespace from each cell (empty cells become empty strings)
         return [cell.strip() for cell in cells]
 

--- a/tests/data/asciidoc/groundtruth/asciidoc_01.asciidoc.md
+++ b/tests/data/asciidoc/groundtruth/asciidoc_01.asciidoc.md
@@ -21,7 +21,7 @@ This is some introductory text in section 1.1.
 
 This is some text in section 2.
 
-| Header 1 | Header 2 |
-| - | - |
-| Value 1 | Value 2 |
-| Value 3 | Value 4 |
+| Header 1 | Header 2 |  |
+| - | - | - |
+| Value 1 | Value 2 |  |
+| Value 3 | Value 4 |  |

--- a/tests/data/asciidoc/groundtruth/asciidoc_02.asciidoc.md
+++ b/tests/data/asciidoc/groundtruth/asciidoc_02.asciidoc.md
@@ -27,10 +27,10 @@ bla bla bla bli bla ble
 
 ## Section 4: test tables
 
-| Header 1 | Header 2 |
-| - | - |
-| Value 1 | Value 2 |
-| Value 3 | Value 4 |
+| Header 1 | Header 2 |  |
+| - | - | - |
+| Value 1 | Value 2 |  |
+| Value 3 | Value 4 |  |
 
 Caption for the table 1
 
@@ -63,15 +63,15 @@ Caption for the table 4
 
 Table 5 with multiple empty cells
 
-| Column 1 Heading | Column 2 Heading | Column 3 Heading |
-| - | - | - |
-| Cell 1 |  | Cell 3 |
-| Cell 4 |  |  |
-| Cell 7 |  |  |
-| Cell 10 | Cell 11 | Cell 12 |
-|  | Cell 14 | Cell 15 |
-|  |  |  |
-| Cell 19 | Cell 20 | Cell 21 |
+| Column 1 Heading | Column 2 Heading | Column 3 Heading |  |
+| - | - | - | - |
+| Cell 1 |  | Cell 3 |  |
+| Cell 4 |  |  |  |
+| Cell 7 |  |  |  |
+| Cell 10 | Cell 11 | Cell 12 |  |
+|  | Cell 14 | Cell 15 |  |
+|  |  |  |  |
+| Cell 19 | Cell 20 | Cell 21 |  |
 
 #### SubSubSection 2.1.1
 

--- a/tests/test_backend_asciidoc.py
+++ b/tests/test_backend_asciidoc.py
@@ -78,31 +78,6 @@ def test_table_cell_content_preserved():
     ]
 
 
-def test_table_trailing_pipe_no_phantom_cell():
-    # A "|" that terminates a row (trailing-pipe style) must not add a phantom
-    # empty cell, which would inflate the table's column count.
-    assert AsciiDocBackend._parse_table_line("|Header 1|Header 2|") == [
-        "Header 1",
-        "Header 2",
-    ]
-    assert AsciiDocBackend._parse_table_line("|Cell 10|Cell 11|Cell 12|") == [
-        "Cell 10",
-        "Cell 11",
-        "Cell 12",
-    ]
-    # Leading and mid-row empty cells must still be preserved.
-    assert AsciiDocBackend._parse_table_line("|Cell 1 | | Cell 3") == [
-        "Cell 1",
-        "",
-        "Cell 3",
-    ]
-    assert AsciiDocBackend._parse_table_line("|| Cell 14 | Cell 15 |") == [
-        "",
-        "Cell 14",
-        "Cell 15",
-    ]
-
-
 def test_empty_table_does_not_crash():
     # An empty table must yield an empty grid rather than raising.
     data = AsciiDocBackend._populate_table_as_grid([])


### PR DESCRIPTION
Reverts docling-project/docling#3787