### PR TITLE
fix(html): count rows for header cells whose rowspan runs past the table

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -2566,8 +2566,12 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         for t in cast(list[Tag], tag.find_all(["thead", "tbody"], recursive=False)):
             t.unwrap()
         # Find the number of rows and columns (taking into account spans)
-        num_rows: int = 0
         num_cols: int = 0
+        # num_rows tracks the last grid row a cell lands on (as parse_table_data
+        # places them), so a spanning-header row with no row below still gets one.
+        row_idx = -1
+        start_row_span = 0
+        max_row = -1
         for row in tag("tr", recursive=False):
             col_count = 0
             is_row_header = True
@@ -2583,7 +2587,12 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
                     is_row_header = False
             num_cols = max(num_cols, col_count)
             if not is_row_header:
-                num_rows += 1
+                row_idx += 1
+                start_row_span = 0
+            else:
+                start_row_span += 1
+            max_row = max(max_row, row_idx + start_row_span)
+        num_rows = max_row + 1
         return num_rows, num_cols
 
     def _handle_block(self, tag: Tag, doc: DoclingDocument) -> list[RefItem]:  # noqa: C901

--- a/tests/test_backend_html.py
+++ b/tests/test_backend_html.py
@@ -310,6 +310,41 @@ def test_nested_table_in_description_list_item():
     assert len(doc.tables) == 1
 
 
+def test_table_header_rowspan_past_table_end_does_not_crash():
+    """Regression: a table whose only row is header cells with rowspan>1 (the
+    rowspan runs past the table's last row) made get_html_table_row_col count
+    num_rows=0, so parse_table_data indexed an empty grid and raised IndexError,
+    failing the whole conversion. The header row must still produce a 1-row table
+    with both cells rather than crash or drop the data.
+    """
+    html = (
+        b"<html><body><table>"
+        b"<tr><th rowspan='2'>A</th><th rowspan='2'>B</th></tr>"
+        b"</table></body></html>"
+    )
+    in_doc = InputDocument(
+        path_or_stream=BytesIO(html),
+        format=InputFormat.HTML,
+        backend=HTMLDocumentBackend,
+        filename="test",
+    )
+    backend = HTMLDocumentBackend(in_doc=in_doc, path_or_stream=BytesIO(html))
+    doc: DoclingDocument = backend.convert()
+
+    assert len(doc.tables) == 1
+    table = doc.tables[0].data
+    assert table.num_rows == 1
+    assert table.num_cols == 2
+    cells = {
+        (cell.text, cell.start_row_offset_idx, cell.start_col_offset_idx)
+        for cell in table.table_cells
+    }
+    assert cells == {("A", 0, 0), ("B", 0, 1)}
+    # both cells survive to export instead of being silently dropped
+    md = doc.export_to_markdown()
+    assert "A" in md and "B" in md
+
+
 def test_description_lists():
     """Test that HTML description lists (<dl>, <dt>, <dd>) are properly parsed."""
     test_set: list[tuple[bytes, str]] = []


### PR DESCRIPTION
`get_html_table_row_col` treats a row of only `<th>` cells with `rowspan > 1` as a spanning header that contributes no row of its own. When such a row has no row below for the span to reach (the rowspan runs past the table's last row), `num_rows` comes out `0`, so `parse_table_data` builds an empty grid and then indexes it, raising `IndexError` and failing the whole document conversion on otherwise valid HTML (browsers just clamp the rowspan).

The fix derives `num_rows` from the last grid row a cell actually lands on, mirroring how `parse_table_data` places cells (`row_idx + start_row_span`), so a spanning-header row with no row below still gets a row instead of crashing. Non-crashing tables are unaffected: over a differential sweep of 4000 random tables, 257 that raised `IndexError` now render and every other table is byte-identical (same `num_rows`/`num_cols`/cells).

Repro:

```python
from io import BytesIO
from docling.backend.html_backend import HTMLDocumentBackend
from docling.datamodel.base_models import InputFormat
from docling.datamodel.document import InputDocument

html = b"<table><tr><th rowspan='2'>A</th><th rowspan='2'>B</th></tr></table>"
in_doc = InputDocument(path_or_stream=BytesIO(html), format=InputFormat.HTML,
                       backend=HTMLDocumentBackend, filename="t.html")
HTMLDocumentBackend(in_doc=in_doc, path_or_stream=BytesIO(html)).convert()
# before: IndexError: list index out of range
# after:  1x2 table with cells A, B
```

Added `test_table_header_rowspan_past_table_end_does_not_crash`.
