### PR TITLE
fix(video): append TrackSource to picture.source list

### DIFF
--- a/docling/pipeline/video_pipeline.py
+++ b/docling/pipeline/video_pipeline.py
@@ -279,14 +279,16 @@ class VideoPipeline(BasePipeline):
                             image=ImageRef.from_pil(frame.image, dpi=72),
                             content_layer=ContentLayer.BODY,
                         )
-                        picture.source = TrackSource(
-                            start_time=frame.timestamp,
-                            end_time=frame.timestamp + 0.001,
-                            identifier=(
-                                f"scene:{frame.scene_id}"
-                                if frame.scene_id is not None
-                                else None
-                            ),
+                        picture.source.append(
+                            TrackSource(
+                                start_time=frame.timestamp,
+                                end_time=frame.timestamp + 0.001,
+                                identifier=(
+                                    f"scene:{frame.scene_id}"
+                                    if frame.scene_id is not None
+                                    else None
+                                ),
+                            )
                         )
                     except Exception as exc:
                         _log.warning(


### PR DESCRIPTION
## What

Fixes #3924.

`VideoPipeline._process_video()` assigned a single `TrackSource` to `PictureItem.source`, but that field is a `list[TrackSource]`. Because the pydantic models don't validate on assignment, this silently produced a schema-invalid document.

## Why it matters

- Exporting the document emits a pydantic serialization warning.
- Loading the exported JSON back raises:

```
pydantic_core._pydantic_core.ValidationError: N validation errors for DoclingDocument
pictures.0.source
  Input should be a valid array [type=list_type, input_value={'kind': 'track', ...}, input_type=dict]
...
```

One error per sampled frame — all on `pictures.*`, none on `texts.*`, because the transcript path uses `add_text(..., source=...)`, which internally **appends** to the list. Only the picture path assigned a bare object.

## The fix

Append the `TrackSource` instead of assigning it, mirroring `add_text` (`add_picture` initializes `source` to an empty list, so `append` is safe):

```python
picture.source.append(
    TrackSource(
        start_time=frame.timestamp,
        end_time=frame.timestamp + 0.001,
        identifier=(...),
    )
)
```

## Verification

Converted a video through `VideoPipeline`, then:

- **Before:** `doc.save_as_json(...)` → `DoclingDocument.load_from_json(...)` raises the `ValidationError` above.
- **After:** the round-trip succeeds and `picture.source` is a list with one `TrackSource` per frame.

## Note

A deeper fix would be to give `add_picture` a `source` parameter (like `add_text` has) in docling-core, so callers don't assign `picture.source` after the fact. This PR is the minimal, self-contained fix in docling.
