### PR TITLE
docs: add Model Backends page and document AMD ROCm support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -337,6 +337,7 @@ celerybeat.pid
 # Environments
 .env
 .venv
+.venv*
 env/
 venv/
 ENV/

--- a/docs/usage/gpu.md
+++ b/docs/usage/gpu.md
@@ -124,6 +124,92 @@ Here is a list of known models which are available in gguf format and how to use
 
 TBA.
 
+## AMD ROCm support
+
+Docling has no separate "ROCm" device option: a ROCm-built PyTorch exposes
+itself under the same `torch.cuda` namespace that CUDA uses (`torch.cuda.is_available()`,
+`.to("cuda")`, etc.), so `AcceleratorDevice.CUDA` / `device="cuda"` is the
+correct setting on both NVIDIA and AMD hardware. No Docling code changes are
+required to target an AMD GPU.
+
+This was verified end-to-end on an AMD Ryzen AI 7 PRO 350 (Radeon 860M,
+`gfx1152`, ROCm 7.14): with `AcceleratorOptions(device=AcceleratorDevice.CUDA)`,
+both the default layout model and TableFormer ran their real GPU kernels
+through the standard PDF pipeline and produced correct output (detected text
+and a structured table), with no code changes to Docling.
+
+### Installing a ROCm-enabled PyTorch
+
+For GPUs with an official ROCm PyTorch build, install from the versioned
+wheel index:
+
+```sh
+pip install torch torchvision --index-url https://download.pytorch.org/whl/rocm6.4
+```
+
+Brand-new APUs are often not yet covered by that index (their `gfx` target
+isn't in the prebuilt wheel's compiled kernel list). For those, AMD publishes
+a multi-arch index with per-architecture kernel packages:
+
+```sh
+pip install --index-url https://repo.amd.com/rocm/whl-multi-arch/ \
+  "torch[device-gfx1152]==2.12.0+rocm7.14.0" \
+  "torchvision[device-gfx1152]==0.27.0+rocm7.14.0"
+```
+
+Replace `gfx1152` with your GPU's actual LLVM target (see below) and pick the
+`torch`/ROCm version pair the index currently offers.
+
+### Verifying the wheel actually covers your GPU
+
+Installing *a* ROCm wheel is not the same as installing one with kernels for
+your specific chip. Silent mismatches surface as a segfault or hang at kernel
+dispatch time, not a clean Python exception. Before relying on GPU inference:
+
+1. Get the GPU's real LLVM target from `rocminfo`, not from the marketing
+   name: look for the `Name:` field directly under the GPU's `Agent` block
+   (e.g. `gfx1152`), and treat this as ground truth over anything a
+   heuristic or lookup table infers from the product name.
+2. Compare it against what PyTorch actually shipped kernels for:
+   ```py
+   import torch
+   print(torch.cuda.get_arch_list())
+   ```
+   If your GPU's target is missing, expect a crash rather than a graceful
+   error the moment a kernel launches.
+3. Only after both agree, confirm with a real kernel launch (a plain
+   `torch.matmul` on `device="cuda"`), since that's the only step that can't
+   be fooled by version tags.
+
+Do **not** reach for `HSA_OVERRIDE_GFX_VERSION` as a first fix for a missing
+kernel target — it makes `rocminfo` and library init report a different
+(supported) `gfx` value than the hardware actually implements, which trades a
+loud, early failure for a silent, later one (page faults / wrong results at
+kernel dispatch). It's a last-resort spoof, not a substitute for installing a
+wheel that actually ships kernels for your chip.
+
+### Known caveats on ROCm
+
+- **ONNX-backed models** (RapidOCR's default ONNX backend, the opt-in ONNX
+  layout detector, ONNX image-classification/object-detection engines) only
+  request `CUDAExecutionProvider`/`CPUExecutionProvider`; there is no
+  `ROCMExecutionProvider` branch yet, so these currently fall back to CPU on
+  AMD GPUs regardless of `accelerator_options.device`.
+- **`cuda_use_flash_attention2`** assumes the CUDA-only `flash-attn` PyPI
+  wheel and will not install/work on ROCm. Leave it `False`. PyTorch's SDPA
+  still runs its Flash/Memory-efficient attention kernels on ROCm, but
+  `transformers` currently flags them as experimental on AMD GPUs
+  (`Flash Efficient attention on Current AMD GPU is still experimental.
+  Enable it with TORCH_ROCM_AOTRITON_ENABLE_EXPERIMENTAL=1.`) and falls back
+  correctly if disabled.
+- **Nemotron OCR** hard-requires `torch.version.cuda` to be set (CUDA-only
+  gate); `torch.version.cuda` is always `None` on a ROCm build, so this model
+  cannot run on AMD GPUs.
+- **WhisperS2T** (CTranslate2 backend) has no ROCm build upstream; use the
+  native Whisper backend instead for AMD GPUs.
+- **vLLM** has an official ROCm build; the VLM pipeline's vLLM engine should
+  work against it but has not been verified here.
+
 ## Performance results
 
 ### Test data

--- a/docs/usage/model_backends.md
+++ b/docs/usage/model_backends.md
@@ -1,0 +1,112 @@
+# Model Backends
+
+This page complements the [Model Catalog](model_catalog.md) by organizing Docling's
+models along a different axis: the runtime **backend** each one executes on. Use it
+to answer questions like "which models need `onnxruntime`?" or "which stages are pure
+PyTorch vs. calling out to an external engine/API?"
+
+Backends fall into five groups:
+
+- **Pure PyTorch** — local weights loaded via `torch`/`transformers`/`safetensors`.
+- **ONNX** — local weights executed via `onnxruntime.InferenceSession`.
+- **MLX** — Apple Silicon-only, via `mlx`/`mlx_vlm`/`mlx_whisper`.
+- **vLLM** — high-throughput local serving engine (itself PyTorch-based).
+- **Other** — a non-Python inference engine (Tesseract, macOS Vision, CTranslate2), or
+  a remote call (HTTP API, KServe/Triton gRPC).
+
+!!! note "AMD ROCm"
+
+    "Pure PyTorch / Transformers" backends also run on AMD GPUs via a
+    ROCm-built PyTorch — `device="cuda"` is correct on ROCm too, since ROCm
+    PyTorch aliases HIP under the same `torch.cuda` namespace. This has been
+    verified for the default layout model and TableFormer. The ONNX backend
+    has no ROCm execution provider yet and falls back to CPU on AMD GPUs. See
+    [GPU Support](gpu.md#amd-rocm-support) for install instructions and
+    caveats.
+
+## Standard PDF pipeline
+
+| Model | Purpose | Backend |
+|---|---|---|
+| Layout model (default) | Page-layout object detection | Pure PyTorch (`docling-ibm-models`) |
+| Layout model — new pluggable path (opt-in) | RT-DETR-style layout detector | ONNX by default; Transformers or remote KServe selectable |
+| TableFormer v1 (default) | Table structure recognition | Pure PyTorch (`docling-ibm-models`) |
+| TableFormer v2 (opt-in) | Table structure, OTSL sequence output | Pure PyTorch (`docling-ibm-models`) |
+| GraniteVision table structure (opt-in) | VLM-based table structure | Pure PyTorch / Transformers |
+| OCR — Auto (default) | Picks best OCR engine for the platform | Delegates to one of the engines below |
+| EasyOCR | OCR | Pure PyTorch |
+| Tesseract (`tesserocr` / CLI) | OCR | Other — Tesseract C++ engine (binding or subprocess) |
+| RapidOCR | OCR | ONNX by default; torch / OpenVINO / Paddle selectable |
+| OcrMac | OCR | Other — macOS native Vision framework |
+| Nemotron OCR | OCR | Pure PyTorch, CUDA-only |
+| KServe v2 OCR | Remote OCR | Other — Triton/KServe gRPC/HTTP server |
+| Document Picture Classifier | Picture type classification | Transformers by default; ONNX or remote KServe selectable |
+| Code/Formula model | Code/formula transcription | Transformers by default; MLX/vLLM/API selectable |
+| Chart extraction (GraniteVision) | Chart → CSV/summary/code | Pure PyTorch / Transformers |
+| Picture description — local VLM | Image captioning | Transformers by default; MLX on Apple Silicon, vLLM selectable |
+| Picture description — API | Remote image captioning | Other — HTTP API |
+
+## VLM pipeline (Granite-Docling, SmolDocling, etc.)
+
+| Model | Purpose | Backend |
+|---|---|---|
+| VlmConvertModel (`AUTO_INLINE`) | Full-page document → DocTags/Markdown | Transformers on Linux/Windows/CUDA, MLX on Apple Silicon; vLLM or remote API selectable |
+| Legacy `HuggingFaceTransformersVlmModel` | Same, legacy path | Pure PyTorch / Transformers |
+| Legacy `HuggingFaceMlxModel` | Same, Apple Silicon | MLX |
+| Legacy `VllmVlmModel` | Same, high-throughput serving | vLLM |
+| Legacy `ApiVlmModel` | Same, remote model | Other — HTTP API |
+
+## Extraction pipeline
+
+| Model | Purpose | Backend |
+|---|---|---|
+| `TransformersExtractionModel` | Structured data extraction from document images | Pure PyTorch / Transformers |
+| `NuExtractTransformersModel` | Template-guided extraction | Pure PyTorch / Transformers |
+
+## ASR and video pipelines
+
+| Model | Purpose | Backend |
+|---|---|---|
+| Native Whisper (default) | Speech-to-text | Pure PyTorch |
+| MLX Whisper | Speech-to-text, Apple Silicon | MLX |
+| WhisperS2T | Speech-to-text, fast batched inference | Other — CTranslate2 backend |
+| Speaker diarization (`resemblyzer`, video only) | Voice-embedding clustering | Pure PyTorch |
+
+## Non-ML utility components
+
+- `ReadingOrderModel` (`docling-ibm-models`) and the list-item normalizer are
+  rule-based heuristics, not trained models.
+- `HeadingHierarchyModel` is heuristic/regex-based, no ML involved.
+- KServe v2 clients (HTTP and gRPC) are shared infrastructure used by the OCR,
+  classification, and object-detection engines above.
+
+## Summary by backend
+
+| Backend | Models / components |
+|---|---|
+| **Pure PyTorch / Transformers** | Layout model (default), TableFormer v1 & v2, GraniteVision table structure & chart extraction, EasyOCR, Nemotron OCR, Document Picture Classifier (default engine), Code/Formula model (default engine), local VLM picture description, VLM-convert models (default engine), extraction models, Native Whisper, `resemblyzer` |
+| **ONNX (onnxruntime)** | RapidOCR (default backend), new-path layout object detector (opt-in), image-classification/object-detection ONNX engines (alternate to Transformers default) |
+| **MLX (Apple Silicon)** | VLM-convert / picture description / code-formula (`AUTO_INLINE` on macOS ARM), legacy `HuggingFaceMlxModel`, MLX Whisper |
+| **vLLM** | VLM-convert / legacy `VllmVlmModel` (opt-in, high-throughput serving) |
+| **Other — Tesseract engine** | `tesserocr` binding, Tesseract CLI (`subprocess`) |
+| **Other — macOS native OCR** | OcrMac (Apple Vision framework) |
+| **Other — CTranslate2** | WhisperS2T |
+| **Other — HTTP/remote API** | Picture description API model, legacy `ApiVlmModel`, VLM-convert API engines (Ollama, LM Studio, OpenAI-compatible) |
+| **Other — remote inference server (Triton/KServe)** | KServe v2 OCR, KServe v2 image-classification & object-detection engines |
+
+## Confirmed defaults
+
+- `PdfPipelineOptions.layout_options` → `LayoutOptions()` → `LayoutModel` (PyTorch, `docling-ibm-models`).
+- `PdfPipelineOptions.table_structure_options` → `TableStructureOptions()` → `TableStructureModel` (PyTorch, TableFormer v1).
+- `PdfPipelineOptions.ocr_options` → `OcrAutoOptions()` → `OcrAutoModel` (platform-dependent: OcrMac → Nemotron → RapidOCR+onnxruntime → EasyOCR → RapidOCR+torch).
+- Picture classification default → `document_figure_classifier_v2` preset, `TRANSFORMERS` engine (PyTorch); ONNX/API also available.
+- Picture description default → `smolvlm` preset, `AUTO_INLINE` (Transformers/MLX auto-select).
+- VLM-convert default (VLM pipeline) → `granite_docling` preset, `AUTO_INLINE`.
+- Code/formula default → `codeformulav2` preset, `AUTO_INLINE`.
+- `docling-ibm-models` depends on `torch`, `torchvision`, `safetensors[torch]`, `transformers`, `accelerate` — it is **not** onnxruntime-based.
+
+## Related pages
+
+- [Model Catalog](model_catalog.md) — models organized by pipeline stage and preset.
+- [Vision Models Usage Guide](vision_models.md) — VLM-specific configuration.
+- [GPU Support](gpu.md) — GPU acceleration setup.

--- a/docs/usage/model_catalog.md
+++ b/docs/usage/model_catalog.md
@@ -346,6 +346,7 @@ options = CodeFormulaVlmOptions.from_preset("codeformulav2")
 
 ## Additional Resources
 
+- [Model Backends](model_backends.md) - Models organized by runtime backend (ONNX, PyTorch, MLX, vLLM, other)
 - [Vision Models Usage Guide](vision_models.md) - VLM-specific documentation
 - [Advanced Options](advanced_options.md) - Advanced configuration
 - [GPU Support](gpu.md) - GPU acceleration setup

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -71,6 +71,7 @@ nav:
       - Enrichment features: usage/enrichments.md
       - Vision models: usage/vision_models.md
       - Model catalog: usage/model_catalog.md
+      - Model backends: usage/model_backends.md
       - GPU support: usage/gpu.md
       - MCP server: usage/mcp.md
       - Jobkit: usage/jobkit.md


### PR DESCRIPTION
## Summary
- Adds `docs/usage/model_backends.md`, organizing Docling's models along the runtime-backend axis (Pure PyTorch, ONNX, MLX, vLLM, other), wired into the nav and cross-linked from the model catalog.
- Adds an **AMD ROCm** section to `gpu.md`: `device="cuda"` is correct on a ROCm-built PyTorch too (it aliases HIP under `torch.cuda`), with install instructions for the standard ROCm wheel index and AMD's multi-arch per-`gfx` index for newer APUs, how to verify a wheel actually ships kernels for your GPU's `gfx` target before trusting it (mismatches segfault/hang rather than raising cleanly), and known caveats (ONNX has no ROCm execution provider yet, `cuda_use_flash_attention2` assumes the CUDA-only `flash-attn` wheel, Nemotron OCR and WhisperS2T are CUDA/CTranslate2-only).
- Verified end-to-end on an AMD Ryzen AI 7 PRO 350 (Radeon 860M, `gfx1152`, ROCm 7.14): the default layout model and TableFormer ran their real GPU kernels through the standard PDF pipeline and produced correct output (text extraction + a structured table), with zero Docling code changes.

## Test plan
- [x] Manually verified `torch.cuda.get_arch_list()` includes `gfx1152` after installing from `repo.amd.com/rocm/whl-multi-arch`
- [x] Ran `DocumentConverter` with `AcceleratorOptions(device=AcceleratorDevice.CUDA)` against a real PDF on the AMD iGPU; `ConversionStatus.SUCCESS`, text + 1 table extracted correctly
- [x] Docs-only change; no code paths modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)