### PR TITLE
docs: add format-specific behavior of table serializers

### DIFF
--- a/docs/concepts/serialization.md
+++ b/docs/concepts/serialization.md
@@ -34,6 +34,37 @@ The respective `DoclingDocument` export methods (e.g. `export_to_markdown()`) ar
 provided as user shorthands — internally directly instantiating and delegating to
 respective serializers.
 
+## Format-specific behaviors
+
+Each serializer makes format-specific trade-offs when representing document
+features that have no direct equivalent in the target format. The most notable
+case is **table cell spanning** (rowspan / colspan).
+
+### Table cell spans
+
+Docling's internal table model (`TableData.grid`) preserves full span metadata
+for every cell - `row_span`, `col_span`, `start_row_offset_idx`, and
+`start_col_offset_idx`. How that metadata is rendered depends on the output
+format:
+
+| Format | Span handling |
+|----------|---------------|
+| JSON | Preserved. The full `TableData` model is serialized losslessly, including all span fields. |
+| Doclang | Preserved. Tables are serialized via OTSL with explicit continuation tokens (`LCEL` for colspan, `UCEL` for rowspan, `XCEL` for both). |
+| DocTags | Preserved. Tables are serialized via OTSL, which natively encodes span structure. |
+| HTML | Preserved. Cells are emitted with native `rowspan` / `colspan` attributes. |
+| Markdown | **Flattened.** Markdown tables have no span syntax, so the serializer writes cell text at the origin position only; all other grid positions covered by the span are rendered as empty cells. |
+| LaTeX | **Flattened.** The `tabular` environment is emitted without `\multirow` / `\multicolumn` commands for now. |
+| WebVTT | **Not applicable.** Tables are not serialized (WebVTT is a subtitle/caption format). |
+
+
+If your downstream workflow depends on accurate table structure (e.g. merged
+header cells), prefer `export_to_html()` or `export_to_dict()` over
+`export_to_markdown()`. Alternatively, you can override the default table
+serializer for any format by subclassing `BaseTableSerializer` and passing your
+implementation when instantiating the document serializer.
+
+
 ## Examples
 
 For an example showcasing how to use serializers, see


### PR DESCRIPTION
This PR adds a new _Format-specific behaviors_ section to `docs/concepts/serialization.md` documenting how each output format handles table cell spans (rowspan/colspan):

- HTML, JSON, DocTags, Doclang: preserve spans natively
- Markdown, LaTeX: flatten spans due to format limitations
- WebVTT: tables are not serialized

Resolves #3830 

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
