### PR TITLE
fix(odf): skip a draw:object whose embedded part is missing

### DIFF
--- a/docling/backend/opendocument_backend.py
+++ b/docling/backend/opendocument_backend.py
@@ -997,10 +997,16 @@ def _chart_data_from_frame(
 
     try:
         chart_content = odf_obj.get_part(_embedded_odf_content_path(object_href))
-    except Exception:
+        # odfdo resolves XML parts lazily, so a reference to a part that is missing
+        # from the package only fails once the part is actually read.
+        chart_classification = _odf_chart_classification(chart_content)
+        chart_tables = chart_content.get_elements("descendant::table:table")
+    except Exception as e:
+        _log.warning(
+            "Could not read embedded OpenDocument object %s: %s", object_href, e
+        )
         return None
-    chart_classification = _odf_chart_classification(chart_content)
-    for table in chart_content.get_elements("descendant::table:table"):
+    for table in chart_tables:
         if isinstance(table, OdfTable) and table.name == "local-table":
             table_data = _table_data_from_odf(table)
             if table_data is not None:

--- a/tests/test_backend_opendocument.py
+++ b/tests/test_backend_opendocument.py
@@ -41,6 +41,7 @@ pytest.importorskip("odfdo")
 from odfdo import (
     Document as OdfDocument,
     DrawPage,
+    Element,
     Frame,
     Header,
     List as OdfList,
@@ -555,6 +556,27 @@ def test_odt_text_document_embedded_chart():
     assert cell_texts[(1, 0)] == "Row 1"
     assert cell_texts[(1, 1)] == "9.1"
     assert cell_texts[(4, 3)] == "6.2"
+
+
+def test_odt_dangling_embedded_object_is_skipped(tmp_path: Path):
+    """A draw:object whose part is missing must not abort the conversion."""
+    path = tmp_path / "dangling_object.odt"
+    source = OdfDocument("text")
+    body = source.body
+    body.clear()
+    body.append(Paragraph("Before the dangling object."))
+    frame = Frame(name="dangling", size=("6cm", "4cm"))
+    frame.append(Element.from_tag('<draw:object xlink:href="./Object 1"/>'))
+    body.append(frame)
+    body.append(Paragraph("After the dangling object."))
+    source.save(str(path))
+
+    result = DocumentConverter(allowed_formats=[InputFormat.ODT]).convert(path)
+
+    texts = [item.text for item in result.document.texts]
+    assert "Before the dangling object." in texts
+    assert "After the dangling object." in texts
+    assert result.document.pictures == []
 
 
 def test_odt_text_document_embedded_bitmap_image():


### PR DESCRIPTION
Fixes #3848.

## Problem

A `<draw:frame>` containing `<draw:object xlink:href="./Object N"/>` whose part is **absent from the package** aborts the entire conversion with `RuntimeError: Pipeline SimplePipeline failed`, instead of skipping the object.

`_chart_data_from_frame` already wraps the part lookup in a `try`, but odfdo resolves XML parts **lazily**:

```python
# odfdo/document.py, Document.get_part
part = self.__xmlparts.get(path)
if part is None:
    self.__xmlparts[path] = part = cls(path, self.container)   # no archive read yet
return part
```

So `get_part()` succeeds for a dangling reference and the archive read — and the `KeyError` — happens on first access, i.e. inside `_odf_chart_classification(chart_content)`, one line *after* the `except`.

Verified against odfdo 3.23.1:

```
get_part returned OK -> Content
RAISED on get_elements: KeyError "There is no item named 'Object 1/content.xml' in the archive"
```

## Fix

Move the two reads that actually touch the part (`_odf_chart_classification` and the `descendant::table:table` lookup) inside the existing guard, and log a warning so the skip is visible. The rest of the document is extracted normally.

## Test

`test_odt_dangling_embedded_object_is_skipped` builds the fixture on the fly with odfdo (matching the "unit tests with fixtures built on the fly" pattern already documented at the top of the file), so no binary fixture and no reference-data regeneration is needed. It fails on `main` with the `KeyError` and passes with the fix.

## Verification

- Replayed the patched control flow against `tests/data/odf/sources/text_document_02.odt`: the embedded bar chart still resolves to its `local-table` with the same 4×5 shape asserted by `test_odt_text_document_embedded_chart`, so the existing chart path is unaffected.
- `ruff 0.15.12` (the `.pre-commit-config.yaml` pin) `format --check` and `check` are clean on both files; the only `check` findings are the two pre-existing `I001` reports that the unmodified files already produce.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
