### PR TITLE
feat(package): expose docling.__version__ (#3733)

### DIFF
--- a/docling/__init__.py
+++ b/docling/__init__.py
@@ -1,0 +1,23 @@
+"""Docling: parse documents and convert them to a unified representation."""
+
+import importlib.metadata
+
+__all__ = ["__version__"]
+
+
+def _resolve_version() -> str:
+    """Return the installed Docling version, or ``"unknown"``.
+
+    ``docling`` is a meta-package that is absent on slim installs, where only
+    ``docling-slim`` is present. This mirrors the fallback that ``docling
+    --version`` applies to :class:`docling.datamodel.document.DoclingVersion`.
+    """
+    for name in ("docling", "docling-slim"):
+        try:
+            return importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+    return "unknown"
+
+
+__version__: str = _resolve_version()

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,0 +1,29 @@
+"""Tests for the package-level ``docling.__version__`` attribute."""
+
+import importlib.metadata
+
+import docling
+
+
+def test_version_is_exposed():
+    assert isinstance(docling.__version__, str)
+    assert docling.__version__
+
+
+def test_version_matches_installed_distribution():
+    for name in ("docling", "docling-slim"):
+        try:
+            expected = importlib.metadata.version(name)
+        except importlib.metadata.PackageNotFoundError:
+            continue
+        assert docling.__version__ == expected
+        return
+    assert docling.__version__ == "unknown"
+
+
+def test_resolve_version_falls_back_to_unknown(monkeypatch):
+    def _missing(name: str) -> str:
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", _missing)
+    assert docling._resolve_version() == "unknown"


### PR DESCRIPTION
Fixes #3733 (first half).

### Problem

`docling/__init__.py` is empty, so the attribute users reach for first does not exist:

```console
$ python -c "import docling; print(docling.__version__)"
AttributeError: module 'docling' has no attribute '__version__'
```

The version is already known to the package — it is just not reachable from the top-level module. `DoclingVersion` resolves it via `safe_version()`, and `docling --version` prints it. Only the conventional `docling.__version__` was missing.

### Fix

Resolve the version from the installed distribution metadata in `docling/__init__.py`:

```python
__version__: str = _resolve_version()
```

Two details worth flagging:

- **`docling-slim` fallback.** The `docling` meta-package is absent on slim installs, so `importlib.metadata.version("docling")` raises there. `_resolve_version()` tries `docling`, then `docling-slim`, then returns `"unknown"` — the same order `version_callback()` in `docling/cli/main.py` already applies to `DoclingVersion`, so a slim install reports its real version rather than failing or reporting `"unknown"`.
- **`safe_version()` is deliberately not reused.** It lives in `docling.utils.utils`, which imports `requests` and `tqdm` at module level; importing it from `__init__.py` would pull third-party packages into every bare `import docling`. The 8-line resolver here uses only `importlib.metadata` from the stdlib, so `import docling` stays as cheap as it is today.

### Not addressed

The second half of #3733 (`ModuleNotFoundError: No module named 'docling.cli.main'`) is a broken install rather than a packaging bug — that module is present in the tree and on PyPI — so this PR does not touch it.

### Tests

`tests/test_version.py` covers that the attribute exists and is a non-empty string, that it matches whichever of the two distributions is installed, and that the resolver degrades to `"unknown"` when neither is found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
