### PR TITLE
fix: guard scipy import in to avoid crash in docling-slim[service-client]

### DIFF
--- a/docling/utils/video_frame_sampling.py
+++ b/docling/utils/video_frame_sampling.py
@@ -23,7 +23,6 @@ from typing import Final
 import numpy as np
 from PIL import Image
 from pydantic import BaseModel, ConfigDict, Field
-from scipy.signal import find_peaks
 
 
 class VideoFrameSamplingMode(str, Enum):
@@ -445,6 +444,10 @@ class SimpleSceneChangeFrameSampler:
                 min_dist, int((60.0 / self.cuts_per_minute) * self.probe_fps)
             )
             noise_floor = float(np.percentile(smoothed, 75))
+            from scipy.signal import (
+                find_peaks,  # guarded: not available in slim installations
+            )
+
             peaks, _ = find_peaks(
                 smoothed, distance=target_interval, prominence=noise_floor
             )
@@ -460,6 +463,10 @@ class SimpleSceneChangeFrameSampler:
             else:
                 prominence = _auto_prominence(diffs)
             _log.debug("Prominence mode: prominence=%.4f", prominence)
+            from scipy.signal import (
+                find_peaks,  # guarded: not available in slim installations
+            )
+
             peaks, _ = find_peaks(smoothed, prominence=prominence, distance=min_dist)
 
         # Filter peaks too close to video start


### PR DESCRIPTION
## Problem

`scipy` is pulled in at module-level in `video_frame_sampling.py`, which is transitively imported
by `pipeline_options.py` on every startup. This causes an immediate `ModuleNotFoundError` in slim
installs (e.g. `docling-slim[service-client]`) where `scipy` is not installed, even when no video
processing is requested.

Import chain:

```
cli/main.py
  → datamodel/service/responses.py
    → datamodel/base_models.py
      → datamodel/pipeline_options.py          # module-level import ↓
        → utils/video_frame_sampling.py
          → from scipy.signal import find_peaks  # 💥 not available in slim
```

## Solution

Move `from scipy.signal import find_peaks` from the module level into the two call sites inside
`SimpleSceneChangeFrameSampler.detect_scenes()` where it is actually used. `scipy` is only ever
needed at runtime when scene-change detection runs — never at import time.

This matches the existing pattern used to guard `pypdfium2` elsewhere in the codebase.

## Changes

- `docling/utils/video_frame_sampling.py` — removed top-level `from scipy.signal import
  find_peaks`; added the same import lazily inside the two branches of `detect_scenes()` that call
  `find_peaks`.

## Testing

Verified the fix manually by simulating a missing `scipy`:

```python
import sys
sys.modules['scipy'] = None
sys.modules['scipy.signal'] = None

from docling.datamodel.pipeline_options import VideoPipelineOptions  # no longer crashes
from docling.utils.video_frame_sampling import VideoFrameSamplingMode  # no longer crashes
```

Resolves #3859 