### PR TITLE
docs: add trivial (pass-through) chunker example

### DIFF
--- a/docs/examples/trivial_chunking.py
+++ b/docs/examples/trivial_chunking.py
@@ -1,0 +1,105 @@
+# %% [markdown]
+# A trivial (pass-through) chunker: one chunk per document item.
+#
+# Docling's built-in chunkers are retrieval-oriented: `HierarchicalChunker`
+# GROUPS items by section, and `HybridChunker` additionally MERGES undersized
+# chunks and SPLITS oversized ones to fit a token window. Sometimes the opposite
+# is wanted — one chunk per document element, verbatim, with no grouping and no
+# splitting — so that each chunk maps back to exactly one item. That is handy for
+# element-level extraction, indexing, or row-per-element storage.
+#
+# What this example does
+# - Implements `TrivialChunker` by subclassing `BaseChunker` and providing its
+#   single abstract method, `chunk()`.
+# - Emits one `DocChunk` per `DocItem` (heading, text, table, picture, ...), in
+#   reading order — no grouping, no splitting.
+# - Reuses the same `ChunkingSerializerProvider` the built-in chunkers use, so the
+#   chunk text is formatted identically; only the granularity differs.
+#
+# When to use this
+# - Downstream systems that need INDIVIDUAL document elements (one per chunk)
+#   rather than the retrieval-oriented, token-bounded chunks the built-in chunkers
+#   produce.
+#
+# Prerequisites
+# - Install Docling.
+#
+# How to run
+# - From the repo root: `python docs/examples/trivial_chunking.py`.
+#
+# Input document
+# - Defaults to a bundled sample (a 4-page PDF already converted to a
+#   DoclingDocument JSON). Any `DoclingDocument` works, including one produced by
+#   `DocumentConverter().convert(source).document`.
+
+# %%
+
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+from docling_core.transforms.chunker.base import BaseChunk, BaseChunker
+from docling_core.transforms.chunker.doc_chunk import DocChunk, DocMeta
+from docling_core.transforms.chunker.hierarchical_chunker import (
+    ChunkingSerializerProvider,
+)
+from docling_core.transforms.serializer.base import BaseSerializerProvider
+from docling_core.types.doc import DocItem, DoclingDocument
+from pydantic import ConfigDict
+
+
+class TrivialChunker(BaseChunker):
+    """A pass-through chunker that emits one chunk per document item.
+
+    Unlike `HierarchicalChunker` (which groups items by section) and
+    `HybridChunker` (which additionally merges and splits to fit a token window),
+    this chunker applies no grouping and no splitting: every `DocItem` in the
+    document becomes exactly one `DocChunk`, in reading order. Chunk text is
+    produced with the same serializer the built-in chunkers use, so the output
+    formatting is consistent — only the granularity differs.
+    """
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    serializer_provider: BaseSerializerProvider = ChunkingSerializerProvider()
+
+    def chunk(self, dl_doc: DoclingDocument, **kwargs: Any) -> Iterator[BaseChunk]:
+        """Chunk the document into one chunk per item.
+
+        Args:
+            dl_doc: the document to chunk.
+
+        Yields:
+            One `DocChunk` per `DocItem`, in reading order. Items that serialize
+            to empty text (e.g. a picture with no caption) are skipped.
+        """
+        doc_ser = self.serializer_provider.get_serializer(doc=dl_doc)
+        excluded_refs = doc_ser.get_excluded_refs(**kwargs)
+        for item, _level in dl_doc.iterate_items():
+            if not isinstance(item, DocItem) or item.self_ref in excluded_refs:
+                continue
+            ser_res = doc_ser.serialize(item=item)
+            if not ser_res.text:
+                continue
+            yield DocChunk(
+                text=ser_res.text,
+                meta=DocMeta(doc_items=[item], origin=dl_doc.origin),
+            )
+
+
+def main() -> None:
+    data_folder = Path(__file__).parent / "../../tests/data"
+    input_doc_path = data_folder / "pdf/groundtruth/normal_4pages.json"
+
+    doc = DoclingDocument.load_from_json(input_doc_path)
+    chunker = TrivialChunker()
+
+    chunks = list(chunker.chunk(doc))
+    print(f"{len(chunks)} chunks (one per item)\n")
+    for i, chunk in enumerate(chunks[:8]):
+        item = chunk.meta.doc_items[0]
+        print(f"{i}: [{item.label}] {chunk.text[:70]!r}")
+
+
+if __name__ == "__main__":
+    main()

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -125,6 +125,7 @@ nav:
       - _generated/examples/hybrid_chunking.md
       - _generated/examples/line_based_chunking.md
       - _generated/examples/advanced_chunking_and_serialization.md
+      - "Trivial chunker": _generated/examples/trivial_chunking.md
     - 📤 Information extraction:
       - _generated/examples/extraction.md
     - 🤖 RAG with AI dev frameworks:


### PR DESCRIPTION
## Motivation

Some downstream tasks need each document element as its own unit — element-level
extraction, per-element storage (one record per paragraph/table), or precise
citation back to a single element  with a stable reference to the source item.
docling's existing chunkers are retrieval-oriented: they group elements by
section and split/merge to fit a token window, so there was no simple way to get
a faithful one-chunk-per-element view from within the chunker interface. This is
the gap the earlier #3835 request was really about.

## What this adds

A `TrivialChunker` (`BaseChunker` subclass) that emits one `DocChunk` per
document item  no grouping, no splitting  in reading order. It reuses the
existing `ChunkingSerializerProvider`, so chunk text is formatted identically to
the built-in chunkers; only the granularity differs. Because it's a `BaseChunker`,
it's swappable with `HierarchicalChunker`/`HybridChunker` with no other pipeline
changes. Registered under Serialization & chunking in the docs nav.

This supersedes the element-level JSONL export originally proposed here for #3835,
following the suggestion from  @dolfim-ibm to express the use case as
a custom chunker. If useful, `TrivialChunker` could later move upstream into
docling-core.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.