### PR TITLE
fix(ocr): make the OCR render scale configurable instead of hardcoded

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -216,6 +216,20 @@ class OcrOptions(BaseOptions):
         ),
     ]
 
+    scale: Annotated[
+        float,
+        Field(
+            description=(
+                "Image scale multiplier applied before running OCR. The page is "
+                "rendered at 72 DPI times this factor, so the default 3 yields "
+                "216 DPI. Lower it when the source image is already high "
+                "resolution and upscaling degrades recognition."
+            ),
+            examples=[1.0, 3.0],
+            gt=0.0,
+        ),
+    ] = 3.0
+
     # Deprecated: superseded by `OcrMode.FULL_PAGE`. Kept for backwards compatibility
     # When set to True it forces `mode` to FULL_PAGE
     force_full_page_ocr: Annotated[

--- a/docling/models/stages/ocr/easyocr_model.py
+++ b/docling/models/stages/ocr/easyocr_model.py
@@ -88,7 +88,8 @@ class EasyOcrModel(BaseOcrModel):
         )
         self.options: EasyOcrOptions
 
-        self.scale = 3  # multiplier for 72 dpi == 216 dpi.
+        # multiplier for 72 dpi; the default 3.0 == 216 dpi.
+        self.scale = self.options.scale
 
         if self.enabled:
             try:

--- a/docling/models/stages/ocr/nemotron_ocr_model.py
+++ b/docling/models/stages/ocr/nemotron_ocr_model.py
@@ -120,7 +120,8 @@ class NemotronOcrModel(BaseOcrModel):
             accelerator_options=accelerator_options,
         )
         self.options: NemotronOcrOptions
-        self.scale = 3  # multiplier for 72 dpi == 216 dpi.
+        # multiplier for 72 dpi; the default 3.0 == 216 dpi.
+        self.scale = self.options.scale
 
         if self.enabled:
             self.validate_runtime(accelerator_options=accelerator_options)
@@ -246,7 +247,7 @@ class NemotronOcrModel(BaseOcrModel):
         ocr_rect: BoundingBox,
         image_width: int,
         image_height: int,
-        scale: int,
+        scale: float,
     ) -> TextCell:
         # `nemotron_ocr` returns normalized `left/right` and an inverted
         # pair `lower/upper`, where `lower` is the top Y and `upper` is the

--- a/docling/models/stages/ocr/ocr_mac_model.py
+++ b/docling/models/stages/ocr/ocr_mac_model.py
@@ -38,7 +38,8 @@ class OcrMacModel(BaseOcrModel):
         )
         self.options: OcrMacOptions
 
-        self.scale = 3  # multiplier for 72 dpi == 216 dpi.
+        # multiplier for 72 dpi; the default 3.0 == 216 dpi.
+        self.scale = self.options.scale
 
         if self.enabled:
             if "darwin" != sys.platform:

--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -325,7 +325,8 @@ class RapidOcrModel(BaseOcrModel):
         )
         self.options: RapidOcrOptions
 
-        self.scale = 3  # multiplier for 72 dpi == 216 dpi.
+        # multiplier for 72 dpi; the default 3.0 == 216 dpi.
+        self.scale = self.options.scale
 
         if self.enabled:
             try:

--- a/docling/models/stages/ocr/tesseract_ocr_cli_model.py
+++ b/docling/models/stages/ocr/tesseract_ocr_cli_model.py
@@ -52,7 +52,8 @@ class TesseractOcrCliModel(BaseOcrModel):
         )
         self.options: TesseractCliOcrOptions
 
-        self.scale = 3  # multiplier for 72 dpi == 216 dpi.
+        # multiplier for 72 dpi; the default 3.0 == 216 dpi.
+        self.scale = self.options.scale
 
         self._name: Optional[str] = None
         self._version: Optional[str] = None

--- a/docling/models/stages/ocr/tesseract_ocr_model.py
+++ b/docling/models/stages/ocr/tesseract_ocr_model.py
@@ -42,7 +42,8 @@ class TesseractOcrModel(BaseOcrModel):
         )
         self.options: TesseractOcrOptions
         self._is_auto: bool = "auto" in self.options.lang
-        self.scale = 3  # multiplier for 72 dpi == 216 dpi.
+        # multiplier for 72 dpi; the default 3.0 == 216 dpi.
+        self.scale = self.options.scale
         self.reader = None
         self.script_readers: dict[str, tesserocr.PyTessBaseAPI] = {}
 

--- a/tests/test_options.py
+++ b/tests/test_options.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
+from pydantic import ValidationError
 
 from docling.backend.docling_parse_backend import (
     DoclingParseDocumentBackend,
@@ -21,9 +22,11 @@ from docling.datamodel.image_classification_engine_options import (
     ApiKserveV2ImageClassificationEngineOptions,
 )
 from docling.datamodel.pipeline_options import (
+    EasyOcrOptions,
     NemotronOcrOptions,
     PdfPipelineOptions,
     TableFormerMode,
+    TesseractCliOcrOptions,
 )
 from docling.document_converter import (
     ConversionError,
@@ -31,7 +34,9 @@ from docling.document_converter import (
     PdfFormatOption,
 )
 from docling.models.factories import get_ocr_factory
+from docling.models.stages.ocr.easyocr_model import EasyOcrModel
 from docling.models.stages.ocr.nemotron_ocr_model import NemotronOcrModel
+from docling.models.stages.ocr.tesseract_ocr_cli_model import TesseractOcrCliModel
 from docling.pipeline.legacy_standard_pdf_pipeline import LegacyStandardPdfPipeline
 
 
@@ -453,6 +458,33 @@ def test_page_error_carries_page_no(test_doc_path):
         assert isinstance(err, ErrorItem)
         assert err.page_no >= 1
         assert not err.error_message.startswith("Page ")
+
+
+def test_ocr_scale_is_configurable():
+    """The OCR render scale comes from the options instead of a hardcoded 3."""
+    assert TesseractCliOcrOptions().scale == 3.0
+    assert EasyOcrOptions().scale == 3.0
+
+    accelerator_options = AcceleratorOptions()
+
+    tesseract_model = TesseractOcrCliModel(
+        enabled=False,
+        artifacts_path=None,
+        options=TesseractCliOcrOptions(scale=1.0),
+        accelerator_options=accelerator_options,
+    )
+    assert tesseract_model.scale == 1.0
+
+    easyocr_model = EasyOcrModel(
+        enabled=False,
+        artifacts_path=None,
+        options=EasyOcrOptions(scale=1.5),
+        accelerator_options=accelerator_options,
+    )
+    assert easyocr_model.scale == 1.5
+
+    with pytest.raises(ValidationError):
+        TesseractCliOcrOptions(scale=0)
 
 
 def test_nemotron_ocr_backend_registration():


### PR DESCRIPTION
Fixes #3866

### Problem

Every local OCR engine hardcoded its render scale:

```python
self.scale = 3  # multiplier for 72 dpi == 216 dpi.
```

so pages are always upscaled to 216 DPI before being handed to the OCR engine. As reported in #3866, that is the wrong default for sources that are *already* high resolution: the reporter's clean flattened-acroform image OCR'd correctly with `tesseract` directly, but produced errors through Docling — and the errors disappeared when the temp image was not enlarged. There was no way to change this short of editing the model class.

### Change

Add a `scale` field to the shared `OcrOptions` base and have the engines read `self.options.scale` instead of the literal:

- `EasyOcrModel`
- `RapidOcrModel`
- `OcrMacModel`
- `NemotronOcrModel`
- `TesseractOcrModel` (tesserocr)
- `TesseractOcrCliModel`

The default is `3.0`, so **behaviour is unchanged** for anyone who does not set it. `gt=0.0` rejects a zero/negative scale at validation time.

This follows the pattern already used elsewhere in the codebase — `KserveV2OcrOptions.scale` and `PictureDescriptionBaseOptions.scale` are both configurable float multipliers. `KserveV2OcrOptions` keeps its own `2.0` default via the existing override.

```python
converter = DocumentConverter(
    format_options={
        InputFormat.IMAGE: ImageFormatOption(
            pipeline_options=PdfPipelineOptions(
                do_ocr=True,
                ocr_options=TesseractCliOcrOptions(scale=1.0),  # no upscaling
            )
        )
    }
)
```

The one non-mechanical edit is `NemotronOcrModel._to_bounding_rect`, whose `scale: int` parameter annotation becomes `scale: float` so `ty` stays happy.

### Verification

- `ruff@0.15.12 check` / `format --check` clean on the changed files (pinned pre-commit version).
- Added `test_ocr_scale_is_configurable` in `tests/test_options.py`, which asserts the default stays `3.0`, that a custom scale reaches the model instance, and that `scale=0` is rejected. Run against a local build:

```
tesseract model.scale = 1.0
easyocr model.scale = 1.5
default model.scale = 3.0
OK: scale=0 rejected
```

A dynamic "figure out the effective resolution automatically" heuristic — the reporter's stretch suggestion — is deliberately left out of scope here; this PR only removes the hardcode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
