### PR TITLE
fix(asr): handle DocumentStream input in MLX Whisper

### DIFF
--- a/docling/pipeline/asr_transcriber.py
+++ b/docling/pipeline/asr_transcriber.py
@@ -414,9 +414,27 @@ class _MlxWhisperModel:
             self.compression_ratio_threshold = asr_options.compression_ratio_threshold
 
     def run(self, conv_res: ConversionResult) -> ConversionResult:
-        audio_path: Path = Path(conv_res.input.file).resolve()
+        path_or_stream = conv_res.input._backend.path_or_stream
+        temp_file_path: Path | None = None
+
+        if not isinstance(path_or_stream, (BytesIO, Path)):
+            raise RuntimeError(
+                f"ASR pipeline requires a file path or BytesIO stream, "
+                f"but got {type(path_or_stream)}"
+            )
 
         try:
+            if isinstance(path_or_stream, BytesIO):
+                suffix = Path(conv_res.input.file.name).suffix or ".wav"
+                with tempfile.NamedTemporaryFile(
+                    delete=False, suffix=suffix
+                ) as tmp_file:
+                    temp_file_path = Path(tmp_file.name)
+                    tmp_file.write(path_or_stream.getvalue())
+                audio_path = temp_file_path
+            else:
+                audio_path = path_or_stream
+
             if shutil.which("ffmpeg") is None:
                 _log.error(MISSING_FFMPEG_MESSAGE)
                 conv_res.errors.append(
@@ -436,9 +454,17 @@ class _MlxWhisperModel:
 
         except Exception as exc:
             _log.error(f"MLX Audio transcription has an error: {exc}")
+            conv_res.status = ConversionStatus.FAILURE
+            return conv_res
 
-        conv_res.status = ConversionStatus.FAILURE
-        return conv_res
+        finally:
+            if temp_file_path is not None and temp_file_path.exists():
+                try:
+                    temp_file_path.unlink()
+                except Exception as exc:
+                    _log.warning(
+                        f"Failed to delete temporary file {temp_file_path}: {exc}"
+                    )
 
     def transcribe(self, fpath: Path) -> list[_ConversationItem]:
         """Transcribe audio using MLX Whisper.

--- a/tests/test_asr_pipeline.py
+++ b/tests/test_asr_pipeline.py
@@ -454,6 +454,88 @@ def test_mlx_whisper_reports_missing_ffmpeg_before_transcription(
     mlx_whisper.transcribe.assert_not_called()
 
 
+def test_mlx_run_materializes_document_stream(monkeypatch) -> None:
+    from docling.pipeline.asr_pipeline import _MlxWhisperModel
+
+    audio_data = b"RIFF....WAVE"
+    input_doc = InputDocument(
+        path_or_stream=BytesIO(audio_data),
+        format=InputFormat.AUDIO,
+        backend=NoOpBackend,
+        filename="recording.ogg",
+    )
+    conv_res = ConversionResult(input=input_doc)
+    options = InlineAsrMlxWhisperOptions(
+        repo_id="mlx-community/whisper-tiny",
+        inference_framework=InferenceAsrFramework.MLX,
+        language="en",
+    )
+    model = _MlxWhisperModel(
+        enabled=False,
+        artifacts_path=None,
+        accelerator_options=AcceleratorOptions(device=AcceleratorDevice.CPU),
+        asr_options=options,
+    )
+    audio_path: Path | None = None
+
+    def transcribe(path: Path):
+        nonlocal audio_path
+        audio_path = path
+        assert path.suffix == ".ogg"
+        assert path.read_bytes() == audio_data
+        return []
+
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(model, "transcribe", transcribe)
+
+    out = model.run(conv_res)
+
+    assert out.status == ConversionStatus.SUCCESS
+    assert audio_path is not None
+    assert not audio_path.exists()
+
+
+def test_mlx_run_removes_document_stream_file_after_failure(monkeypatch) -> None:
+    from docling.pipeline.asr_pipeline import _MlxWhisperModel
+
+    input_doc = InputDocument(
+        path_or_stream=BytesIO(b"RIFF....WAVE"),
+        format=InputFormat.AUDIO,
+        backend=NoOpBackend,
+        filename="recording.wav",
+    )
+    conv_res = ConversionResult(input=input_doc)
+    options = InlineAsrMlxWhisperOptions(
+        repo_id="mlx-community/whisper-tiny",
+        inference_framework=InferenceAsrFramework.MLX,
+        language="en",
+    )
+    model = _MlxWhisperModel(
+        enabled=False,
+        artifacts_path=None,
+        accelerator_options=AcceleratorOptions(device=AcceleratorDevice.CPU),
+        asr_options=options,
+    )
+    audio_path: Path | None = None
+    existed_during_transcription = False
+
+    def transcribe(path: Path):
+        nonlocal audio_path, existed_during_transcription
+        audio_path = path
+        existed_during_transcription = path.exists()
+        raise RuntimeError("transcription failed")
+
+    monkeypatch.setattr(shutil, "which", lambda _: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(model, "transcribe", transcribe)
+
+    out = model.run(conv_res)
+
+    assert out.status == ConversionStatus.FAILURE
+    assert existed_during_transcription
+    assert audio_path is not None
+    assert not audio_path.exists()
+
+
 def test_mlx_run_success_and_failure(tmp_path):
     """Cover _MlxWhisperModel.run success and failure paths."""
     from docling.pipeline.asr_pipeline import _MlxWhisperModel


### PR DESCRIPTION
MLX Whisper was treating the `DocumentStream` name as a local path. It now writes the stream to a temporary file for transcription and removes it afterward.

**Issue resolved by this Pull Request:**
Resolves #3373

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
