### PR TITLE
fix(md): size table to the widest row, not the header

### DIFF
--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -244,7 +244,8 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                     tcells.append(icell)
 
             num_rows = len(result_table)
-            num_cols = len(result_table[0])
+            # a body row may hold more cells than the header; size to the widest row
+            num_cols = max((len(row) for row in result_table), default=0)
             self.in_table = False
             self.md_table_buffer = []  # clean table markdown buffer
             # Initialize Docling TableData

--- a/tests/test_backend_markdown.py
+++ b/tests/test_backend_markdown.py
@@ -301,3 +301,28 @@ def test_convert_table_has_no_duplicate_cells():
         for cell in table_data.table_cells
     ]
     assert len(positions) == len(set(positions))
+
+
+def test_convert_table_body_row_wider_than_header():
+    """
+    Regression test:
+    num_cols was taken from the header row, so a body row with more cells than
+    the header produced a table whose num_cols under-counted the real width. The
+    extra cell stayed in table_cells but was dropped by every exporter (its
+    column index fell outside num_cols), silently losing data.
+    """
+    markdown = """| A | B |
+| --- | --- |
+| 1 | 2 | 3 |
+"""
+    conv_result = get_converter().convert_string(markdown, format=InputFormat.MD)
+    assert conv_result.status == ConversionStatus.SUCCESS
+
+    table = conv_result.document.tables[0]
+    table_data = table.data
+    assert table_data.num_rows == 2
+    assert table_data.num_cols == 3
+    texts = {cell.text for cell in table_data.table_cells}
+    assert {"1", "2", "3"} <= texts
+    # the third-column cell used to be dropped by the exporter; it must survive now
+    assert "3" in conv_result.document.export_to_markdown()


### PR DESCRIPTION
The Markdown table parser sets `num_cols` from the header row's cell count (`num_cols = len(result_table[0])`). When a body row has more cells than the header, the extra cells stay in `table_cells` but their column index falls outside `num_cols`, so `export_to_markdown` and `export_to_dataframe` build a header-width grid and silently drop them.

This sizes `num_cols` to the widest row instead, matching the CSV backend (`num_cols = max(len(row) ...)`), so wider body rows keep all their cells on export. The `default=0` also removes a latent `result_table[0]` IndexError on an empty table.

Repro:

```python
from docling.document_converter import DocumentConverter
from docling.datamodel.base_models import InputFormat

md = "| A | B |\n| --- | --- |\n| 1 | 2 | 3 |\n"
doc = DocumentConverter().convert_string(md, format=InputFormat.MD).document
print(doc.tables[0].data.num_cols)          # before: 2 (expected 3)
print("3" in doc.export_to_markdown())      # before: False -- the cell is lost
```

Added `test_convert_table_body_row_wider_than_header`.

Distinct from the trailing-pipe splitting in #3817 and the cell-duplication fix in #3781; this is the `num_cols` sizing on a different line.
