### PR TITLE
fix: avoid lossy supersample of raster-only (scanned) pages in PDFium-rendering backends

### DIFF
--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -76,8 +76,9 @@ class DoclingParsePageBackend(ManagedPdfiumPageBackend):
         keep_chars: bool = False,
         keep_lines: bool = False,
         keep_images: bool = True,
+        supersample_factor: float = 1.5,
     ):
-        super().__init__()
+        super().__init__(supersample_factor=supersample_factor)
         self._ppage = page_obj
         self._dp_doc: Optional[PdfDocument] = dp_doc
         self._page_no = page_no
@@ -187,42 +188,6 @@ class DoclingParsePageBackend(ManagedPdfiumPageBackend):
 
                 yield cropbox
 
-    def get_page_image(
-        self, scale: float = 1, cropbox: Optional[BoundingBox] = None
-    ) -> Image.Image:
-        page_size = self.get_size()
-
-        if not cropbox:
-            cropbox = BoundingBox(
-                l=0,
-                r=page_size.width,
-                t=0,
-                b=page_size.height,
-                coord_origin=CoordOrigin.TOPLEFT,
-            )
-            padbox = BoundingBox(
-                l=0, r=0, t=0, b=0, coord_origin=CoordOrigin.BOTTOMLEFT
-            )
-        else:
-            padbox = cropbox.to_bottom_left_origin(page_size.height).model_copy()
-            padbox.r = page_size.width - padbox.r
-            padbox.t = page_size.height - padbox.t
-
-        with pypdfium2_lock:
-            bitmap = self._ppage.render(
-                scale=scale * 1.5,
-                rotation=0,  # no additional rotation
-                crop=padbox.as_tuple(),
-            )
-            image = bitmap.to_pil().copy()
-            bitmap.close()
-        # We resize the image from 1.5x the given scale to make it sharper.
-        image = image.resize(
-            size=(round(cropbox.width * scale), round(cropbox.height * scale))
-        )
-
-        return image
-
     def get_size(self) -> Size:
         with pypdfium2_lock:
             page = self._require_page()
@@ -301,6 +266,7 @@ class DoclingParseDocumentBackend(ManagedPdfiumDocumentBackend):
             page_no=page_no,
             create_words=create_words,
             create_textlines=create_textlines,
+            supersample_factor=self.options.supersample_factor,
         )
 
     def is_valid(self) -> bool:

--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -94,8 +94,9 @@ class DoclingParsePageBackend(ManagedPdfiumPageBackend):
         keep_chars: bool = False,
         keep_lines: bool = False,
         keep_images: bool = True,
+        supersample_factor: float = 1.5,
     ):
-        super().__init__()
+        super().__init__(supersample_factor=supersample_factor)
         self._ppage = page_obj
         self._dp_doc: Optional[PdfDocument] = dp_doc
         self._page_no = page_no
@@ -204,42 +205,6 @@ class DoclingParsePageBackend(ManagedPdfiumPageBackend):
 
                 yield cropbox
 
-    def get_page_image(
-        self, scale: float = 1, cropbox: Optional[BoundingBox] = None
-    ) -> Image.Image:
-        page_size = self.get_size()
-
-        if not cropbox:
-            cropbox = BoundingBox(
-                l=0,
-                r=page_size.width,
-                t=0,
-                b=page_size.height,
-                coord_origin=CoordOrigin.TOPLEFT,
-            )
-            padbox = BoundingBox(
-                l=0, r=0, t=0, b=0, coord_origin=CoordOrigin.BOTTOMLEFT
-            )
-        else:
-            padbox = cropbox.to_bottom_left_origin(page_size.height).model_copy()
-            padbox.r = page_size.width - padbox.r
-            padbox.t = page_size.height - padbox.t
-
-        with pypdfium2_lock:
-            bitmap = self._ppage.render(
-                scale=scale * 1.5,
-                rotation=0,  # no additional rotation
-                crop=padbox.as_tuple(),
-            )
-            image = bitmap.to_pil().copy()
-            bitmap.close()
-        # We resize the image from 1.5x the given scale to make it sharper.
-        image = image.resize(
-            size=(round(cropbox.width * scale), round(cropbox.height * scale))
-        )
-
-        return image
-
     def get_size(self) -> Size:
         with pypdfium2_lock:
             page = self._require_page()
@@ -334,6 +299,7 @@ class DoclingParseDocumentBackend(ManagedPdfiumDocumentBackend):
             page_no=page_no,
             create_words=create_words,
             create_textlines=create_textlines,
+            supersample_factor=self.options.supersample_factor,
         )
 
     def is_valid(self) -> bool:

--- a/docling/backend/managed_pdfium_backend.py
+++ b/docling/backend/managed_pdfium_backend.py
@@ -1,15 +1,25 @@
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from io import BytesIO
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union
 
+import pypdfium2 as pdfium
+import pypdfium2.raw as pdfium_c
+from docling_core.types.doc import BoundingBox, CoordOrigin
+from PIL import Image
+from pypdfium2._helpers.misc import PdfiumError
+
 from docling.backend.pdf_backend import PdfDocumentBackend, PdfPageBackend
 from docling.datamodel.backend_options import PdfBackendOptions
+from docling.utils.locks import pypdfium2_lock
 
 if TYPE_CHECKING:
     from docling.datamodel.document import InputDocument
+
+_log = logging.getLogger(__name__)
 
 
 class ManagedPdfiumDocumentBackend(PdfDocumentBackend, ABC):
@@ -39,14 +49,119 @@ class ManagedPdfiumDocumentBackend(PdfDocumentBackend, ABC):
 
 
 class ManagedPdfiumPageBackend(PdfPageBackend, ABC):
-    """Shared page lifecycle for PDFium-backed page backends."""
+    """Shared page lifecycle and rendering for PDFium-backed page backends."""
 
-    def __init__(self) -> None:
+    # Maximum Form XObject nesting depth considered when classifying a page
+    # as raster-only.
+    _RASTER_ONLY_MAX_DEPTH = 16
+
+    def __init__(self, supersample_factor: float = 1.5) -> None:
         self._closed = False
+        self.supersample_factor = supersample_factor
+        self._raster_only: Optional[bool] = None
+
+    @abstractmethod
+    def _require_page(self) -> pdfium.PdfPage:
+        pass
 
     @abstractmethod
     def _close_native_page(self) -> None:
         pass
+
+    def _is_raster_only(self) -> bool:
+        """Whether the rendered page content consists solely of image objects.
+
+        This is the common case for scanned documents, where each page is a
+        single full-page image with no text or vector content. Pages carrying
+        annotations are not considered raster-only, since annotations are
+        drawn on rendering but are not part of the page content objects.
+        """
+        if self._raster_only is None:
+            max_depth = self._RASTER_ONLY_MAX_DEPTH
+            has_image = False
+            raster_only = True
+            try:
+                with pypdfium2_lock:
+                    page = self._require_page()
+                    if pdfium_c.FPDFPage_GetAnnotCount(page) > 0:
+                        raster_only = False
+                    else:
+                        for obj in page.get_objects(max_depth=max_depth):
+                            if obj.type == pdfium_c.FPDF_PAGEOBJ_IMAGE:
+                                has_image = True
+                            elif obj.type == pdfium_c.FPDF_PAGEOBJ_FORM:
+                                if obj.level >= max_depth - 1:
+                                    # Content nested beyond the recursion limit
+                                    # was not inspected; assume it is not raster.
+                                    raster_only = False
+                                    break
+                            else:
+                                raster_only = False
+                                break
+            except PdfiumError:
+                _log.info(
+                    f"Failed to inspect the page objects of page {self.page_no}.",
+                    exc_info=True,
+                )
+                raster_only = False
+            self._raster_only = has_image and raster_only
+        return self._raster_only
+
+    def get_page_image(
+        self, scale: float = 1, cropbox: Optional[BoundingBox] = None
+    ) -> Image.Image:
+        page_size = self.get_size()
+
+        if not cropbox:
+            cropbox = BoundingBox(
+                l=0,
+                r=page_size.width,
+                t=0,
+                b=page_size.height,
+                coord_origin=CoordOrigin.TOPLEFT,
+            )
+            padbox = BoundingBox(
+                l=0, r=0, t=0, b=0, coord_origin=CoordOrigin.BOTTOMLEFT
+            )
+        else:
+            padbox = cropbox.to_bottom_left_origin(page_size.height).model_copy()
+            padbox.r = page_size.width - padbox.r
+            padbox.t = page_size.height - padbox.t
+
+        # Supersampling (rendering at a higher scale, then downsizing) sharpens
+        # vector content, but for raster-only (scanned) pages it is a lossy
+        # resample round-trip of already-rasterized pixels that can destroy
+        # borderline OCR text detections. Render those pages directly instead.
+        factor = self.supersample_factor
+        if factor != 1.0 and self._is_raster_only():
+            factor = 1.0
+
+        with pypdfium2_lock:
+            bitmap = self._require_page().render(
+                scale=scale * factor,
+                rotation=0,  # no additional rotation
+                crop=padbox.as_tuple(),
+            )
+            image = bitmap.to_pil().copy()
+            bitmap.close()
+
+        target_size = (round(cropbox.width * scale), round(cropbox.height * scale))
+        if image.size != target_size:
+            if (
+                factor == 1.0
+                and image.width >= target_size[0]
+                and image.height >= target_size[1]
+            ):
+                # pdfium sizes bitmaps with ceil() per side; trim the rounding
+                # excess at the right/bottom edges instead of resampling.
+                image = image.crop((0, 0, *target_size))
+            else:
+                # Downsize the supersampled render to the requested scale. Only
+                # reached on the direct-render path if per-side crop rounding
+                # made the bitmap smaller than the target (max 1-2 px).
+                image = image.resize(size=target_size)
+
+        return image
 
     def unload(self) -> None:
         if self._closed:

--- a/docling/backend/pypdfium2_backend.py
+++ b/docling/backend/pypdfium2_backend.py
@@ -116,10 +116,8 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
         page_no: int,
         supersample_factor: float = 1.5,
     ):
-        super().__init__()
+        super().__init__(supersample_factor=supersample_factor)
         self._page_no = page_no
-        self.supersample_factor = supersample_factor
-        self._raster_only: Optional[bool] = None
         # Note: lock applied by the caller
         self.valid = True  # No better way to tell from pypdfium.
         self._ppage: pdfium.PdfPage | None = None
@@ -354,75 +352,6 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
 
     def get_text_cells(self) -> Iterable[TextCell]:
         return self._compute_text_cells()
-
-    def _is_raster_only(self) -> bool:
-        """Whether the page content consists solely of image objects.
-
-        This is the common case for scanned documents, where each page is a
-        single full-page image with no text or vector content.
-        """
-        if self._raster_only is None:
-            has_image = False
-            raster_only = True
-            try:
-                with pypdfium2_lock:
-                    for obj in self._require_page().get_objects(max_depth=16):
-                        if obj.type == pdfium_c.FPDF_PAGEOBJ_IMAGE:
-                            has_image = True
-                        elif obj.type != pdfium_c.FPDF_PAGEOBJ_FORM:
-                            raster_only = False
-                            break
-            except PdfiumError:
-                _log.info(
-                    f"Failed to inspect page objects of page {self.page_no}.",
-                    exc_info=True,
-                )
-                raster_only = False
-            self._raster_only = has_image and raster_only
-        return self._raster_only
-
-    def get_page_image(
-        self, scale: float = 1, cropbox: Optional[BoundingBox] = None
-    ) -> Image.Image:
-        page_size = self.get_size()
-
-        if not cropbox:
-            cropbox = BoundingBox(
-                l=0,
-                r=page_size.width,
-                t=0,
-                b=page_size.height,
-                coord_origin=CoordOrigin.TOPLEFT,
-            )
-            padbox = BoundingBox(
-                l=0, r=0, t=0, b=0, coord_origin=CoordOrigin.BOTTOMLEFT
-            )
-        else:
-            padbox = cropbox.to_bottom_left_origin(page_size.height).model_copy()
-            padbox.r = page_size.width - padbox.r
-            padbox.t = page_size.height - padbox.t
-
-        # Supersampling (rendering at a higher scale, then downsizing) sharpens
-        # vector content, but for raster-only (scanned) pages it is a lossy
-        # resample round-trip of already-rasterized pixels that can destroy
-        # borderline OCR text detections. Render those pages directly instead.
-        factor = 1.0 if self._is_raster_only() else self.supersample_factor
-
-        with pypdfium2_lock:
-            bitmap = self._require_page().render(
-                scale=scale * factor,
-                rotation=0,  # no additional rotation
-                crop=padbox.as_tuple(),
-            )
-            image = bitmap.to_pil().copy()
-            bitmap.close()
-        # Downsize the supersampled render to the requested scale (and align
-        # exact pixel dimensions with the requested cropbox in general).
-        target_size = (round(cropbox.width * scale), round(cropbox.height * scale))
-        if image.size != target_size:
-            image = image.resize(size=target_size)
-
-        return image
 
     def get_size(self) -> Size:
         with pypdfium2_lock:

--- a/docling/backend/pypdfium2_backend.py
+++ b/docling/backend/pypdfium2_backend.py
@@ -114,9 +114,12 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
         pdfium_doc: pdfium.PdfDocument,
         document_hash: str,
         page_no: int,
+        supersample_factor: float = 1.5,
     ):
         super().__init__()
         self._page_no = page_no
+        self.supersample_factor = supersample_factor
+        self._raster_only: Optional[bool] = None
         # Note: lock applied by the caller
         self.valid = True  # No better way to tell from pypdfium.
         self._ppage: pdfium.PdfPage | None = None
@@ -352,6 +355,32 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
     def get_text_cells(self) -> Iterable[TextCell]:
         return self._compute_text_cells()
 
+    def _is_raster_only(self) -> bool:
+        """Whether the page content consists solely of image objects.
+
+        This is the common case for scanned documents, where each page is a
+        single full-page image with no text or vector content.
+        """
+        if self._raster_only is None:
+            has_image = False
+            raster_only = True
+            try:
+                with pypdfium2_lock:
+                    for obj in self._require_page().get_objects(max_depth=16):
+                        if obj.type == pdfium_c.FPDF_PAGEOBJ_IMAGE:
+                            has_image = True
+                        elif obj.type != pdfium_c.FPDF_PAGEOBJ_FORM:
+                            raster_only = False
+                            break
+            except PdfiumError:
+                _log.info(
+                    f"Failed to inspect page objects of page {self.page_no}.",
+                    exc_info=True,
+                )
+                raster_only = False
+            self._raster_only = has_image and raster_only
+        return self._raster_only
+
     def get_page_image(
         self, scale: float = 1, cropbox: Optional[BoundingBox] = None
     ) -> Image.Image:
@@ -373,18 +402,25 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
             padbox.r = page_size.width - padbox.r
             padbox.t = page_size.height - padbox.t
 
+        # Supersampling (rendering at a higher scale, then downsizing) sharpens
+        # vector content, but for raster-only (scanned) pages it is a lossy
+        # resample round-trip of already-rasterized pixels that can destroy
+        # borderline OCR text detections. Render those pages directly instead.
+        factor = 1.0 if self._is_raster_only() else self.supersample_factor
+
         with pypdfium2_lock:
             bitmap = self._require_page().render(
-                scale=scale * 1.5,
+                scale=scale * factor,
                 rotation=0,  # no additional rotation
                 crop=padbox.as_tuple(),
             )
             image = bitmap.to_pil().copy()
             bitmap.close()
-        # We resize the image from 1.5x the given scale to make it sharper.
-        image = image.resize(
-            size=(round(cropbox.width * scale), round(cropbox.height * scale))
-        )
+        # Downsize the supersampled render to the requested scale (and align
+        # exact pixel dimensions with the requested cropbox in general).
+        target_size = (round(cropbox.width * scale), round(cropbox.height * scale))
+        if image.size != target_size:
+            image = image.resize(size=target_size)
 
         return image
 
@@ -432,7 +468,12 @@ class PyPdfiumDocumentBackend(ManagedPdfiumDocumentBackend):
 
     def load_page(self, page_no: int) -> PyPdfiumPageBackend:
         with pypdfium2_lock:
-            return PyPdfiumPageBackend(self._pdoc, self.document_hash, page_no)
+            return PyPdfiumPageBackend(
+                self._pdoc,
+                self.document_hash,
+                page_no,
+                supersample_factor=self.options.supersample_factor,
+            )
 
     def is_valid(self) -> bool:
         return self.page_count() > 0

--- a/docling/backend/pypdfium2_backend.py
+++ b/docling/backend/pypdfium2_backend.py
@@ -116,9 +116,12 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
         pdfium_doc: pdfium.PdfDocument,
         document_hash: str,
         page_no: int,
+        supersample_factor: float = 1.5,
     ):
         super().__init__()
         self._page_no = page_no
+        self.supersample_factor = supersample_factor
+        self._raster_only: Optional[bool] = None
         # Note: lock applied by the caller
         self.valid = True  # No better way to tell from pypdfium.
         self._ppage: pdfium.PdfPage | None = None
@@ -354,6 +357,32 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
     def get_text_cells(self) -> Iterable[TextCell]:
         return self._compute_text_cells()
 
+    def _is_raster_only(self) -> bool:
+        """Whether the page content consists solely of image objects.
+
+        This is the common case for scanned documents, where each page is a
+        single full-page image with no text or vector content.
+        """
+        if self._raster_only is None:
+            has_image = False
+            raster_only = True
+            try:
+                with pypdfium2_lock:
+                    for obj in self._require_page().get_objects(max_depth=16):
+                        if obj.type == pdfium_c.FPDF_PAGEOBJ_IMAGE:
+                            has_image = True
+                        elif obj.type != pdfium_c.FPDF_PAGEOBJ_FORM:
+                            raster_only = False
+                            break
+            except PdfiumError:
+                _log.info(
+                    f"Failed to inspect page objects of page {self.page_no}.",
+                    exc_info=True,
+                )
+                raster_only = False
+            self._raster_only = has_image and raster_only
+        return self._raster_only
+
     def get_page_image(
         self, scale: float = 1, cropbox: Optional[BoundingBox] = None
     ) -> Image.Image:
@@ -375,18 +404,25 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
             padbox.r = page_size.width - padbox.r
             padbox.t = page_size.height - padbox.t
 
+        # Supersampling (rendering at a higher scale, then downsizing) sharpens
+        # vector content, but for raster-only (scanned) pages it is a lossy
+        # resample round-trip of already-rasterized pixels that can destroy
+        # borderline OCR text detections. Render those pages directly instead.
+        factor = 1.0 if self._is_raster_only() else self.supersample_factor
+
         with pypdfium2_lock:
             bitmap = self._require_page().render(
-                scale=scale * 1.5,
+                scale=scale * factor,
                 rotation=0,  # no additional rotation
                 crop=padbox.as_tuple(),
             )
             image = bitmap.to_pil().copy()
             bitmap.close()
-        # We resize the image from 1.5x the given scale to make it sharper.
-        image = image.resize(
-            size=(round(cropbox.width * scale), round(cropbox.height * scale))
-        )
+        # Downsize the supersampled render to the requested scale (and align
+        # exact pixel dimensions with the requested cropbox in general).
+        target_size = (round(cropbox.width * scale), round(cropbox.height * scale))
+        if image.size != target_size:
+            image = image.resize(size=target_size)
 
         return image
 
@@ -434,7 +470,12 @@ class PyPdfiumDocumentBackend(ManagedPdfiumDocumentBackend):
 
     def load_page(self, page_no: int) -> PyPdfiumPageBackend:
         with pypdfium2_lock:
-            return PyPdfiumPageBackend(self._pdoc, self.document_hash, page_no)
+            return PyPdfiumPageBackend(
+                self._pdoc,
+                self.document_hash,
+                page_no,
+                supersample_factor=self.options.supersample_factor,
+            )
 
     def is_valid(self) -> bool:
         return self.page_count() > 0

--- a/docling/backend/pypdfium2_backend.py
+++ b/docling/backend/pypdfium2_backend.py
@@ -118,10 +118,8 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
         page_no: int,
         supersample_factor: float = 1.5,
     ):
-        super().__init__()
+        super().__init__(supersample_factor=supersample_factor)
         self._page_no = page_no
-        self.supersample_factor = supersample_factor
-        self._raster_only: Optional[bool] = None
         # Note: lock applied by the caller
         self.valid = True  # No better way to tell from pypdfium.
         self._ppage: pdfium.PdfPage | None = None
@@ -356,75 +354,6 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
 
     def get_text_cells(self) -> Iterable[TextCell]:
         return self._compute_text_cells()
-
-    def _is_raster_only(self) -> bool:
-        """Whether the page content consists solely of image objects.
-
-        This is the common case for scanned documents, where each page is a
-        single full-page image with no text or vector content.
-        """
-        if self._raster_only is None:
-            has_image = False
-            raster_only = True
-            try:
-                with pypdfium2_lock:
-                    for obj in self._require_page().get_objects(max_depth=16):
-                        if obj.type == pdfium_c.FPDF_PAGEOBJ_IMAGE:
-                            has_image = True
-                        elif obj.type != pdfium_c.FPDF_PAGEOBJ_FORM:
-                            raster_only = False
-                            break
-            except PdfiumError:
-                _log.info(
-                    f"Failed to inspect page objects of page {self.page_no}.",
-                    exc_info=True,
-                )
-                raster_only = False
-            self._raster_only = has_image and raster_only
-        return self._raster_only
-
-    def get_page_image(
-        self, scale: float = 1, cropbox: Optional[BoundingBox] = None
-    ) -> Image.Image:
-        page_size = self.get_size()
-
-        if not cropbox:
-            cropbox = BoundingBox(
-                l=0,
-                r=page_size.width,
-                t=0,
-                b=page_size.height,
-                coord_origin=CoordOrigin.TOPLEFT,
-            )
-            padbox = BoundingBox(
-                l=0, r=0, t=0, b=0, coord_origin=CoordOrigin.BOTTOMLEFT
-            )
-        else:
-            padbox = cropbox.to_bottom_left_origin(page_size.height).model_copy()
-            padbox.r = page_size.width - padbox.r
-            padbox.t = page_size.height - padbox.t
-
-        # Supersampling (rendering at a higher scale, then downsizing) sharpens
-        # vector content, but for raster-only (scanned) pages it is a lossy
-        # resample round-trip of already-rasterized pixels that can destroy
-        # borderline OCR text detections. Render those pages directly instead.
-        factor = 1.0 if self._is_raster_only() else self.supersample_factor
-
-        with pypdfium2_lock:
-            bitmap = self._require_page().render(
-                scale=scale * factor,
-                rotation=0,  # no additional rotation
-                crop=padbox.as_tuple(),
-            )
-            image = bitmap.to_pil().copy()
-            bitmap.close()
-        # Downsize the supersampled render to the requested scale (and align
-        # exact pixel dimensions with the requested cropbox in general).
-        target_size = (round(cropbox.width * scale), round(cropbox.height * scale))
-        if image.size != target_size:
-            image = image.resize(size=target_size)
-
-        return image
 
     def get_size(self) -> Size:
         with pypdfium2_lock:

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -165,16 +165,17 @@ class PdfBackendOptions(BaseBackendOptions):
 
     kind: Literal["pdf"] = Field("pdf", exclude=True, repr=False)
     password: Optional[SecretStr] = None
-    supersample_factor: Annotated[float, Field(ge=1.0)] = Field(
+    supersample_factor: float = Field(
         1.5,
+        ge=1.0,
         description=(
-            "Supersampling factor for page image rendering: pages are rendered "
-            "at scale * supersample_factor and then downsized to the requested "
-            "scale, which sharpens vector content. Set to 1.0 to render at the "
-            "requested scale directly. Pages whose content is raster-only "
-            "(e.g. scanned pages) are always rendered directly, since the "
-            "supersample round-trip resamples already-rasterized pixels and "
-            "degrades OCR quality."
+            "Supersampling factor for page image rendering in PDFium-rendering "
+            "backends: pages are rendered at scale * supersample_factor and "
+            "then downsized to the requested scale, which sharpens vector "
+            "content. Set to 1.0 to render at the requested scale directly. "
+            "Pages whose content is raster-only (e.g. scanned pages) are "
+            "always rendered directly, since the supersample round-trip "
+            "resamples already-rasterized pixels and degrades OCR quality."
         ),
     )
 

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -165,6 +165,18 @@ class PdfBackendOptions(BaseBackendOptions):
 
     kind: Literal["pdf"] = Field("pdf", exclude=True, repr=False)
     password: Optional[SecretStr] = None
+    supersample_factor: Annotated[float, Field(ge=1.0)] = Field(
+        1.5,
+        description=(
+            "Supersampling factor for page image rendering: pages are rendered "
+            "at scale * supersample_factor and then downsized to the requested "
+            "scale, which sharpens vector content. Set to 1.0 to render at the "
+            "requested scale directly. Pages whose content is raster-only "
+            "(e.g. scanned pages) are always rendered directly, since the "
+            "supersample round-trip resamples already-rasterized pixels and "
+            "degrades OCR quality."
+        ),
+    )
 
 
 class ThreadedDoclingParseBackendOptions(PdfBackendOptions):

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -187,16 +187,17 @@ class PdfBackendOptions(BaseBackendOptions):
             "diacritics that should remain in the same text cell."
         ),
     )
-    supersample_factor: Annotated[float, Field(ge=1.0)] = Field(
+    supersample_factor: float = Field(
         1.5,
+        ge=1.0,
         description=(
-            "Supersampling factor for page image rendering: pages are rendered "
-            "at scale * supersample_factor and then downsized to the requested "
-            "scale, which sharpens vector content. Set to 1.0 to render at the "
-            "requested scale directly. Pages whose content is raster-only "
-            "(e.g. scanned pages) are always rendered directly, since the "
-            "supersample round-trip resamples already-rasterized pixels and "
-            "degrades OCR quality."
+            "Supersampling factor for page image rendering in PDFium-rendering "
+            "backends: pages are rendered at scale * supersample_factor and "
+            "then downsized to the requested scale, which sharpens vector "
+            "content. Set to 1.0 to render at the requested scale directly. "
+            "Pages whose content is raster-only (e.g. scanned pages) are "
+            "always rendered directly, since the supersample round-trip "
+            "resamples already-rasterized pixels and degrades OCR quality."
         ),
     )
 

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -187,6 +187,18 @@ class PdfBackendOptions(BaseBackendOptions):
             "diacritics that should remain in the same text cell."
         ),
     )
+    supersample_factor: Annotated[float, Field(ge=1.0)] = Field(
+        1.5,
+        description=(
+            "Supersampling factor for page image rendering: pages are rendered "
+            "at scale * supersample_factor and then downsized to the requested "
+            "scale, which sharpens vector content. Set to 1.0 to render at the "
+            "requested scale directly. Pages whose content is raster-only "
+            "(e.g. scanned pages) are always rendered directly, since the "
+            "supersample round-trip resamples already-rasterized pixels and "
+            "degrades OCR quality."
+        ),
+    )
 
 
 class ThreadedDoclingParseBackendOptions(PdfBackendOptions):

--- a/docs/usage/advanced_options.md
+++ b/docs/usage/advanced_options.md
@@ -132,6 +132,24 @@ doc_converter = DocumentConverter(
 ```
 
 
+### Control page image supersampling
+
+Backends that render PDF pages with PDFium (the default `DoclingParseDocumentBackend` and `PyPdfiumDocumentBackend`) render page images at 1.5x the requested scale and then downsize them, which sharpens vector content. Pages whose content is raster-only (e.g. scanned pages) are automatically rendered at the requested scale directly, since resampling already-rasterized pixels degrades OCR quality. The factor can be tuned — or supersampling disabled entirely with `1.0` — through the backend options:
+
+```python
+from docling.datamodel.backend_options import PdfBackendOptions
+from docling.datamodel.base_models import InputFormat
+from docling.document_converter import DocumentConverter, PdfFormatOption
+
+doc_converter = DocumentConverter(
+    format_options={
+        InputFormat.PDF: PdfFormatOption(
+            backend_options=PdfBackendOptions(supersample_factor=1.0)
+        )
+    }
+)
+```
+
 ## Impose limits on the document size
 
 You can limit the file size and number of pages which should be allowed to process per document:

--- a/docs/usage/advanced_options.md
+++ b/docs/usage/advanced_options.md
@@ -142,6 +142,24 @@ doc_converter = DocumentConverter(
 ```
 
 
+### Control page image supersampling
+
+Backends that render PDF pages with PDFium (the default `DoclingParseDocumentBackend` and `PyPdfiumDocumentBackend`) render page images at 1.5x the requested scale and then downsize them, which sharpens vector content. Pages whose content is raster-only (e.g. scanned pages) are automatically rendered at the requested scale directly, since resampling already-rasterized pixels degrades OCR quality. The factor can be tuned — or supersampling disabled entirely with `1.0` — through the backend options:
+
+```python
+from docling.datamodel.backend_options import PdfBackendOptions
+from docling.datamodel.base_models import InputFormat
+from docling.document_converter import DocumentConverter, PdfFormatOption
+
+doc_converter = DocumentConverter(
+    format_options={
+        InputFormat.PDF: PdfFormatOption(
+            backend_options=PdfBackendOptions(supersample_factor=1.0)
+        )
+    }
+)
+```
+
 ## Impose limits on the document size
 
 You can limit the file size and number of pages which should be allowed to process per document:

--- a/tests/test_backend_docling_parse.py
+++ b/tests/test_backend_docling_parse.py
@@ -96,6 +96,31 @@ def test_crop_page_image(test_doc_path):
     doc_backend.unload()
 
 
+def test_supersample_factor_backend_option(test_doc_path):
+    # supersample_factor=1.0 must be honored by the default PDF backend,
+    # yielding a direct pdfium render at the requested scale (issue #3587).
+    import pypdfium2 as pdfium
+
+    from docling.datamodel.backend_options import PdfBackendOptions
+
+    in_doc = InputDocument(
+        path_or_stream=test_doc_path,
+        format=InputFormat.PDF,
+        backend=DoclingParseDocumentBackend,
+        backend_options=PdfBackendOptions(supersample_factor=1.0),
+    )
+    page_backend = in_doc._backend.load_page(0)
+
+    image = page_backend.get_page_image(scale=2)
+
+    pdf = pdfium.PdfDocument(test_doc_path)
+    reference = pdf[0].render(scale=2, rotation=0, crop=(0, 0, 0, 0)).to_pil()
+    pdf.close()
+
+    assert image.size == reference.size
+    assert image.tobytes() == reference.tobytes()
+
+
 def test_num_pages(test_doc_path):
     doc_backend = _get_backend(test_doc_path)
     assert doc_backend.page_count() == 9

--- a/tests/test_backend_docling_parse.py
+++ b/tests/test_backend_docling_parse.py
@@ -112,12 +112,17 @@ def test_supersample_factor_backend_option(test_doc_path):
         backend_options=PdfBackendOptions(supersample_factor=1.0),
     )
     page_backend = in_doc._backend.load_page(0)
-
-    image = page_backend.get_page_image(scale=2)
+    try:
+        image = page_backend.get_page_image(scale=2)
+    finally:
+        page_backend.unload()
+        in_doc._backend.unload()
 
     pdf = pdfium.PdfDocument(test_doc_path)
-    reference = pdf[0].render(scale=2, rotation=0, crop=(0, 0, 0, 0)).to_pil()
-    pdf.close()
+    try:
+        reference = pdf[0].render(scale=2, rotation=0, crop=(0, 0, 0, 0)).to_pil()
+    finally:
+        pdf.close()
 
     assert image.size == reference.size
     assert image.tobytes() == reference.tobytes()

--- a/tests/test_backend_docling_parse.py
+++ b/tests/test_backend_docling_parse.py
@@ -98,6 +98,31 @@ def test_crop_page_image(test_doc_path):
     doc_backend.unload()
 
 
+def test_supersample_factor_backend_option(test_doc_path):
+    # supersample_factor=1.0 must be honored by the default PDF backend,
+    # yielding a direct pdfium render at the requested scale (issue #3587).
+    import pypdfium2 as pdfium
+
+    from docling.datamodel.backend_options import PdfBackendOptions
+
+    in_doc = InputDocument(
+        path_or_stream=test_doc_path,
+        format=InputFormat.PDF,
+        backend=DoclingParseDocumentBackend,
+        backend_options=PdfBackendOptions(supersample_factor=1.0),
+    )
+    page_backend = in_doc._backend.load_page(0)
+
+    image = page_backend.get_page_image(scale=2)
+
+    pdf = pdfium.PdfDocument(test_doc_path)
+    reference = pdf[0].render(scale=2, rotation=0, crop=(0, 0, 0, 0)).to_pil()
+    pdf.close()
+
+    assert image.size == reference.size
+    assert image.tobytes() == reference.tobytes()
+
+
 def test_num_pages(test_doc_path):
     doc_backend = _get_backend(test_doc_path)
     assert doc_backend.page_count() == 9

--- a/tests/test_backend_docling_parse.py
+++ b/tests/test_backend_docling_parse.py
@@ -109,17 +109,23 @@ def test_supersample_factor_backend_option(test_doc_path):
         backend=DoclingParseDocumentBackend,
         backend_options=PdfBackendOptions(supersample_factor=1.0),
     )
-    page_backend = in_doc._backend.load_page(0)
+    doc_backend = in_doc._backend
+    page_backend = doc_backend.load_page(0)
 
-    image = page_backend.get_page_image(scale=2)
+    try:
+        image = page_backend.get_page_image(scale=2)
 
-    pdf = pdfium.PdfDocument(test_doc_path)
-    reference = pdf[0].render(scale=2, rotation=0, crop=(0, 0, 0, 0)).to_pil()
-    pdf.close()
+        pdf = pdfium.PdfDocument(test_doc_path)
+        try:
+            reference = pdf[0].render(scale=2, rotation=0, crop=(0, 0, 0, 0)).to_pil()
+        finally:
+            pdf.close()
 
-    assert image.size == reference.size
-    assert image.tobytes() == reference.tobytes()
-
+        assert image.size == reference.size
+        assert image.tobytes() == reference.tobytes()
+    finally:
+        page_backend.unload()
+        doc_backend.unload()
 
 def test_num_pages(test_doc_path):
     doc_backend = _get_backend(test_doc_path)

--- a/tests/test_backend_pdfium.py
+++ b/tests/test_backend_pdfium.py
@@ -131,20 +131,25 @@ def test_crop_page_image(test_doc_path):
     # im.show()
 
 
-def test_raster_only_page_skips_supersample():
+# The fractional page size exercises the ceil/round mismatch between pdfium
+# bitmap sizing and the requested pixel dimensions (real scans commonly have
+# non-integer media boxes, e.g. 595.2 x 841.9).
+@pytest.mark.parametrize("page_size", [(612, 792), (611.3, 791.7)])
+def test_raster_only_page_skips_supersample(page_size):
     # For image-only (scanned) pages, get_page_image must return the direct
     # render at the requested scale: the 1.5x supersample-downsample round-trip
     # resamples already-rasterized pixels and degrades OCR quality (issue #3587).
-    pdf_bytes = _make_image_only_pdf()
+    pdf_bytes = _make_image_only_pdf(*page_size)
 
     doc_backend = _get_backend(BytesIO(pdf_bytes))
     page_backend: PyPdfiumPageBackend = doc_backend.load_page(0)
     assert page_backend._is_raster_only()
 
     image = page_backend.get_page_image(scale=2)
-    reference = _direct_render(pdf_bytes, scale=2)
+    assert image.size == (round(page_size[0] * 2), round(page_size[1] * 2))
 
-    assert image.size == reference.size
+    # Trimming pdfium's ceil() rounding excess is allowed; resampling is not.
+    reference = _direct_render(pdf_bytes, scale=2).crop((0, 0, *image.size))
     assert image.mode == reference.mode
     assert image.tobytes() == reference.tobytes()
 

--- a/tests/test_backend_pdfium.py
+++ b/tests/test_backend_pdfium.py
@@ -1,12 +1,16 @@
+from io import BytesIO
 from pathlib import Path
 
+import pypdfium2 as pdfium
 import pytest
 from docling_core.types.doc import BoundingBox
+from PIL import Image
 
 from docling.backend.pypdfium2_backend import (
     PyPdfiumDocumentBackend,
     PyPdfiumPageBackend,
 )
+from docling.datamodel.backend_options import PdfBackendOptions
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
 from docling.datamodel.pipeline_options import PdfPipelineOptions
@@ -20,15 +24,49 @@ def test_doc_path():
     return Path("./tests/data/pdf/2206.01062.pdf")
 
 
-def _get_backend(pdf_doc):
+def _get_backend(pdf_doc, backend_options=None):
     in_doc = InputDocument(
         path_or_stream=pdf_doc,
         format=InputFormat.PDF,
         backend=PyPdfiumDocumentBackend,
+        backend_options=backend_options,
+        filename="test.pdf" if isinstance(pdf_doc, BytesIO) else None,
     )
 
     doc_backend = in_doc._backend
     return doc_backend
+
+
+def _make_image_only_pdf(page_width=612, page_height=792) -> bytes:
+    """Build a PDF whose single page is one full-bleed image, like a scan."""
+    img_w, img_h = 306, 396
+    pixels = bytes(
+        (x * 7 + y * 13 + channel * 41) % 256
+        for y in range(img_h)
+        for x in range(img_w)
+        for channel in range(3)
+    )
+    pil_image = Image.frombytes("RGB", (img_w, img_h), pixels)
+
+    pdf = pdfium.PdfDocument.new()
+    image = pdfium.PdfImage.new(pdf)
+    image.set_bitmap(pdfium.PdfBitmap.from_pil(pil_image))
+    image.set_matrix(pdfium.PdfMatrix().scale(page_width, page_height))
+    page = pdf.new_page(page_width, page_height)
+    page.insert_obj(image)
+    page.gen_content()
+    buf = BytesIO()
+    pdf.save(buf)
+    pdf.close()
+    return buf.getvalue()
+
+
+def _direct_render(pdf_bytes_or_path, scale: float) -> Image.Image:
+    """Reference render of page 0 at the given scale, without supersampling."""
+    pdf = pdfium.PdfDocument(pdf_bytes_or_path)
+    image = pdf[0].render(scale=scale, rotation=0, crop=(0, 0, 0, 0)).to_pil()
+    pdf.close()
+    return image
 
 
 def test_get_text_from_rect_rotated():
@@ -91,6 +129,53 @@ def test_crop_page_image(test_doc_path):
         scale=2, cropbox=BoundingBox(l=317, t=246, r=574, b=527)
     )
     # im.show()
+
+
+def test_raster_only_page_skips_supersample():
+    # For image-only (scanned) pages, get_page_image must return the direct
+    # render at the requested scale: the 1.5x supersample-downsample round-trip
+    # resamples already-rasterized pixels and degrades OCR quality (issue #3587).
+    pdf_bytes = _make_image_only_pdf()
+
+    doc_backend = _get_backend(BytesIO(pdf_bytes))
+    page_backend: PyPdfiumPageBackend = doc_backend.load_page(0)
+    assert page_backend._is_raster_only()
+
+    image = page_backend.get_page_image(scale=2)
+    reference = _direct_render(pdf_bytes, scale=2)
+
+    assert image.size == reference.size
+    assert image.mode == reference.mode
+    assert image.tobytes() == reference.tobytes()
+
+
+def test_vector_page_keeps_supersample(test_doc_path):
+    # Pages with text/vector content keep the default 1.5x supersampling,
+    # so the rendered image differs from a direct render at the same scale.
+    doc_backend = _get_backend(test_doc_path)
+    page_backend: PyPdfiumPageBackend = doc_backend.load_page(0)
+    assert not page_backend._is_raster_only()
+
+    image = page_backend.get_page_image(scale=2)
+    reference = _direct_render(test_doc_path, scale=2)
+
+    assert image.size == reference.size
+    assert image.tobytes() != reference.tobytes()
+
+
+def test_supersample_factor_option(test_doc_path):
+    # supersample_factor=1.0 renders any page directly at the requested scale.
+    doc_backend = _get_backend(
+        test_doc_path, backend_options=PdfBackendOptions(supersample_factor=1.0)
+    )
+    page_backend: PyPdfiumPageBackend = doc_backend.load_page(0)
+    assert not page_backend._is_raster_only()
+
+    image = page_backend.get_page_image(scale=2)
+    reference = _direct_render(test_doc_path, scale=2)
+
+    assert image.size == reference.size
+    assert image.tobytes() == reference.tobytes()
 
 
 def test_num_pages(test_doc_path):

--- a/tests/test_backend_pdfium.py
+++ b/tests/test_backend_pdfium.py
@@ -1,12 +1,16 @@
+from io import BytesIO
 from pathlib import Path
 
+import pypdfium2 as pdfium
 import pytest
 from docling_core.types.doc import BoundingBox
+from PIL import Image
 
 from docling.backend.pypdfium2_backend import (
     PyPdfiumDocumentBackend,
     PyPdfiumPageBackend,
 )
+from docling.datamodel.backend_options import PdfBackendOptions
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
 from docling.datamodel.pipeline_options import PdfPipelineOptions
@@ -20,15 +24,49 @@ def test_doc_path():
     return Path("./tests/data/pdf/sources/2206.01062.pdf")
 
 
-def _get_backend(pdf_doc):
+def _get_backend(pdf_doc, backend_options=None):
     in_doc = InputDocument(
         path_or_stream=pdf_doc,
         format=InputFormat.PDF,
         backend=PyPdfiumDocumentBackend,
+        backend_options=backend_options,
+        filename="test.pdf" if isinstance(pdf_doc, BytesIO) else None,
     )
 
     doc_backend = in_doc._backend
     return doc_backend
+
+
+def _make_image_only_pdf(page_width=612, page_height=792) -> bytes:
+    """Build a PDF whose single page is one full-bleed image, like a scan."""
+    img_w, img_h = 306, 396
+    pixels = bytes(
+        (x * 7 + y * 13 + channel * 41) % 256
+        for y in range(img_h)
+        for x in range(img_w)
+        for channel in range(3)
+    )
+    pil_image = Image.frombytes("RGB", (img_w, img_h), pixels)
+
+    pdf = pdfium.PdfDocument.new()
+    image = pdfium.PdfImage.new(pdf)
+    image.set_bitmap(pdfium.PdfBitmap.from_pil(pil_image))
+    image.set_matrix(pdfium.PdfMatrix().scale(page_width, page_height))
+    page = pdf.new_page(page_width, page_height)
+    page.insert_obj(image)
+    page.gen_content()
+    buf = BytesIO()
+    pdf.save(buf)
+    pdf.close()
+    return buf.getvalue()
+
+
+def _direct_render(pdf_bytes_or_path, scale: float) -> Image.Image:
+    """Reference render of page 0 at the given scale, without supersampling."""
+    pdf = pdfium.PdfDocument(pdf_bytes_or_path)
+    image = pdf[0].render(scale=scale, rotation=0, crop=(0, 0, 0, 0)).to_pil()
+    pdf.close()
+    return image
 
 
 def test_get_text_from_rect_rotated():
@@ -91,6 +129,53 @@ def test_crop_page_image(test_doc_path):
         scale=2, cropbox=BoundingBox(l=317, t=246, r=574, b=527)
     )
     # im.show()
+
+
+def test_raster_only_page_skips_supersample():
+    # For image-only (scanned) pages, get_page_image must return the direct
+    # render at the requested scale: the 1.5x supersample-downsample round-trip
+    # resamples already-rasterized pixels and degrades OCR quality (issue #3587).
+    pdf_bytes = _make_image_only_pdf()
+
+    doc_backend = _get_backend(BytesIO(pdf_bytes))
+    page_backend: PyPdfiumPageBackend = doc_backend.load_page(0)
+    assert page_backend._is_raster_only()
+
+    image = page_backend.get_page_image(scale=2)
+    reference = _direct_render(pdf_bytes, scale=2)
+
+    assert image.size == reference.size
+    assert image.mode == reference.mode
+    assert image.tobytes() == reference.tobytes()
+
+
+def test_vector_page_keeps_supersample(test_doc_path):
+    # Pages with text/vector content keep the default 1.5x supersampling,
+    # so the rendered image differs from a direct render at the same scale.
+    doc_backend = _get_backend(test_doc_path)
+    page_backend: PyPdfiumPageBackend = doc_backend.load_page(0)
+    assert not page_backend._is_raster_only()
+
+    image = page_backend.get_page_image(scale=2)
+    reference = _direct_render(test_doc_path, scale=2)
+
+    assert image.size == reference.size
+    assert image.tobytes() != reference.tobytes()
+
+
+def test_supersample_factor_option(test_doc_path):
+    # supersample_factor=1.0 renders any page directly at the requested scale.
+    doc_backend = _get_backend(
+        test_doc_path, backend_options=PdfBackendOptions(supersample_factor=1.0)
+    )
+    page_backend: PyPdfiumPageBackend = doc_backend.load_page(0)
+    assert not page_backend._is_raster_only()
+
+    image = page_backend.get_page_image(scale=2)
+    reference = _direct_render(test_doc_path, scale=2)
+
+    assert image.size == reference.size
+    assert image.tobytes() == reference.tobytes()
 
 
 def test_num_pages(test_doc_path):


### PR DESCRIPTION
`get_page_image()` in the PDFium-rendering backends renders every page at 1.5× the requested scale and PIL-resizes down. For vector content that supersampling sharpens the output, but for image-only (scanned) pages it is a lossy resample round-trip of already-rasterized pixels that can destroy borderline OCR text detections — see #3587 for isolated evidence (an entire sentence silently lost end-to-end on a degraded scan; page CER 0.184 vs ~0.05 for direct rasterization).

This implements suggestions 1 and 2 from the issue:

1. **Raster-only pages render directly at the requested scale.** A page whose content consists solely of image objects (the common scanned-document case) skips the supersample round-trip. Detection walks `page.get_objects()` (traversing form XObjects, since scans are often form-wrapped — e.g. `tests/data_scanned/ocr_test.pdf`) and is conservative: pages with annotations, or with content nested beyond the inspection depth, keep supersampling. Pages with any text/vector content are unaffected.
2. **`PdfBackendOptions.supersample_factor`** (default `1.5`, i.e. no behavior change for non-raster pages) makes the factor configurable; `1.0` restores direct rendering everywhere.

Implementation notes:

- The previously duplicated `get_page_image()` in `PyPdfiumPageBackend` and `DoclingParsePageBackend` is hoisted into their shared base `ManagedPdfiumPageBackend`, so the fix and the new option apply consistently to both the default `DoclingParseDocumentBackend` and `PyPdfiumDocumentBackend` (rather than the option being silently ignored by the default backend).
- pdfium sizes bitmaps with `ceil()` per side while the requested pixel dimensions use `round()`; on the direct-render path the rounding excess is now **cropped** instead of resampled. This matters in practice: real scans commonly have fractional media boxes (e.g. 595.2×841.9 pt), where a naive size check would have re-triggered the lossy resize.
- The threaded docling-parse (v4) backend renders through docling-parse's own path and is not affected.

**Verification**

- New tests: a raster-only page (generated deterministically in-memory, integer and fractional page sizes) renders pixel-identical to a direct `pdfium` render at the same scale; a vector page keeps supersampling by default; `supersample_factor=1.0` yields a direct render on vector pages through both backends.
- The self-contained repro from #3587 now recovers the lost line through `get_page_image`:
  ```
  direct pdfium render @3x:        9 text lines detected
  docling get_page_image(scale=3): 9 text lines detected
  line 'A second paragraph...' -> direct: True, docling render: True
  ```
- **No reference-data churn:** the scanned fixtures (`ocr_test*.pdf`) are raster-only, so their render path changes; I replicated `test_e2e_ocr_conversion` locally for EasyOCR and RapidOCR (onnxruntime, standard + `force_full_page_ocr`) and the conversions verify against the stored groundtruth unchanged. Tesseract variants could not run in my environment (no tessdata) — CI should confirm.
- `tests/test_backend_pdfium.py`, `tests/test_backend_docling_parse.py`, `tests/test_backend_docling_parse_legacy.py`, `tests/test_pdf_password.py` pass; `make validate` (ruff, ty, tach) is clean.

**Issue resolved by this Pull Request:**
Resolves #3587

**Checklist:**

- [x] Documentation has been updated, if necessary. (new section in `docs/usage/advanced_options.md`)
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
