### PR TITLE
fix: lazy-load chart extraction so docling-slim needs no torch

### DIFF
--- a/docling/models/stages/chart_extraction/granite_vision.py
+++ b/docling/models/stages/chart_extraction/granite_vision.py
@@ -8,7 +8,6 @@ from pathlib import Path
 from typing import Any, List, Literal, Optional, cast
 
 import pandas as pd
-import torch
 from docling_core.types.doc import (
     CodeLanguageLabel,
     DescriptionMetaField,
@@ -24,7 +23,6 @@ from docling_core.types.doc import (
 from docling_core.types.doc.document import CodeMetaField
 from PIL import Image
 from pydantic import BaseModel
-from transformers import AutoModelForImageTextToText, AutoProcessor
 
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
 from docling.datamodel.base_models import ItemAndImageEnrichmentElement
@@ -200,6 +198,8 @@ class ChartExtractionModelGraniteVision(_BaseChartExtractionModelGraniteVision):
     _model_repo_revision = "6e1fbaae4604ecc85f4f371416d82154ca49ad67"
 
     def _load_model(self, artifacts_path: Path) -> None:
+        from transformers import AutoModelForImageTextToText, AutoProcessor
+
         self._processor = AutoProcessor.from_pretrained(
             artifacts_path,
             trust_remote_code=True,
@@ -357,6 +357,9 @@ class ChartExtractionModelGraniteVisionV4(_BaseChartExtractionModelGraniteVision
                 message=".*incorrect regex pattern.*",
                 category=UserWarning,
             )
+            from transformers import AutoModelForImageTextToText, AutoProcessor
+            import torch
+
             self._processor = AutoProcessor.from_pretrained(
                 artifacts_path,
                 trust_remote_code=True,

--- a/docling/models/stages/chart_extraction/granite_vision.py
+++ b/docling/models/stages/chart_extraction/granite_vision.py
@@ -346,6 +346,9 @@ class ChartExtractionModelGraniteVisionV4(_BaseChartExtractionModelGraniteVision
     _model_repo_revision = "dd48e97503de471803850df70843cf9eb5da8712"
 
     def _load_model(self, artifacts_path: Path) -> None:
+        import torch
+        from transformers import AutoModelForImageTextToText, AutoProcessor
+
         with warnings.catch_warnings():
             warnings.filterwarnings(
                 "ignore",
@@ -357,8 +360,6 @@ class ChartExtractionModelGraniteVisionV4(_BaseChartExtractionModelGraniteVision
                 message=".*incorrect regex pattern.*",
                 category=UserWarning,
             )
-            import torch
-            from transformers import AutoModelForImageTextToText, AutoProcessor
 
             self._processor = AutoProcessor.from_pretrained(
                 artifacts_path,

--- a/docling/models/stages/chart_extraction/granite_vision.py
+++ b/docling/models/stages/chart_extraction/granite_vision.py
@@ -357,8 +357,8 @@ class ChartExtractionModelGraniteVisionV4(_BaseChartExtractionModelGraniteVision
                 message=".*incorrect regex pattern.*",
                 category=UserWarning,
             )
-            from transformers import AutoModelForImageTextToText, AutoProcessor
             import torch
+            from transformers import AutoModelForImageTextToText, AutoProcessor
 
             self._processor = AutoProcessor.from_pretrained(
                 artifacts_path,

--- a/docling/pipeline/base_pipeline.py
+++ b/docling/pipeline/base_pipeline.py
@@ -185,7 +185,7 @@ class ConvertPipeline(BasePipeline):
 
         # Lazily import torch-backed chart extraction only when enabled so
         # docling-slim / ONNX-only installs can import DocumentConverter without
-        # pulling torch+transformers (#3805).
+        # pulling torch+transformers.
         if pipeline_options.do_chart_extraction:
             from docling.models.stages.chart_extraction.granite_vision import (
                 ChartExtractionModelGraniteVision,

--- a/docling/pipeline/base_pipeline.py
+++ b/docling/pipeline/base_pipeline.py
@@ -34,10 +34,6 @@ from docling.datamodel.settings import settings
 from docling.models.base_model import GenericEnrichmentModel
 from docling.models.factories import get_picture_description_factory
 from docling.models.picture_description_base_model import PictureDescriptionBaseModel
-from docling.models.stages.chart_extraction.granite_vision import (
-    ChartExtractionModelGraniteVision,
-    ChartExtractionModelGraniteVisionV4,
-)
 from docling.models.stages.picture_classifier.document_picture_classifier import (
     DocumentPictureClassifier,
 )
@@ -185,28 +181,39 @@ class ConvertPipeline(BasePipeline):
             ),
             # Document Picture description
             picture_description_model,
-            # Document Chart Extraction
-            ChartExtractionModelGraniteVision(
-                enabled=(
-                    pipeline_options.do_chart_extraction
-                    and pipeline_options.chart_extraction_options.model
-                    == ChartExtractionModelKind.GRANITE_VISION
-                ),
-                artifacts_path=self.artifacts_path,
-                options=pipeline_options.chart_extraction_options,
-                accelerator_options=pipeline_options.accelerator_options,
-            ),
-            ChartExtractionModelGraniteVisionV4(
-                enabled=(
-                    pipeline_options.do_chart_extraction
-                    and pipeline_options.chart_extraction_options.model
-                    == ChartExtractionModelKind.GRANITE_VISION_V4
-                ),
-                artifacts_path=self.artifacts_path,
-                options=pipeline_options.chart_extraction_options,
-                accelerator_options=pipeline_options.accelerator_options,
-            ),
         ]
+
+        # Lazily import torch-backed chart extraction only when enabled so
+        # docling-slim / ONNX-only installs can import DocumentConverter without
+        # pulling torch+transformers (#3805).
+        if pipeline_options.do_chart_extraction:
+            from docling.models.stages.chart_extraction.granite_vision import (
+                ChartExtractionModelGraniteVision,
+                ChartExtractionModelGraniteVisionV4,
+            )
+
+            self.enrichment_pipe.extend(
+                [
+                    ChartExtractionModelGraniteVision(
+                        enabled=(
+                            pipeline_options.chart_extraction_options.model
+                            == ChartExtractionModelKind.GRANITE_VISION
+                        ),
+                        artifacts_path=self.artifacts_path,
+                        options=pipeline_options.chart_extraction_options,
+                        accelerator_options=pipeline_options.accelerator_options,
+                    ),
+                    ChartExtractionModelGraniteVisionV4(
+                        enabled=(
+                            pipeline_options.chart_extraction_options.model
+                            == ChartExtractionModelKind.GRANITE_VISION_V4
+                        ),
+                        artifacts_path=self.artifacts_path,
+                        options=pipeline_options.chart_extraction_options,
+                        accelerator_options=pipeline_options.accelerator_options,
+                    ),
+                ]
+            )
 
     def _get_picture_description_model(
         self, artifacts_path: Optional[Path] = None

--- a/tests/test_backend_optional_dependencies.py
+++ b/tests/test_backend_optional_dependencies.py
@@ -176,3 +176,21 @@ def test_service_client_imports_without_pdf_pipeline_dependency() -> None:
         "from docling.datamodel.service.options import ConvertDocumentsOptions\n",
     )
     assert result.returncode == 0, result.stderr
+
+
+def test_converter_constructs_without_chart_extraction_dependency() -> None:
+    """Importing DocumentConverter must not require transformers.
+
+    docling-slim[models-onnxruntime] ships without torch or transformers.
+    This regression test verifies the import is fully deferred behind the
+    `do_chart_extraction` flag.
+
+    Note: torch cannot be blocked via sys.modules here because scipy (an
+    unrelated transitive dependency) also inspects sys.modules["torch"] and
+    crashes on None.
+    """
+    result = _run_with_blocked_module(
+        "transformers",
+        "from docling.document_converter import DocumentConverter\nDocumentConverter()\n",
+    )
+    assert result.returncode == 0, result.stderr

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -564,13 +564,17 @@ def test_pipeline_cache_with_chart_extraction():
 
     with (
         patch(
-            "docling.pipeline.base_pipeline.ChartExtractionModelGraniteVisionV4"
-        ) as mock_chart,
+            "docling.models.stages.chart_extraction.granite_vision.ChartExtractionModelGraniteVision"
+        ) as mock_chart_v1,
+        patch(
+            "docling.models.stages.chart_extraction.granite_vision.ChartExtractionModelGraniteVisionV4"
+        ) as mock_chart_v4,
         patch(
             "docling.pipeline.base_pipeline.DocumentPictureClassifier"
         ) as mock_classifier,
     ):
-        mock_chart.return_value = Mock(enabled=True)
+        mock_chart_v1.return_value = Mock(enabled=True)
+        mock_chart_v4.return_value = Mock(enabled=True)
         mock_classifier.return_value = Mock(enabled=True)
 
         converter = DocumentConverter(


### PR DESCRIPTION
## Summary

`docling-slim[models-onnxruntime]` could not `from docling.document_converter import DocumentConverter` without torch, because `base_pipeline` eagerly imported `granite_vision` (top-level `import torch` / `transformers`) even when chart extraction was disabled (#3805).

### Changes

1. **`base_pipeline`**: remove top-level granite import; only import/add chart extraction models when `do_chart_extraction` is true.
2. **`granite_vision`**: lazy-import `torch` / `transformers` inside model loaders so merely importing the module does not require them.

## Testing

- `py_compile` on changed files.
- Logic: DocumentConverter → base_pipeline no longer imports torch-backed chart models unless chart extraction is enabled.

Fixes #3805
