### PR TITLE
test(docx): isolate chart opt-out test from shared documents fixture

### DIFF
--- a/tests/test_backend_msword.py
+++ b/tests/test_backend_msword.py
@@ -324,13 +324,9 @@ def test_chart_image_rendering():
     )
 
 
-def test_chart_image_opt_out_keeps_no_image(documents):
-    """Charts stay image-free under default options (render_chart_images=False).
-
-    Reuses the shared conversion, which runs with the default options, so the
-    same document is not converted again just to check the opt-out.
-    """
-    doc = next(item[1] for item in documents if item[0].name == "drawingml.docx")
+def test_chart_image_opt_out_keeps_no_image():
+    """Charts stay image-free under default options (render_chart_images=False)."""
+    doc = _chart_converter(render_chart_images=False).convert(CHART_DOCX).document
     chart = _single_chart_picture(doc)
 
     assert chart.get_image(doc=doc) is None


### PR DESCRIPTION
### Problem

`test_e2e_docx_conversions` was failing non-deterministically in CI when
tests ran in parallel.

The root cause was introduced in #3809 (commit `26ff0b25`), where
`test_chart_image_opt_out_keeps_no_image` was refactored to reuse the
module-scoped `documents` fixture instead of performing its own isolated
conversion.

Two tests in the same module patch `msword_backend_module.get_docx_to_pdf_converter`
to `lambda: None` at the process-wide module level for the duration of their
execution:

- `test_text_with_drawingml_without_libreoffice`
- `test_chart_classification_and_data_without_libreoffice`

The `documents` fixture is module-scoped and initialised **lazily** — on the
first setup of any test that requests it. In a parallel run, if either
monkeypatching test is executing concurrently with that first setup,
`get_docx_to_pdf_converter()` returns `None` during the conversion of
`drawingml.docx`. Without LibreOffice, only 2 pictures are produced instead
of 4 (the three non-chart DrawingML shapes are silently dropped). That
poisoned result is then **cached for the rest of the module session**.

When `test_e2e_docx_conversions` subsequently runs `verify_document` against
the ground truth (which has 4 pictures), the picture count mismatch causes
the assertion to fail.

### Fix

Revert `test_chart_image_opt_out_keeps_no_image` to create its own isolated
document via `_chart_converter(render_chart_images=False)`, consistent with
how the other two chart tests work. This removes the dependency on the shared
`documents` fixture and eliminates the race condition entirely.

### Verification

- All 51 tests in `test_backend_msword.py` pass.
- `make validate` passes cleanly.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
