### PR TITLE
fix(asr): auto-detect language instead of forcing English (#3892)

### DIFF
--- a/docling/datamodel/asr_model_specs.py
+++ b/docling/datamodel/asr_model_specs.py
@@ -485,10 +485,6 @@ WHISPER_MEDIUM_EN_NATIVE = InlineAsrNativeWhisperOptions(
 WHISPER_DISTIL_SMALL_EN_NATIVE = InlineAsrNativeWhisperOptions(
     repo_id="distil-small.en",
     inference_framework=InferenceAsrFramework.WHISPER,
-    # Distil-Whisper checkpoints are English-only; pin the language so the
-    # default language=None never triggers a detection pass (distil-large-v3/
-    # v3.5 keep large-v3's multilingual vocab, so whisper would otherwise
-    # auto-detect on them).
     language="en",
     verbose=True,
     timestamps=True,

--- a/docling/datamodel/asr_model_specs.py
+++ b/docling/datamodel/asr_model_specs.py
@@ -65,7 +65,6 @@ def _get_whisper_tiny_model():
         return InlineAsrMlxWhisperOptions(
             repo_id="mlx-community/whisper-tiny-mlx",
             inference_framework=InferenceAsrFramework.MLX,
-            language="en",
             task="transcribe",
             word_timestamps=True,
             no_speech_threshold=0.6,
@@ -108,7 +107,6 @@ def _get_whisper_small_model():
         return InlineAsrMlxWhisperOptions(
             repo_id="mlx-community/whisper-small-mlx",
             inference_framework=InferenceAsrFramework.MLX,
-            language="en",
             task="transcribe",
             word_timestamps=True,
             no_speech_threshold=0.6,
@@ -151,7 +149,6 @@ def _get_whisper_medium_model():
         return InlineAsrMlxWhisperOptions(
             repo_id="mlx-community/whisper-medium-mlx-8bit",
             inference_framework=InferenceAsrFramework.MLX,
-            language="en",
             task="transcribe",
             word_timestamps=True,
             no_speech_threshold=0.6,
@@ -194,7 +191,6 @@ def _get_whisper_base_model():
         return InlineAsrMlxWhisperOptions(
             repo_id="mlx-community/whisper-base-mlx",
             inference_framework=InferenceAsrFramework.MLX,
-            language="en",
             task="transcribe",
             word_timestamps=True,
             no_speech_threshold=0.6,
@@ -237,7 +233,6 @@ def _get_whisper_large_model():
         return InlineAsrMlxWhisperOptions(
             repo_id="mlx-community/whisper-large-mlx-8bit",
             inference_framework=InferenceAsrFramework.MLX,
-            language="en",
             task="transcribe",
             word_timestamps=True,
             no_speech_threshold=0.6,
@@ -280,7 +275,6 @@ def _get_whisper_turbo_model():
         return InlineAsrMlxWhisperOptions(
             repo_id="mlx-community/whisper-turbo",
             inference_framework=InferenceAsrFramework.MLX,
-            language="en",
             task="transcribe",
             word_timestamps=True,
             no_speech_threshold=0.6,
@@ -311,7 +305,6 @@ WHISPER_TURBO = _get_whisper_turbo_model()
 WHISPER_TINY_MLX = InlineAsrMlxWhisperOptions(
     repo_id="mlx-community/whisper-tiny-mlx",
     inference_framework=InferenceAsrFramework.MLX,
-    language="en",
     task="transcribe",
     word_timestamps=True,
     no_speech_threshold=0.6,
@@ -322,7 +315,6 @@ WHISPER_TINY_MLX = InlineAsrMlxWhisperOptions(
 WHISPER_SMALL_MLX = InlineAsrMlxWhisperOptions(
     repo_id="mlx-community/whisper-small-mlx",
     inference_framework=InferenceAsrFramework.MLX,
-    language="en",
     task="transcribe",
     word_timestamps=True,
     no_speech_threshold=0.6,
@@ -333,7 +325,6 @@ WHISPER_SMALL_MLX = InlineAsrMlxWhisperOptions(
 WHISPER_MEDIUM_MLX = InlineAsrMlxWhisperOptions(
     repo_id="mlx-community/whisper-medium-mlx-8bit",
     inference_framework=InferenceAsrFramework.MLX,
-    language="en",
     task="transcribe",
     word_timestamps=True,
     no_speech_threshold=0.6,
@@ -344,7 +335,6 @@ WHISPER_MEDIUM_MLX = InlineAsrMlxWhisperOptions(
 WHISPER_BASE_MLX = InlineAsrMlxWhisperOptions(
     repo_id="mlx-community/whisper-base-mlx",
     inference_framework=InferenceAsrFramework.MLX,
-    language="en",
     task="transcribe",
     word_timestamps=True,
     no_speech_threshold=0.6,
@@ -355,7 +345,6 @@ WHISPER_BASE_MLX = InlineAsrMlxWhisperOptions(
 WHISPER_LARGE_MLX = InlineAsrMlxWhisperOptions(
     repo_id="mlx-community/whisper-large-mlx-8bit",
     inference_framework=InferenceAsrFramework.MLX,
-    language="en",
     task="transcribe",
     word_timestamps=True,
     no_speech_threshold=0.6,
@@ -366,7 +355,6 @@ WHISPER_LARGE_MLX = InlineAsrMlxWhisperOptions(
 WHISPER_TURBO_MLX = InlineAsrMlxWhisperOptions(
     repo_id="mlx-community/whisper-turbo",
     inference_framework=InferenceAsrFramework.MLX,
-    language="en",
     task="transcribe",
     word_timestamps=True,
     no_speech_threshold=0.6,

--- a/docling/datamodel/asr_model_specs.py
+++ b/docling/datamodel/asr_model_specs.py
@@ -485,6 +485,11 @@ WHISPER_MEDIUM_EN_NATIVE = InlineAsrNativeWhisperOptions(
 WHISPER_DISTIL_SMALL_EN_NATIVE = InlineAsrNativeWhisperOptions(
     repo_id="distil-small.en",
     inference_framework=InferenceAsrFramework.WHISPER,
+    # Distil-Whisper checkpoints are English-only; pin the language so the
+    # default language=None never triggers a detection pass (distil-large-v3/
+    # v3.5 keep large-v3's multilingual vocab, so whisper would otherwise
+    # auto-detect on them).
+    language="en",
     verbose=True,
     timestamps=True,
     word_timestamps=True,
@@ -496,6 +501,7 @@ WHISPER_DISTIL_SMALL_EN_NATIVE = InlineAsrNativeWhisperOptions(
 WHISPER_DISTIL_MEDIUM_EN_NATIVE = InlineAsrNativeWhisperOptions(
     repo_id="distil-medium.en",
     inference_framework=InferenceAsrFramework.WHISPER,
+    language="en",
     verbose=True,
     timestamps=True,
     word_timestamps=True,
@@ -507,6 +513,7 @@ WHISPER_DISTIL_MEDIUM_EN_NATIVE = InlineAsrNativeWhisperOptions(
 WHISPER_DISTIL_LARGE_V3_NATIVE = InlineAsrNativeWhisperOptions(
     repo_id="distil-large-v3",
     inference_framework=InferenceAsrFramework.WHISPER,
+    language="en",
     verbose=True,
     timestamps=True,
     word_timestamps=True,
@@ -518,6 +525,7 @@ WHISPER_DISTIL_LARGE_V3_NATIVE = InlineAsrNativeWhisperOptions(
 WHISPER_DISTIL_LARGE_V3_5_NATIVE = InlineAsrNativeWhisperOptions(
     repo_id="distil-large-v3.5",
     inference_framework=InferenceAsrFramework.WHISPER,
+    language="en",
     verbose=True,
     timestamps=True,
     word_timestamps=True,

--- a/docling/datamodel/pipeline_options_asr_model.py
+++ b/docling/datamodel/pipeline_options_asr_model.py
@@ -159,16 +159,18 @@ class InlineAsrNativeWhisperOptions(InlineAsrOptions):
         ),
     ] = InferenceAsrFramework.WHISPER
     language: Annotated[
-        str,
+        Optional[str],
         Field(
             description=(
-                "Language code for transcription. Specifying the correct "
-                "language improves accuracy. Use ISO 639-1 codes (e.g., `en`, "
-                "`es`, `fr`)."
+                "Language code for transcription. When `None` (the default), "
+                "Whisper auto-detects the language from the first 30 seconds "
+                "of audio. Specifying the correct language skips detection and "
+                "improves accuracy. Use ISO 639-1 codes (e.g., `en`, `es`, "
+                "`fr`)."
             ),
             examples=["en", "es", "fr", "de"],
         ),
-    ] = "en"
+    ] = None
     supported_devices: Annotated[
         list[AcceleratorDevice],
         Field(
@@ -230,16 +232,18 @@ class InlineAsrMlxWhisperOptions(InlineAsrOptions):
         ),
     ] = InferenceAsrFramework.MLX
     language: Annotated[
-        str,
+        Optional[str],
         Field(
             description=(
-                "Language code for transcription. Specifying the correct "
-                "language improves accuracy. Use ISO 639-1 codes (e.g., `en`, "
-                "`es`, `fr`)."
+                "Language code for transcription. When `None` (the default), "
+                "Whisper auto-detects the language from the first 30 seconds "
+                "of audio. Specifying the correct language skips detection and "
+                "improves accuracy. Use ISO 639-1 codes (e.g., `en`, `es`, "
+                "`fr`)."
             ),
             examples=["en", "es", "fr", "de"],
         ),
-    ] = "en"
+    ] = None
     task: Annotated[
         str,
         Field(

--- a/tests/test_asr_pipeline.py
+++ b/tests/test_asr_pipeline.py
@@ -646,3 +646,51 @@ def test_native_whisper_skips_empty_zero_duration(tmp_path):
         assert len(out.document.texts) == 2
         assert out.document.texts[0].text == "valid segment"
         assert out.document.texts[1].text == "another valid"
+
+
+def test_whisper_language_defaults_to_auto_detect():
+    """Regression for #3892.
+
+    The native and MLX Whisper options defaulted ``language`` to ``"en"``, and
+    every MLX preset pinned ``language="en"`` on top of that, so transcribing
+    non-English audio with the stock presets forced English decoding instead of
+    openai-whisper's own auto-detection (which is what ``language=None``
+    selects). English-only ``.en`` checkpoints are unaffected: whisper forces
+    ``"en"`` for non-multilingual models when no language is given.
+    """
+    assert (
+        InlineAsrNativeWhisperOptions(
+            repo_id="tiny",
+            inference_framework=InferenceAsrFramework.WHISPER,
+        ).language
+        is None
+    )
+    assert (
+        InlineAsrMlxWhisperOptions(
+            repo_id="mlx-community/whisper-tiny-mlx",
+            inference_framework=InferenceAsrFramework.MLX,
+        ).language
+        is None
+    )
+
+    for preset in (
+        asr_model_specs.WHISPER_TINY,
+        asr_model_specs.WHISPER_SMALL,
+        asr_model_specs.WHISPER_MEDIUM,
+        asr_model_specs.WHISPER_BASE,
+        asr_model_specs.WHISPER_LARGE,
+        asr_model_specs.WHISPER_TURBO,
+        asr_model_specs.WHISPER_TINY_MLX,
+        asr_model_specs.WHISPER_SMALL_MLX,
+        asr_model_specs.WHISPER_MEDIUM_MLX,
+        asr_model_specs.WHISPER_BASE_MLX,
+        asr_model_specs.WHISPER_LARGE_MLX,
+        asr_model_specs.WHISPER_TURBO_MLX,
+        asr_model_specs.WHISPER_TINY_NATIVE,
+        asr_model_specs.WHISPER_LARGE_NATIVE,
+    ):
+        assert preset.language is None, preset.repo_id
+
+    # WhisperS2T is deliberately untouched: its English-only repos are
+    # validated against ``language == "en"``.
+    assert asr_model_specs.WHISPER_TINY_S2T.language == "en"


### PR DESCRIPTION
Fixes #3892.

### Problem

`InlineAsrNativeWhisperOptions.language` and `InlineAsrMlxWhisperOptions.language` default to `"en"`, and `_NativeWhisperModel.transcribe()` / `_MlxWhisperModel.transcribe()` forward that value straight to `whisper.transcribe(..., language=...)`. Transcribing non-English audio with the stock presets therefore forces English decoding, which yields mistranslated or hallucinated output rather than a faithful transcript.

`openai-whisper`'s own default is `language=None`, which auto-detects from the first 30 seconds. docling was overriding that with a hard-coded `"en"`.

### What this changes

- **`pipeline_options_asr_model.py`** — the native and MLX `language` fields become `Optional[str]` defaulting to `None`, with the description updated to document auto-detection.
- **`asr_model_specs.py`** — dropped the redundant `language="en"` from the 12 MLX preset sites (6 explicit `WHISPER_*_MLX` constants + the 6 MLX branches inside the `_get_whisper_*_model()` auto-selection factories).

  The issue's root-cause section only names the two class defaults, but that alone fixes the native path only: every MLX preset pins `language="en"` explicitly, so on Apple Silicon `WHISPER_TINY` would still have forced English. Both halves are needed for the reported behaviour to actually go away.

### What this deliberately does not change

- **WhisperS2T** keeps `language: str = "en"`. `InlineAsrWhisperS2TOptions._validate_repo_capabilities` rejects any language other than `"en"` for the repos in `_ENGLISH_ONLY_S2T_REPOS`, so a `None` default there would break those presets at construction time. Its `transcribe_with_vad(lang_codes=[...])` call also has no auto-detect sentinel.
- **The `*_EN_NATIVE` presets** (`tiny.en`, `base.en`, …) inherit the new `None` and keep behaving identically: when no language is given, whisper substitutes `"en"` itself for non-multilingual checkpoints ([`transcribe.py`](https://github.com/openai/whisper/blob/main/whisper/transcribe.py) — `if decode_options.get("language", None) is None: if not model.is_multilingual: decode_options["language"] = "en"`).

### Test

`test_whisper_language_defaults_to_auto_detect` in `tests/test_asr_pipeline.py` asserts the two class defaults are `None`, that all multilingual/MLX presets no longer pin a language, and that `WHISPER_TINY_S2T` still reports `"en"` so the S2T carve-out stays locked in.

Verified with the pinned `ruff` 0.15.12 from `.pre-commit-config.yaml` (`ruff format` clean, `ruff check` introduces no new findings against the base files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
