### PR TITLE
feat(layout): add opt-out for dropping pictures that coincide with tables (#3922)

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1597,6 +1597,16 @@ class BaseLayoutPostprocessorOptions(BaseOptions):
             )
         ),
     ] = True
+    remove_pictures_coinciding_with_tables: Annotated[
+        bool,
+        Field(
+            description=(
+                "Remove a PICTURE cluster whose bbox nearly coincides with a TABLE cluster, keeping only the "
+                "structured TABLE. When False both are kept, so consumers that use the rendered picture crop as a "
+                "fallback for imperfect table extraction still receive it."
+            )
+        ),
+    ] = True
 
 
 class LayoutPostprocessorOptions(BaseLayoutPostprocessorOptions):

--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -388,7 +388,8 @@ class LayoutPostprocessor:
 
         In particular, KEY_VALUE_REGION proposals that are almost identical to a TABLE
         should be removed. A PICTURE proposal that nearly coincides with a TABLE is also
-        removed, keeping the structured TABLE.
+        removed, keeping the structured TABLE, unless
+        ``remove_pictures_coinciding_with_tables`` is disabled.
         """
         clusters_to_remove = set()
 
@@ -415,14 +416,15 @@ class LayoutPostprocessor:
         # When a PICTURE nearly coincides with a TABLE (high IoU), keep the structured
         # TABLE and drop the PICTURE. IoU (not containment) is used so a genuine small
         # figure fully inside a large table region is not removed.
-        tables = [c for c in special_clusters if c.label == DocItemLabel.TABLE]
-        for picture in special_clusters:
-            if picture.label != DocItemLabel.PICTURE:
-                continue
-            for table in tables:
-                if picture.bbox.intersection_over_union(table.bbox) > 0.8:
-                    clusters_to_remove.add(picture.id)
-                    break
+        if self.options.remove_pictures_coinciding_with_tables:
+            tables = [c for c in special_clusters if c.label == DocItemLabel.TABLE]
+            for picture in special_clusters:
+                if picture.label != DocItemLabel.PICTURE:
+                    continue
+                for table in tables:
+                    if picture.bbox.intersection_over_union(table.bbox) > 0.8:
+                        clusters_to_remove.add(picture.id)
+                        break
 
         # Filter out the identified clusters
         special_clusters = [

--- a/tests/test_layout_postprocessor.py
+++ b/tests/test_layout_postprocessor.py
@@ -2,6 +2,7 @@ from docling_core.types.doc import DocItemLabel
 from docling_core.types.doc.page import BoundingRectangle, TextCell
 
 from docling.datamodel.base_models import BoundingBox, Cluster
+from docling.datamodel.pipeline_options import LayoutPostprocessorOptions
 from docling.utils.layout_postprocessor import LayoutPostprocessor
 
 
@@ -51,6 +52,7 @@ def test_cross_type_overlaps_removes_picture_coinciding_with_table() -> None:
     # The PICTURE (near-identical bbox, high IoU) must be removed; the TABLE kept.
     processor = object.__new__(LayoutPostprocessor)
     processor.regular_clusters = []
+    processor.options = LayoutPostprocessorOptions()
 
     table = _cluster(1, DocItemLabel.TABLE, (10, 10, 200, 150), confidence=0.72)
     picture = _cluster(2, DocItemLabel.PICTURE, (10, 10, 200, 150), confidence=0.81)
@@ -66,6 +68,7 @@ def test_cross_type_overlaps_keeps_picture_not_overlapping_table() -> None:
     # A genuine figure elsewhere on the page must be preserved.
     processor = object.__new__(LayoutPostprocessor)
     processor.regular_clusters = []
+    processor.options = LayoutPostprocessorOptions()
 
     table = _cluster(1, DocItemLabel.TABLE, (10, 10, 200, 150))
     picture = _cluster(2, DocItemLabel.PICTURE, (10, 300, 200, 450))
@@ -81,11 +84,31 @@ def test_cross_type_overlaps_keeps_small_picture_inside_table() -> None:
     # must NOT be removed -- only a near-coinciding picture is a true mislabel.
     processor = object.__new__(LayoutPostprocessor)
     processor.regular_clusters = []
+    processor.options = LayoutPostprocessorOptions()
 
     table = _cluster(1, DocItemLabel.TABLE, (0, 0, 400, 400))
     small_picture = _cluster(2, DocItemLabel.PICTURE, (10, 10, 60, 60))
 
     result = processor._handle_cross_type_overlaps([table, small_picture])
+
+    ids = {c.id for c in result}
+    assert ids == {1, 2}
+
+
+def test_cross_type_overlaps_keeps_coinciding_picture_when_opted_out() -> None:
+    # With remove_pictures_coinciding_with_tables disabled, the coinciding PICTURE is
+    # kept alongside the TABLE so consumers can still use the rendered crop as a
+    # fallback when table extraction is poor.
+    processor = object.__new__(LayoutPostprocessor)
+    processor.regular_clusters = []
+    processor.options = LayoutPostprocessorOptions(
+        remove_pictures_coinciding_with_tables=False
+    )
+
+    table = _cluster(1, DocItemLabel.TABLE, (10, 10, 200, 150), confidence=0.72)
+    picture = _cluster(2, DocItemLabel.PICTURE, (10, 10, 200, 150), confidence=0.81)
+
+    result = processor._handle_cross_type_overlaps([table, picture])
 
     ids = {c.id for c in result}
     assert ids == {1, 2}


### PR DESCRIPTION
Fixes #3922

### Problem

Since 2.103.0 (#3523, extended by #3536 and #3789) `LayoutPostprocessor._handle_cross_type_overlaps` drops a PICTURE cluster whose bbox nearly coincides with a TABLE cluster (IoU > 0.8), keeping only the structured TABLE.

That is the right call in the common case, but there is no way to opt out. Dropping the picture also removes the only signal that there is an image there — including the region's rendered crop. As reported in #3922, some pipelines use that crop as a safety net: when TableFormer extracts a table badly, a vision-model description of the same region recovers the content. With the picture gone, the fallback is gone too.

### Change

Add `remove_pictures_coinciding_with_tables` to `BaseLayoutPostprocessorOptions`, defaulting to `True` so current behaviour is unchanged. When set to `False`, the coinciding PICTURE is kept alongside the TABLE.

The option lives on the layout-postprocessor options rather than on `PdfPipelineOptions` (as sketched in the issue), because that is where the deduplication actually runs and where the sibling toggles (`keep_empty_clusters`, `skip_cell_assignment`, `create_orphan_clusters`) already live.

The table itself is untouched — this only controls whether the duplicate PICTURE survives.

### Tests

`tests/test_layout_postprocessor.py` gains `test_cross_type_overlaps_keeps_coinciding_picture_when_opted_out`, asserting both clusters survive when the option is disabled. The three existing cross-type tests build a half-initialized postprocessor via `object.__new__`, so they now also set `processor.options`; their assertions are unchanged.

Verified locally against the postprocessor as it stands on `main` (byte-identical to the file in this PR's base):

- new test against unpatched postprocessor → **fails** (picture removed despite the opt-out)
- new test against patched postprocessor → **passes**
- the three pre-existing cross-type tests → **pass**, default behaviour unchanged

The ML-backed integration test `tests/test_layout_picture_table_overlap.py` keeps passing unchanged, since the default stays `True`.

`ruff` 0.15.12 (`check` + `format`, repo `pyproject.toml`) reports nothing new relative to `main` on the three touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
