### PR TITLE
fix: skip empty display formulas in the JATS backend instead of truncating the document

### DIFF
--- a/docling/backend/xml/jats_backend.py
+++ b/docling/backend/xml/jats_backend.py
@@ -637,6 +637,8 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
         self, doc: DoclingDocument, parent: NodeItem, node: etree._Element
     ) -> None:
         math_text = node.text
+        if not math_text:
+            return
         math_parts = math_text.split("$$")
         if len(math_parts) == 3:
             math_formula = math_parts[1]

--- a/tests/test_backend_jats.py
+++ b/tests/test_backend_jats.py
@@ -170,6 +170,26 @@ def test_jats_inline_formula_is_not_grouped(paragraph, expected_formulas):
     assert formulas == expected_formulas
 
 
+def test_jats_empty_display_formula_does_not_drop_following_content():
+    # A display equation whose <tex-math> is empty must be skipped, not crash the
+    # walk. _add_equation used to call node.text.split("$$") unconditionally, so an
+    # empty <tex-math/> raised AttributeError; convert() swallows it and returns a
+    # truncated document, silently losing everything after the equation.
+    doc = convert_jats_body(
+        "<sec><title>T</title>"
+        "<p>Before the equation.</p>"
+        "<disp-formula><tex-math/></disp-formula>"
+        "<p>After the equation.</p>"
+        "</sec>"
+    )
+
+    md = doc.export_to_markdown()
+    assert "Before the equation." in md
+    assert "After the equation." in md
+    # The empty display formula produced no FORMULA item.
+    assert [t.text for t in doc.texts if t.label == DocItemLabel.FORMULA] == []
+
+
 def test_jats_footnotes_are_preserved():
     doc = convert_jats_body(
         """


### PR DESCRIPTION
A `<disp-formula>` whose `<tex-math>` is empty (`<tex-math/>`) has `node.text is None`, so `_add_equation` raised `AttributeError` on `node.text.split("$$")`. `convert()` swallows walk exceptions and returns the partial document, so the article was silently truncated at the first such formula, dropping the rest of the body and all back matter. The inline path (`_get_inline_equation`) already guards this case; the display path did not.

Guard for empty text so the empty equation is skipped and the rest of the document is preserved.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
