### PR TITLE
fix(uspto): detect Grant Full Text Data/XML v2.5 patents case-insensitively

### DIFF
--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -919,14 +919,8 @@ class _DocumentConversionInput(BaseModel):
             match_doctype = re.search(r"<!DOCTYPE [^>]+>", content_str)
             if match_doctype:
                 xml_doctype = match_doctype.group()
-                # Compare case-insensitively: USPTO DTD filenames are inconsistently
-                # cased across format eras (e.g. the 2002-2004 Grant v2.5 DTD is
-                # named "ST32-US-Grant-025xml.dtd", capitalized unlike the fully
-                # lowercase v4.x names such as "us-patent-grant-v42-...dtd"). A
-                # case-sensitive check silently fails to identify older files.
-                xml_doctype_lower = xml_doctype.lower()
                 if InputFormat.XML_USPTO in formats and any(
-                    item in xml_doctype_lower
+                    item in xml_doctype.lower()
                     for item in (
                         "us-patent-application-v4",
                         "us-patent-grant-v4",

--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -919,8 +919,14 @@ class _DocumentConversionInput(BaseModel):
             match_doctype = re.search(r"<!DOCTYPE [^>]+>", content_str)
             if match_doctype:
                 xml_doctype = match_doctype.group()
+                # Compare case-insensitively: USPTO DTD filenames are inconsistently
+                # cased across format eras (e.g. the 2002-2004 Grant v2.5 DTD is
+                # named "ST32-US-Grant-025xml.dtd", capitalized unlike the fully
+                # lowercase v4.x names such as "us-patent-grant-v42-...dtd"). A
+                # case-sensitive check silently fails to identify older files.
+                xml_doctype_lower = xml_doctype.lower()
                 if InputFormat.XML_USPTO in formats and any(
-                    item in xml_doctype
+                    item in xml_doctype_lower
                     for item in (
                         "us-patent-application-v4",
                         "us-patent-grant-v4",

--- a/tests/test_input_doc.py
+++ b/tests/test_input_doc.py
@@ -299,10 +299,7 @@ def test_guess_format(tmp_path):
     doc_path = Path("./tests/data/uspto/sources/ipa20110039701.xml")
     assert dci._guess_format(doc_path) == InputFormat.XML_USPTO
 
-    # Valid XML USPTO patent grant, Full Text Data/XML v2.5 (JAN 2002 - DEC 2004).
-    # Regression test for #2290: the DTD filename for this era is
-    # "ST32-US-Grant-025xml.dtd", cased differently from the fully lowercase
-    # v4.x DTD filenames, and was previously missed by a case-sensitive check.
+    # Valid XML USPTO patent grant, Full Text Data/XML v2.5
     buf = BytesIO(Path("./tests/data/uspto/sources/pg06442728.xml").open("rb").read())
     stream = DocumentStream(name="pg06442728.xml", stream=buf)
     assert dci._guess_format(stream) == InputFormat.XML_USPTO

--- a/tests/test_input_doc.py
+++ b/tests/test_input_doc.py
@@ -299,6 +299,18 @@ def test_guess_format(tmp_path):
     doc_path = Path("./tests/data/uspto/sources/ipa20110039701.xml")
     assert dci._guess_format(doc_path) == InputFormat.XML_USPTO
 
+    # Valid XML USPTO patent grant, Full Text Data/XML v2.5 (JAN 2002 - DEC 2004).
+    # Regression test for #2290: the DTD filename for this era is
+    # "ST32-US-Grant-025xml.dtd", cased differently from the fully lowercase
+    # v4.x DTD filenames, and was previously missed by a case-sensitive check.
+    buf = BytesIO(
+        Path("./tests/data/uspto/sources/pg06442728.xml").open("rb").read()
+    )
+    stream = DocumentStream(name="pg06442728.xml", stream=buf)
+    assert dci._guess_format(stream) == InputFormat.XML_USPTO
+    doc_path = Path("./tests/data/uspto/sources/pg06442728.xml")
+    assert dci._guess_format(doc_path) == InputFormat.XML_USPTO
+
     buf = BytesIO(
         Path("./tests/data/uspto/sources/pftaps057006474.txt").open("rb").read()
     )

--- a/tests/test_input_doc.py
+++ b/tests/test_input_doc.py
@@ -303,9 +303,7 @@ def test_guess_format(tmp_path):
     # Regression test for #2290: the DTD filename for this era is
     # "ST32-US-Grant-025xml.dtd", cased differently from the fully lowercase
     # v4.x DTD filenames, and was previously missed by a case-sensitive check.
-    buf = BytesIO(
-        Path("./tests/data/uspto/sources/pg06442728.xml").open("rb").read()
-    )
+    buf = BytesIO(Path("./tests/data/uspto/sources/pg06442728.xml").open("rb").read())
     stream = DocumentStream(name="pg06442728.xml", stream=buf)
     assert dci._guess_format(stream) == InputFormat.XML_USPTO
     doc_path = Path("./tests/data/uspto/sources/pg06442728.xml")


### PR DESCRIPTION
## What

Fixes #2290. USPTO Patent Grant Full Text Data/XML v2.5 files
(Jan 2002 to Dec 2004) were never classified as `InputFormat.XML_USPTO`
during format auto-detection, even though docling already has a fully
working parser for this exact format (`PatentUsptoGrantV2`) and an
existing passing test for it.

## Root cause

`_guess_from_content()` in `docling/datamodel/document.py` checks the
matched `<!DOCTYPE ...>` text against a set of lowercase literals
(`"us-grant-025"`, etc.) without lowercasing the matched text first. USPTO's
v2.5-era DTD filename is `ST32-US-Grant-025xml.dtd`, mixed case, unlike
the fully lowercase v4.x filenames (`us-patent-grant-v42-2006-08-23.dtd`).
So the case-sensitive substring check silently fails for this one era,
while incidentally working for v4.x since those filenames happen to
already be lowercase.

This was never caught by the existing parser test
(`test_patent_uspto_grant_v2`) because that test constructs
`InputDocument(..., format=InputFormat.XML_USPTO, ...)` explicitly,
bypassing detection, so the auto-detect path was never exercised against a
real v2.5 file.

## Fix

Lowercase the matched DOCTYPE substring once before the comparison,
mirroring the normalization `uspto_backend.py`'s own `_set_parser()`
already performs on the same data one file over.

## Testing

- Reproduced the exact reported error against the repo's own v2.5 fixture
  (`tests/data/uspto/sources/pg06442728.xml`) via
  `_DocumentConversionInput._guess_from_content()` directly, confirmed
  `None` before the fix, `InputFormat.XML_USPTO` after.
- Verified no regression across all other USPTO format eras already
  covered by the test suite (v4.2 grant, v4.4 application, pap-v1
  application), all still detect correctly.
- Verified no regression in adjacent DOCTYPE-based detection: XML_JATS
  routing, XML_XBRL short-circuit, DOCLANG fallback, and the
  format-not-requested case (`XML_USPTO` excluded from the allowed
  `formats` list correctly still returns `None`).
- `tests/test_backend_patent_uspto.py` (parser-level tests): 6 passed,
  1 skipped, unchanged.
- Added a regression case to `test_guess_format` in `tests/test_input_doc.py`
  using the existing `pg06442728.xml` fixture, since v2.5 was the one era
  never exercised through the real auto-detect path.

## Scope note

The `XML_JATS` branch immediately below has the same theoretical
case-sensitivity shape, but real JATS DOCTYPE filenames are consistently
cased the way the existing literals expect, so I left it untouched rather
than changing unverified code.