### PR TITLE
fix(ocr): support Latin languages with RapidOCR ONNX

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -284,7 +284,7 @@ class RapidOcrOptions(OcrOptions):
         list[str],
         Field(
             description=(
-                "List of OCR languages. Note: RapidOCR currently supports 'english' and 'chinese' (default). "
+                "List of OCR languages. RapidOCR supports 'english', 'chinese' (default), and common Latin-script language aliases. "
                 "See RapidOCR documentation for other supported languages."
             )
         ),

--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -261,7 +261,7 @@ def _rapidocr_lang_type_params(ocr_lang: str) -> dict[str, object]:
     return mapping.get(ocr_lang, {})
 
 
-def _rapidocr_torch_ppocrv4_params() -> dict[str, object]:
+def _rapidocr_ppocrv4_params() -> dict[str, object]:
     try:
         from rapidocr.utils.typings import ModelType, OCRVersion  # type: ignore
     except ImportError:
@@ -433,8 +433,11 @@ class RapidOcrModel(BaseOcrModel):
                 )
             if det_model_path is None and rec_model_path is None:
                 params.update(_rapidocr_lang_type_params(ocr_lang))
-                if backend_enum == EngineType.TORCH:
-                    params.update(_rapidocr_torch_ppocrv4_params())
+                # PP-OCRv6 has per-language routes but no generic Latin route.
+                if backend_enum == EngineType.TORCH or (
+                    backend_enum == EngineType.ONNXRUNTIME and ocr_lang == "latin"
+                ):
+                    params.update(_rapidocr_ppocrv4_params())
 
             user_params = self.options.rapidocr_params
             if user_params:

--- a/tests/test_rapid_ocr_lang.py
+++ b/tests/test_rapid_ocr_lang.py
@@ -217,3 +217,32 @@ def test_rapidocr_passes_lang_type_without_artifacts(monkeypatch) -> None:
     assert params["Det.lang_type"] == "en"
     # No pinned paths: rapidocr resolves the models itself.
     assert params["Rec.model_path"] is None
+
+
+def test_rapidocr_uses_ppocrv4_for_onnx_latin_without_artifacts(monkeypatch) -> None:
+    captured_params: list[dict[str, object]] = []
+    _install_fake_rapidocr(monkeypatch, captured_params)
+
+    fake_typings = ModuleType("rapidocr.utils.typings")
+    fake_typings.LangDet = SimpleNamespace(EN="en", CH="ch", MULTI="multi")
+    fake_typings.LangRec = SimpleNamespace(EN="en", LATIN="latin", CH="ch")
+    fake_typings.ModelType = SimpleNamespace(MOBILE="mobile")
+    fake_typings.OCRVersion = SimpleNamespace(PPOCRV4="PP-OCRv4")
+    fake_utils = ModuleType("rapidocr.utils")
+    fake_utils.typings = fake_typings
+    monkeypatch.setitem(sys.modules, "rapidocr.utils", fake_utils)
+    monkeypatch.setitem(sys.modules, "rapidocr.utils.typings", fake_typings)
+
+    RapidOcrModel(
+        enabled=True,
+        artifacts_path=None,
+        options=RapidOcrOptions(lang=["es"], backend="onnxruntime"),
+        accelerator_options=AcceleratorOptions(),
+    )
+
+    assert len(captured_params) == 1
+    params = captured_params[0]
+    assert params["Rec.lang_type"] == "latin"
+    for stage in ("Det", "Cls", "Rec"):
+        assert params[f"{stage}.ocr_version"] == "PP-OCRv4"
+        assert params[f"{stage}.model_type"] == "mobile"


### PR DESCRIPTION
## Summary

- use PP-OCRv4 mobile models when the default ONNX path receives a language that resolves to the generic `latin` model set
- keep the existing PP-OCRv6 behavior for English, Chinese, and explicitly configured model paths
- add regression coverage for the generated RapidOCR parameters and update the language option description

Fixes #3840

## Tests

- `python -m pytest tests/test_rapid_ocr_lang.py tests/test_rapid_ocr_model.py -q` (19 passed)
- `python -m ruff check docling/models/stages/ocr/rapid_ocr_model.py docling/datamodel/pipeline_options.py tests/test_rapid_ocr_lang.py`
- `python -m ruff format --check docling/models/stages/ocr/rapid_ocr_model.py docling/datamodel/pipeline_options.py tests/test_rapid_ocr_lang.py`
- verified with RapidOCR 3.9.1 and ONNX Runtime 1.23.2 that `lang=[es]` initializes successfully and runs inference on a synthetic Spanish text image
- verified the default Chinese and English ONNX initialization paths remain successful

## Checklist

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.