### PR TITLE
fix(pdf): remove NUL characters from parsed text

### DIFF
--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -79,6 +79,18 @@ def _make_docling_parse_page_content_config(
     )
 
 
+def _sanitize_text_cells(cells: Iterable[TextCell]) -> None:
+    for cell in cells:
+        cell.text = cell.text.replace("\x00", "")
+        cell.orig = cell.orig.replace("\x00", "")
+
+
+def _sanitize_segmented_page_text(seg_page: SegmentedPdfPage) -> None:
+    _sanitize_text_cells(seg_page.char_cells)
+    _sanitize_text_cells(seg_page.word_cells)
+    _sanitize_text_cells(seg_page.textline_cells)
+
+
 class DoclingParsePageBackend(ManagedPdfiumPageBackend):
     def __init__(
         self,
@@ -130,6 +142,7 @@ class DoclingParsePageBackend(ManagedPdfiumPageBackend):
             self._page_no + 1,
             content_config=content_config,
         )
+        _sanitize_segmented_page_text(seg_page)
 
         # In Docling, all TextCell instances are expected with top-left origin.
         [
@@ -412,6 +425,7 @@ class ThreadedDoclingParsePageBackend(PdfPageBackend):
             return None
         if self._seg_page is None:
             seg_page = self._result.get_page()
+            _sanitize_segmented_page_text(seg_page)
             page_height = seg_page.dimension.height
             for tc in seg_page.textline_cells:
                 tc.to_top_left_origin(page_height)

--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -115,6 +115,18 @@ def _make_docling_parse_page_content_config(
     )
 
 
+def _sanitize_text_cells(cells: Iterable[TextCell]) -> None:
+    for cell in cells:
+        cell.text = cell.text.replace("\x00", "")
+        cell.orig = cell.orig.replace("\x00", "")
+
+
+def _sanitize_segmented_page_text(seg_page: SegmentedPdfPage) -> None:
+    _sanitize_text_cells(seg_page.char_cells)
+    _sanitize_text_cells(seg_page.word_cells)
+    _sanitize_text_cells(seg_page.textline_cells)
+
+
 class DoclingParsePageBackend(ManagedPdfiumPageBackend):
     def __init__(
         self,
@@ -173,6 +185,7 @@ class DoclingParsePageBackend(ManagedPdfiumPageBackend):
             self._page_no + 1,
             content_config=content_config,
         )
+        _sanitize_segmented_page_text(seg_page)
 
         # In Docling, all TextCell instances are expected with top-left origin.
         [
@@ -467,6 +480,7 @@ class ThreadedDoclingParsePageBackend(PdfPageBackend):
             return None
         if self._seg_page is None:
             seg_page = self._result.get_page()
+            _sanitize_segmented_page_text(seg_page)
             page_height = seg_page.dimension.height
             for tc in seg_page.textline_cells:
                 tc.to_top_left_origin(page_height)

--- a/tests/test_backend_docling_parse.py
+++ b/tests/test_backend_docling_parse.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pytest
 from docling_core.types.doc import CoordOrigin
+from docling_core.types.doc.page import BoundingRectangle, TextCell
 from docling_parse.pdf_parser import ContentLevel
 from PIL import Image, ImageDraw, ImageStat
 
@@ -13,6 +14,7 @@ from docling.backend.docling_parse_backend import (
     DoclingParsePageBackend,
     ThreadedDoclingParseDocumentBackend,
     ThreadedDoclingParsePageBackend,
+    _sanitize_text_cells,
 )
 from docling.backend.pdf_backend import PdfDocumentBackend
 from docling.datamodel.backend_options import ThreadedDoclingParseBackendOptions
@@ -36,6 +38,38 @@ def _get_backend(pdf_doc):
 
     doc_backend = in_doc._backend
     return doc_backend
+
+
+def test_sanitize_text_cells_removes_nul_characters():
+    rect = BoundingRectangle(
+        r_x0=0,
+        r_y0=0,
+        r_x1=1,
+        r_y1=0,
+        r_x2=1,
+        r_y2=1,
+        r_x3=0,
+        r_y3=1,
+    )
+    cell = TextCell(
+        rect=rect,
+        text="30.45 mg.mL \x00 1",
+        orig="30.45 mg.mL \x00 1",
+        from_ocr=False,
+    )
+    unicode_cell = TextCell(
+        rect=rect,
+        text="30.45 mg.mL\u207b\u00b9",
+        orig="30.45 mg.mL\u207b\u00b9",
+        from_ocr=False,
+    )
+
+    _sanitize_text_cells([cell, unicode_cell])
+
+    assert cell.text == "30.45 mg.mL  1"
+    assert cell.orig == "30.45 mg.mL  1"
+    assert unicode_cell.text == "30.45 mg.mL\u207b\u00b9"
+    assert unicode_cell.orig == "30.45 mg.mL\u207b\u00b9"
 
 
 def test_text_cell_counts():
@@ -554,6 +588,9 @@ def test_non_threaded_page_backend_disables_bitmap_byte_materialization() -> Non
     captured_content_config: Any | None = None
 
     class _FakeCell:
+        text = "text\x00"
+        orig = "orig\x00"
+
         def to_top_left_origin(self, _page_height: float) -> "_FakeCell":
             return self
 
@@ -596,6 +633,8 @@ def test_non_threaded_page_backend_disables_bitmap_byte_materialization() -> Non
         page_backend.unload()
 
     assert len(cells) == 1
+    assert cells[0].text == "text"
+    assert cells[0].orig == "orig"
     assert captured_content_config is not None
     assert captured_content_config.include_bitmap_bytes is False
 
@@ -648,6 +687,9 @@ def test_threaded_page_backend_delegates_image_access() -> None:
 
 def test_threaded_page_backend_disables_bitmap_materialization() -> None:
     class _FakeCell:
+        text = "text\x00"
+        orig = "orig\x00"
+
         def to_top_left_origin(self, _page_height: float) -> "_FakeCell":
             return self
 
@@ -669,6 +711,8 @@ def test_threaded_page_backend_disables_bitmap_materialization() -> None:
     cells = list(page_backend.get_text_cells())
 
     assert len(cells) == 1
+    assert cells[0].text == "text"
+    assert cells[0].orig == "orig"
 
 
 def _create_black_square_pdf(path: Path) -> None:

--- a/tests/test_backend_docling_parse.py
+++ b/tests/test_backend_docling_parse.py
@@ -8,7 +8,11 @@ from typing import Any
 
 import pytest
 from docling_core.types.doc import CoordOrigin
-from docling_core.types.doc.page import PdfCellRenderingMode
+from docling_core.types.doc.page import (
+    BoundingRectangle,
+    PdfCellRenderingMode,
+    TextCell,
+)
 from docling_parse.pdf_parser import ContentLevel
 from PIL import Image, ImageDraw, ImageStat
 
@@ -18,6 +22,7 @@ from docling.backend.docling_parse_backend import (
     DoclingParsePageBackend,
     ThreadedDoclingParseDocumentBackend,
     ThreadedDoclingParsePageBackend,
+    _sanitize_text_cells,
 )
 from docling.backend.pdf_backend import PdfDocumentBackend, iter_pdf_page_backends
 from docling.datamodel.backend_options import ThreadedDoclingParseBackendOptions
@@ -45,6 +50,38 @@ def _get_backend(pdf_doc):
 
     doc_backend = in_doc._backend
     return doc_backend
+
+
+def test_sanitize_text_cells_removes_nul_characters():
+    rect = BoundingRectangle(
+        r_x0=0,
+        r_y0=0,
+        r_x1=1,
+        r_y1=0,
+        r_x2=1,
+        r_y2=1,
+        r_x3=0,
+        r_y3=1,
+    )
+    cell = TextCell(
+        rect=rect,
+        text="30.45 mg.mL \x00 1",
+        orig="30.45 mg.mL \x00 1",
+        from_ocr=False,
+    )
+    unicode_cell = TextCell(
+        rect=rect,
+        text="30.45 mg.mL\u207b\u00b9",
+        orig="30.45 mg.mL\u207b\u00b9",
+        from_ocr=False,
+    )
+
+    _sanitize_text_cells([cell, unicode_cell])
+
+    assert cell.text == "30.45 mg.mL  1"
+    assert cell.orig == "30.45 mg.mL  1"
+    assert unicode_cell.text == "30.45 mg.mL\u207b\u00b9"
+    assert unicode_cell.orig == "30.45 mg.mL\u207b\u00b9"
 
 
 def test_text_cell_counts():
@@ -599,6 +636,9 @@ def test_non_threaded_page_backend_disables_bitmap_byte_materialization() -> Non
     captured_content_config: Any | None = None
 
     class _FakeCell:
+        text = "text\x00"
+        orig = "orig\x00"
+
         def to_top_left_origin(self, _page_height: float) -> "_FakeCell":
             return self
 
@@ -641,6 +681,8 @@ def test_non_threaded_page_backend_disables_bitmap_byte_materialization() -> Non
         page_backend.unload()
 
     assert len(cells) == 1
+    assert cells[0].text == "text"
+    assert cells[0].orig == "orig"
     assert captured_content_config is not None
     assert captured_content_config.include_bitmap_bytes is False
 
@@ -693,6 +735,9 @@ def test_threaded_page_backend_delegates_image_access() -> None:
 
 def test_threaded_page_backend_disables_bitmap_materialization() -> None:
     class _FakeCell:
+        text = "text\x00"
+        orig = "orig\x00"
+
         def to_top_left_origin(self, _page_height: float) -> "_FakeCell":
             return self
 
@@ -714,6 +759,8 @@ def test_threaded_page_backend_disables_bitmap_materialization() -> None:
     cells = list(page_backend.get_text_cells())
 
     assert len(cells) == 1
+    assert cells[0].text == "text"
+    assert cells[0].orig == "orig"
 
 
 def _create_black_square_pdf(path: Path) -> None:


### PR DESCRIPTION
## Summary

- remove embedded NUL characters from parsed PDF text cells before they enter downstream document assembly
- sanitize character, word, and text-line cells for both standard and threaded Docling Parse backends
- preserve valid Unicode text, including superscript unit exponents

**Issue resolved by this Pull Request:**
Resolves #3858

## Tests

- `python -m pytest tests/test_backend_docling_parse.py -q` (24 passed)
- changed-file `prek` hooks (Ruff, formatter, ty, Tach)
- converted the issue's 22-page source PDF with `ConversionStatus.SUCCESS` and verified zero NUL characters in both exported Markdown and the full serialized `DoclingDocument`

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.