### PR TITLE
fix(cli): preserve outputs for duplicate stems

### DIFF
--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -445,6 +445,7 @@ def export_documents(
 ):
     success_count = 0
     failure_count = 0
+    used_output_stems: set[str] = set()
 
     # Initialize chunker once for all documents
     chunker_obj = None
@@ -474,7 +475,19 @@ def export_documents(
     for conv_res in conv_results:
         doc_failed = conv_res.status != ConversionStatus.SUCCESS
         if not doc_failed:
-            doc_filename = conv_res.input.file.stem
+            source_stem = conv_res.input.file.stem
+            doc_filename = source_stem
+            suffix = 2
+            while doc_filename.casefold() in used_output_stems:
+                doc_filename = f"{source_stem}_{suffix}"
+                suffix += 1
+            used_output_stems.add(doc_filename.casefold())
+
+            if doc_filename != source_stem:
+                _log.warning(
+                    f"Output filename collision for {conv_res.input.file}; "
+                    f"using stem {doc_filename!r}"
+                )
 
             # Export JSON format:
             if export_json:
@@ -1079,7 +1092,8 @@ def convert(  # noqa: C901
 
     with tempfile.TemporaryDirectory() as tempdir:
         input_doc_paths: list[Path | str] = []
-        for src in source:
+        for source_index, src in enumerate(source):
+            source_workdir = Path(tempdir) / f"source_{source_index}"
             try:
                 if _is_http_url(src) and _is_html_source(src, from_formats):
                     input_doc_paths.append(src)
@@ -1097,14 +1111,18 @@ def convert(  # noqa: C901
                         input_doc_paths.append(local_path)
                     else:
                         resolved_source = resolve_source_to_path(
-                            source=src, headers=parsed_headers, workdir=Path(tempdir)
+                            source=src,
+                            headers=parsed_headers,
+                            workdir=source_workdir,
                         )
                         input_doc_paths.append(resolved_source)
                     continue
 
                 # check if we can fetch some remote url
                 resolved_source = resolve_source_to_path(
-                    source=src, headers=parsed_headers, workdir=Path(tempdir)
+                    source=src,
+                    headers=parsed_headers,
+                    workdir=source_workdir,
                 )
                 input_doc_paths.append(resolved_source)
             except FileNotFoundError:

--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -483,6 +483,7 @@ def export_documents(
 ):
     success_count = 0
     failure_count = 0
+    used_output_stems: set[str] = set()
 
     # Initialize chunker once for all documents
     chunker_obj = None
@@ -512,7 +513,19 @@ def export_documents(
     for conv_res in conv_results:
         doc_failed = conv_res.status != ConversionStatus.SUCCESS
         if not doc_failed:
-            doc_filename = conv_res.input.file.stem
+            source_stem = conv_res.input.file.stem
+            doc_filename = source_stem
+            suffix = 2
+            while doc_filename.casefold() in used_output_stems:
+                doc_filename = f"{source_stem}_{suffix}"
+                suffix += 1
+            used_output_stems.add(doc_filename.casefold())
+
+            if doc_filename != source_stem:
+                _log.warning(
+                    f"Output filename collision for {conv_res.input.file}; "
+                    f"using stem {doc_filename!r}"
+                )
 
             # Export JSON format:
             if export_json:
@@ -1276,7 +1289,8 @@ def convert(  # noqa: C901
 
     with tempfile.TemporaryDirectory() as tempdir:
         input_doc_paths: list[Path | str] = []
-        for src in source:
+        for source_index, src in enumerate(source):
+            source_workdir = Path(tempdir) / f"source_{source_index}"
             try:
                 if _is_http_url(src) and _is_html_source(src, from_formats):
                     input_doc_paths.append(src)
@@ -1294,14 +1308,18 @@ def convert(  # noqa: C901
                         input_doc_paths.append(local_path)
                     else:
                         resolved_source = resolve_source_to_path(
-                            source=src, headers=parsed_headers, workdir=Path(tempdir)
+                            source=src,
+                            headers=parsed_headers,
+                            workdir=source_workdir,
                         )
                         input_doc_paths.append(resolved_source)
                     continue
 
                 # check if we can fetch some remote url
                 resolved_source = resolve_source_to_path(
-                    source=src, headers=parsed_headers, workdir=Path(tempdir)
+                    source=src,
+                    headers=parsed_headers,
+                    workdir=source_workdir,
                 )
                 input_doc_paths.append(resolved_source)
             except FileNotFoundError:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -146,6 +146,65 @@ def test_cli_exports_dclx(tmp_path):
     assert b"DCLX CLI" in payload
 
 
+def test_cli_preserves_outputs_for_inputs_with_same_stem(tmp_path):
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    first_source = first_dir / "document.md"
+    second_source = second_dir / "document.md"
+    first_source.write_text("# First source\n\nFirst unique content.", encoding="utf-8")
+    second_source.write_text(
+        "# Second source\n\nSecond unique content.", encoding="utf-8"
+    )
+    output = tmp_path / "out"
+
+    result = runner.invoke(
+        app,
+        [
+            str(first_source),
+            str(second_source),
+            "--from",
+            "md",
+            "--to",
+            "md",
+            "--to",
+            "chunks",
+            "--chunks-type",
+            "hierarchical",
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert {path.name for path in output.iterdir()} == {
+        "document.md",
+        "document_2.md",
+        "document.chunks.jsonl",
+        "document_2.chunks.jsonl",
+    }
+    markdown_outputs = {
+        stem: (output / f"{stem}.md").read_text(encoding="utf-8")
+        for stem in ("document", "document_2")
+    }
+    chunk_outputs = {
+        stem: (output / f"{stem}.chunks.jsonl").read_text(encoding="utf-8")
+        for stem in ("document", "document_2")
+    }
+
+    assert any("First unique content" in text for text in markdown_outputs.values())
+    assert any("Second unique content" in text for text in markdown_outputs.values())
+    for stem, markdown_text in markdown_outputs.items():
+        chunk_text = chunk_outputs[stem]
+        assert ("First unique content" in markdown_text) == (
+            "First unique content" in chunk_text
+        )
+        assert ("Second unique content" in markdown_text) == (
+            "Second unique content" in chunk_text
+        )
+
+
 def test_cli_from_odf_expands_to_open_document_formats(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -189,6 +189,65 @@ def test_cli_exports_latex(tmp_path):
     assert "100\\% special chars" in content
 
 
+def test_cli_preserves_outputs_for_inputs_with_same_stem(tmp_path):
+    first_dir = tmp_path / "first"
+    second_dir = tmp_path / "second"
+    first_dir.mkdir()
+    second_dir.mkdir()
+    first_source = first_dir / "document.md"
+    second_source = second_dir / "document.md"
+    first_source.write_text("# First source\n\nFirst unique content.", encoding="utf-8")
+    second_source.write_text(
+        "# Second source\n\nSecond unique content.", encoding="utf-8"
+    )
+    output = tmp_path / "out"
+
+    result = runner.invoke(
+        app,
+        [
+            str(first_source),
+            str(second_source),
+            "--from",
+            "md",
+            "--to",
+            "md",
+            "--to",
+            "chunks",
+            "--chunks-type",
+            "hierarchical",
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert {path.name for path in output.iterdir()} == {
+        "document.md",
+        "document_2.md",
+        "document.chunks.jsonl",
+        "document_2.chunks.jsonl",
+    }
+    markdown_outputs = {
+        stem: (output / f"{stem}.md").read_text(encoding="utf-8")
+        for stem in ("document", "document_2")
+    }
+    chunk_outputs = {
+        stem: (output / f"{stem}.chunks.jsonl").read_text(encoding="utf-8")
+        for stem in ("document", "document_2")
+    }
+
+    assert any("First unique content" in text for text in markdown_outputs.values())
+    assert any("Second unique content" in text for text in markdown_outputs.values())
+    for stem, markdown_text in markdown_outputs.items():
+        chunk_text = chunk_outputs[stem]
+        assert ("First unique content" in markdown_text) == (
+            "First unique content" in chunk_text
+        )
+        assert ("Second unique content" in markdown_text) == (
+            "Second unique content" in chunk_text
+        )
+
+
 def test_cli_from_odf_expands_to_open_document_formats(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
The CLI had two collision points when one invocation received files from different directories with the same name:

- all non-HTML sources were staged in one temporary directory, allowing a later source to replace an earlier source before conversion;
- all converted documents used only the source stem in the flat output directory, allowing later exports to replace earlier exports.

This change stages each source in its own temporary subdirectory and assigns case-insensitive, order-of-processing output stems (`document`, `document_2`, and so on) within one export run. The unique stem is shared by every selected format, including chunks and profiling output, while the existing behavior for files already present from earlier CLI runs remains unchanged.

The end-to-end regression converts two distinct `document.md` inputs in one invocation and verifies that both Markdown and hierarchical chunks are retained with matching content.

**Issue resolved by this Pull Request:**
Resolves #3811

**Tests:**

- `uv run pytest tests/test_cli.py::test_cli_preserves_outputs_for_inputs_with_same_stem -q`
- `uv run pytest tests/test_cli.py -q -k "not test_cli_convert"` (`25 passed, 2 deselected`)
- `uv run prek run --files docling/cli/main.py tests/test_cli.py` (all applicable hooks pass; Windows-only `python3` hook entries were run directly with `uv run python`)
- Real CLI reproduction with the two repository README files: 28 and 57 chunks are retained in separate outputs

**Checklist:**

- [x] Documentation has been updated, if necessary. (No public API or option changed.)
- [x] Examples have been added, if necessary. (Not necessary for this regression fix.)
- [x] Tests have been added, if necessary.