### PR TITLE
fix(uspto): guard out-of-range namest in CALS table spans

### DIFF
--- a/docling/backend/xml/uspto_backend.py
+++ b/docling/backend/xml/uspto_backend.py
@@ -1713,7 +1713,8 @@ class XmlTable:
                                     end = ientry + 2
                                     shift = 1
 
-                                if end > len(tg_range["cell_offst"]):
+                                n_offst = len(tg_range["cell_offst"])
+                                if start < 1 or start > n_offst or end > n_offst:
                                     wrong_nbr_cols = True
                                     self.nbr_messages += 1
                                     if self.nbr_messages <= self.max_nbr_messages:

--- a/tests/test_backend_patent_uspto.py
+++ b/tests/test_backend_patent_uspto.py
@@ -143,6 +143,29 @@ def test_tables(tables):
     assert len(file_table.table_cells) == 130
 
 
+def test_table_out_of_range_namest_does_not_crash():
+    """An entry whose numeric namest points past the declared columns must degrade, not crash."""
+    xml = (
+        '<table><tgroup cols="2">'
+        '<colspec colname="1" colwidth="1"/><colspec colname="2" colwidth="1"/>'
+        '<tbody><row><entry namest="9">a</entry></row></tbody>'
+        "</tgroup></table>"
+    )
+    table = XmlTable(xml).parse()
+    assert table is not None
+    assert table.num_cols == 2
+    # the malformed cell is dropped; a well-formed sibling table still parses
+    well_formed = (
+        '<table><tgroup cols="2">'
+        '<colspec colname="1" colwidth="1"/><colspec colname="2" colwidth="1"/>'
+        "<tbody><row><entry>a</entry><entry>b</entry></row></tbody>"
+        "</tgroup></table>"
+    )
+    ok = XmlTable(well_formed).parse()
+    assert ok is not None
+    assert [cell.text for cell in ok.table_cells] == ["a", "b"]
+
+
 def test_patent_uspto_ice(patents):
     """Test applications and grants Full Text Data/XML Version 4.x ICE."""
 


### PR DESCRIPTION
In the USPTO CALS table parser, a cell's span is computed from `namest` (start) and `nameend` (end). The `end` value is bounds-checked against the column-offset list, but `start` is not, so a numeric `namest` pointing past the declared columns reaches `cell_offst[start - 1]` and raises `IndexError`. As with proportional widths, the crash is caught at the call site, so the whole table is dropped from the output document.

This extends the existing wrong-column guard to also reject a `start` below 1 or past the last column, so such an entry degrades like a mismatched-column row instead of crashing the table.

Repro against the real backend:

```python
from docling.backend.xml.uspto_backend import XmlTable

xml = (
    '<table><tgroup cols="2">'
    '<colspec colname="1" colwidth="1"/><colspec colname="2" colwidth="1"/>'
    '<tbody><row><entry namest="9">a</entry></row></tbody>'
    '</tgroup></table>'
)
XmlTable(xml).parse()  # before: IndexError: list index out of range
```

Added `test_table_out_of_range_namest_does_not_crash`, which also checks a well-formed sibling table still parses.
