### PR TITLE
docs: Cleanup removed examples from nav and fix rendering of Surya OCR example

### DIFF
--- a/docs/examples/suryaocr_with_custom_models.py
+++ b/docs/examples/suryaocr_with_custom_models.py
@@ -23,7 +23,8 @@
 # - Models cached in `~/.cache/huggingface`; override with HF_HOME env var.
 # - Use proxy config for restricted networks.
 # - **Important Licensing Note**: The `docling-surya` package integrates SuryaOCR, which is licensed under the GNU General Public License (GPL).
-# - Using this integration may impose GPL obligations on your project. Review the license terms carefully.
+#
+# Using this integration may impose GPL obligations on your project. Review the license terms carefully.
 
 # Requires `pip install docling-surya`
 # See [https://pypi.org/project/docling-surya/](https://pypi.org/project/docling-surya/)

--- a/docs/examples/suryaocr_with_custom_models.py
+++ b/docs/examples/suryaocr_with_custom_models.py
@@ -1,27 +1,35 @@
-# Example: Integrating SuryaOCR with Docling for PDF OCR and Markdown Export
+# %% [markdown]
+# Integrating SuryaOCR with Docling for PDF OCR and Markdown Export
 #
 # Overview:
+#
 # - Configures SuryaOCR options for OCR.
 # - Executes PDF pipeline with SuryaOCR integration.
 # - Models auto-download from Hugging Face on first run.
 #
 # Prerequisites:
+#
 # - Install: `pip install docling-surya`
 # - Ensure `docling` imports successfully.
 #
 # Execution:
+#
 # - Run from repo root: `python docs/examples/suryaocr_with_custom_models.py`
 # - Outputs Markdown to stdout.
 #
 # Notes:
+#
 # - Default source: EPA PDF URL; substitute with local path as needed.
 # - Models cached in `~/.cache/huggingface`; override with HF_HOME env var.
 # - Use proxy config for restricted networks.
 # - **Important Licensing Note**: The `docling-surya` package integrates SuryaOCR, which is licensed under the GNU General Public License (GPL).
-#   Using this integration may impose GPL obligations on your project. Review the license terms carefully.
+# - Using this integration may impose GPL obligations on your project. Review the license terms carefully.
 
 # Requires `pip install docling-surya`
-# See https://pypi.org/project/docling-surya/
+# See [https://pypi.org/project/docling-surya/](https://pypi.org/project/docling-surya/)
+
+# %%
+
 from docling_surya import SuryaOcrOptions
 
 from docling.datamodel.base_models import InputFormat

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,7 +108,6 @@ nav:
       - _generated/examples/video_pipeline.md
       - "Figure export": _generated/examples/export_figures.md
       - "Table export": _generated/examples/export_tables.md
-      - "Multimodal export": _generated/examples/export_multimodal.md
       - "Force full page OCR": _generated/examples/full_page_ocr.md
       - "Automatic OCR language detection with tesseract": _generated/examples/tesseract_lang_detection.md
       - "RapidOCR with custom OCR models": _generated/examples/rapidocr_with_custom_models.md


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

1. Cleaning up reference of `docs/examples/export_multimodal.py` from `mkdocs.yml` as the actual file was removed in 
#3592 
2. Surya OCR example didn't render correctly as it was missing `%% [markdown]` header, and some small clean up to have things show up as list (it showed 404 earlier)

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
