### PR TITLE
fix(vlm): use each element's own page for force_backend_text

### DIFF
--- a/docling/pipeline/vlm_pipeline.py
+++ b/docling/pipeline/vlm_pipeline.py
@@ -466,20 +466,23 @@ class VlmPipeline(PaginatedPipeline):
         )
 
         # If forced backend text, replace model predicted text with backend one
-        if page.size:
-            if self.force_backend_text:
-                scale = self.pipeline_options.images_scale
-                for element, _level in conv_res.document.iterate_items():
-                    if not isinstance(element, TextItem) or len(element.prov) == 0:
-                        continue
-                    crop_bbox = (
-                        element.prov[0]
-                        .bbox.scaled(scale=scale)
-                        .to_top_left_origin(page_height=page.size.height * scale)
-                    )
-                    txt = self.extract_text_from_backend(page, crop_bbox)
-                    element.text = txt
-                    element.orig = txt
+        if self.force_backend_text:
+            scale = self.pipeline_options.images_scale
+            for element, _level in conv_res.document.iterate_items():
+                if not isinstance(element, TextItem) or len(element.prov) == 0:
+                    continue
+                page_ix = element.prov[0].page_no - 1
+                page = conv_res.pages[page_ix]
+                if not page.size:
+                    continue
+                crop_bbox = (
+                    element.prov[0]
+                    .bbox.scaled(scale=scale)
+                    .to_top_left_origin(page_height=page.size.height * scale)
+                )
+                txt = self.extract_text_from_backend(page, crop_bbox)
+                element.text = txt
+                element.orig = txt
 
         return conv_res.document
 

--- a/tests/test_vlm_pipeline_force_backend_text.py
+++ b/tests/test_vlm_pipeline_force_backend_text.py
@@ -1,0 +1,77 @@
+"""Tests for VlmPipeline._turn_dt_into_doc with force_backend_text on multipage docs.
+
+When force_backend_text=True on a multi-page DocTags (SmolDocling) document,
+each text element must be re-extracted from its OWN page's backend, using that
+page's size. A regression made every element use the last page's backend and
+height, so all pages received the final page's text.
+
+Related: https://github.com/docling-project/docling/pull/1371
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from docling_core.types.doc import TextItem
+from docling_core.types.doc.base import Size
+from PIL import Image as PILImage
+
+from docling.datamodel.base_models import Page, PagePredictions, VlmPrediction
+from docling.datamodel.document import ConversionResult
+from docling.pipeline.vlm_pipeline import VlmPipeline
+
+pytestmark = pytest.mark.ml_vlm
+
+
+def _make_page(page_no: int, height: int, backend_text: str) -> tuple[Page, MagicMock]:
+    """Build a Page whose backend returns a page-specific string for any rect."""
+    page = Page(page_no=page_no)
+    page.size = Size(width=100, height=height)
+    page.predictions = PagePredictions(
+        vlm_response=VlmPrediction(
+            text=(
+                "<doctag><text><loc_10><loc_10><loc_90><loc_20>"
+                f"model text {page_no}</text></doctag>"
+            )
+        )
+    )
+    page._image_cache = {1.0: PILImage.new("RGB", (100, height), "white")}
+
+    backend = MagicMock()
+    backend.get_text_in_rect.return_value = backend_text
+    page._backend = backend
+    return page, backend
+
+
+@pytest.fixture
+def pipeline() -> VlmPipeline:
+    """VlmPipeline instance without running __init__ (no model download)."""
+    pipe = VlmPipeline.__new__(VlmPipeline)
+    pipe.force_backend_text = True
+    pipe.pipeline_options = MagicMock()
+    pipe.pipeline_options.images_scale = 1.0
+    return pipe
+
+
+def test_force_backend_text_uses_each_elements_own_page(
+    pipeline: VlmPipeline,
+) -> None:
+    """Each page's text must come from that page's backend, not the last page's."""
+    page1, backend1 = _make_page(1, height=200, backend_text="backend text page 1")
+    page2, backend2 = _make_page(2, height=400, backend_text="backend text page 2")
+    conv_res = MagicMock(spec=ConversionResult)
+    conv_res.pages = [page1, page2]
+
+    document = pipeline._turn_dt_into_doc(conv_res)
+
+    texts_by_page = {
+        item.prov[0].page_no: item.text
+        for item, _level in document.iterate_items()
+        if isinstance(item, TextItem) and item.prov
+    }
+    assert texts_by_page[1] == "backend text page 1"
+    assert texts_by_page[2] == "backend text page 2"
+
+    # The bug routed every element through the last page's backend, so page 1's
+    # backend was never queried while page 2's was queried for both elements.
+    assert backend1.get_text_in_rect.call_count == 1
+    assert backend2.get_text_in_rect.call_count == 1


### PR DESCRIPTION

In the VLM DocTags pipeline, `_turn_dt_into_doc` re-extracted backend text using the `page` variable left over from the preceding page-collection loop, which is always the last page. On a multi-page document converted with `force_backend_text=True`, every text element was therefore re-extracted from the last page's backend and scaled by the last page's height, so all pages received the final page's text (and wrong crop coordinates).

This derives each element's page from its own provenance (`page = conv_res.pages[element.prov[0].page_no - 1]`) and skips pages without a size, mirroring the pattern already used for picture extraction in `_assemble_document`. Single-page conversions are unaffected. This restores the per-element behavior that was originally added in #1371 and later lost during the vlm-models refactor, so no reference conversion data changes.

A regression test converts a two-page DocTags document with `force_backend_text=True` and asserts each page's text comes from its own page's backend (it fails before this change because page 1's element receives page 2's text).

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
