### PR TITLE
feat: make StandardPdfPipeline stage shutdown timeout configurable

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -2062,6 +2062,17 @@ class PdfPipelineOptions(PaginatedPipelineOptions):
             )
         ),
     ] = 100
+    # Shutdown control
+    stage_shutdown_timeout_seconds: Annotated[
+        float,
+        Field(
+            description=(
+                "Seconds to wait for each pipeline stage thread to terminate during shutdown before it is "
+                "abandoned as stuck (its resources may then leak for the rest of the process lifetime). Only "
+                "used by `StandardPdfPipeline` (threaded mode)."
+            )
+        ),
+    ] = 15.0
 
 
 class ProcessingPipeline(str, Enum):

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -232,6 +232,7 @@ class ThreadedPipelineStage:
         batch_size: int,
         batch_timeout: float,
         queue_max_size: int,
+        shutdown_timeout: float = 15.0,
         postprocess: Callable[[ThreadedItem], None] | None = None,
         timed_out_run_ids: set[int] | None = None,
     ) -> None:
@@ -239,6 +240,7 @@ class ThreadedPipelineStage:
         self.model = model
         self.batch_size = batch_size
         self.batch_timeout = batch_timeout
+        self.shutdown_timeout = shutdown_timeout
         self.input_queue = ThreadedQueue(queue_max_size)
         self._outputs: list[ThreadedQueue] = []
         self._thread: threading.Thread | None = None
@@ -268,13 +270,14 @@ class ThreadedPipelineStage:
         self._running = False
         self.input_queue.close()
         if self._thread is not None:
-            # Give thread 15s to finish naturally before abandoning
-            self._thread.join(timeout=15.0)
+            # Give the thread self.shutdown_timeout seconds to finish naturally before abandoning
+            self._thread.join(timeout=self.shutdown_timeout)
             if self._thread.is_alive():
                 _log.warning(
-                    "Stage %s thread did not terminate within 15s. "
+                    "Stage %s thread did not terminate within %.1fs. "
                     "Thread is likely stuck in a blocking call and will be abandoned (resources may leak).",
                     self.name,
+                    self.shutdown_timeout,
                 )
 
     # ------------------------------------------------------------------ _run
@@ -411,6 +414,7 @@ class PreprocessThreadedStage(ThreadedPipelineStage):
         batch_timeout: float,
         queue_max_size: int,
         model: Any,
+        shutdown_timeout: float = 15.0,
         timed_out_run_ids: set[int] | None = None,
     ) -> None:
         super().__init__(
@@ -419,6 +423,7 @@ class PreprocessThreadedStage(ThreadedPipelineStage):
             batch_size=1,
             batch_timeout=batch_timeout,
             queue_max_size=queue_max_size,
+            shutdown_timeout=shutdown_timeout,
             timed_out_run_ids=timed_out_run_ids,
         )
 
@@ -711,6 +716,7 @@ class StandardPdfPipeline(ConvertPipeline):
             batch_timeout=opts.batch_polling_interval_seconds,
             queue_max_size=opts.queue_max_size,
             model=self.preprocessing_model,
+            shutdown_timeout=opts.stage_shutdown_timeout_seconds,
             timed_out_run_ids=timed_out_run_ids,
         )
         ocr = ThreadedPipelineStage(
@@ -719,6 +725,7 @@ class StandardPdfPipeline(ConvertPipeline):
             batch_size=opts.ocr_batch_size,
             batch_timeout=opts.batch_polling_interval_seconds,
             queue_max_size=opts.queue_max_size,
+            shutdown_timeout=opts.stage_shutdown_timeout_seconds,
             timed_out_run_ids=timed_out_run_ids,
         )
         layout = ThreadedPipelineStage(
@@ -727,6 +734,7 @@ class StandardPdfPipeline(ConvertPipeline):
             batch_size=opts.layout_batch_size,
             batch_timeout=opts.batch_polling_interval_seconds,
             queue_max_size=opts.queue_max_size,
+            shutdown_timeout=opts.stage_shutdown_timeout_seconds,
             timed_out_run_ids=timed_out_run_ids,
         )
         layout_postprocess = ThreadedPipelineStage(
@@ -735,6 +743,7 @@ class StandardPdfPipeline(ConvertPipeline):
             batch_size=1,
             batch_timeout=opts.batch_polling_interval_seconds,
             queue_max_size=opts.queue_max_size,
+            shutdown_timeout=opts.stage_shutdown_timeout_seconds,
             timed_out_run_ids=timed_out_run_ids,
         )
         table = ThreadedPipelineStage(
@@ -743,6 +752,7 @@ class StandardPdfPipeline(ConvertPipeline):
             batch_size=opts.table_batch_size,
             batch_timeout=opts.batch_polling_interval_seconds,
             queue_max_size=opts.queue_max_size,
+            shutdown_timeout=opts.stage_shutdown_timeout_seconds,
             timed_out_run_ids=timed_out_run_ids,
         )
         assemble = ThreadedPipelineStage(
@@ -751,6 +761,7 @@ class StandardPdfPipeline(ConvertPipeline):
             batch_size=1,
             batch_timeout=opts.batch_polling_interval_seconds,
             queue_max_size=opts.queue_max_size,
+            shutdown_timeout=opts.stage_shutdown_timeout_seconds,
             postprocess=self._release_page_resources,
             timed_out_run_ids=timed_out_run_ids,
         )
@@ -799,7 +810,8 @@ class StandardPdfPipeline(ConvertPipeline):
         """Stream-build the document with a dedicated producer thread.
 
         Note: If a worker thread gets stuck in a blocking call (model inference or PDF backend
-        iter_pages/get_size), that thread will be abandoned after a brief wait (15s) during cleanup.
+        iter_pages/get_size), that thread will be abandoned after a brief wait
+        (`PdfPipelineOptions.stage_shutdown_timeout_seconds`, 15s by default) during cleanup.
         The thread continues running until the blocking call completes, potentially holding
         resources (e.g., pypdfium2_lock).
         """
@@ -961,11 +973,13 @@ class StandardPdfPipeline(ConvertPipeline):
             for st in ctx.stages:
                 st.stop()
             ctx.output_queue.close()
-            producer_thread.join(timeout=15.0)
+            shutdown_timeout = self.pipeline_options.stage_shutdown_timeout_seconds
+            producer_thread.join(timeout=shutdown_timeout)
             if producer_thread.is_alive():
                 _log.warning(
-                    "Producer thread for run %d did not terminate within 15s and will be abandoned.",
+                    "Producer thread for run %d did not terminate within %.1fs and will be abandoned.",
                     run_id,
+                    shutdown_timeout,
                 )
 
         self._integrate_results(conv_res, proc, timeout_exceeded=timeout_exceeded)

--- a/tests/test_threaded_pipeline.py
+++ b/tests/test_threaded_pipeline.py
@@ -1,3 +1,4 @@
+import threading
 import time
 from pathlib import Path
 
@@ -8,12 +9,16 @@ from docling.backend.docling_parse_backend import (
     ThreadedDoclingParseDocumentBackend,
 )
 from docling.backend.pypdfium2_backend import PyPdfiumDocumentBackend
-from docling.datamodel.base_models import ConversionStatus, InputFormat
+from docling.datamodel.base_models import ConversionStatus, InputFormat, Page
 from docling.datamodel.pipeline_options import (
     ThreadedPdfPipelineOptions,
 )
 from docling.document_converter import DocumentConverter, PdfFormatOption
-from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline
+from docling.pipeline.standard_pdf_pipeline import (
+    StandardPdfPipeline,
+    ThreadedItem,
+    ThreadedPipelineStage,
+)
 
 _TEST_FILES = [
     "tests/data/pdf/sources/2203.01017v2.pdf",
@@ -108,3 +113,42 @@ def test_threaded_pipeline_page_range():
 
     assert result.status == ConversionStatus.SUCCESS
     assert [p.page_no for p in result.pages] == [2, 3, 4]
+
+
+def test_threaded_pipeline_stage_shutdown_timeout():
+    """A stage stuck in a blocking model call is abandoned after
+    `shutdown_timeout`, not the hardcoded 15s the pipeline used to have."""
+    entered = threading.Event()
+    release = threading.Event()
+
+    class SlowModel:
+        def __call__(self, conv_res, pages):
+            entered.set()
+            release.wait()
+            return pages
+
+    stage = ThreadedPipelineStage(
+        name="slow",
+        model=SlowModel(),
+        batch_size=1,
+        batch_timeout=0.05,
+        queue_max_size=10,
+        shutdown_timeout=1.0,
+    )
+    stage.start()
+    try:
+        stage.input_queue.put(
+            ThreadedItem(payload=Page(page_no=1), run_id=1, page_no=1, conv_res=None)
+        )
+        assert entered.wait(timeout=5.0), "stage never entered the blocking call"
+
+        start = time.monotonic()
+        stage.stop()
+        elapsed = time.monotonic() - start
+
+        assert 1.0 <= elapsed < 5.0
+        assert stage._thread is not None and stage._thread.is_alive()
+    finally:
+        release.set()
+        if stage._thread is not None:
+            stage._thread.join(timeout=5.0)


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

## Description

A `StandardPdfPipeline` (threaded mode) stage thread stuck in a blocking call
(slow model inference, slow PDF backend call) is abandoned after a hardcoded
15s during shutdown. Python cannot forcibly terminate a running thread, so an
abandoned thread's resources leak for the remaining lifetime of the process.

This adds `PdfPipelineOptions.stage_shutdown_timeout_seconds` (default `15.0`,
matching the previous hardcoded value, so no behavior change by default) so
callers can raise it for legitimately slow stages or lower it to abandon
stuck threads sooner. Also fixes the two related log warnings, which
previously always said "15s" regardless of the actual timeout used.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.