### PR TITLE
fix(odf): preserve content inside sections

### DIFF
--- a/docling/backend/opendocument_backend.py
+++ b/docling/backend/opendocument_backend.py
@@ -69,6 +69,7 @@ try:  # pragma: no cover - import-time guard
         List as OdfList,
         ListItem,
         Paragraph,
+        Section,
         Table as OdfTable,
     )
 
@@ -901,6 +902,14 @@ def _add_odf_child(
             content_layer=content_layer,
             odf_obj=odf_obj,
         )
+    elif isinstance(element, Section):
+        _add_odf_children(
+            doc,
+            element.children,
+            parent=parent,
+            content_layer=content_layer,
+            odf_obj=odf_obj,
+        )
     elif isinstance(element, Frame):
         chart_count = _add_odf_charts(doc, element, parent, content_layer, odf_obj)
         _add_odf_images(
@@ -920,6 +929,38 @@ def _add_odf_child(
                 "Ignoring ODF element with tag: %s", getattr(element, "tag", None)
             )
     return None
+
+
+def _add_odf_children(
+    doc: DoclingDocument,
+    elements: list[Any],
+    *,
+    parent: NodeItem | None,
+    content_layer: ContentLayer | None,
+    odf_obj: OdfDocument | None,
+) -> None:
+    previous_list_state: _OdfListState | None = None
+    for element in elements:
+        if isinstance(element, OdfList):
+            previous_list_state = _add_odf_list(
+                doc,
+                element,
+                parent=parent,
+                content_layer=content_layer,
+                odf_obj=odf_obj,
+                enumerated=False,
+                continued_state=previous_list_state,
+                flatten_nested_text=False,
+            )
+        else:
+            previous_list_state = None
+            _add_odf_child(
+                doc,
+                element,
+                parent=parent,
+                content_layer=content_layer,
+                odf_obj=odf_obj,
+            )
 
 
 def _embedded_odf_content_path(href: str) -> str:
@@ -1380,28 +1421,13 @@ class OdtDocumentBackend(_OdfBaseBackend):
         parent: NodeItem | None,
         doc: DoclingDocument,
     ) -> None:
-        previous_list_state: _OdfListState | None = None
-        for el in elements:
-            if isinstance(el, OdfList):
-                previous_list_state = _add_odf_list(
-                    doc,
-                    el,
-                    parent=parent,
-                    content_layer=None,
-                    odf_obj=self.odf_obj,
-                    enumerated=False,
-                    continued_state=previous_list_state,
-                    flatten_nested_text=False,
-                )
-            else:
-                previous_list_state = None
-                _add_odf_child(
-                    doc,
-                    el,
-                    parent=parent,
-                    odf_obj=self.odf_obj,
-                    content_layer=None,
-                )
+        _add_odf_children(
+            doc,
+            elements,
+            parent=parent,
+            content_layer=None,
+            odf_obj=self.odf_obj,
+        )
 
 
 class OdpDocumentBackend(_OdfBaseBackend, PaginatedDocumentBackend):

--- a/tests/test_backend_opendocument.py
+++ b/tests/test_backend_opendocument.py
@@ -46,6 +46,7 @@ from odfdo import (
     List as OdfList,
     ListItem,
     Paragraph,
+    Section,
     Span,
     Style,
     Table,
@@ -174,6 +175,70 @@ def test_odt_conversion(odt_path: Path):
         for c in table.data.table_cells
     }
     assert cell_texts == {(0, 0): "h1", (0, 1): "h2", (1, 0): "v1", (1, 1): "v2"}
+
+
+def test_odt_section_content(tmp_path: Path):
+    path = tmp_path / "section.odt"
+    source = OdfDocument("text")
+    body = source.body
+    body.clear()
+
+    section = Section(name="Section1")
+    section.append(Header(1, "Heading inside section"))
+    section.append(Paragraph("Paragraph inside section."))
+    table = Table("Nested", width=2, height=1)
+    table.set_value("A1", "left")
+    table.set_value("B1", "right")
+    section.append(table)
+    body.append(section)
+    source.save(str(path))
+
+    result = DocumentConverter(allowed_formats=[InputFormat.ODT]).convert(path)
+
+    assert [
+        item.text for item in result.document.texts if item.label == "section_header"
+    ] == ["Heading inside section"]
+    assert any(
+        item.text == "Paragraph inside section." for item in result.document.texts
+    )
+    assert len(result.document.tables) == 1
+    assert [cell.text for cell in result.document.tables[0].data.table_cells] == [
+        "left",
+        "right",
+    ]
+
+
+def test_odt_section_preserves_split_list_continuation(tmp_path: Path):
+    path = tmp_path / "section_split_list.odt"
+    source = OdfDocument("text")
+    body = source.body
+    body.clear()
+
+    section = Section(name="Section1")
+    first = OdfList()
+    first.append(ListItem("Outer"))
+    section.append(first)
+
+    continuation = OdfList()
+    bridge = ListItem()
+    nested = OdfList()
+    nested.append(ListItem("Nested"))
+    bridge.append(nested)
+    continuation.append(bridge)
+    section.append(continuation)
+    body.append(section)
+    source.save(str(path))
+
+    result = DocumentConverter(allowed_formats=[InputFormat.ODT]).convert(path)
+    list_items = [
+        item
+        for item, _level in result.document.iterate_items()
+        if isinstance(item, TextItem) and item.label == "list_item"
+    ]
+
+    assert [item.text for item in list_items] == ["Outer", "Nested"]
+    nested_group = list_items[1].parent.resolve(result.document)
+    assert nested_group.parent == list_items[0].get_ref()
 
 
 def test_ods_conversion(ods_path: Path):


### PR DESCRIPTION
## Description

Treat odfdo `Section` elements as transparent ODT containers so their headings, paragraphs, tables, lists, frames, and nested sections reach the existing converters.

The shared child walker preserves adjacent-list continuation state at both the document root and inside sections. This prevents split nested lists from being flattened when they occur inside a `text:section`.

**Issue resolved by this Pull Request:**
Resolves #3846

## Testing

- `pytest tests/test_backend_opendocument.py -k "not test_e2e_odf_conversions"`: 27 passed, 1 deselected
- Focused Section tests: 2 passed
- Ruff format and lint: passed
- Tach dependency and module-coverage checks: passed
- ty: exit 0 (existing optional-dependency diagnostics remain)
- Relevant prek hooks: passed
- compileall: passed

The complete OpenDocument test file has one existing ODP ground-truth failure involving an unavailable embedded HTML image; the same failure was reproduced from a clean `origin/main` worktree.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
