### PR TITLE
fix(asciidoc): stop a dedented list from crashing the backend

### DIFF
--- a/docling/backend/asciidoc_backend.py
+++ b/docling/backend/asciidoc_backend.py
@@ -153,7 +153,7 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
 
                 elif in_list and item["indent"] < indents[level]:
                     # print(item["indent"], " => ", indents[level])
-                    while item["indent"] < indents[level]:
+                    while level > 0 and item["indent"] < indents[level]:
                         # print(item["indent"], " => ", indents[level])
                         parents[level] = None
                         indents[level] = None

--- a/tests/test_backend_asciidoc.py
+++ b/tests/test_backend_asciidoc.py
@@ -1,4 +1,5 @@
 import glob
+from io import BytesIO
 from pathlib import Path
 
 from docling.backend.asciidoc_backend import (
@@ -22,6 +23,23 @@ def _get_backend(fname):
 
     doc_backend = in_doc._backend
     return doc_backend
+
+
+def test_list_dedent_to_base_does_not_crash():
+    # A list that starts indented and then dedents back to the base level used
+    # to raise "TypeError: '<' not supported between instances of 'int' and
+    # 'NoneType'": the dedent loop walked past level 0, where the base indent is
+    # never set. It should keep both items instead.
+    src = b"  * a\n* b\n"
+    in_doc = InputDocument(
+        path_or_stream=BytesIO(src),
+        format=InputFormat.ASCIIDOC,
+        backend=AsciiDocBackend,
+        filename="dedent.asciidoc",
+    )
+    doc = in_doc._backend.convert()
+
+    assert [item.text for item in doc.texts] == ["a", "b"]
 
 
 def test_parse_picture():


### PR DESCRIPTION
An AsciiDoc list that starts indented and then dedents back to the base level crashes the backend:

```python
AsciiDocBackend(...).convert()   # source: "  * a\n* b\n"
# TypeError: '<' not supported between instances of 'int' and 'NoneType'
```

The dedent loop in `_parse_list_item` handling keeps decrementing `level` and comparing `item["indent"] < indents[level]`, but `indents[0]` (the base level) is never assigned an int — only `indents[level + 1]` is set when a list starts or nests deeper. So once the loop walks past level 0 the comparison hits `None` and raises.

The fix stops the loop at level 0, where there is no enclosing list to dedent out of. Nested and flat lists are unaffected; only the previously-crashing dedent-to-base case changes (it now keeps both items).

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

`test_list_dedent_to_base_does_not_crash` converts `"  * a\n* b\n"` and asserts both items survive; it fails before this change (TypeError) and passes after. The existing `tests/test_backend_asciidoc.py` stays green (7 passed); `ruff check` / `ruff format` pass.

---

*Disclosure: this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, wrote and ran the repro and the test, and wrote this description; the human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.*

