### PR TITLE
docs(chunking): extend notebook for chunking with OCR text

### DIFF
--- a/docs/examples/advanced_chunking_and_serialization.ipynb
+++ b/docs/examples/advanced_chunking_and_serialization.ipynb
@@ -214,7 +214,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Token indices sequence length is longer than the specified maximum sequence length for this model (2942 > 512). Running this sequence through the model will result in indexing errors\n"
+      "[transformers] Token indices sequence length is longer than the specified maximum sequence length for this model (2942 > 512). Running this sequence through the model will result in indexing errors\n"
      ]
     },
     {
@@ -295,6 +295,11 @@
     }
    },
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": []
+    },
     {
      "data": {
       "text/html": [
@@ -489,12 +494,7 @@
     ")\n",
     "from docling_core.transforms.serializer.common import create_ser_result\n",
     "from docling_core.transforms.serializer.markdown import MarkdownPictureSerializer\n",
-    "from docling_core.types.doc.document import (\n",
-    "    PictureClassificationData,\n",
-    "    PictureDescriptionData,\n",
-    "    PictureItem,\n",
-    "    PictureMoleculeData,\n",
-    ")\n",
+    "from docling_core.types.doc.document import PictureItem\n",
     "from typing_extensions import override\n",
     "\n",
     "\n",
@@ -599,6 +599,189 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "### Handling OCR text nested in pictures"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When Docling converts a PDF, OCR is applied to images by default. Any text recognized inside an image is stored as `TextItem` objects nested under the corresponding `PictureItem` in the `DoclingDocument`.\n",
+    "\n",
+    "However, the `HybridChunker` skips this nested text by default, because `traverse_pictures=False` in the default serializer. This is intentional: OCR on images often yields low-quality text — a disorganized cloud of characters that can pollute downstream applications such as RAG. Furthermore, because serialization to text (e.g., Markdown) flattens the document structure, it is impossible to distinguish that noisy content from meaningful prose once it is mixed in.\n",
+    "\n",
+    "That said, there are documents where the text embedded in images is valuable and should be included in chunks. In those cases, you can opt in by setting `traverse_pictures=True` in a custom serializer.\n",
+    "\n",
+    "The example below uses page 16 of a document from the [ViDoRe V3 Physics dataset](https://huggingface.co/datasets/vidore/vidore_v3_physics), which contains images that are heavily processed by OCR.[¹](#ocr-attribution)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/vnd.jupyter.widget-view+json": {
+       "model_id": "482a61fd8b854fabac0c7d1bd7c5cbbd",
+       "version_major": 2,
+       "version_minor": 0
+      },
+      "text/plain": [
+       "Loading weights:   0%|          | 0/770 [00:00<?, ?it/s]"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of pictures: 3\n",
+      "Number of text items: 18718\n"
+     ]
+    }
+   ],
+   "source": [
+    "from docling.document_converter import DocumentConverter\n",
+    "\n",
+    "SOURCE = \"https://huggingface.co/datasets/vidore/vidore_v3_physics/resolve/main/pdfs/Autrement_Ch-6b-Les-reseaux-dautomates.pdf\"\n",
+    "\n",
+    "converter = DocumentConverter()\n",
+    "result = converter.convert(source=SOURCE, page_range=(16, 16))\n",
+    "ocr_doc = result.document\n",
+    "\n",
+    "print(f\"Number of pictures: {len(ocr_doc.pictures)}\")\n",
+    "print(f\"Number of text items: {len(ocr_doc.texts)}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice the high number of `TextItem` objects produced from a single page. This is caused by OCR picking up the dense grid of `1`s and `0`s rendered inside one of the images. You can inspect a sample to get a sense of the noise:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0', '0']\n"
+     ]
+    }
+   ],
+   "source": [
+    "print([item.text for item in ocr_doc.texts[10:30]])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Default behavior: OCR text under pictures is skipped\n",
+    "\n",
+    "Using `HybridChunker` with its default serializer silently skips all text nested under `PictureItem` nodes. Only the text that belongs to the document body proper is chunked:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created 2 chunk(s) in 0.33s.\n",
+      "'Wolfram (1983): étude systématique des automates logiques à 1 dimension'\n",
+      "'- Conduit à un état homogène (attracteur point fixe); ex  0, 32, 160 & 232\\n- Structures périodiques : 4, 108, 218 & 250.\\n- Structures chaotiques : 22, 30, 126, 150, 182\\n- Structures complexes, non\n"
+     ]
+    }
+   ],
+   "source": [
+    "import time\n",
+    "\n",
+    "from docling_core.transforms.chunker import HybridChunker\n",
+    "\n",
+    "chunker_default = HybridChunker()\n",
+    "\n",
+    "start = time.time()\n",
+    "chunks_default = list(chunker_default.chunk(ocr_doc))\n",
+    "elapsed = round(time.time() - start, 2)\n",
+    "\n",
+    "print(f\"Created {len(chunks_default)} chunk(s) in {elapsed}s.\")\n",
+    "for chunk in chunks_default:\n",
+    "    print(repr(chunk.text)[:200])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Opting in: include OCR text from pictures\n",
+    "\n",
+    "To include the OCR text nested under pictures, pass a custom serializer provider that enables `traverse_pictures=True`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Created 76 chunk(s) in 17.41s.\n"
+     ]
+    }
+   ],
+   "source": [
+    "from docling_core.transforms.chunker.hierarchical_chunker import (\n",
+    "    ChunkingDocSerializer,\n",
+    "    ChunkingSerializerProvider,\n",
+    ")\n",
+    "from docling_core.transforms.serializer.markdown import MarkdownParams\n",
+    "\n",
+    "\n",
+    "class TraversePicturesProvider(ChunkingSerializerProvider):\n",
+    "    def get_serializer(self, doc):\n",
+    "        params = MarkdownParams(traverse_pictures=True)\n",
+    "        return ChunkingDocSerializer(doc=doc, params=params)\n",
+    "\n",
+    "\n",
+    "chunker_traverse = HybridChunker(serializer_provider=TraversePicturesProvider())\n",
+    "\n",
+    "start = time.time()\n",
+    "num_chunks_traverse = len(list(chunker_traverse.chunk(ocr_doc)))\n",
+    "elapsed = round(time.time() - start, 2)\n",
+    "\n",
+    "print(f\"Created {num_chunks_traverse} chunk(s) in {elapsed}s.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the example above, the OCR text from a single image page results in many more chunks compared to the default behavior — most of which would be pure noise in a RAG pipeline.\n",
+    "\n",
+    "💡 Use this option only when you are confident that the text inside your images is meaningful and clean.\n",
+    "\n",
+    "---\n",
+    "<a name=\"ocr-attribution\"></a>\n",
+    "¹ Document used in this example: *Un peu de Science pour comprendre le monde moderne Saison 3 - Autrement*, by Bernard Remaud. File sourced from the [ViDoRe V3 Physics dataset](https://huggingface.co/datasets/vidore/vidore_v3_physics/blob/main/pdfs/Autrement_Ch-6b-Les-reseaux-dautomates.pdf) hosted on [Hugging Face](https://huggingface.co)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Chunk expansion\n",
     "In this section, we demonstrate how to expand chunks to include additional context from their containing document items or pages. This is useful when we want to ensure that chunks include complete semantic units or when we need more context for downstream tasks."
    ]
@@ -613,7 +796,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 16,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-05-20T20:00:53.124048Z",
@@ -707,7 +890,6 @@
    ],
    "source": [
     "from docling_core.transforms.chunker.chunk_expander import TreeChunkExpander\n",
-    "from docling_core.transforms.chunker.hierarchical_chunker import ChunkingDocSerializer\n",
     "\n",
     "# Create a chunk expander for expanding to containing doc items\n",
     "tree_expander = TreeChunkExpander()\n",
@@ -745,7 +927,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 17,
    "metadata": {
     "execution": {
      "iopub.execute_input": "2026-05-20T20:00:53.151179Z",
@@ -933,7 +1115,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.13.12"
+   "version": "3.13.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
## Description

Extends the *Advanced chunking & serialization* notebook with a new subsection: **Handling OCR text nested in pictures*, under the existing *Picture serialization* section.

Resolves #3845 

## Background

A recurring user question concerns documents where the layout model classifies a large portion of a page as a picture. In those cases, OCR-extracted text is stored as `TextItem` objects nested under a `PictureItem` in the `DoclingDocument`, and the `HybridChunker` silently skips it by default (`traverse_pictures=False`). This is intentional behavior, but it is not obvious to users, and the silence (no warning, no empty-chunk error) makes it hard to diagnose.

## What was added

- **Background explanation**: describes why `HybridChunker` skips picture-nested text by default (noise risk, structure flattening), and when opting in is appropriate.
- **Worked example** using page 16 of a real document from the ViDoRe V3 Physics dataset, which produces 18,718 `TextItem` objects from a single page due to a dense binary image being OCR'd.
- **Default behavior demonstration**: shows that the default chunker produces only 2 clean chunks and ignores the OCR noise.
- **Opt-in example**: shows how to define a `TraversePicturesProvider` with `traverse_pictures=True` to include picture-nested text, along with a note on the significant increase in chunk count and processing time.

## Other changes

- Cleaned up an unused import in the custom picture serializer cell (`PictureClassificationData`, `PictureDescriptionData`, `PictureMoleculeData` → only `PictureItem` is needed).
