### PR TITLE
feat(pdf): preserve nested tables inside table cells

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -127,6 +127,9 @@ class TableFormerMode(str, Enum):
     ACCURATE = "accurate"
 
 
+DEFAULT_RICH_CELL_ELEMENT_COVERAGE_THRESHOLD: float = 0.8
+
+
 class BaseTableStructureOptions(BaseOptions):
     """Base options for table structure extraction models.
 
@@ -137,6 +140,18 @@ class BaseTableStructureOptions(BaseOptions):
     See Also:
         `TableStructureOptions`: Default TableFormer-based implementation.
     """
+
+    rich_cell_element_coverage_threshold: Annotated[
+        float,
+        Field(
+            gt=0.0,
+            le=1.0,
+            description=(
+                "Minimum fraction of a child element that must overlap its containing table or cell "
+                "to be represented in a rich table cell."
+            ),
+        ),
+    ] = DEFAULT_RICH_CELL_ELEMENT_COVERAGE_THRESHOLD
 
 
 class TableStructureOptions(BaseTableStructureOptions):

--- a/docling/models/base_table_model.py
+++ b/docling/models/base_table_model.py
@@ -4,7 +4,10 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Sequence
 from typing import Type
 
-from docling.datamodel.base_models import Page, TableStructurePrediction
+from docling_core.types.doc.page import TextCell
+from PIL import Image, ImageDraw
+
+from docling.datamodel.base_models import Cluster, Page, TableStructurePrediction
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import BaseTableStructureOptions
 from docling.models.base_model import BaseModelWithOptions, BasePageModel
@@ -14,6 +17,47 @@ class BaseTableStructureModel(BasePageModel, BaseModelWithOptions, ABC):
     """Shared interface for table structure models."""
 
     enabled: bool
+    options: BaseTableStructureOptions
+    scale: float
+
+    def _prepare_table_input(
+        self,
+        page_image: Image.Image,
+        *,
+        table_cluster: Cluster,
+        table_clusters: Sequence[Cluster],
+        text_cells: Sequence[TextCell],
+    ) -> tuple[Image.Image, list[TextCell], list[Cluster]]:
+        coverage_threshold = self.options.rich_cell_element_coverage_threshold
+        nested_tables = [
+            candidate
+            for candidate in table_clusters
+            if candidate.id != table_cluster.id
+            and candidate.bbox.area() < table_cluster.bbox.area()
+            and candidate.bbox.intersection_over_self(table_cluster.bbox)
+            >= coverage_threshold
+        ]
+        if not nested_tables:
+            return page_image, list(text_cells), []
+
+        masked_image = page_image.copy()
+        draw = ImageDraw.Draw(masked_image)
+        for nested_table in nested_tables:
+            draw.rectangle(
+                nested_table.bbox.scaled(scale=self.scale).as_tuple(),
+                fill="white",
+            )
+
+        parent_cells = [
+            cell
+            for cell in text_cells
+            if not any(
+                cell.rect.to_bounding_box().intersection_over_self(nested_table.bbox)
+                >= coverage_threshold
+                for nested_table in nested_tables
+            )
+        ]
+        return masked_image, parent_cells, nested_tables
 
     @classmethod
     @abstractmethod

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -21,7 +21,7 @@ from docling_ibm_models.reading_order.reading_order_rb import (
     PageElement as ReadingOrderPageElement,
     ReadingOrderPredictor,
 )
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
 from docling.datamodel.base_models import (
     BasePageElement,
@@ -32,6 +32,9 @@ from docling.datamodel.base_models import (
     TextElement,
 )
 from docling.datamodel.document import ConversionResult
+from docling.datamodel.pipeline_options import (
+    DEFAULT_RICH_CELL_ELEMENT_COVERAGE_THRESHOLD,
+)
 from docling.utils.profiling import ProfilingScope, TimeRecorder
 
 
@@ -39,11 +42,14 @@ class ReadingOrderOptions(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
     model_names: str = ""  # e.g. "language;term;reference"
+    rich_cell_element_coverage_threshold: float = Field(
+        default=DEFAULT_RICH_CELL_ELEMENT_COVERAGE_THRESHOLD,
+        gt=0.0,
+        le=1.0,
+    )
 
 
 class ReadingOrderModel:
-    _RICH_CELL_PICTURE_COVERAGE_THRESHOLD = 0.8
-
     def __init__(self, options: ReadingOrderOptions):
         self.options = options
         self.ro_model = ReadingOrderPredictor()
@@ -158,67 +164,72 @@ class ReadingOrderModel:
     def _element_ref(element: BasePageElement) -> str:
         return f"#/{element.page_no}/{element.cluster.id}"
 
-    @classmethod
-    def _match_table_pictures(
-        cls,
+    def _match_table_children(
+        self,
         elements: list[BasePageElement],
-        excluded_picture_refs: set[str],
-    ) -> dict[str, dict[int, list[FigureElement]]]:
+        excluded_child_refs: set[str],
+    ) -> dict[str, dict[int, list[FigureElement | Table]]]:
         tables = [element for element in elements if isinstance(element, Table)]
-        matches: dict[str, dict[int, list[FigureElement]]] = {}
+        matches: dict[str, dict[int, list[FigureElement | Table]]] = {}
 
-        for picture in (
-            element for element in elements if isinstance(element, FigureElement)
+        for child in (
+            element
+            for element in elements
+            if isinstance(element, (FigureElement, Table))
         ):
-            if cls._element_ref(picture) in excluded_picture_refs:
+            if self._element_ref(child) in excluded_child_refs:
                 continue
 
-            best_match: tuple[float, Table, int] | None = None
+            best_match: tuple[tuple[float, float], Table, int] | None = None
             for table in tables:
-                if table.page_no != picture.page_no:
+                if table is child or table.page_no != child.page_no:
                     continue
                 if (
-                    picture.cluster.bbox.intersection_over_self(table.cluster.bbox)
-                    < cls._RICH_CELL_PICTURE_COVERAGE_THRESHOLD
+                    isinstance(child, Table)
+                    and table.cluster.bbox.area() <= child.cluster.bbox.area()
+                ):
+                    continue
+                if (
+                    child.cluster.bbox.intersection_over_self(table.cluster.bbox)
+                    < self.options.rich_cell_element_coverage_threshold
                 ):
                     continue
 
-                cell_match = cls._match_picture_to_table_cell(table, picture)
-                if cell_match is not None and (
-                    best_match is None or cell_match[0] > best_match[0]
-                ):
-                    best_match = (cell_match[0], table, cell_match[1])
+                cell_match = self._match_element_to_table_cell(table, child)
+                if cell_match is None:
+                    continue
+                score = (-table.cluster.bbox.area(), cell_match[0])
+                if best_match is None or score > best_match[0]:
+                    best_match = (score, table, cell_match[1])
 
             if best_match is None:
                 continue
 
             _, table, cell_index = best_match
-            matches.setdefault(cls._element_ref(table), {}).setdefault(
+            matches.setdefault(self._element_ref(table), {}).setdefault(
                 cell_index, []
-            ).append(picture)
+            ).append(child)
 
         return matches
 
-    @classmethod
-    def _match_picture_to_table_cell(
-        cls, table: Table, picture: FigureElement
+    def _match_element_to_table_cell(
+        self, table: Table, element: BasePageElement
     ) -> tuple[float, int] | None:
         eligible = [
             (
-                picture.cluster.bbox.intersection_over_self(cell.bbox),
+                element.cluster.bbox.intersection_over_self(cell.bbox),
                 cell_index,
-                cell,
             )
             for cell_index, cell in enumerate(table.table_cells)
             if cell.bbox is not None
-            and picture.cluster.bbox.intersection_over_self(cell.bbox)
-            >= cls._RICH_CELL_PICTURE_COVERAGE_THRESHOLD
+            and element.cluster.bbox.intersection_over_self(cell.bbox)
+            >= self.options.rich_cell_element_coverage_threshold
         ]
-        if not eligible:
+        if not eligible and not isinstance(element, Table):
             return None
 
         # Cell boxes can overlap across logical rows and columns. Infer the
-        # picture's grid position before choosing among containing cells.
+        # element's grid position before choosing among containing cells.
         row_centers: dict[int, list[float]] = {}
         column_centers: dict[int, list[float]] = {}
         for cell in table.table_cells:
@@ -231,34 +242,48 @@ class ReadingOrderModel:
                     (cell.bbox.l + cell.bbox.r) / 2
                 )
 
-        picture_x = (picture.cluster.bbox.l + picture.cluster.bbox.r) / 2
-        picture_y = (picture.cluster.bbox.t + picture.cluster.bbox.b) / 2
+        if not row_centers or not column_centers:
+            return None
+
+        element_x = (element.cluster.bbox.l + element.cluster.bbox.r) / 2
+        element_y = (element.cluster.bbox.t + element.cluster.bbox.b) / 2
         row = min(
             row_centers,
-            key=lambda index: abs(median(row_centers[index]) - picture_y),
+            key=lambda index: abs(median(row_centers[index]) - element_y),
         )
         column = min(
             column_centers,
-            key=lambda index: abs(median(column_centers[index]) - picture_x),
+            key=lambda index: abs(median(column_centers[index]) - element_x),
         )
-        logical_matches = [
-            match
-            for match in eligible
-            if match[2].start_row_offset_idx <= row < match[2].end_row_offset_idx
-            and match[2].start_col_offset_idx <= column < match[2].end_col_offset_idx
+        logical_cell_indices = [
+            cell_index
+            for cell_index, cell in enumerate(table.table_cells)
+            if cell.start_row_offset_idx <= row < cell.end_row_offset_idx
+            and cell.start_col_offset_idx <= column < cell.end_col_offset_idx
         ]
-        coverage, cell_index, _ = max(logical_matches or eligible)
-        return coverage, cell_index
+        logical_matches = [
+            match for match in eligible if match[1] in logical_cell_indices
+        ]
+        if eligible:
+            coverage, cell_index = max(logical_matches or eligible)
+            return coverage, cell_index
+        if logical_cell_indices:
+            coverage = element.cluster.bbox.intersection_over_self(table.cluster.bbox)
+            return coverage, logical_cell_indices[0]
+        return None
 
-    def _add_rich_table_pictures(
+    def _add_rich_table_children(
         self,
         *,
+        table: Table,
         table_item: TableItem,
-        pictures_by_cell: dict[int, list[FigureElement]],
+        table_children: dict[str, dict[int, list[FigureElement | Table]]],
         doc: DoclingDocument,
         page_height: float,
     ) -> None:
-        for cell_index, pictures in pictures_by_cell.items():
+        for cell_index, children in table_children.get(
+            self._element_ref(table), {}
+        ).items():
             cell = table_item.data.table_cells[cell_index]
             group = doc.add_group(
                 label=GroupLabel.UNSPECIFIED,
@@ -271,30 +296,46 @@ class ReadingOrderModel:
 
             if cell.text:
                 cell_bbox = (
-                    cell.bbox if cell.bbox is not None else pictures[0].cluster.bbox
+                    cell.bbox if cell.bbox is not None else children[0].cluster.bbox
                 )
                 doc.add_text(
                     label=DocItemLabel.TEXT,
                     text=cell.text,
                     prov=ProvenanceItem(
-                        page_no=pictures[0].page_no,
+                        page_no=children[0].page_no,
                         charspan=(0, len(cell.text)),
                         bbox=cell_bbox.to_bottom_left_origin(page_height),
                     ),
                     parent=group,
                 )
 
-            for picture in pictures:
-                picture_item = doc.add_picture(
-                    annotations=picture.annotations,
-                    prov=ProvenanceItem(
-                        page_no=picture.page_no,
-                        charspan=(0, 0),
-                        bbox=picture.cluster.bbox.to_bottom_left_origin(page_height),
-                    ),
-                    parent=group,
+            for child in children:
+                prov = ProvenanceItem(
+                    page_no=child.page_no,
+                    charspan=(0, 0),
+                    bbox=child.cluster.bbox.to_bottom_left_origin(page_height),
                 )
-                self._add_child_elements(picture, picture_item, doc)
+                if isinstance(child, FigureElement):
+                    child_item = doc.add_picture(
+                        annotations=child.annotations,
+                        prov=prov,
+                        parent=group,
+                    )
+                    self._add_child_elements(child, child_item, doc)
+                else:
+                    child_item = doc.add_table(
+                        data=self._table_data_from_table(child),
+                        prov=prov,
+                        label=child.cluster.label,
+                        parent=group,
+                    )
+                    self._add_rich_table_children(
+                        table=child,
+                        table_item=child_item,
+                        table_children=table_children,
+                        doc=doc,
+                        page_height=page_height,
+                    )
 
             table_item.data.table_cells[cell_index] = RichTableCell(
                 **cell.model_dump(exclude={"ref"}),
@@ -313,20 +354,20 @@ class ReadingOrderModel:
             self._element_ref(elem): elem for elem in conv_res.assembled.elements
         }
         cid_to_rels = {rel.cid: rel for rel in ro_elements}
-        excluded_picture_refs = {
+        excluded_child_refs = {
             rel.ref.cref
             for rel in ro_elements
             if rel.cid in el_to_captions_mapping or rel.cid in el_to_footnotes_mapping
         }
-        rich_table_pictures = self._match_table_pictures(
+        rich_table_children = self._match_table_children(
             conv_res.assembled.elements,
-            excluded_picture_refs=excluded_picture_refs,
+            excluded_child_refs=excluded_child_refs,
         )
-        rich_picture_refs = {
-            self._element_ref(picture)
-            for cells in rich_table_pictures.values()
-            for pictures in cells.values()
-            for picture in pictures
+        rich_child_refs = {
+            self._element_ref(child)
+            for cells in rich_table_children.values()
+            for children in cells.values()
+            for child in children
         }
 
         origin = DocumentOrigin(
@@ -357,7 +398,7 @@ class ReadingOrderModel:
             for cid in lst
         }
         skippable_cids.update(
-            rel.cid for rel in ro_elements if rel.ref.cref in rich_picture_refs
+            rel.cid for rel in ro_elements if rel.ref.cref in rich_child_refs
         )
 
         page_no_to_pages = {p.page_no: p for p in conv_res.pages}
@@ -423,13 +464,13 @@ class ReadingOrderModel:
                 tbl = out_doc.add_table(
                     data=tbl_data, prov=prov, label=element.cluster.label
                 )
-                if rel.ref.cref in rich_table_pictures:
-                    self._add_rich_table_pictures(
-                        table_item=tbl,
-                        pictures_by_cell=rich_table_pictures[rel.ref.cref],
-                        doc=out_doc,
-                        page_height=page_height,
-                    )
+                self._add_rich_table_children(
+                    table=element,
+                    table_item=tbl,
+                    table_children=rich_table_children,
+                    doc=out_doc,
+                    page_height=page_height,
+                )
 
                 if rel.cid in el_to_captions_mapping.keys():
                     for caption_cid in el_to_captions_mapping[rel.cid]:

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from statistics import median
 
 from docling_core.types.doc import (
     DocItemLabel,
@@ -10,6 +11,7 @@ from docling_core.types.doc import (
     RefItem,
     RichTableCell,
     TableData,
+    TableItem,
 )
 from docling_core.types.doc.document import ContentLayer
 from docling_ibm_models.list_item_normalizer.list_marker_processor import (
@@ -40,6 +42,8 @@ class ReadingOrderOptions(BaseModel):
 
 
 class ReadingOrderModel:
+    _RICH_CELL_PICTURE_COVERAGE_THRESHOLD = 0.8
+
     def __init__(self, options: ReadingOrderOptions):
         self.options = options
         self.ro_model = ReadingOrderPredictor()
@@ -59,7 +63,7 @@ class ReadingOrderModel:
             elements.append(
                 ReadingOrderPageElement(
                     cid=len(elements),
-                    ref=RefItem(cref=f"#/{element.page_no}/{element.cluster.id}"),
+                    ref=RefItem(cref=self._element_ref(element)),
                     text=text,
                     page_no=element.page_no,
                     page_size=page_no_to_pages[element.page_no].size,
@@ -150,6 +154,153 @@ class ReadingOrderModel:
             orientation=element.orientation,
         )
 
+    @staticmethod
+    def _element_ref(element: BasePageElement) -> str:
+        return f"#/{element.page_no}/{element.cluster.id}"
+
+    @classmethod
+    def _match_table_pictures(
+        cls,
+        elements: list[BasePageElement],
+        excluded_picture_refs: set[str],
+    ) -> dict[str, dict[int, list[FigureElement]]]:
+        tables = [element for element in elements if isinstance(element, Table)]
+        matches: dict[str, dict[int, list[FigureElement]]] = {}
+
+        for picture in (
+            element for element in elements if isinstance(element, FigureElement)
+        ):
+            if cls._element_ref(picture) in excluded_picture_refs:
+                continue
+
+            best_match: tuple[float, Table, int] | None = None
+            for table in tables:
+                if table.page_no != picture.page_no:
+                    continue
+                if (
+                    picture.cluster.bbox.intersection_over_self(table.cluster.bbox)
+                    < cls._RICH_CELL_PICTURE_COVERAGE_THRESHOLD
+                ):
+                    continue
+
+                cell_match = cls._match_picture_to_table_cell(table, picture)
+                if cell_match is not None and (
+                    best_match is None or cell_match[0] > best_match[0]
+                ):
+                    best_match = (cell_match[0], table, cell_match[1])
+
+            if best_match is None:
+                continue
+
+            _, table, cell_index = best_match
+            matches.setdefault(cls._element_ref(table), {}).setdefault(
+                cell_index, []
+            ).append(picture)
+
+        return matches
+
+    @classmethod
+    def _match_picture_to_table_cell(
+        cls, table: Table, picture: FigureElement
+    ) -> tuple[float, int] | None:
+        eligible = [
+            (
+                picture.cluster.bbox.intersection_over_self(cell.bbox),
+                cell_index,
+                cell,
+            )
+            for cell_index, cell in enumerate(table.table_cells)
+            if cell.bbox is not None
+            and picture.cluster.bbox.intersection_over_self(cell.bbox)
+            >= cls._RICH_CELL_PICTURE_COVERAGE_THRESHOLD
+        ]
+        if not eligible:
+            return None
+
+        # Cell boxes can overlap across logical rows and columns. Infer the
+        # picture's grid position before choosing among containing cells.
+        row_centers: dict[int, list[float]] = {}
+        column_centers: dict[int, list[float]] = {}
+        for cell in table.table_cells:
+            if cell.bbox is None:
+                continue
+            for row in range(cell.start_row_offset_idx, cell.end_row_offset_idx):
+                row_centers.setdefault(row, []).append((cell.bbox.t + cell.bbox.b) / 2)
+            for column in range(cell.start_col_offset_idx, cell.end_col_offset_idx):
+                column_centers.setdefault(column, []).append(
+                    (cell.bbox.l + cell.bbox.r) / 2
+                )
+
+        picture_x = (picture.cluster.bbox.l + picture.cluster.bbox.r) / 2
+        picture_y = (picture.cluster.bbox.t + picture.cluster.bbox.b) / 2
+        row = min(
+            row_centers,
+            key=lambda index: abs(median(row_centers[index]) - picture_y),
+        )
+        column = min(
+            column_centers,
+            key=lambda index: abs(median(column_centers[index]) - picture_x),
+        )
+        logical_matches = [
+            match
+            for match in eligible
+            if match[2].start_row_offset_idx <= row < match[2].end_row_offset_idx
+            and match[2].start_col_offset_idx <= column < match[2].end_col_offset_idx
+        ]
+        coverage, cell_index, _ = max(logical_matches or eligible)
+        return coverage, cell_index
+
+    def _add_rich_table_pictures(
+        self,
+        *,
+        table_item: TableItem,
+        pictures_by_cell: dict[int, list[FigureElement]],
+        doc: DoclingDocument,
+        page_height: float,
+    ) -> None:
+        for cell_index, pictures in pictures_by_cell.items():
+            cell = table_item.data.table_cells[cell_index]
+            group = doc.add_group(
+                label=GroupLabel.UNSPECIFIED,
+                name=(
+                    f"rich_cell_group_{len(doc.tables)}_"
+                    f"{cell.start_col_offset_idx}_{cell.start_row_offset_idx}"
+                ),
+                parent=table_item,
+            )
+
+            if cell.text:
+                cell_bbox = (
+                    cell.bbox if cell.bbox is not None else pictures[0].cluster.bbox
+                )
+                doc.add_text(
+                    label=DocItemLabel.TEXT,
+                    text=cell.text,
+                    prov=ProvenanceItem(
+                        page_no=pictures[0].page_no,
+                        charspan=(0, len(cell.text)),
+                        bbox=cell_bbox.to_bottom_left_origin(page_height),
+                    ),
+                    parent=group,
+                )
+
+            for picture in pictures:
+                picture_item = doc.add_picture(
+                    annotations=picture.annotations,
+                    prov=ProvenanceItem(
+                        page_no=picture.page_no,
+                        charspan=(0, 0),
+                        bbox=picture.cluster.bbox.to_bottom_left_origin(page_height),
+                    ),
+                    parent=group,
+                )
+                self._add_child_elements(picture, picture_item, doc)
+
+            table_item.data.table_cells[cell_index] = RichTableCell(
+                **cell.model_dump(exclude={"ref"}),
+                ref=group.get_ref(),
+            )
+
     def _readingorder_elements_to_docling_doc(
         self,
         conv_res: ConversionResult,
@@ -159,10 +310,24 @@ class ReadingOrderModel:
         el_merges_mapping: dict[int, list[int]],
     ) -> DoclingDocument:
         id_to_elem = {
-            RefItem(cref=f"#/{elem.page_no}/{elem.cluster.id}").cref: elem
-            for elem in conv_res.assembled.elements
+            self._element_ref(elem): elem for elem in conv_res.assembled.elements
         }
         cid_to_rels = {rel.cid: rel for rel in ro_elements}
+        excluded_picture_refs = {
+            rel.ref.cref
+            for rel in ro_elements
+            if rel.cid in el_to_captions_mapping or rel.cid in el_to_footnotes_mapping
+        }
+        rich_table_pictures = self._match_table_pictures(
+            conv_res.assembled.elements,
+            excluded_picture_refs=excluded_picture_refs,
+        )
+        rich_picture_refs = {
+            self._element_ref(picture)
+            for cells in rich_table_pictures.values()
+            for pictures in cells.values()
+            for picture in pictures
+        }
 
         origin = DocumentOrigin(
             mimetype="application/pdf",
@@ -191,6 +356,9 @@ class ReadingOrderModel:
             for lst in mapping.values()
             for cid in lst
         }
+        skippable_cids.update(
+            rel.cid for rel in ro_elements if rel.ref.cref in rich_picture_refs
+        )
 
         page_no_to_pages = {p.page_no: p for p in conv_res.pages}
 
@@ -255,6 +423,13 @@ class ReadingOrderModel:
                 tbl = out_doc.add_table(
                     data=tbl_data, prov=prov, label=element.cluster.label
                 )
+                if rel.ref.cref in rich_table_pictures:
+                    self._add_rich_table_pictures(
+                        table_item=tbl,
+                        pictures_by_cell=rich_table_pictures[rel.ref.cref],
+                        doc=out_doc,
+                        page_height=page_height,
+                    )
 
                 if rel.cid in el_to_captions_mapping.keys():
                     for caption_cid in el_to_captions_mapping[rel.cid]:

--- a/docling/models/stages/table_structure/table_structure_model.py
+++ b/docling/models/stages/table_structure/table_structure_model.py
@@ -3,7 +3,7 @@ import logging
 import warnings
 from collections.abc import Iterable, Sequence
 from pathlib import Path
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 
 import numpy
 from docling_core.types.doc import BoundingBox, DocItemLabel, TableCell
@@ -218,11 +218,15 @@ class TableStructureModel(BaseTableStructureModel):
                     predictions.append(table_prediction)
                     continue
 
-                page_input = {
+                page_image = page.get_image(scale=self.scale)
+                assert page_image is not None
+                page_array = numpy.asarray(page_image)
+                page_input: dict[str, Any] = {
                     "width": page.size.width * self.scale,
                     "height": page.size.height * self.scale,
-                    "image": numpy.asarray(page.get_image(scale=self.scale)),
+                    "image": page_array,
                 }
+                table_clusters = [cluster for cluster, _ in in_tables]
 
                 for table_cluster, tbl_box in in_tables:
                     # Check if word-level cells are available from backend:
@@ -238,6 +242,17 @@ class TableStructureModel(BaseTableStructureModel):
                     else:
                         # Otherwise - we use normal (line/phrase) cells
                         tcells = table_cluster.cells
+                    table_image, tcells, _ = self._prepare_table_input(
+                        page_image,
+                        table_cluster=table_cluster,
+                        table_clusters=table_clusters,
+                        text_cells=tcells,
+                    )
+                    page_input["image"] = (
+                        page_array
+                        if table_image is page_image
+                        else numpy.asarray(table_image)
+                    )
                     tokens = []
                     for c in tcells:
                         # Only allow non empty strings (spaces) into the cells of a table

--- a/docling/models/stages/table_structure/table_structure_model_v2.py
+++ b/docling/models/stages/table_structure/table_structure_model_v2.py
@@ -397,12 +397,27 @@ class TableStructureModelV2(BaseTableStructureModel):
                     predictions.append(table_prediction)
                     continue
 
-                page_image = numpy.asarray(page.get_image(scale=self.scale))
+                page_image = page.get_image(scale=self.scale)
+                assert page_image is not None
+                page_array = numpy.asarray(page_image)
+                table_clusters = [cluster for cluster, _ in in_tables]
 
                 for table_cluster, tbl_box in in_tables:
+                    input_image, text_cells, nested_tables = self._prepare_table_input(
+                        page_image,
+                        table_cluster=table_cluster,
+                        table_clusters=table_clusters,
+                        text_cells=table_cluster.cells,
+                    )
+
                     # Crop table region
                     x1, y1, x2, y2 = [int(v) for v in tbl_box]
-                    table_image = page_image[y1:y2, x1:x2]
+                    input_array = (
+                        page_array
+                        if input_image is page_image
+                        else numpy.asarray(input_image)
+                    )
+                    table_image = input_array[y1:y2, x1:x2]
 
                     # Convert to PIL and preprocess
                     pil_image = Image.fromarray(table_image).convert("RGB")
@@ -440,13 +455,18 @@ class TableStructureModelV2(BaseTableStructureModel):
                     for element in cell_data:
                         if element["bbox"] is not None:
                             bbox = BoundingBox.model_validate(element["bbox"])
+                            overlaps_nested_table = any(
+                                bbox.get_intersection_bbox(nested_table.bbox)
+                                is not None
+                                for nested_table in nested_tables
+                            )
                             if self.do_cell_matching:
                                 # Prefer text from cluster cells (includes OCR-assigned cells),
                                 # then fall back to backend text extraction.
                                 text_piece = self._match_text(
-                                    bbox, table_cluster.cells, textcell_overlap=0.3
+                                    bbox, text_cells, textcell_overlap=0.3
                                 )
-                                if not text_piece.strip():
+                                if not text_piece.strip() and not overlaps_nested_table:
                                     text_piece = page._backend.get_text_in_rect(bbox)
                             else:
                                 text_piece = page._backend.get_text_in_rect(bbox)

--- a/docling/pipeline/legacy_standard_pdf_pipeline.py
+++ b/docling/pipeline/legacy_standard_pdf_pipeline.py
@@ -66,7 +66,11 @@ class LegacyStandardPdfPipeline(PaginatedPipeline):
                 or self.pipeline_options.generate_table_images
             )
 
-        self.reading_order_model = ReadingOrderModel(options=ReadingOrderOptions())
+        self.reading_order_model = ReadingOrderModel(
+            options=ReadingOrderOptions(
+                rich_cell_element_coverage_threshold=self.pipeline_options.table_structure_options.rich_cell_element_coverage_threshold
+            )
+        )
         self.heading_hierarchy_model = HeadingHierarchyModel(
             options=self.pipeline_options.heading_hierarchy_options
         )

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -638,7 +638,11 @@ class StandardPdfPipeline(ConvertPipeline):
             enable_remote_services=self.pipeline_options.enable_remote_services,
         )
         self.assemble_model = PageAssembleModel(options=PageAssembleOptions())
-        self.reading_order_model = ReadingOrderModel(options=ReadingOrderOptions())
+        self.reading_order_model = ReadingOrderModel(
+            options=ReadingOrderOptions(
+                rich_cell_element_coverage_threshold=self.pipeline_options.table_structure_options.rich_cell_element_coverage_threshold
+            )
+        )
         self.heading_hierarchy_model = HeadingHierarchyModel(
             options=self.pipeline_options.heading_hierarchy_options
         )

--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -531,12 +531,24 @@ class LayoutPostprocessor:
             candidates.discard(cluster.id)
 
             for other_id in candidates:
-                if spatial_index.check_overlap(
-                    cluster.bbox,
-                    valid_clusters[other_id].bbox,
-                    overlap_threshold,
-                    containment_threshold,
+                other = valid_clusters[other_id]
+                if (
+                    cluster_type == "wrapper"
+                    and cluster.label == other.label == DocItemLabel.TABLE
                 ):
+                    # Containment is meaningful for nested tables; only merge duplicates.
+                    overlaps = (
+                        cluster.bbox.intersection_over_union(other.bbox)
+                        > overlap_threshold
+                    )
+                else:
+                    overlaps = spatial_index.check_overlap(
+                        cluster.bbox,
+                        other.bbox,
+                        overlap_threshold,
+                        containment_threshold,
+                    )
+                if overlaps:
                     uf.union(cluster.id, other_id)
 
         result = []

--- a/tests/test_layout_postprocessor.py
+++ b/tests/test_layout_postprocessor.py
@@ -2,7 +2,7 @@ from docling_core.types.doc import DocItemLabel
 from docling_core.types.doc.page import BoundingRectangle, TextCell
 
 from docling.datamodel.base_models import BoundingBox, Cluster
-from docling.utils.layout_postprocessor import LayoutPostprocessor
+from docling.utils.layout_postprocessor import LayoutPostprocessor, SpatialClusterIndex
 
 
 def _cluster(
@@ -89,3 +89,16 @@ def test_cross_type_overlaps_keeps_small_picture_inside_table() -> None:
 
     ids = {c.id for c in result}
     assert ids == {1, 2}
+
+
+def test_wrapper_overlaps_keeps_nested_table_and_deduplicates_duplicate() -> None:
+    processor = object.__new__(LayoutPostprocessor)
+    parent = _cluster(1, DocItemLabel.TABLE, (0, 0, 400, 400))
+    nested = _cluster(2, DocItemLabel.TABLE, (100, 100, 200, 200))
+    nested_duplicate = _cluster(3, DocItemLabel.TABLE, (101, 101, 201, 201))
+    tables = [parent, nested, nested_duplicate]
+    processor.wrapper_index = SpatialClusterIndex(tables)
+
+    result = processor._remove_overlapping_clusters(tables, "wrapper")
+
+    assert {cluster.id for cluster in result} == {1, 2}

--- a/tests/test_readingorder_table_orientation.py
+++ b/tests/test_readingorder_table_orientation.py
@@ -3,6 +3,7 @@ from pathlib import PurePath
 from docling_core.types.doc import (
     BoundingBox,
     DocItemLabel,
+    DoclingDocument,
     PictureItem,
     RichTableCell,
     Size,
@@ -33,17 +34,19 @@ def _make_table(
     num_rows: int,
     num_cols: int,
     orientation: Orientation,
+    element_id: int = 1,
+    bbox: BoundingBox | None = None,
     table_cells: list[TableCell] | None = None,
     children: list[Cluster] | None = None,
 ) -> Table:
     return Table(
         label=DocItemLabel.TABLE,
-        id=1,
+        id=element_id,
         page_no=1,
         cluster=Cluster(
-            id=1,
+            id=element_id,
             label=DocItemLabel.TABLE,
-            bbox=BoundingBox(l=0, t=0, r=10, b=10),
+            bbox=bbox or BoundingBox(l=0, t=0, r=10, b=10),
             children=children or [],
         ),
         otsl_seq=[],
@@ -73,14 +76,48 @@ def _make_picture(
     )
 
 
-def test_structured_table_orientation_is_carried_to_table_data():
-    cell = TableCell(
-        text="cell",
-        start_row_offset_idx=0,
-        end_row_offset_idx=1,
-        start_col_offset_idx=0,
-        end_col_offset_idx=1,
+def _make_cell(
+    row: int,
+    column: int,
+    *,
+    text: str = "",
+    bbox: BoundingBox | None = None,
+) -> TableCell:
+    return TableCell(
+        text=text,
+        bbox=bbox,
+        start_row_offset_idx=row,
+        end_row_offset_idx=row + 1,
+        start_col_offset_idx=column,
+        end_col_offset_idx=column + 1,
     )
+
+
+def _assemble_document(
+    elements: list[Table | FigureElement],
+    model: ReadingOrderModel | None = None,
+) -> DoclingDocument:
+    conv_res = ConversionResult(
+        input=InputDocument.model_construct(
+            file=PurePath("rich-table.pdf"),
+            document_hash="0" * 64,
+            format=InputFormat.PDF,
+        ),
+        pages=[Page(page_no=1, size=Size(width=100, height=100))],
+        assembled=AssembledUnit(elements=elements),
+    )
+    reading_order_model = model or ReadingOrderModel(options=ReadingOrderOptions())
+    return reading_order_model._readingorder_elements_to_docling_doc(
+        conv_res,
+        reading_order_model._assembled_to_readingorder_elements(conv_res),
+        el_to_captions_mapping={},
+        el_to_footnotes_mapping={},
+        el_merges_mapping={},
+    )
+
+
+def test_structured_table_orientation_is_carried_to_table_data():
+    cell = _make_cell(0, 0, text="cell")
     table = _make_table(
         num_rows=1,
         num_cols=1,
@@ -130,37 +167,19 @@ def test_rich_cell_fallback_table_orientation_is_carried_to_table_data():
 
 def test_picture_inside_overlapping_table_cells_is_nested_in_rich_cell():
     cells = [
-        TableCell(
-            text="",
-            bbox=None,
-            start_row_offset_idx=0,
-            end_row_offset_idx=1,
-            start_col_offset_idx=0,
-            end_col_offset_idx=1,
-        ),
-        TableCell(
-            text="",
-            bbox=BoundingBox(l=4, t=0, r=6, b=2),
-            start_row_offset_idx=0,
-            end_row_offset_idx=1,
-            start_col_offset_idx=1,
-            end_col_offset_idx=2,
-        ),
-        TableCell(
+        _make_cell(0, 0),
+        _make_cell(0, 1, bbox=BoundingBox(l=4, t=0, r=6, b=2)),
+        _make_cell(
+            1,
+            0,
             text="wrong overlapping cell",
             bbox=BoundingBox(l=0, t=2, r=8, b=8),
-            start_row_offset_idx=1,
-            end_row_offset_idx=2,
-            start_col_offset_idx=0,
-            end_col_offset_idx=1,
         ),
-        TableCell(
+        _make_cell(
+            1,
+            1,
             text="structure",
             bbox=BoundingBox(l=2, t=3, r=10, b=9),
-            start_row_offset_idx=1,
-            end_row_offset_idx=2,
-            start_col_offset_idx=1,
-            end_col_offset_idx=2,
         ),
     ]
     table = _make_table(
@@ -194,25 +213,7 @@ def test_picture_inside_overlapping_table_cells_is_nested_in_rich_cell():
         element_id=3,
         bbox=BoundingBox(l=8, t=0, r=10, b=2),
     )
-    conv_res = ConversionResult(
-        input=InputDocument.model_construct(
-            file=PurePath("rich-table-picture.pdf"),
-            document_hash="0" * 64,
-            format=InputFormat.PDF,
-        ),
-        pages=[Page(page_no=1, size=Size(width=100, height=100))],
-        assembled=AssembledUnit(
-            elements=[table, nested_picture, unmatched_picture],
-        ),
-    )
-    model = ReadingOrderModel(options=ReadingOrderOptions())
-    doc = model._readingorder_elements_to_docling_doc(
-        conv_res,
-        model._assembled_to_readingorder_elements(conv_res),
-        el_to_captions_mapping={},
-        el_to_footnotes_mapping={},
-        el_merges_mapping={},
-    )
+    doc = _assemble_document([table, nested_picture, unmatched_picture])
 
     table_item = doc.tables[0]
     rich_cell = table_item.data.table_cells[3]
@@ -231,4 +232,75 @@ def test_picture_inside_overlapping_table_cells_is_nested_in_rich_cell():
     assert len(body_children) == 2
     assert isinstance(body_children[0], TableItem)
     assert isinstance(body_children[1], PictureItem)
+    doc.validate_document()
+
+
+def test_nested_table_is_nested_in_rich_cell():
+    parent = _make_table(
+        num_rows=2,
+        num_cols=2,
+        orientation=Orientation.ROT_0,
+        bbox=BoundingBox(l=0, t=0, r=8.7, b=10),
+        table_cells=[
+            _make_cell(0, 0, bbox=BoundingBox(l=1, t=1, r=2, b=2)),
+            _make_cell(0, 1, bbox=BoundingBox(l=6, t=1, r=7, b=2)),
+            _make_cell(1, 0, bbox=BoundingBox(l=1, t=6, r=2, b=7)),
+            _make_cell(
+                1,
+                1,
+                text="outer cell",
+                bbox=BoundingBox(l=6, t=6, r=7, b=7),
+            ),
+        ],
+    )
+    nested = _make_table(
+        element_id=2,
+        bbox=BoundingBox(l=6, t=7.5, r=9, b=9),
+        num_rows=1,
+        num_cols=1,
+        orientation=Orientation.ROT_0,
+        table_cells=[
+            _make_cell(
+                0,
+                0,
+                text="nested cell",
+                bbox=BoundingBox(l=6, t=7.5, r=9, b=9),
+            )
+        ],
+    )
+    nested_picture = _make_picture(
+        element_id=3,
+        bbox=BoundingBox(l=6.5, t=8, r=8.5, b=8.8),
+    )
+    elements = [parent, nested, nested_picture]
+    strict_model = ReadingOrderModel(
+        options=ReadingOrderOptions(rich_cell_element_coverage_threshold=0.95)
+    )
+    assert ReadingOrderModel._element_ref(parent) not in (
+        strict_model._match_table_children(elements, excluded_child_refs=set())
+    )
+    model = ReadingOrderModel(
+        options=ReadingOrderOptions(rich_cell_element_coverage_threshold=0.85)
+    )
+    doc = _assemble_document(elements, model=model)
+
+    assert len(doc.tables) == 2
+    parent_item = doc.tables[0]
+    rich_cell = parent_item.data.table_cells[3]
+    assert isinstance(rich_cell, RichTableCell)
+    group = rich_cell.ref.resolve(doc)
+    children = [child.resolve(doc) for child in group.children]
+    assert len(children) == 2
+    assert isinstance(children[0], TextItem)
+    assert children[0].text == "outer cell"
+    assert isinstance(children[1], TableItem)
+    nested_cell = children[1].data.table_cells[0]
+    assert isinstance(nested_cell, RichTableCell)
+    nested_group = nested_cell.ref.resolve(doc)
+    nested_children = [child.resolve(doc) for child in nested_group.children]
+    assert len(nested_children) == 2
+    assert isinstance(nested_children[0], TextItem)
+    assert nested_children[0].text == "nested cell"
+    assert isinstance(nested_children[1], PictureItem)
+    assert [child.resolve(doc) for child in doc.body.children] == [parent_item]
     doc.validate_document()

--- a/tests/test_readingorder_table_orientation.py
+++ b/tests/test_readingorder_table_orientation.py
@@ -1,8 +1,31 @@
-from docling_core.types.doc import BoundingBox, DocItemLabel, TableCell
-from docling_core.types.doc.document import Orientation
+from pathlib import PurePath
 
-from docling.datamodel.base_models import Cluster, Table
-from docling.models.stages.reading_order.readingorder_model import ReadingOrderModel
+from docling_core.types.doc import (
+    BoundingBox,
+    DocItemLabel,
+    PictureItem,
+    RichTableCell,
+    Size,
+    TableCell,
+    TableItem,
+    TextItem,
+)
+from docling_core.types.doc.document import Orientation
+from docling_core.types.doc.page import BoundingRectangle, TextCell
+
+from docling.datamodel.base_models import (
+    AssembledUnit,
+    Cluster,
+    FigureElement,
+    InputFormat,
+    Page,
+    Table,
+)
+from docling.datamodel.document import ConversionResult, InputDocument
+from docling.models.stages.reading_order.readingorder_model import (
+    ReadingOrderModel,
+    ReadingOrderOptions,
+)
 
 
 def _make_table(
@@ -28,6 +51,25 @@ def _make_table(
         num_cols=num_cols,
         table_cells=table_cells or [],
         orientation=orientation,
+    )
+
+
+def _make_picture(
+    *,
+    element_id: int,
+    bbox: BoundingBox,
+    children: list[Cluster] | None = None,
+) -> FigureElement:
+    return FigureElement(
+        label=DocItemLabel.PICTURE,
+        id=element_id,
+        page_no=1,
+        cluster=Cluster(
+            id=element_id,
+            label=DocItemLabel.PICTURE,
+            bbox=bbox,
+            children=children or [],
+        ),
     )
 
 
@@ -84,3 +126,109 @@ def test_rich_cell_fallback_table_orientation_is_carried_to_table_data():
     assert table_data.orientation == Orientation.ROT_270
     assert table_data.num_rows == 1
     assert table_data.num_cols == 1
+
+
+def test_picture_inside_overlapping_table_cells_is_nested_in_rich_cell():
+    cells = [
+        TableCell(
+            text="",
+            bbox=None,
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+        ),
+        TableCell(
+            text="",
+            bbox=BoundingBox(l=4, t=0, r=6, b=2),
+            start_row_offset_idx=0,
+            end_row_offset_idx=1,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
+        ),
+        TableCell(
+            text="wrong overlapping cell",
+            bbox=BoundingBox(l=0, t=2, r=8, b=8),
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=0,
+            end_col_offset_idx=1,
+        ),
+        TableCell(
+            text="structure",
+            bbox=BoundingBox(l=2, t=3, r=10, b=9),
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=1,
+            end_col_offset_idx=2,
+        ),
+    ]
+    table = _make_table(
+        num_rows=2,
+        num_cols=2,
+        table_cells=cells,
+        orientation=Orientation.ROT_0,
+    )
+    child_bbox = BoundingBox(l=3, t=3, r=7, b=4)
+    nested_picture = _make_picture(
+        element_id=2,
+        bbox=BoundingBox(l=2, t=2, r=8, b=8),
+        children=[
+            Cluster(
+                id=4,
+                label=DocItemLabel.TEXT,
+                bbox=child_bbox,
+                cells=[
+                    TextCell(
+                        rect=BoundingRectangle.from_bounding_box(child_bbox),
+                        text="inside picture",
+                        orig="inside picture",
+                        from_ocr=False,
+                    )
+                ],
+            )
+        ],
+    )
+    # Inside the table box, but outside every predicted cell.
+    unmatched_picture = _make_picture(
+        element_id=3,
+        bbox=BoundingBox(l=8, t=0, r=10, b=2),
+    )
+    conv_res = ConversionResult(
+        input=InputDocument.model_construct(
+            file=PurePath("rich-table-picture.pdf"),
+            document_hash="0" * 64,
+            format=InputFormat.PDF,
+        ),
+        pages=[Page(page_no=1, size=Size(width=100, height=100))],
+        assembled=AssembledUnit(
+            elements=[table, nested_picture, unmatched_picture],
+        ),
+    )
+    model = ReadingOrderModel(options=ReadingOrderOptions())
+    doc = model._readingorder_elements_to_docling_doc(
+        conv_res,
+        model._assembled_to_readingorder_elements(conv_res),
+        el_to_captions_mapping={},
+        el_to_footnotes_mapping={},
+        el_merges_mapping={},
+    )
+
+    table_item = doc.tables[0]
+    rich_cell = table_item.data.table_cells[3]
+    assert isinstance(rich_cell, RichTableCell)
+    group = rich_cell.ref.resolve(doc)
+    children = [child.resolve(doc) for child in group.children]
+    assert len(children) == 2
+    assert isinstance(children[0], TextItem)
+    assert children[0].text == "structure"
+    assert isinstance(children[1], PictureItem)
+    picture_children = [child.resolve(doc) for child in children[1].children]
+    assert len(picture_children) == 1
+    assert isinstance(picture_children[0], TextItem)
+    assert picture_children[0].text == "inside picture"
+    body_children = [child.resolve(doc) for child in doc.body.children]
+    assert len(body_children) == 2
+    assert isinstance(body_children[0], TableItem)
+    assert isinstance(body_children[1], PictureItem)
+    doc.validate_document()

--- a/tests/test_table_structure_model.py
+++ b/tests/test_table_structure_model.py
@@ -1,0 +1,158 @@
+from types import SimpleNamespace
+from typing import Any
+
+import numpy
+import pytest
+import torch
+from docling_core.types.doc import BoundingBox, DocItemLabel, Size
+from docling_core.types.doc.page import BoundingRectangle, TextCell
+from PIL import Image
+
+from docling.datamodel.accelerator_options import AcceleratorOptions
+from docling.datamodel.base_models import Cluster, LayoutPrediction, Page
+from docling.datamodel.pipeline_options import (
+    TableStructureOptions,
+    TableStructureV2Options,
+)
+from docling.models.stages.table_structure.table_structure_model import (
+    TableStructureModel,
+)
+from docling.models.stages.table_structure.table_structure_model_v2 import (
+    TableStructureModelV2,
+)
+
+
+class _Backend:
+    def __init__(self, page_image: Image.Image) -> None:
+        self.page_image = page_image
+
+    def is_valid(self) -> bool:
+        return True
+
+    def get_page_image(self, scale: float) -> Image.Image:
+        assert scale == 1.0
+        return self.page_image
+
+    def get_segmented_page(self) -> None:
+        return None
+
+
+class _TablePredictor:
+    def __init__(self) -> None:
+        self.calls: list[tuple[numpy.ndarray, list[dict[str, Any]]]] = []
+
+    def multi_table_predict(
+        self,
+        page_input: dict[str, Any],
+        table_boxes: list[list[float]],
+        do_matching: bool,
+    ) -> list[dict[str, Any]]:
+        assert len(table_boxes) == 1
+        assert do_matching is True
+        self.calls.append((page_input["image"].copy(), page_input["tokens"].copy()))
+        return [{"tf_responses": [], "predict_details": {}}]
+
+
+def _text_cell(index: int, text: str, bbox: BoundingBox) -> TextCell:
+    return TextCell(
+        index=index,
+        text=text,
+        orig=text,
+        from_ocr=False,
+        rect=BoundingRectangle.from_bounding_box(bbox),
+    )
+
+
+def _nested_table_page() -> tuple[Page, Cluster, Cluster]:
+    parent_cell = _text_cell(1, "parent", BoundingBox(l=1, t=1, r=3, b=3))
+    nested_cell = _text_cell(2, "nested", BoundingBox(l=5, t=5, r=7, b=7))
+    parent = Cluster(
+        id=1,
+        label=DocItemLabel.TABLE,
+        bbox=BoundingBox(l=0, t=0, r=9.6, b=10),
+        cells=[parent_cell, nested_cell],
+    )
+    nested = Cluster(
+        id=2,
+        label=DocItemLabel.TABLE,
+        bbox=BoundingBox(l=4, t=4, r=10, b=8),
+        cells=[nested_cell],
+    )
+    page = Page(page_no=1, size=Size(width=10, height=10))
+    page._backend = _Backend(  # type: ignore[assignment]
+        Image.new("RGB", (10, 10), "black")
+    )
+    page.predictions.layout = LayoutPrediction(clusters=[parent, nested])
+    return page, parent, nested
+
+
+@pytest.mark.parametrize(
+    ("coverage_threshold", "nested_is_masked"),
+    [(0.9, True), (0.95, False)],
+)
+def test_nested_table_threshold_controls_parent_prediction_input(
+    coverage_threshold: float, nested_is_masked: bool
+) -> None:
+    page, parent, nested = _nested_table_page()
+
+    model = TableStructureModel(
+        enabled=False,
+        artifacts_path=None,
+        options=TableStructureOptions(
+            rich_cell_element_coverage_threshold=coverage_threshold
+        ),
+        accelerator_options=AcceleratorOptions(),
+    )
+    model.scale = 1.0
+    predictor = _TablePredictor()
+    model.tf_predictor = predictor  # type: ignore[attr-defined]
+
+    [prediction] = model.predict_tables(SimpleNamespace(timings={}), [page])  # type: ignore[arg-type]
+
+    assert prediction.table_map.keys() == {parent.id, nested.id}
+    assert len(predictor.calls) == 2
+    parent_image, parent_tokens = predictor.calls[0]
+    nested_image, nested_tokens = predictor.calls[1]
+    expected_nested_pixel = [255, 255, 255] if nested_is_masked else [0, 0, 0]
+    assert parent_image[6, 6].tolist() == expected_nested_pixel
+    assert parent_image[2, 2].tolist() == [0, 0, 0]
+    expected_parent_tokens = ["parent"] if nested_is_masked else ["parent", "nested"]
+    assert [token["text"] for token in parent_tokens] == expected_parent_tokens
+    assert nested_image[6, 6].tolist() == [0, 0, 0]
+    assert [token["text"] for token in nested_tokens] == ["nested"]
+
+
+def test_table_structure_v2_masks_nested_table_only_in_parent() -> None:
+    page, parent, nested = _nested_table_page()
+    captured_images: list[Image.Image] = []
+
+    def capture_image(image: Image.Image) -> torch.Tensor:
+        captured_images.append(image.copy())
+        return torch.zeros((3, 8, 8))
+
+    model = TableStructureModelV2(
+        enabled=False,
+        artifacts_path=None,
+        options=TableStructureV2Options(),
+        accelerator_options=AcceleratorOptions(),
+    )
+    model.scale = 1.0
+    model.device = "cpu"
+    model.transform = capture_image  # type: ignore[attr-defined]
+    model.model = SimpleNamespace(  # type: ignore[attr-defined]
+        generate=lambda *_args, **_kwargs: {
+            "generated_ids": torch.tensor([[1]]),
+            "predicted_bboxes": torch.tensor([[[0.0, 0.0, 1.0, 1.0]]]),
+        }
+    )
+    model.tokenizer = SimpleNamespace(  # type: ignore[attr-defined]
+        decode=lambda _ids: "<fcel>"
+    )
+
+    [prediction] = model.predict_tables(SimpleNamespace(timings={}), [page])  # type: ignore[arg-type]
+
+    assert prediction.table_map.keys() == {parent.id, nested.id}
+    assert captured_images[0].getpixel((6, 6)) == (255, 255, 255)
+    assert captured_images[1].getpixel((2, 2)) == (0, 0, 0)
+    assert prediction.table_map[parent.id].table_cells[0].text == "parent"
+    assert prediction.table_map[nested.id].table_cells[0].text == "nested"


### PR DESCRIPTION
## Summary

- retain strongly contained PDF table layout regions while still deduplicating near-identical table proposals
- mask nested-table pixels and text tokens from parent TableFormer V1 and V2 inputs, while parsing each child table normally
- attach a structured child `TableItem` under its parent `RichTableCell` and omit the duplicate body-level child
- expose `table_structure_options.rich_cell_element_coverage_threshold` (default `0.8`, valid range `0 < value <= 1`) so containment can be tuned consistently

This is a stacked follow-up to #3906 and generalizes its rich-cell assembly from pictures to nested tables. Until #3906 merges, this PR also contains that prerequisite commit.

Related to #2824 and #1613.

## Why this does not require retraining

The public #1613 fixture already contains the necessary signals when using Layout V2: separate outer- and inner-table regions. The loss happened in postprocessing, parent table-structure input preparation, and document assembly. This change keeps both detections, isolates their table-structure inputs, and represents the result with the existing rich-table data model; the model weights are unchanged.

## Scope and remaining work

This intentionally does **not** close #2824 or #1613.

The structured nested-table path requires a layout provider to emit both table regions and a table-structure provider to produce a parent grid that can locate the child logically. On the public fixture, current Heron emits only one flat table, so assembly cannot recover the missing child; that remains detector/model work. Full-page VLM pipelines also bypass this standard PDF reading-order stage.

The configurable coverage threshold drives provider-independent rich-cell matching. Parent input masking is implemented for TableFormer V1 and V2; other table-structure providers may still need equivalent input isolation. With `do_cell_matching=False`, backend text extraction can still duplicate nested-table text. Unstructured nested tables without predicted cells remain outside this change.

The `DoclingDocument` and HTML export preserve the nested table. Markdown flattens the rich-cell content because Markdown has no native nested-table representation.

## Validation

- `uv run --no-sync pytest -q tests/test_layout_postprocessor.py tests/test_table_structure_model.py tests/test_readingorder_table_orientation.py` (13 passed)
- `make validate`
- converted the public #1613 attachment with Layout V2, the default `0.8` threshold, and unchanged model weights:
  - TableFormer V1: outer 3x2, inner 4x3, one rich cell, one body-level table
  - TableFormer V2: outer 3x2, inner 4x3, one rich cell, one body-level table
  - `doc.validate_document()` passes, and HTML contains the nested 4x3 table

**Checklist:**

- [x] Documentation has been updated, if necessary. (The public option includes generated schema metadata; no standalone guide is needed.)
- [x] Examples have been added, if necessary. (Not necessary.)
- [x] Tests have been added, if necessary.
