### PR TITLE
fix(html): stop a header-only rowspan table from crashing the backend

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -1522,6 +1522,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
                     row_span -= 1
                 while (
                     col_idx < num_cols
+                    and row_idx + start_row_span < num_rows
                     and grid[row_idx + start_row_span][col_idx] is not None
                 ):
                     col_idx += 1

--- a/tests/test_backend_html.py
+++ b/tests/test_backend_html.py
@@ -168,6 +168,24 @@ def test_heading_levels():
     assert found_lvl_1 and found_lvl_2
 
 
+def test_table_header_rowspan_without_body_does_not_crash():
+    # A table whose only row is a `th` with rowspan (no body rows to span into)
+    # used to raise IndexError: get_html_table_row_col counts no rows for an
+    # all-header-rowspan row, so the grid was empty and the cell-placement read
+    # went out of bounds. It should not crash and should keep the cell.
+    src = b"<table><tr><th rowspan='2'>h</th></tr></table>"
+    in_doc = InputDocument(
+        path_or_stream=BytesIO(src),
+        format=InputFormat.HTML,
+        backend=HTMLDocumentBackend,
+        filename="t.html",
+    )
+    doc = HTMLDocumentBackend(in_doc=in_doc, path_or_stream=BytesIO(src)).convert()
+
+    assert len(doc.tables) == 1
+    assert [cell.text for cell in doc.tables[0].data.table_cells] == ["h"]
+
+
 def test_ordered_lists():
     test_set: list[tuple[bytes, str]] = []
 


### PR DESCRIPTION
An HTML table whose only row is a `th` with `rowspan` — no body rows for it to span into — crashes the backend:

```python
HTMLDocumentBackend(...).convert()   # <table><tr><th rowspan="2">h</th></tr></table>
# IndexError: list index out of range
```

`get_html_table_row_col` treats an all-header row that uses `rowspan` as a spanning header and doesn't count it, so for a table with only such a row `num_rows` is `0` and the grid is empty. The cell-placement `while` loop then reads `grid[row_idx + start_row_span][col_idx]` without a row bound and goes out of range — while the write just below it already guards `row_idx + r < num_rows`.

The fix adds the same row bound to the read. The cell is kept and the whole document no longer aborts on this one table. Normal tables (including header rows that span into real body rows) are unaffected — this only adds a bounds check.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

`test_table_header_rowspan_without_body_does_not_crash` converts that table and asserts it doesn't crash and keeps the cell; it fails before this change (IndexError) and passes after. The full `tests/test_backend_html.py` stays green (37 passed); `ruff check` / `ruff format` pass.

---

*Disclosure: this contribution is fully AI-authored and autonomous (Claude Code, acting on this account). An AI found the bug, wrote and ran the repro and the test, and wrote this description; the human account holder reviews every change and is accountable for it. The verification above is real and re-runnable from the diff. If this isn't the kind of contribution you want, say so and I'll close it.*

