### PR TITLE
fix(odf): preserve text after space elements

### DIFF
--- a/docling/backend/opendocument_backend.py
+++ b/docling/backend/opendocument_backend.py
@@ -313,6 +313,9 @@ def _odf_text_runs(
         if text_recursive.startswith(text):
             text = text_recursive
         return [_OdfTextRun(text=text, formatting=formatting)]
+    if tag == "text:s":
+        text_recursive = getattr(element, "text_recursive", " ")
+        return [_OdfTextRun(text=text_recursive, formatting=formatting)]
     if tag == "text:tab":
         return [_OdfTextRun(text="\t", formatting=formatting)]
 

--- a/tests/test_backend_opendocument.py
+++ b/tests/test_backend_opendocument.py
@@ -46,6 +46,7 @@ from odfdo import (
     List as OdfList,
     ListItem,
     Paragraph,
+    Spacer,
     Span,
     Style,
     Table,
@@ -434,6 +435,24 @@ def test_odt_text_document_text_formatting():
     assert "**Lorem Ipsum is not simply random text**" in markdown
     assert "*a Latin professor at Hampden-Sydney College in Virginia*" in markdown
     assert "~~The Extremes of Good and Evil~~" in markdown
+
+
+def test_odt_text_after_space_in_span(tmp_path: Path):
+    path = tmp_path / "span_tail.odt"
+    doc = OdfDocument("text")
+    body = doc.body
+    body.clear()
+
+    space = Spacer()
+    space.tail = "connective prose here"
+    span = Span()
+    span.append(space)
+    body.append(Paragraph(span))
+    doc.save(str(path))
+
+    res = DocumentConverter(allowed_formats=[InputFormat.ODT]).convert(path)
+
+    assert res.document.export_to_markdown() == "connective prose here"
 
 
 def test_odt_text_document_script_formatting():


### PR DESCRIPTION
Text following `<text:s/>` is stored in the element's tail. `_odf_text_runs()` reads the space itself but not that tail, so the rest of the span is lost.

Use `text_recursive` for `<text:s>` and add an ODT regression test for the reported structure.

**Issue resolved by this Pull Request:**
Resolves #3847

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
