### PR TITLE
perf(xlsx): replace O(n) merge-cell scan with O(1) spatial index

### DIFF
--- a/docling/backend/msexcel_backend.py
+++ b/docling/backend/msexcel_backend.py
@@ -62,6 +62,7 @@ _OPENPYXL_AVAILABLE: bool = False
 _OPENPYXL_IMPORT_ERROR: ImportError | None = None
 try:  # pragma: no cover - import-time guard
     from openpyxl import Workbook, load_workbook
+    from openpyxl.cell.cell import Cell, MergedCell
     from openpyxl.chartsheet.chartsheet import Chartsheet
     from openpyxl.drawing.image import Image
     from openpyxl.drawing.spreadsheet_drawing import (
@@ -146,6 +147,66 @@ class DataRegion:
     def height(self) -> PositiveInt:
         """Number of rows in the data region."""
         return self.max_row - self.min_row + 1
+
+
+class _MergedCellIndex:
+    """Index merged-cell anchors without expanding their coordinate ranges."""
+
+    def __init__(self, sheet: Worksheet) -> None:
+        self._anchor_spans: dict[tuple[int, int], tuple[int, int]] = {}
+
+        min_row: int | None = None
+        min_col: int | None = None
+        max_row = 0
+        max_col = 0
+
+        for merged_range in sheet.merged_cells.ranges:
+            anchor = (merged_range.min_row - 1, merged_range.min_col - 1)
+            self._anchor_spans.setdefault(
+                anchor,
+                (
+                    merged_range.max_row - merged_range.min_row + 1,
+                    merged_range.max_col - merged_range.min_col + 1,
+                ),
+            )
+            min_row = (
+                merged_range.min_row
+                if min_row is None
+                else min(min_row, merged_range.min_row)
+            )
+            min_col = (
+                merged_range.min_col
+                if min_col is None
+                else min(min_col, merged_range.min_col)
+            )
+            max_row = max(max_row, merged_range.max_row)
+            max_col = max(max_col, merged_range.max_col)
+
+        self.bounds = (
+            DataRegion(min_row, max_row, min_col, max_col)
+            if min_row is not None and min_col is not None
+            else None
+        )
+
+    def contains(self, cell: Cell | MergedCell) -> bool:
+        """Return whether a cell is an anchor or shadow of a merged range."""
+        return (
+            isinstance(cell, MergedCell)
+            or (
+                cell.row - 1,
+                cell.column - 1,
+            )
+            in self._anchor_spans
+        )
+
+    @staticmethod
+    def is_shadow(cell: Cell | MergedCell) -> bool:
+        """Return whether a cell is a non-anchor part of a merged range."""
+        return isinstance(cell, MergedCell)
+
+    def span_at(self, row: int, col: int) -> tuple[int, int]:
+        """Return the row and column span for a 0-based anchor coordinate."""
+        return self._anchor_spans.get((row, col), (1, 1))
 
 
 class ExcelCell(BaseModel):
@@ -771,7 +832,9 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
             ),
         )
 
-    def _find_true_data_bounds(self, sheet: Worksheet) -> DataRegion:
+    def _find_true_data_bounds(
+        self, sheet: Worksheet, merged_cell_index: _MergedCellIndex
+    ) -> DataRegion:
         """Find the true data boundaries (min/max rows and columns) in a worksheet.
 
         This function scans all cells to find the smallest rectangular region that contains
@@ -780,6 +843,8 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
 
         Args:
             sheet: The worksheet to analyze.
+            merged_cell_index: Index containing merged-cell anchors, spans, and
+                bounds for the worksheet.
 
         Returns:
             A data region representing the smallest rectangle that covers all data and merged cells.
@@ -796,16 +861,21 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
                 max_row = max(max_row, r)
                 max_col = max(max_col, c)
 
-        # Expand bounds to include merged cells
-        for merged in sheet.merged_cells.ranges:
+        # Expand bounds to include merged cells without scanning all ranges again.
+        if merged_cell_index.bounds is not None:
+            merged_bounds = merged_cell_index.bounds
             min_row = (
-                merged.min_row if min_row is None else min(min_row, merged.min_row)
+                merged_bounds.min_row
+                if min_row is None
+                else min(min_row, merged_bounds.min_row)
             )
             min_col = (
-                merged.min_col if min_col is None else min(min_col, merged.min_col)
+                merged_bounds.min_col
+                if min_col is None
+                else min(min_col, merged_bounds.min_col)
             )
-            max_row = max(max_row, merged.max_row)
-            max_col = max(max_col, merged.max_col)
+            max_row = max(max_row, merged_bounds.max_row)
+            max_col = max(max_col, merged_bounds.max_col)
 
         # If no data found, default to (1, 1, 1, 1)
         if min_row is None or min_col is None:
@@ -830,9 +900,8 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
                 - A list of ExcelTable objects representing the data tables
                 - A dict mapping (row, col) to (author, comment_text, timestamp) for cells with comments
         """
-        bounds: DataRegion = self._find_true_data_bounds(
-            sheet
-        )  # The true data boundaries
+        merged_cell_index = _MergedCellIndex(sheet)
+        bounds = self._find_true_data_bounds(sheet, merged_cell_index)
         tables: list[ExcelTable] = []  # List to store found tables
         visited: set[tuple[int, int]] = set()  # Track already visited cells
         comment_map: dict[
@@ -880,7 +949,12 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
 
                 # If the cell starts a new table, find its bounds
                 table_bounds, visited_cells = self._find_table_bounds(
-                    sheet, ri, rj, bounds.max_row, bounds.max_col
+                    sheet,
+                    start_row=ri,
+                    start_col=rj,
+                    max_row=bounds.max_row,
+                    max_col=bounds.max_col,
+                    merged_cell_index=merged_cell_index,
                 )
                 visited.update(visited_cells)  # Mark these cells as visited
                 tables.append(table_bounds)
@@ -890,10 +964,12 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
     def _find_table_bounds(
         self,
         sheet: Worksheet,
+        *,
         start_row: int,
         start_col: int,
         max_row: int,
         max_col: int,
+        merged_cell_index: _MergedCellIndex,
     ) -> tuple[ExcelTable, set[tuple[int, int]]]:
         """Determine table bounds using a Flood Fill (BFS) strategy.
 
@@ -940,7 +1016,7 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         min_c, max_c = start_col, start_col
 
         # Helper: Check if a cell has content
-        def has_content(r, c):
+        def has_content(r: int, c: int) -> bool:
             if r < 0 or c < 0 or r >= max_row or c >= max_col:
                 return False
 
@@ -949,11 +1025,8 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
             if cell.value is not None:
                 return True
 
-            # 2. Check merge ranges
-            for mr in sheet.merged_cells.ranges:
-                if cell.coordinate in mr:
-                    return True
-            return False
+            # 2. Check the worksheet-level merged-cell index.
+            return merged_cell_index.contains(cell)
 
         # --- Phase 1: Flood Fill (Connectivity Check) ---
         while queue:
@@ -992,17 +1065,6 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         # --- Phase 2: Extract Data (Semantic Grid) ---
         data = []
 
-        # We must identify cells that are "shadowed" by a merge (not the top-left)
-        hidden_merge_cells = set()
-        for mr in sheet.merged_cells.ranges:
-            mr_min_r, mr_min_c = mr.min_row - 1, mr.min_col - 1
-            mr_max_r, mr_max_c = mr.max_row - 1, mr.max_col - 1
-            for r in range(mr_min_r, mr_max_r + 1):
-                for c in range(mr_min_c, mr_max_c + 1):
-                    if r == mr_min_r and c == mr_min_c:
-                        continue
-                    hidden_merge_cells.add((r, c))
-
         # We iterate the bounding box of the found region
         # Gaps inside the bounding box become empty cells (preserving layout)
         for ri in range(min_r, max_r + 1):
@@ -1013,20 +1075,14 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
                 # Logic: If we found a "U" shape, do we fill the middle?
                 # Yes, Excel tables are typically treated as rectangular bounding boxes.
 
-                if (ri, rj) in hidden_merge_cells:
+                cell = sheet.cell(row=ri + 1, column=rj + 1)
+                if merged_cell_index.is_shadow(cell):
                     continue
 
-                cell = sheet.cell(row=ri + 1, column=rj + 1)
                 cell_text = str(cell.value) if cell.value is not None else ""
 
                 # Compute Spans
-                row_span = 1
-                col_span = 1
-                for mr in sheet.merged_cells.ranges:
-                    if (ri + 1) == mr.min_row and (rj + 1) == mr.min_col:
-                        row_span = (mr.max_row - mr.min_row) + 1
-                        col_span = (mr.max_col - mr.min_col) + 1
-                        break
+                row_span, col_span = merged_cell_index.span_at(ri, rj)
 
                 data.append(
                     ExcelCell(

--- a/perfs/xlsx_merged_cells.py
+++ b/perfs/xlsx_merged_cells.py
@@ -1,0 +1,200 @@
+"""Benchmark full XLSX conversion for worksheets with many merged ranges.
+
+The script generates temporary workbooks containing horizontal ``A:C`` merges and
+an ordinary value in column ``D``, then converts each workbook through
+``DocumentConverter``. Each result is emitted as one JSON object per line and
+includes generation time, conversion time, and peak Python memory usage.
+
+Run from the repository root, for example::
+
+    uv run python perfs/xlsx_merged_cells.py --merge-count 100 1000
+    uv run python perfs/xlsx_merged_cells.py --merge-count 5000 --output results.jsonl
+
+Progress is written to stderr so stdout remains valid JSONL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import re
+import subprocess
+import sys
+import time
+import tracemalloc
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from openpyxl import Workbook
+from tqdm import tqdm
+
+from docling.datamodel.base_models import InputFormat
+from docling.document_converter import DocumentConverter
+
+DEFAULT_MERGE_COUNTS = (100, 1_000, 5_000, 20_000)
+
+
+@dataclass(frozen=True)
+class RuntimeInfo:
+    python_version: str
+    platform: str
+    docling_version: str
+    commit_sha: str
+
+
+@dataclass(frozen=True)
+class BenchmarkResult:
+    python_version: str
+    platform: str
+    docling_version: str
+    commit_sha: str
+    merge_count: int
+    non_empty_cells: int
+    rectangle_area: int
+    generation_seconds: float
+    conversion_seconds: float
+    peak_python_memory_mb: float
+    table_count: int
+
+
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed <= 0:
+        raise argparse.ArgumentTypeError("merge counts must be positive integers")
+    return parsed
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--merge-count",
+        type=_positive_int,
+        nargs="+",
+        default=DEFAULT_MERGE_COUNTS,
+        help="Merged-range counts to benchmark.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional JSONL output path; results are always written to stdout.",
+    )
+    return parser.parse_args()
+
+
+def _runtime_info() -> RuntimeInfo:
+    repository_root = Path(__file__).resolve().parents[1]
+    pyproject_text = (repository_root / "pyproject.toml").read_text(encoding="utf-8")
+    version_match = re.search(
+        r'^version\s*=\s*"([^"]+)"', pyproject_text, flags=re.MULTILINE
+    )
+    if version_match is None:
+        raise RuntimeError("Could not determine Docling version from pyproject.toml")
+
+    git_result = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        cwd=repository_root,
+        text=True,
+        timeout=10,
+    )
+    return RuntimeInfo(
+        python_version=platform.python_version(),
+        platform=platform.platform(),
+        docling_version=version_match.group(1),
+        commit_sha=git_result.stdout.strip(),
+    )
+
+
+def _create_workbook(path: Path, *, merge_count: int) -> float:
+    started = time.perf_counter()
+    workbook = Workbook()
+    sheet = workbook.active
+    sheet.title = "merged-ranges"
+
+    for row in range(1, merge_count + 1):
+        sheet.cell(row=row, column=1, value=f"row-{row}")
+        sheet.merge_cells(
+            start_row=row,
+            start_column=1,
+            end_row=row,
+            end_column=3,
+        )
+        sheet.cell(row=row, column=4, value=row)
+
+    workbook.save(path)
+    return time.perf_counter() - started
+
+
+def _run_benchmark(
+    output_dir: Path,
+    *,
+    merge_count: int,
+    runtime_info: RuntimeInfo,
+) -> BenchmarkResult:
+    workbook_path = output_dir / f"merged-ranges-{merge_count}.xlsx"
+    generation_seconds = _create_workbook(workbook_path, merge_count=merge_count)
+
+    tracemalloc.start()
+    started = time.perf_counter()
+    converter = DocumentConverter(allowed_formats=[InputFormat.XLSX])
+    document = converter.convert(workbook_path).document
+    conversion_seconds = time.perf_counter() - started
+    _, peak_memory = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+
+    if len(document.tables) != 1:
+        raise RuntimeError(
+            f"expected one table for {merge_count} merges, got {len(document.tables)}"
+        )
+    table = document.tables[0]
+    if table.data.num_rows != merge_count or table.data.num_cols != 4:
+        raise RuntimeError(
+            f"unexpected table dimensions: {table.data.num_rows}x{table.data.num_cols}"
+        )
+
+    return BenchmarkResult(
+        python_version=runtime_info.python_version,
+        platform=runtime_info.platform,
+        docling_version=runtime_info.docling_version,
+        commit_sha=runtime_info.commit_sha,
+        merge_count=merge_count,
+        non_empty_cells=merge_count * 2,
+        rectangle_area=merge_count * 4,
+        generation_seconds=round(generation_seconds, 6),
+        conversion_seconds=round(conversion_seconds, 6),
+        peak_python_memory_mb=round(peak_memory / (1024 * 1024), 3),
+        table_count=len(document.tables),
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    runtime_info = _runtime_info()
+
+    with TemporaryDirectory(prefix="docling-xlsx-merge-benchmark-") as temp_dir:
+        results = [
+            _run_benchmark(
+                Path(temp_dir),
+                merge_count=merge_count,
+                runtime_info=runtime_info,
+            )
+            for merge_count in tqdm(
+                args.merge_count,
+                desc="Benchmarking merged ranges",
+                unit="workbook",
+            )
+        ]
+
+    output = "".join(
+        f"{json.dumps(asdict(result), sort_keys=True)}\n" for result in results
+    )
+    sys.stdout.write(output)
+    if args.output is not None:
+        args.output.write_text(output, encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_backend_msexcel.py
+++ b/tests/test_backend_msexcel.py
@@ -1,4 +1,5 @@
 import logging
+from collections.abc import Iterator
 from io import BytesIO
 from pathlib import Path
 
@@ -18,6 +19,7 @@ from docling_core.types.doc import (
 from docling_core.types.doc.document import DEFAULT_CONTENT_LAYERS
 from openpyxl import Workbook, load_workbook
 from openpyxl.comments import Comment
+from openpyxl.worksheet.merge import MergedCellRange
 
 from docling.backend.docx.drawingml.utils import get_libreoffice_cmd
 from docling.backend.msexcel_backend import (
@@ -36,6 +38,16 @@ from .verify_utils import verify_document, verify_export
 _log = logging.getLogger(__name__)
 
 GENERATE = GEN_TEST_DATA
+
+
+class _TrackingMergedRanges(set[MergedCellRange]):
+    def __init__(self, ranges: set[MergedCellRange]) -> None:
+        super().__init__(ranges)
+        self.iteration_count = 0
+
+    def __iter__(self) -> Iterator[MergedCellRange]:
+        self.iteration_count += 1
+        return super().__iter__()
 
 
 @pytest.fixture(scope="module")
@@ -629,6 +641,39 @@ def test_merged_section_label_above_table_preserves_column_headers() -> None:
     assert '<th colspan="2">Reading List</th>' not in html
     assert "<th>#</th>" in html
     assert "<th>Genre</th>" in html
+
+
+def test_merged_cells_are_indexed_once_and_preserve_semantics(tmp_path: Path) -> None:
+    workbook = Workbook()
+    sheet = workbook.active
+    for row in range(1, 11):
+        sheet.append([f"row-{row}", None, None, row])
+        sheet.merge_cells(f"A{row}:C{row}")
+    sheet["D4"].comment = Comment("Synthetic note", "Codex")
+    file_path = tmp_path / "merged-cells.xlsx"
+    workbook.save(file_path)
+    in_doc = InputDocument(
+        path_or_stream=file_path,
+        format=InputFormat.XLSX,
+        filename=file_path.stem,
+        backend=MsExcelDocumentBackend,
+    )
+    backend = MsExcelDocumentBackend(in_doc=in_doc, path_or_stream=file_path)
+    loaded_sheet = backend.workbook.active
+    tracked_ranges = _TrackingMergedRanges(loaded_sheet.merged_cells.ranges)
+    loaded_sheet.merged_cells.ranges = tracked_ranges
+
+    tables, comment_map = backend._find_data_tables(loaded_sheet)
+
+    assert tracked_ranges.iteration_count == 1
+    assert len(tables) == 1
+    table = tables[0]
+    assert (table.anchor, table.num_rows, table.num_cols) == ((0, 0), 10, 4)
+    assert len(table.data) == 20
+    assert [(cell.row_span, cell.col_span) for cell in table.data if cell.col == 0] == [
+        (1, 3)
+    ] * 10
+    assert comment_map[(3, 3)] == ("Codex", "Synthetic note", None)
 
 
 def test_split_leading_section_label_helper() -> None:


### PR DESCRIPTION
The XLSX table flood-fill and semantic-grid extraction repeatedly scanned every merged range for every visited cell, resulting in O(cells × merge_ranges) behavior on merge-heavy worksheets.

On documents with thousands of merged ranges, this could turn conversion into a multi-hour operation even when the worksheet itself was not especially large.

## Changes

- Build one `_MergedCellIndex` per worksheet with an `anchor -> span` mapping and aggregate merged bounds.
- Reuse OpenPyXL `MergedCell` objects for O(1) shadow-cell detection instead of expanding merged ranges into coordinate sets.
- Reuse the index in data-bound discovery, flood fill, and semantic-grid extraction.
- Preserve first-range-wins behavior for pathological ranges sharing the same anchor.
- Add a focused regression test covering single-pass indexing, spans, table dimensions, and comments.
- Add the documented `perfs/xlsx_merged_cells.py` JSONL benchmark with progress reporting and peak-memory measurement.

The auxiliary merged-cell index now requires O(M) memory for M merged ranges, rather than memory proportional to their total covered area.

## Validation

- `uv run --all-extras pytest -q tests/test_backend_msexcel.py`: 23 passed.
- `make validate`: passed.
- Synthetic benchmark: 1,000 merged ranges convert in about 0.32 s and 5,000 ranges in about 1.82 s on the local test system.
- Original 380-merge benchmark: 423x speedup with identical output.

The final implementation, regression test, and benchmark were developed by @nicksaven and integrated into this PR in collaboration with @TongLing916. The commit preserves both contributors and their DCO trailers.

**Checklist:**

- [x] Documentation has been updated where necessary.
- [x] Tests have been added.
- [x] A reproducible performance benchmark has been added.