### PR TITLE
fix: fall back to default image size for non-numeric AsciiDoc dimensions

### DIFF
--- a/docling/backend/asciidoc_backend.py
+++ b/docling/backend/asciidoc_backend.py
@@ -209,9 +209,10 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
                 item = self._parse_picture(line)
 
                 size: Size
-                if "width" in item and "height" in item:
+                try:
                     size = Size(width=int(item["width"]), height=int(item["height"]))
-                else:
+                except (KeyError, ValueError):
+                    # width/height may be absent or non-numeric (e.g. "50%", "auto")
                     size = Size(width=DEFAULT_IMAGE_WIDTH, height=DEFAULT_IMAGE_HEIGHT)
 
                 uri = None

--- a/tests/test_backend_asciidoc.py
+++ b/tests/test_backend_asciidoc.py
@@ -85,6 +85,36 @@ def test_empty_table_does_not_crash():
     assert data.num_cols == 0
 
 
+def test_non_numeric_image_dimensions_do_not_crash():
+    # image width/height can be non-numeric in real AsciiDoc (e.g. "50%", "auto").
+    # convert() used int(item["width"]) directly, so such an image raised
+    # ValueError and failed the whole document; it must fall back to the default
+    # size and keep converting the rest of the content.
+    from io import BytesIO
+
+    adoc = (
+        b"= Title\n\n"
+        b"Intro text.\n\n"
+        b"image::diagram.png[Architecture, width=50%, height=auto]\n\n"
+        b"Text after the image.\n"
+    )
+    in_doc = InputDocument(
+        path_or_stream=BytesIO(adoc),
+        format=InputFormat.ASCIIDOC,
+        backend=AsciiDocBackend,
+        filename="dims.adoc",
+    )
+    doc = in_doc._backend.convert()
+
+    md = doc.export_to_markdown()
+    assert "Intro text." in md
+    assert "Text after the image." in md
+
+    picture = doc.pictures[0]
+    assert picture.image.size.width == DEFAULT_IMAGE_WIDTH
+    assert picture.image.size.height == DEFAULT_IMAGE_HEIGHT
+
+
 def test_asciidocs_examples():
     fnames = sorted(glob.glob("./tests/data/asciidoc/sources/*.asciidoc"))
 


### PR DESCRIPTION
`_parse_picture` extracts image `width`/`height` attributes verbatim, and `convert()` called `int()` on them directly. An image with a non-numeric dimension such as `image::x.png[Alt, width=50%, height=auto]` raised `ValueError` and failed the whole document. Fall back to the default image size, matching what the missing-attribute case already does.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
