### PR TITLE
fix(jats): count rows for header cells whose rowspan runs past the table

### DIFF
--- a/docling/backend/xml/jats_backend.py
+++ b/docling/backend/xml/jats_backend.py
@@ -718,8 +718,12 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
             return None
 
         # Find the number of rows and columns (taking into account spans)
-        num_rows = 0
         num_cols = 0
+        # num_rows tracks the last grid row a cell lands on (as the placement loop
+        # below does), so a spanning-header row with no row below still gets one.
+        row_idx = -1
+        start_row_span = 0
+        max_row = -1
         for row in element("tr"):
             col_count = 0
             is_row_header = True
@@ -735,7 +739,12 @@ class JatsDocumentBackend(DeclarativeDocumentBackend):
                     is_row_header = False
             num_cols = max(num_cols, col_count)
             if not is_row_header:
-                num_rows += 1
+                row_idx += 1
+                start_row_span = 0
+            else:
+                start_row_span += 1
+            max_row = max(max_row, row_idx + start_row_span)
+        num_rows = max_row + 1
 
         _log.debug(f"The table has {num_rows} rows and {num_cols} cols.")
 

--- a/tests/test_backend_jats.py
+++ b/tests/test_backend_jats.py
@@ -233,6 +233,30 @@ def test_jats_empty_display_formula_does_not_drop_following_content():
     assert [t.text for t in doc.texts if t.label == DocItemLabel.FORMULA] == []
 
 
+def test_jats_table_header_rowspan_past_table_end_is_not_dropped():
+    # A table whose only row is header <th> cells with rowspan>1 (the span runs
+    # past the last row) made parse_table_data count num_rows=0, index an empty
+    # grid, and raise IndexError; convert() swallows it as "unsupported table" and
+    # silently drops the whole table. The table must render with both cells.
+    doc = convert_jats_body(
+        "<table-wrap><label>Table 1</label>"
+        "<table><tr><th rowspan='2'>A</th><th rowspan='2'>B</th></tr></table>"
+        "</table-wrap>"
+    )
+
+    assert len(doc.tables) == 1
+    table = doc.tables[0].data
+    assert table.num_rows == 1
+    assert table.num_cols == 2
+    cells = {
+        (cell.text, cell.start_row_offset_idx, cell.start_col_offset_idx)
+        for cell in table.table_cells
+    }
+    assert cells == {("A", 0, 0), ("B", 0, 1)}
+    md = doc.export_to_markdown()
+    assert "A" in md and "B" in md
+
+
 def test_jats_footnotes_are_preserved():
     doc = convert_jats_body(
         """


### PR DESCRIPTION
`parse_table_data` counts `num_rows` only for non-header rows, so a table whose only row is `<th>` cells with `rowspan > 1` (the span runs past the table's last row) comes out with `num_rows = 0`. It then builds an empty grid and indexes it, raising `IndexError`. `_add_table`'s caller catches that and logs `Skipping unsupported table`, so the whole table is silently dropped from an otherwise valid JATS article.

The fix counts `num_rows` from the last grid row a cell actually lands on, mirroring the placement loop below, so the header row yields a table instead of vanishing. Non-header tables are unaffected: over a differential sweep of 4000 random tables, 257 that raised `IndexError` now render and every other table is byte-identical.

This is the same root cause as #3824 in the HTML backend, in the JATS backend's copy of the table logic.

Repro (through the public converter):

```python
xml = (
    '<article article-type="research-article"><front><article-meta>'
    "<title-group><article-title>T</article-title></title-group>"
    "</article-meta></front><body><table-wrap>"
    "<table><tr><th rowspan='2'>A</th><th rowspan='2'>B</th></tr></table>"
    "</table-wrap></body></article>"
)
# before: the table is dropped ("Skipping unsupported table"); doc.tables == []
# after:  a 1x2 table with cells A, B
```

Added `test_jats_table_header_rowspan_past_table_end_is_not_dropped`.
