### PR TITLE
feat(vlm): expose OpenAI logprobs as generated tokens

### DIFF
--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -63,7 +63,7 @@ class HttpSource(BaseModel):
         dict[str, Any],
         Field(
             description="Additional headers used to fetch the urls, "
-                        "e.g. authorization, agent, etc"
+            "e.g. authorization, agent, etc"
         ),
     ] = {}
 
@@ -77,7 +77,7 @@ class BaseFormatOption(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def backend_options_for_input(
-            self, source: Path | str | DocumentStream
+        self, source: Path | str | DocumentStream
     ) -> "BackendOptions | None":
         return None
 
@@ -416,7 +416,7 @@ class FigureElement(BasePageElement):
 
     @field_serializer("confidence")
     def _serialize(
-            self, value: float | None, info: FieldSerializationInfo
+        self, value: float | None, info: FieldSerializationInfo
     ) -> float | None:
         return (
             round_pydantic_float(value, info.context, PydanticSerCtxKey.CONFID_PREC)
@@ -486,10 +486,10 @@ class Page(BaseModel):
             return []
 
     def get_image(
-            self,
-            scale: float = 1.0,
-            max_size: int | None = None,
-            cropbox: BoundingBox | None = None,
+        self,
+        scale: float = 1.0,
+        max_size: int | None = None,
+        cropbox: BoundingBox | None = None,
     ) -> Image | None:
         if self._backend is None:
             return self._image_cache.get(scale, None)

--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -383,6 +383,7 @@ class ApiImageStreamingRequestResult:
     text: str
     num_tokens: int | None
     usage: Any | None = None
+    logprobs: Any | None = None
 
 
 class ContainerElement(

--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -63,7 +63,7 @@ class HttpSource(BaseModel):
         dict[str, Any],
         Field(
             description="Additional headers used to fetch the urls, "
-            "e.g. authorization, agent, etc"
+                        "e.g. authorization, agent, etc"
         ),
     ] = {}
 
@@ -77,7 +77,7 @@ class BaseFormatOption(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     def backend_options_for_input(
-        self, source: Path | str | DocumentStream
+            self, source: Path | str | DocumentStream
     ) -> "BackendOptions | None":
         return None
 
@@ -373,6 +373,7 @@ class ApiImageRequestResult:
     num_tokens: int | None
     stop_reason: VlmStopReason
     usage: Any | None = None
+    logprobs: Any | None = None
 
 
 @dataclass(frozen=True)
@@ -415,7 +416,7 @@ class FigureElement(BasePageElement):
 
     @field_serializer("confidence")
     def _serialize(
-        self, value: float | None, info: FieldSerializationInfo
+            self, value: float | None, info: FieldSerializationInfo
     ) -> float | None:
         return (
             round_pydantic_float(value, info.context, PydanticSerCtxKey.CONFID_PREC)
@@ -485,10 +486,10 @@ class Page(BaseModel):
             return []
 
     def get_image(
-        self,
-        scale: float = 1.0,
-        max_size: int | None = None,
-        cropbox: BoundingBox | None = None,
+            self,
+            scale: float = 1.0,
+            max_size: int | None = None,
+            cropbox: BoundingBox | None = None,
     ) -> Image | None:
         if self._backend is None:
             return self._image_cache.get(scale, None)
@@ -528,10 +529,29 @@ class OpenAiChatMessage(BaseModel):
     tool_calls: list[dict[str, Any]] | None = None
 
 
+class OpenAiTopLogprob(BaseModel):
+    token: str
+    bytes: list[int] | None = None
+    logprob: float
+
+
+class OpenAiTokenLogprob(BaseModel):
+    token: str
+    bytes: list[int] | None = None
+    logprob: float
+    top_logprobs: list[OpenAiTopLogprob] | None = None
+
+
+class OpenAiResponseLogprobs(BaseModel):
+    content: list[OpenAiTokenLogprob] | None = None
+    refusal: list[OpenAiTokenLogprob] | None = None
+
+
 class OpenAiResponseChoice(BaseModel):
     index: int
     message: OpenAiChatMessage
     finish_reason: str | None
+    logprobs: OpenAiResponseLogprobs | None = None
 
 
 class OpenAiResponseUsage(BaseModel):

--- a/docling/models/inference_engines/vlm/api_openai_compatible_engine.py
+++ b/docling/models/inference_engines/vlm/api_openai_compatible_engine.py
@@ -196,6 +196,7 @@ class ApiVlmEngine(BaseVlmEngine):
                     "generation_time": generation_time,
                     "num_tokens": num_tokens,
                     "usage": api_response.usage,
+                    "logprobs": api_response.logprobs,
                 },
             )
 

--- a/docling/models/stages/vlm_convert/vlm_convert_model.py
+++ b/docling/models/stages/vlm_convert/vlm_convert_model.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from PIL import Image as PILImage
 
 from docling.datamodel.accelerator_options import AcceleratorOptions
-from docling.datamodel.base_models import Page, VlmPrediction, VlmStopReason
+from docling.datamodel.base_models import Page, VlmPrediction, VlmStopReason, VlmPredictionToken
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import VlmConvertOptions
 from docling.models.base_model import BasePageModel
@@ -35,12 +35,26 @@ def _prediction_from_engine_output(output: VlmEngineOutput) -> VlmPrediction:
         stop_reason = VlmStopReason(output.stop_reason)
 
     metadata = output.metadata or {}
+
+    generated_tokens = []
+
+    logprobs = metadata.get("logprobs")
+    if logprobs and logprobs.content:
+        generated_tokens = [
+            VlmPredictionToken(
+                text=token.token,
+                logprob=token.logprob,
+            )
+            for token in logprobs.content
+        ]
+
     return VlmPrediction(
         text=output.text,
         stop_reason=stop_reason,
         generation_time=metadata.get("generation_time", -1),
         num_tokens=metadata.get("num_tokens"),
         usage=metadata.get("usage"),
+        generated_tokens=generated_tokens,
     )
 
 

--- a/docling/models/stages/vlm_convert/vlm_convert_model.py
+++ b/docling/models/stages/vlm_convert/vlm_convert_model.py
@@ -12,7 +12,12 @@ from pathlib import Path
 from PIL import Image as PILImage
 
 from docling.datamodel.accelerator_options import AcceleratorOptions
-from docling.datamodel.base_models import Page, VlmPrediction, VlmStopReason, VlmPredictionToken
+from docling.datamodel.base_models import (
+    Page,
+    VlmPrediction,
+    VlmPredictionToken,
+    VlmStopReason,
+)
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import VlmConvertOptions
 from docling.models.base_model import BasePageModel

--- a/docling/utils/api_image_request.py
+++ b/docling/utils/api_image_request.py
@@ -252,6 +252,7 @@ def api_image_request(
                 num_tokens=num_tokens,
                 stop_reason=stop_reason,
                 usage=usage,
+                logprobs=api_resp.choices[0].logprobs,
             )
         except Exception as e:
             _log.error(f"Error, could not process request: {e}")


### PR DESCRIPTION
## Summary

This PR adds support for propagating OpenAI-compatible `logprobs` through the VLM pipeline and exposes token-level log probabilities as `generated_tokens` in `VlmPrediction`.

## Changes

- Add OpenAI response models for `logprobs`.
- Preserve `logprobs` in `ApiImageRequestResult`.
- Propagate `logprobs` through the OpenAI-compatible VLM inference engine.
- Populate `generated_tokens` with token text and log probabilities in `VlmPrediction`.

## Testing

Tested against a vLLM OpenAI-compatible endpoint with the OpenAI `logprobs=True` request parameter enabled.

Verified that:
- Token-level log probabilities are correctly parsed from the API response.
- `generated_tokens` is populated with the generated token text and corresponding log probabilities.
- Existing VLM prediction functionality remains unchanged.

## Checklist

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.