### PR TITLE
fix(md): keep the last cell of table rows without a trailing pipe

### DIFF
--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -99,6 +99,20 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
     _ENTITY_RE = re.compile(r"&(#\d+|#x[0-9a-fA-F]+|\w+);")
 
     @staticmethod
+    def _split_table_row(row: str) -> list[str]:
+        """Split a table row into its cells.
+
+        The leading and trailing pipes are optional in GFM, so an empty field is
+        only dropped when it comes from a pipe at the very edge of the row.
+        """
+        cells = row.split("|")
+        if cells and not cells[0].strip():
+            cells = cells[1:]
+        if cells and not cells[-1].strip():
+            cells = cells[:-1]
+        return [cell.strip() for cell in cells]
+
+    @staticmethod
     def _unescape_except_pipe(text: str) -> str:
         def replace(match):
             entity = match.group(0)
@@ -212,12 +226,12 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
             for n, md_table_row in enumerate(self.md_table_buffer):
                 data = []
                 if n == 0:
-                    header = [t.strip() for t in md_table_row.split("|")[1:-1]]
+                    header = MarkdownDocumentBackend._split_table_row(md_table_row)
                     for value in header:
                         data.append(value)
                     result_table.append(data)
                 if n > 1:
-                    values = [t.strip() for t in md_table_row.split("|")[1:-1]]
+                    values = MarkdownDocumentBackend._split_table_row(md_table_row)
                     for value in values:
                         data.append(value)
                     result_table.append(data)

--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -122,6 +122,20 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         )
 
     @staticmethod
+    def _inline_text(node) -> str:
+        """The text of an inline node, its markers dropped.
+
+        A pipe goes on delimiting cells inside emphasis, code spans and links,
+        so the markers can go but the text they wrap has to stay.
+        """
+        children = getattr(node, "children", None)
+        if isinstance(children, str):
+            return children
+        return "".join(
+            MarkdownDocumentBackend._inline_text(child) for child in children or []
+        )
+
+    @staticmethod
     def _starts_pipeless_table(element: marko.block.Paragraph) -> bool:
         """Whether a paragraph is a GFM table whose header has no leading pipe.
 
@@ -131,12 +145,17 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         the delimiter row on the second line is the only reliable signal - hence
         the lookahead at paragraph level, where all lines are visible at once.
         """
-        lines = [
-            child.children
-            for child in element.children
-            if isinstance(child, marko.inline.RawText)
-            and isinstance(child.children, str)
-        ]
+        # Rebuilt line by line rather than read off the RawText nodes: a header
+        # cell in bold or a link is a node of its own, so reading those alone
+        # would split one line into several and shift the delimiter row away.
+        lines = [""]
+        for child in element.children:
+            if isinstance(child, marko.inline.LineBreak):
+                if len(lines) == 2:
+                    break
+                lines.append("")
+            else:
+                lines[-1] += MarkdownDocumentBackend._inline_text(child)
         if len(lines) < 2 or lines[0].lstrip().startswith("|"):
             return False
         if "|" not in lines[0] or not MarkdownDocumentBackend._is_delimiter_row(
@@ -548,10 +567,15 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                 element.children if isinstance(element.children, str) else ""
             )
             snippet_text = unescape(original_text.strip())
-            is_table_row = "|" in snippet_text and (
-                self.in_table
-                or original_text.lstrip().startswith("|")
-                or self.in_pipeless_table
+            is_table_row = bool(snippet_text) and (
+                # A header cell in bold or a link arrives as its own node with
+                # no pipe in it, so once the paragraph is known to be a table,
+                # every piece of it belongs to that table, pipe or not.
+                self.in_pipeless_table
+                or (
+                    "|" in snippet_text
+                    and (self.in_table or original_text.lstrip().startswith("|"))
+                )
             )
             if is_table_row:
                 self.in_table = True

--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -97,6 +97,7 @@ _CreationPayload = Annotated[
 
 class MarkdownDocumentBackend(DeclarativeDocumentBackend):
     _ENTITY_RE = re.compile(r"&(#\d+|#x[0-9a-fA-F]+|\w+);")
+    _DELIMITER_CELL_RE = re.compile(r":?-+:?")
 
     @staticmethod
     def _split_table_row(row: str) -> list[str]:
@@ -111,6 +112,42 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         if cells and not cells[-1].strip():
             cells = cells[:-1]
         return [cell.strip() for cell in cells]
+
+    @staticmethod
+    def _is_delimiter_row(row: str) -> bool:
+        """Whether a row is a GFM table delimiter row, e.g. ``--- | :---:``."""
+        cells = MarkdownDocumentBackend._split_table_row(row)
+        return bool(cells) and all(
+            MarkdownDocumentBackend._DELIMITER_CELL_RE.fullmatch(cell) for cell in cells
+        )
+
+    @staticmethod
+    def _starts_pipeless_table(element: marko.block.Paragraph) -> bool:
+        """Whether a paragraph is a GFM table whose header has no leading pipe.
+
+        Tables that do start with a pipe are detected line by line and must not
+        go through here, so that their existing behaviour is left untouched.
+        Without a leading pipe the header is indistinguishable from prose, so
+        the delimiter row on the second line is the only reliable signal - hence
+        the lookahead at paragraph level, where all lines are visible at once.
+        """
+        lines = [
+            child.children
+            for child in element.children
+            if isinstance(child, marko.inline.RawText)
+            and isinstance(child.children, str)
+        ]
+        if len(lines) < 2 or lines[0].lstrip().startswith("|"):
+            return False
+        if "|" not in lines[0] or not MarkdownDocumentBackend._is_delimiter_row(
+            lines[1]
+        ):
+            return False
+        # GFM: "The delimiter row must match the header row in the number of
+        # cells. If not, a table will not be recognized."
+        return len(MarkdownDocumentBackend._split_table_row(lines[0])) == len(
+            MarkdownDocumentBackend._split_table_row(lines[1])
+        )
 
     @staticmethod
     def _unescape_except_pipe(text: str) -> str:
@@ -184,6 +221,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         self.markdown = ""  # To store original Markdown string
 
         self.in_table = False
+        self.in_pipeless_table = False
         self.md_table_buffer: list[str] = []
         self._html_blocks: int = 0
         self._image_loader: Optional[ImageResourceLoader] = None
@@ -216,6 +254,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         return
 
     def _close_table(self, doc: DoclingDocument):
+        self.in_pipeless_table = False
         if self.in_table:
             _log.debug("=== TABLE START ===")
             for md_table_row in self.md_table_buffer:
@@ -235,6 +274,16 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                     for value in values:
                         data.append(value)
                     result_table.append(data)
+
+            # GFM: "The remainder of the table's rows may vary in the number of
+            # cells. If a row has fewer cells than the header row, empty cells
+            # are inserted. If it has greater, the excess is ignored."
+            if result_table and result_table[0]:
+                num_header_cells = len(result_table[0])
+                result_table = [
+                    row[:num_header_cells] + [""] * (num_header_cells - len(row))
+                    for row in result_table
+                ]
 
             for trow_ind, trow in enumerate(result_table):
                 for tcol_ind, cellval in enumerate(trow):
@@ -500,7 +549,9 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
             )
             snippet_text = unescape(original_text.strip())
             is_table_row = "|" in snippet_text and (
-                self.in_table or original_text.lstrip().startswith("|")
+                self.in_table
+                or original_text.lstrip().startswith("|")
+                or self.in_pipeless_table
             )
             if is_table_row:
                 self.in_table = True
@@ -603,6 +654,13 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
             if not isinstance(element, str):
                 self._close_table(doc)
                 _log.debug("Some other element: %s", type(element).__name__)
+
+        if isinstance(element, marko.block.Paragraph):
+            # Set before descending: the RawText branch below reads this to let a
+            # header without a leading pipe open a table. _close_table clears it.
+            self.in_pipeless_table = MarkdownDocumentBackend._starts_pipeless_table(
+                element
+            )
 
         if (
             isinstance(element, marko.block.Paragraph | marko.block.Heading)

--- a/tests/test_backend_markdown.py
+++ b/tests/test_backend_markdown.py
@@ -301,3 +301,30 @@ def test_convert_table_has_no_duplicate_cells():
         for cell in table_data.table_cells
     ]
     assert len(positions) == len(set(positions))
+
+
+def test_convert_table_without_trailing_pipes():
+    """
+    Regression test:
+    The leading and trailing pipes of a GFM table row are both optional, and the
+    backend's own row detector only requires a leading one. Splitting a row with
+    [1:-1] assumed both were present, so a row written without the trailing pipe
+    lost its last cell and the table came out one column short.
+    """
+    with_trailing = """| Region | Q1 |
+| --- | --- |
+| North | 10 |
+"""
+    without_trailing = """| Region | Q1
+| --- | ---
+| North | 10
+"""
+    expected = ["Region", "Q1", "North", "10"]
+
+    for markdown in (with_trailing, without_trailing):
+        conv_result = get_converter().convert_string(markdown, format=InputFormat.MD)
+        assert conv_result.status == ConversionStatus.SUCCESS
+
+        table_data = conv_result.document.tables[0].data
+        assert table_data.num_cols == 2
+        assert [cell.text for cell in table_data.table_cells] == expected

--- a/tests/test_backend_markdown.py
+++ b/tests/test_backend_markdown.py
@@ -328,3 +328,120 @@ def test_convert_table_without_trailing_pipes():
         table_data = conv_result.document.tables[0].data
         assert table_data.num_cols == 2
         assert [cell.text for cell in table_data.table_cells] == expected
+
+
+def test_convert_table_without_leading_pipes():
+    """
+    Regression test:
+    The leading pipe is optional in GFM too, but the row detector only entered
+    table mode on a leading pipe, so a table whose header starts with a bare
+    cell was never recognized: every row was emitted as plain text, delimiter
+    row included.
+    """
+    no_leading = """Region | Q1 |
+--- | --- |
+North | 10 |
+"""
+    no_edges = """Region | Q1
+--- | ---
+North | 10
+"""
+    aligned = """Region | Q1
+:--- | ---:
+North | 10
+"""
+    expected = ["Region", "Q1", "North", "10"]
+
+    for markdown in (no_leading, no_edges, aligned):
+        conv_result = get_converter().convert_string(markdown, format=InputFormat.MD)
+        assert conv_result.status == ConversionStatus.SUCCESS
+
+        assert len(conv_result.document.tables) == 1
+        table_data = conv_result.document.tables[0].data
+        assert table_data.num_cols == 2
+        assert [cell.text for cell in table_data.table_cells] == expected
+
+
+def test_convert_pipes_in_prose_stay_text():
+    """
+    A header without a leading pipe is indistinguishable from prose, so the
+    delimiter row on the second line is what makes a paragraph a table. Text
+    that merely contains pipes must not be turned into one.
+    """
+    cases = [
+        "Some sentence with a | pipe in it.\n",
+        "Some sentence with a | pipe in it.\nAnother | line here.\n",
+        # GFM: the delimiter row must match the header row in cell count.
+        "Region | Q1\n--- | --- | ---\nNorth | 10\n",
+    ]
+
+    for markdown in cases:
+        conv_result = get_converter().convert_string(markdown, format=InputFormat.MD)
+        assert conv_result.status == ConversionStatus.SUCCESS
+        assert conv_result.document.tables == []
+
+
+def test_convert_pipeless_table_does_not_leak_into_later_text():
+    """
+    Regression guard:
+    Detecting a header without a leading pipe needs lookahead, which is only
+    available one paragraph at a time, so the decision is taken before
+    descending into the rows. If that state outlived the table, a later
+    paragraph that merely contains a pipe would be absorbed into it.
+    """
+    markdown = """Region | Q1
+--- | ---
+North | 10
+
+Some sentence with a | pipe in it.
+
+Region | Q2
+--- | ---
+South | 20
+"""
+    conv_result = get_converter().convert_string(markdown, format=InputFormat.MD)
+    assert conv_result.status == ConversionStatus.SUCCESS
+
+    tables = conv_result.document.tables
+    assert len(tables) == 2
+    assert [cell.text for cell in tables[0].data.table_cells] == [
+        "Region",
+        "Q1",
+        "North",
+        "10",
+    ]
+    assert [cell.text for cell in tables[1].data.table_cells] == [
+        "Region",
+        "Q2",
+        "South",
+        "20",
+    ]
+    assert "Some sentence with a | pipe in it." in [
+        item.text for item in conv_result.document.texts
+    ]
+
+
+def test_convert_table_rows_match_header_cell_count():
+    """
+    GFM 4.10: "If a row has fewer cells than the header row, empty cells are
+    inserted. If it has greater, the excess is ignored." Without that,
+    table_cells disagreed with num_rows * num_cols and rows came out ragged.
+    """
+    short_row = """| a | b | c |
+| --- | --- | --- |
+| 1 | 2 |
+"""
+    long_row = """| a | b |
+| --- | --- |
+| 1 | 2 | 3 |
+"""
+    for markdown, expected in (
+        (short_row, ["a", "b", "c", "1", "2", ""]),
+        (long_row, ["a", "b", "1", "2"]),
+    ):
+        conv_result = get_converter().convert_string(markdown, format=InputFormat.MD)
+        assert conv_result.status == ConversionStatus.SUCCESS
+
+        table_data = conv_result.document.tables[0].data
+        assert [cell.text for cell in table_data.table_cells] == expected
+        assert len(table_data.table_cells) == table_data.num_rows * table_data.num_cols

--- a/tests/test_backend_markdown.py
+++ b/tests/test_backend_markdown.py
@@ -362,6 +362,40 @@ North | 10
         assert [cell.text for cell in table_data.table_cells] == expected
 
 
+def test_convert_table_without_leading_pipes_formatted_header():
+    """
+    Regression test:
+    A header cell in bold or a link is an inline node of its own, so reading the
+    paragraph's RawText nodes alone splits one line into several and moves the
+    delimiter row out of second place. The header then measured one cell, and
+    since rows are trimmed to the header's cell count the data cells went with
+    it -- a 2x2 table silently arrived as 1x2, first column dropped to prose.
+    """
+    bold_first = """**Region** | Q1
+--- | ---
+North | 10
+"""
+    bold_last = """Region | **Q1**
+--- | ---
+North | 10
+"""
+    linked = """[Region](https://example.com) | Q1
+--- | ---
+North | 10
+"""
+    expected = ["Region", "Q1", "North", "10"]
+
+    for markdown in (bold_first, bold_last, linked):
+        conv_result = get_converter().convert_string(markdown, format=InputFormat.MD)
+        assert conv_result.status == ConversionStatus.SUCCESS
+
+        assert len(conv_result.document.tables) == 1
+        table_data = conv_result.document.tables[0].data
+        assert table_data.num_cols == 2
+        assert [cell.text for cell in table_data.table_cells] == expected
+        assert conv_result.document.texts == []
+
+
 def test_convert_pipes_in_prose_stay_text():
     """
     A header without a leading pipe is indistinguishable from prose, so the


### PR DESCRIPTION
The leading and trailing pipes of a GFM table row are both optional, and the backend's own row detector only requires a leading one (`md_backend.py:488`):

```python
is_table_row = "|" in snippet_text and (
    self.in_table or original_text.lstrip().startswith("|")
)
```

But the parser split each row with `[1:-1]` (`:215`, `:220`), which assumes both pipes are present. On a row written without the trailing pipe, that slice drops the last cell:

| input | output on `main` |
|---|---|
| `\| Character \| Name in German`<br>`\|---\|---`<br>`\| Scrooge McDuck \| Dagobert Duck` | `\| Character \|`<br>`\|----------------\|`<br>`\| Scrooge McDuck \|` |

"Name in German" and "Dagobert Duck" are gone, silently, with no warning. Directly against the backend: the trailing-pipe form gives `num_cols=2` and four cells; the same table without it gives `num_cols=1` and two.

**The input is legal GFM** — that isn't my reading of the spec: `marko`, docling's own markdown dependency, renders that same table with two `<th>` columns.

The sibling asciidoc backend already gets this right — `_split_row` (`asciidoc_backend.py:373`) does `line.split("|")[1:]` and comments that it removes *the leading empty string* only.

## Fix

Split off an empty field only when it comes from a pipe at the very edge of the row, so both spellings parse identically. Rows that do carry the trailing pipe are unaffected, and an intentionally empty cell in the middle of a row still survives.

Reachable from the public `DocumentConverter().convert()` (`document_converter.py:152`) and also from `vlm_pipeline.py:302`, so a VLM emitting a table without trailing pipes loses columns too.

## Test Plan

Added `test_convert_table_without_trailing_pipes` next to the existing `test_convert_table_has_no_duplicate_cells`, asserting both spellings produce the same two-column table. It fails on `main` and passes with this change; the existing table test passes on both.

- `tests/test_backend_markdown.py` — 9 passed, 1 skipped
- `tests/test_backend_asciidoc.py tests/test_backend_csv.py tests/test_backend_html.py` — 44 passed
- Wider `-k "backend or markdown or md"` sweep — 334 passed, 2 failed; both failures are `test_backend_webp.py::test_e2e_webp_conversions` raising `ImportError` for a missing optional OCR engine, and they reproduce identically on a pristine checkout with no changes applied.
- `ruff check` / `ruff format --check` clean.

## Checklist

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

Disclosure: written with Claude Code. I verified the reproduction, the marko comparison, the sibling backend, and the test red/green myself.
