### PR TITLE
fix: propagate VLM metadata to VlmPrediction

### DIFF
--- a/docling/models/stages/vlm_convert/vlm_convert_model.py
+++ b/docling/models/stages/vlm_convert/vlm_convert_model.py
@@ -34,7 +34,14 @@ def _prediction_from_engine_output(output: VlmEngineOutput) -> VlmPrediction:
     if output.stop_reason in _VLM_STOP_REASON_VALUES:
         stop_reason = VlmStopReason(output.stop_reason)
 
-    return VlmPrediction(text=output.text, stop_reason=stop_reason)
+    metadata = output.metadata or {}
+    return VlmPrediction(
+        text=output.text,
+        stop_reason=stop_reason,
+        generation_time=metadata.get("generation_time", -1),
+        num_tokens=metadata.get("num_tokens"),
+        usage=metadata.get("usage"),
+    )
 
 
 class VlmConvertModel(BasePageModel):


### PR DESCRIPTION
## Summary

`ApiVlmEngine` stores generation metadata (`generation_time`, `num_tokens`, and `usage`) in `VlmEngineOutput.metadata`, but `_prediction_from_engine_output()` currently ignores this metadata.

This change propagates the existing metadata into `VlmPrediction`, allowing downstream applications to access these values after document conversion.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.