### PR TITLE
feat(pdf): recover compound list-item markers missed by the marker processor

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1643,6 +1643,30 @@ class HeadingHierarchyOptions(BaseModel):
     ] = 0.8
 
 
+class ListNormalizationOptions(BaseModel):
+    """Options for inferring ordered vs. unordered list items in the PDF/image pipeline.
+
+    The layout model labels regions as ``LIST_ITEM`` without recording whether they belong to a
+    numbered or a bulleted list. At item-creation time the reading-order stage strips simple
+    leading markers (``1.``, ``a)``, ``•`` ...) and sets ``ListItem.enumerated`` accordingly, but
+    compound/hierarchical markers (``9a.``, ``3.a.``, ``1.2.1``) are missed and leak into the
+    Markdown output as doubled or wrong list markers. When ``enabled``,
+    :class:`ListNormalizationModel` runs right after the reading-order model and recovers those
+    markers. It never adds, removes or reorders items.
+    """
+
+    enabled: Annotated[
+        bool,
+        Field(
+            description=(
+                "Enable ordered/unordered inference for list items in the PDF/image pipeline. "
+                "When disabled (default), only the simple per-item marker inference applies "
+                "(unchanged behavior)."
+            )
+        ),
+    ] = False
+
+
 class PdfPipelineOptions(PaginatedPipelineOptions):
     """Configuration options for the PDF document processing pipeline.
 
@@ -1803,6 +1827,16 @@ class PdfPipelineOptions(PaginatedPipelineOptions):
             )
         ),
     ] = HeadingHierarchyOptions()
+    list_normalization_options: Annotated[
+        ListNormalizationOptions,
+        Field(
+            description=(
+                "Configuration for inferring ordered vs. unordered list items. Disabled by "
+                "default; when enabled, the reading-order stage recovers compound list markers "
+                "(9a., 3.a., 1.2.1) that would otherwise render as doubled Markdown markers."
+            )
+        ),
+    ] = ListNormalizationOptions()
 
     ### Arguments for threaded PDF pipeline with batching and backpressure control
 

--- a/docling/models/stages/list_normalization/list_normalization_model.py
+++ b/docling/models/stages/list_normalization/list_normalization_model.py
@@ -1,0 +1,127 @@
+"""Ordered/unordered list-item inference for the PDF/image pipeline.
+
+The layout model only flags a region as ``LIST_ITEM``; it carries no notion of whether the item
+belongs to a numbered (ordered) or a bulleted (unordered) list. That distinction has to be
+recovered from the item text. At item-creation time the reading-order stage already runs
+``docling_ibm_models``' :class:`ListItemMarkerProcessor`, which strips *simple* leading markers
+(``1.``, ``a)``, ``[3]``, ``•`` ...) into ``ListItem.marker`` and sets ``ListItem.enumerated``.
+
+**Compound / hierarchical markers** such as ``9a.``, ``3.a.`` or ``1.2.1`` are not in the marker
+processor's pattern set. The marker stays fused inside ``text`` and ``marker`` is left empty.
+When such an item sits inside an otherwise-enumerated list, the Markdown serializer sees the
+empty marker and prepends a *position-based* number of its own, yielding a doubled, wrong marker
+(e.g. ``7. 9a. Compute ...`` instead of ``9a. Compute ...``).
+
+:class:`ListNormalizationModel` runs right after the reading-order model and, per list group,
+recovers those compound ordered markers into ``marker`` (removing them from ``text`` and setting
+``enumerated``). Recovery is applied only in a numbered context, so stray dotted-decimal
+*content* (``1.1 million ...``) in a bullet list is left untouched.
+
+It never adds, removes or reorders items, and only rewrites items whose marker was previously
+missed -- items the marker processor already handled are untouched. The core
+(:meth:`ListNormalizationModel.normalize`) works on a bare ``DoclingDocument`` so it can be
+reused outside the pipeline.
+"""
+
+import logging
+import re
+
+from docling_core.types.doc import DoclingDocument
+from docling_core.types.doc.document import ListGroup, ListItem
+
+from docling.datamodel.document import ConversionResult
+from docling.datamodel.pipeline_options import ListNormalizationOptions
+
+_log = logging.getLogger(__name__)
+
+# Leading compound/hierarchical ordered marker that the simple marker processor misses:
+#   dotted decimal   -> 1.1  1.1.1  (1.2)
+#   digit + letter   -> 9a  9a.  9a)  3.a  3.a.
+# followed by whitespace and the item content. Simple markers (``1.``, ``a)`` ...) are
+# intentionally excluded here -- they are already handled at item-creation time.
+_COMPOUND_ORDERED = re.compile(
+    r"^\s*(?P<marker>\(?\d+(?:\.\d+)+[.)\]]?|\(?\d+\.?[A-Za-z][.)\]]?)\s+(?P<content>\S.*)$",
+    re.DOTALL,
+)
+
+# A short alphabetic/roman ordinal token with a delimiter, e.g. ``b.`` ``iv)`` ``(A)``.
+_ALPHA_ORDINAL = re.compile(r"^\(?[A-Za-z]{1,4}[.)\]]$|^\([A-Za-z]{1,4}\)$")
+
+
+def _marker_is_numbered(marker: str) -> bool:
+    """Whether ``marker`` denotes an ordered position (digit, or alpha/roman ordinal)."""
+    m = marker.strip()
+    if not m:
+        return False
+    if any(ch.isdigit() for ch in m):
+        return True
+    return _ALPHA_ORDINAL.match(m) is not None
+
+
+class ListNormalizationModel:
+    """Infer ordered vs. unordered list items after reading-order assembly.
+
+    Enabled via :class:`ListNormalizationOptions`. When disabled (the default) the input
+    document is returned unchanged.
+    """
+
+    def __init__(self, options: ListNormalizationOptions):
+        self.options = options
+
+    def __call__(self, conv_res: ConversionResult) -> DoclingDocument:
+        document = conv_res.document
+        if not self.options.enabled:
+            return document
+        try:
+            return self.normalize(document)
+        except Exception:  # never let list normalization break a conversion
+            _log.warning("List normalization failed; leaving list items unchanged.")
+            return document
+
+    def normalize(self, document: DoclingDocument) -> DoclingDocument:
+        """Normalize every list group in ``document`` in place and return it."""
+        for item, _level in document.iterate_items(with_groups=True):
+            if isinstance(item, ListGroup):
+                self._normalize_group(item, document)
+        return document
+
+    def _normalize_group(self, group: ListGroup, document: DoclingDocument) -> None:
+        items = [
+            child
+            for ref in group.children
+            if isinstance((child := ref.resolve(document)), ListItem)
+        ]
+        if not items:
+            return
+
+        self._recover_ordered_markers(items)
+
+    @staticmethod
+    def _recover_ordered_markers(items: list[ListItem]) -> None:
+        """Extract compound ordered markers left fused in ``text`` into ``marker``.
+
+        Applied only when the group already has a numbered context -- either an item with a
+        recognized numbered marker, or at least two items that themselves look compound-ordered
+        -- so that a lone dotted-decimal value in prose is not mistaken for a marker.
+        """
+        candidates: dict[int, re.Match[str]] = {}
+        for it in items:
+            if it.marker == "":
+                match = _COMPOUND_ORDERED.match(it.text)
+                if match is not None:
+                    candidates[id(it)] = match
+        if not candidates:
+            return
+
+        has_numbered_context = (
+            any(_marker_is_numbered(it.marker) for it in items) or len(candidates) >= 2
+        )
+        if not has_numbered_context:
+            return
+
+        for it in items:
+            match = candidates.get(id(it))
+            if match is not None:
+                it.marker = match.group("marker")
+                it.text = match.group("content")
+                it.enumerated = True

--- a/docling/pipeline/legacy_standard_pdf_pipeline.py
+++ b/docling/pipeline/legacy_standard_pdf_pipeline.py
@@ -26,6 +26,9 @@ from docling.models.stages.code_formula.code_formula_model import (
 from docling.models.stages.heading_hierarchy.heading_hierarchy_model import (
     HeadingHierarchyModel,
 )
+from docling.models.stages.list_normalization.list_normalization_model import (
+    ListNormalizationModel,
+)
 from docling.models.stages.page_assemble.page_assemble_model import (
     PageAssembleModel,
     PageAssembleOptions,
@@ -61,6 +64,9 @@ class LegacyStandardPdfPipeline(PaginatedPipeline):
         self.reading_order_model = ReadingOrderModel(options=ReadingOrderOptions())
         self.heading_hierarchy_model = HeadingHierarchyModel(
             options=self.pipeline_options.heading_hierarchy_options
+        )
+        self.list_normalization_model = ListNormalizationModel(
+            options=self.pipeline_options.list_normalization_options
         )
 
         ocr_model = self.get_ocr_model(artifacts_path=self.artifacts_path)
@@ -190,6 +196,7 @@ class LegacyStandardPdfPipeline(PaginatedPipeline):
 
             conv_res.document = self.reading_order_model(conv_res)
             conv_res.document = self.heading_hierarchy_model(conv_res)
+            conv_res.document = self.list_normalization_model(conv_res)
 
             # Generate page images in the output
             if self.pipeline_options.generate_page_images:

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -59,6 +59,9 @@ from docling.models.stages.code_formula.code_formula_vlm_model import (
 from docling.models.stages.heading_hierarchy.heading_hierarchy_model import (
     HeadingHierarchyModel,
 )
+from docling.models.stages.list_normalization.list_normalization_model import (
+    ListNormalizationModel,
+)
 from docling.models.stages.page_assemble.page_assemble_model import (
     PageAssembleModel,
     PageAssembleOptions,
@@ -617,6 +620,9 @@ class StandardPdfPipeline(ConvertPipeline):
         self.heading_hierarchy_model = HeadingHierarchyModel(
             options=self.pipeline_options.heading_hierarchy_options
         )
+        self.list_normalization_model = ListNormalizationModel(
+            options=self.pipeline_options.list_normalization_options
+        )
 
         # --- optional enrichment ------------------------------------------------
         # Create a copy to avoid mutating pipeline_options in-place,
@@ -1007,6 +1013,7 @@ class StandardPdfPipeline(ConvertPipeline):
             )
             conv_res.document = self.reading_order_model(conv_res)
             conv_res.document = self.heading_hierarchy_model(conv_res)
+            conv_res.document = self.list_normalization_model(conv_res)
 
             # Generate page images in the output
             if self.pipeline_options.generate_page_images:

--- a/tach.toml
+++ b/tach.toml
@@ -347,6 +347,11 @@ layer = "models"
 depends_on = ["docling.datamodel"]
 
 [[modules]]
+path = "docling.models.stages.list_normalization"
+layer = "models"
+depends_on = ["docling.datamodel"]
+
+[[modules]]
 path = "docling.models.stages.reading_order"
 layer = "models"
 depends_on = ["docling.datamodel", "docling.utils"]
@@ -498,6 +503,7 @@ depends_on = [
   "docling.models.factories",
   "docling.models.stages.code_formula",
   "docling.models.stages.heading_hierarchy",
+  "docling.models.stages.list_normalization",
   "docling.models.stages.page_assemble",
   "docling.models.stages.page_preprocessing",
   "docling.models.stages.reading_order",
@@ -521,6 +527,7 @@ depends_on = [
   "docling.models.factories",
   "docling.models.stages.code_formula",
   "docling.models.stages.heading_hierarchy",
+  "docling.models.stages.list_normalization",
   "docling.models.stages.page_assemble",
   "docling.models.stages.page_preprocessing",
   "docling.models.stages.reading_order",

--- a/tests/test_list_normalization.py
+++ b/tests/test_list_normalization.py
@@ -1,0 +1,164 @@
+"""Tests for ordered/unordered list-item inference in the PDF/image pipeline.
+
+The reading-order stage strips only *simple* leading markers; compound/hierarchical markers
+(``9a.``, ``3.a.``, ``1.2.1``) are left fused in the text with an empty ``marker``. Inside an
+enumerated list the Markdown serializer then prepends a position-based number, producing a
+doubled marker (``7. 9a. ...``). :class:`ListNormalizationModel` recovers those markers.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from docling_core.types.doc import DoclingDocument, GroupLabel
+from docling_core.types.doc.document import ListItem
+
+from docling.datamodel.pipeline_options import ListNormalizationOptions
+from docling.models.stages.list_normalization.list_normalization_model import (
+    ListNormalizationModel,
+)
+
+_GT_2203 = Path(__file__).parent / "data" / "pdf" / "groundtruth" / "2203.01017v2.json"
+
+
+def _list_doc(entries: list[tuple[str, str, bool]]) -> DoclingDocument:
+    """Build a single-list document from (marker, text, enumerated) tuples.
+
+    This mirrors what the reading-order stage produces: items whose marker the marker processor
+    could not parse arrive with ``marker == ""`` and the marker still fused into the text.
+    """
+    doc = DoclingDocument(name="t")
+    group = doc.add_group(label=GroupLabel.LIST, name="list")
+    for marker, text, enumerated in entries:
+        doc.add_list_item(text=text, enumerated=enumerated, marker=marker, parent=group)
+    return doc
+
+
+def _normalize(doc: DoclingDocument, **opts) -> DoclingDocument:
+    model = ListNormalizationModel(ListNormalizationOptions(enabled=True, **opts))
+    return model.normalize(doc)
+
+
+def _items(doc: DoclingDocument) -> list[ListItem]:
+    return [it for it in doc.texts if isinstance(it, ListItem)]
+
+
+def test_compound_marker_recovered_in_numbered_list():
+    # The headline bug: a compound "3.a." fused into an item of an otherwise-numbered list
+    # renders as a doubled "4. 3.a." because the empty marker triggers position numbering.
+    doc = _list_doc(
+        [
+            ("1.", "Get the minimal grid dimensions.", True),
+            ("2.", "Generate pair-wise matches.", True),
+            ("", "3.a. If all IOU scores are below the threshold, discard.", False),
+            ("3.", "Use a carefully selected IOU threshold.", True),
+        ]
+    )
+    _normalize(doc)
+
+    recovered = _items(doc)[2]
+    assert recovered.marker == "3.a."
+    assert recovered.text == "If all IOU scores are below the threshold, discard."
+    assert recovered.enumerated is True
+
+    md = doc.export_to_markdown()
+    # The marker is preserved once, not doubled with a spurious position number.
+    assert "3.a. If all IOU scores are below the threshold, discard." in md
+    assert "4. 3.a." not in md
+
+
+def test_digit_letter_marker_recovered():
+    doc = _list_doc(
+        [
+            ("9.", "Pick up the remaining orphan cells.", True),
+            ("", "9a. Compute the top and bottom boundary.", False),
+            ("", "9b. Intersect the orphan's bounding box.", False),
+        ]
+    )
+    _normalize(doc)
+
+    items = _items(doc)
+    assert [it.marker for it in items[1:]] == ["9a.", "9b."]
+    assert all(it.enumerated for it in items[1:])
+    assert items[1].text == "Compute the top and bottom boundary."
+
+
+def test_bullet_list_left_unordered():
+    doc = _list_doc(
+        [
+            ("·", "first bullet", False),
+            ("·", "second bullet", False),
+            ("·", "third bullet", False),
+        ]
+    )
+    _normalize(doc)
+
+    assert not any(it.enumerated for it in _items(doc))
+    assert "1. first bullet" not in doc.export_to_markdown()
+
+
+def test_dotted_value_in_prose_not_treated_as_marker():
+    # A lone dotted-decimal *value* inside a bullet list must not be mistaken for a marker:
+    # there is no numbered context and only one candidate.
+    doc = _list_doc(
+        [
+            ("·", "revenue grew", False),
+            ("", "1.1 million units were shipped", False),
+            ("·", "profit rose", False),
+        ]
+    )
+    _normalize(doc)
+
+    prose = _items(doc)[1]
+    assert prose.marker == ""
+    assert prose.text == "1.1 million units were shipped"
+    assert prose.enumerated is False
+
+
+def test_compound_only_group_recovered_by_repetition():
+    # No simple numbered item, but two or more compound-ordered items establish the context.
+    doc = _list_doc(
+        [
+            ("", "9a. Compute the top and bottom boundary.", False),
+            ("", "9b. Intersect the orphan's bounding box.", False),
+            ("", "9c. Compute the left and right boundary.", False),
+        ]
+    )
+    _normalize(doc)
+
+    items = _items(doc)
+    assert [it.marker for it in items] == ["9a.", "9b.", "9c."]
+    assert all(it.enumerated for it in items)
+
+
+def test_disabled_is_noop():
+    entries = [
+        ("1.", "First.", True),
+        ("", "1.1 nested item here.", False),
+    ]
+    doc = _list_doc(entries)
+    model = ListNormalizationModel(
+        ListNormalizationOptions()
+    )  # enabled=False (default)
+    model(SimpleNamespace(document=doc))
+
+    fused = _items(doc)[1]
+    assert fused.marker == ""
+    assert fused.text == "1.1 nested item here."
+
+
+def test_real_document_recovers_missed_markers():
+    # Regression on real reading-order output: the arXiv table-transformer paper has an
+    # algorithm list with fused "3.a."/"9a.".."9d." sub-items that render as doubled markers.
+    doc = DoclingDocument.load_from_json(_GT_2203)
+    before = doc.export_to_markdown()
+    assert (
+        "4. 3.a." in before
+    )  # the bug is present in the stored (feature-off) ground truth
+
+    _normalize(doc)
+    after = doc.export_to_markdown()
+
+    for doubled in ("4. 3.a.", "7. 9a.", "8. 9b.", "9. 9c.", "10. 9d."):
+        assert doubled not in after
+    for recovered in ("9a. Compute", "9b. Intersect", "9c. Compute", "9d. Intersect"):
+        assert recovered in after


### PR DESCRIPTION
## Summary
Hi maintainers, i saw this as a #TODO in the codebase so i try to implement it!
The PDF/image pipeline labels list regions as `LIST_ITEM` but records no ordered-vs-unordered distinction that has to be inferred from the item text. At item-creation time the reading-order stage already runs docling-ibm-models' `ListItemMarkerProcessor`, which strips *simple* leading markers (`1.`, `a)`, `[3]`, `•` …) into `ListItem.marker` and sets `ListItem.enumerated`. This covers the common cases behind the recurring `# TODO: Infer if this is a numbered or a bullet
list item`.

What it still misses are **compound / hierarchical markers** — `9a.`, `3.a.`, `1.2.1`. These stay fused inside `text` with an empty `marker`. When such an item sits inside an otherwise-enumerated list, the Markdown serializer sees the empty marker and prepends a *position-based* number of its own, producing a doubled, wrong marker. On `tests/data/pdf/.../2203.01017v2` (the Table-Transformer paper) the algorithm list currently renders:

```
3. Use a carefully selected IOU threshold ...
4. 3.a. If all IOU scores ... discard ...        <- doubled + wrong number
4. Find the best-fitting content alignment ...
...
7. 9a. Compute the top and bottom boundary ...   <- doubled + wrong number
8. 9b. Intersect the orphan's bounding box ...
```

This PR adds an opt-in `ListNormalizationModel` that runs right after the reading-order model and, per list group, recovers those compound markers into `marker` (stripping them from `text` and setting `enumerated`). The same list then renders:

```
3. Use a carefully selected IOU threshold ...
- 3.a. If all IOU scores ... discard ...
4. Find the best-fitting content alignment ...
...
- 9a. Compute the top and bottom boundary ...
- 9b. Intersect the orphan's bounding box ...
```

Recovery is deliberately conservative:

- It only touches items the marker processor left with an **empty marker**; items already handled are untouched.
- It runs only in a **numbered context** — the group already has a recognized numbered marker, or at least two items look compound-ordered, so a lone dotted-decimal *value* in prose (`1.1 million units …`) inside a bullet list is never mistaken for a marker.
- It never adds, removes, or reorders items.

### Behavior / compatibility

- Gated behind `PdfPipelineOptions.list_normalization_options.enabled`, **default `False`**: no change to existing output, so no reference data is regenerated.
- Wired into both `StandardPdfPipeline` and `LegacyStandardPdfPipeline`, mirroring the existing heading-hierarchy stage.
- `ListNormalizationModel.normalize` operates on a bare `DoclingDocument`, so the core is reusable outside the pipeline.

### How to enable

```python
opts = PdfPipelineOptions()
opts.list_normalization_options.enabled = True
```

**Checklist:**

- [x] Documentation has been updated, if necessary. 
- [ ] Examples have been added, if necessary. 
- [x] Tests have been added, if necessary. 