### PR TITLE
feat: expose include_converted_doc in client

### DIFF
--- a/docling/service_client/_async_client.py
+++ b/docling/service_client/_async_client.py
@@ -371,6 +371,8 @@ class AsyncDoclingServiceClient(_BaseDoclingServiceClient):
         source: SourceType,
         chunker: ChunkerKind,
         options: ConvertDocumentsRequestOptions | None = None,
+        *,
+        include_converted_doc: bool = False,
     ) -> AsyncConversionJob[ChunkDocumentResponse]:
         resolved = self._resolve_options(
             options=options,
@@ -382,6 +384,7 @@ class AsyncDoclingServiceClient(_BaseDoclingServiceClient):
             source=source,
             chunker=chunker,
             options=resolved.options,
+            include_converted_doc=include_converted_doc,
         )
         handlers: _AsyncJobHandlers[ChunkDocumentResponse] = _AsyncJobHandlers(
             poll=self._poll_task_status,
@@ -767,6 +770,8 @@ class AsyncDoclingServiceClient(_BaseDoclingServiceClient):
         source: SourceType,
         chunker: ChunkerKind,
         options: ConvertDocumentsRequestOptions,
+        *,
+        include_converted_doc: bool,
     ) -> TaskStatusResponse:
         source = self._normalize_source(source)
         if isinstance(source, HttpSourceRequest):
@@ -782,7 +787,7 @@ class AsyncDoclingServiceClient(_BaseDoclingServiceClient):
                     exclude_none=True,
                 ),
                 "sources": [source.model_dump(mode="json", exclude_none=True)],
-                "include_converted_doc": False,
+                "include_converted_doc": include_converted_doc,
                 "target": InBodyTarget().model_dump(mode="json"),
                 "callbacks": [],
             }
@@ -807,7 +812,7 @@ class AsyncDoclingServiceClient(_BaseDoclingServiceClient):
             data.update(
                 {f"chunking_{key}": value for key, value in chunk_payload.items()}
             )
-            data["include_converted_doc"] = False
+            data["include_converted_doc"] = include_converted_doc
             data["target_type"] = InBodyTarget().kind
             response = await self._request_with_retry(
                 method="POST",

--- a/docling/service_client/client.py
+++ b/docling/service_client/client.py
@@ -1006,8 +1006,15 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
         source: SourceType,
         chunker: ChunkerKind,
         options: ConvertDocumentsRequestOptions | None = None,
+        *,
+        include_converted_doc: bool = False,
     ) -> ChunkDocumentResponse:
-        job = self.submit_chunk(source=source, chunker=chunker, options=options)
+        job = self.submit_chunk(
+            source=source,
+            chunker=chunker,
+            options=options,
+            include_converted_doc=include_converted_doc,
+        )
         return job.result(timeout=self._job_timeout)
 
     def submit(
@@ -1090,6 +1097,8 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
         source: SourceType,
         chunker: ChunkerKind,
         options: ConvertDocumentsRequestOptions | None = None,
+        *,
+        include_converted_doc: bool = False,
     ) -> ConversionJob[ChunkDocumentResponse]:
         resolved = self._resolve_options(
             options=options,
@@ -1101,6 +1110,7 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
             source=source,
             chunker=chunker,
             options=resolved.options,
+            include_converted_doc=include_converted_doc,
         )
         handlers = _JobHandlers[ChunkDocumentResponse](
             poll=self._poll_task_status,
@@ -1251,6 +1261,8 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
         source: SourceType,
         chunker: ChunkerKind,
         options: ConvertDocumentsRequestOptions,
+        *,
+        include_converted_doc: bool,
     ) -> TaskStatusResponse:
         source = self._normalize_source(source)
         if isinstance(source, HttpSourceRequest):
@@ -1266,7 +1278,7 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
                     mode="json", exclude_none=True
                 ),
                 "sources": [source.model_dump(mode="json")],
-                "include_converted_doc": False,
+                "include_converted_doc": include_converted_doc,
                 "target": InBodyTarget().model_dump(mode="json"),
                 "callbacks": [],
             }
@@ -1291,7 +1303,7 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
             data.update(
                 {f"chunking_{key}": value for key, value in chunk_payload.items()}
             )
-            data["include_converted_doc"] = False
+            data["include_converted_doc"] = include_converted_doc
             data["target_type"] = "inbody"
             response = self._request_with_retry(
                 method="POST",

--- a/docs/examples/service_client/chunk.py
+++ b/docs/examples/service_client/chunk.py
@@ -27,7 +27,11 @@ def main() -> None:
         url=os.environ["DOCLING_SERVICE_URL"],
         api_key=os.environ.get("DOCLING_SERVICE_API_KEY", ""),
     ) as client:
-        response = client.chunk(source=SOURCE, chunker=ChunkerKind.HIERARCHICAL)
+        response = client.chunk(
+            source=SOURCE,
+            chunker=ChunkerKind.HIERARCHICAL,
+            include_converted_doc=True,
+        )
         print(
             len(response.chunks), "chunks from", len(response.documents), "document(s)"
         )

--- a/tests/test_service_client_sdk_unit.py
+++ b/tests/test_service_client_sdk_unit.py
@@ -1695,17 +1695,45 @@ def test_submit_chunk_local_string_source_uses_file_endpoint(tmp_path: Path) -> 
     with DoclingServiceClient(url=TEST_BASE_URL) as client:
         client._request_with_retry = fake_request_with_retry  # type: ignore[method-assign]
         job = client.submit_chunk(
-            source=str(sample),
-            chunker=ChunkerKind.HYBRID,
-            options=ConvertDocumentsRequestOptions(),
+            str(sample),
+            ChunkerKind.HYBRID,
+            ConvertDocumentsRequestOptions(),
         )
 
     assert job.task_id == "task-chunk-file-string"
     assert captured["path"] == "/v1/chunk/hybrid/file/async"
+    data = captured["data"]
+    assert isinstance(data, dict)
+    assert data["include_converted_doc"] is False
     files = captured["files"]
     assert isinstance(files, dict)
     assert files["files"][0] == "sample.pdf"
     assert files["files"][2] == "application/pdf"
+
+
+def test_submit_chunk_url_source_can_include_converted_doc() -> None:
+    captured: dict[str, object] = {}
+
+    def fake_request_with_retry(**kw: object) -> httpx.Response:
+        captured.update(kw)
+        return httpx.Response(
+            200,
+            json=_status_response("task-chunk-url", "pending").model_dump(mode="json"),
+        )
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        client._request_with_retry = fake_request_with_retry  # type: ignore[method-assign]
+        job = client.submit_chunk(
+            source="https://example.org/sample.pdf",
+            chunker=ChunkerKind.HIERARCHICAL,
+            include_converted_doc=True,
+        )
+
+    assert job.task_id == "task-chunk-url"
+    assert captured["path"] == "/v1/chunk/hierarchical/source/async"
+    payload = captured["json"]
+    assert isinstance(payload, dict)
+    assert payload["include_converted_doc"] is True
 
 
 def test_submit_accepts_http_source_request() -> None:
@@ -3793,6 +3821,7 @@ async def test_async_submit_chunk_url_source_posts_correct_endpoint() -> None:
 
     def handler(method: str, url: str, **kw: object) -> httpx.Response:
         captured["url"] = url
+        captured["json"] = kw["json"]
         return httpx.Response(
             200, json=_status_response("chunk-1", "pending").model_dump(mode="json")
         )
@@ -3801,10 +3830,43 @@ async def test_async_submit_chunk_url_source_posts_correct_endpoint() -> None:
         job = await client.submit_chunk(
             source="https://example.org/doc.pdf",
             chunker=ChunkerKind.HYBRID,
+            include_converted_doc=True,
         )
 
     assert "/v1/chunk/hybrid/source/async" in str(captured["url"])
     assert job.task_id == "chunk-1"
+    payload = captured["json"]
+    assert isinstance(payload, dict)
+    assert payload["include_converted_doc"] is True
+
+
+@pytest.mark.anyio
+async def test_async_submit_chunk_file_can_include_converted_doc(
+    tmp_path: Path,
+) -> None:
+    source = tmp_path / "sample.pdf"
+    source.write_bytes(b"%PDF-1.4\n")
+    captured: dict[str, object] = {}
+
+    def handler(method: str, url: str, **kw: object) -> httpx.Response:
+        captured["url"] = url
+        captured["data"] = kw["data"]
+        return httpx.Response(
+            200, json=_status_response("chunk-2", "pending").model_dump(mode="json")
+        )
+
+    async with _make_async_http_client(handler) as client:
+        job = await client.submit_chunk(
+            source=source,
+            chunker=ChunkerKind.HIERARCHICAL,
+            include_converted_doc=True,
+        )
+
+    assert "/v1/chunk/hierarchical/file/async" in str(captured["url"])
+    assert job.task_id == "chunk-2"
+    data = captured["data"]
+    assert isinstance(data, dict)
+    assert data["include_converted_doc"] is True
 
 
 # --- health / version ---


### PR DESCRIPTION
Adds include_converted_doc to the `chunk` methods in `DoclingServiceClient`

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
