### PR TITLE
docs: note OpenAI client base_url for multi-model gateways

### DIFF
--- a/docs/usage/vision_models.md
+++ b/docs/usage/vision_models.md
@@ -128,6 +128,8 @@ pipeline_options = VlmPipelineOptions(
 Additionally to local models, the `VlmPipeline` allows to offload the inference to a remote service hosting the models.
 Many remote inference services are provided, the key requirement is to offer an OpenAI-compatible API. This includes vLLM, Ollama, etc.
 
+> **Tip:** The same OpenAI-compatible endpoint pattern also works with multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com/?utm_source=github&utm_medium=organic&utm_campaign=docling&utm_content=vlm) at `https://api.daoxe.com/v1`.
+
 More examples on how to connect with the remote inference services can be found in the following examples:
 
 - [vlm_pipeline_api_model.py](./../examples/vlm_pipeline_api_model.py)

--- a/docs/usage/vision_models.md
+++ b/docs/usage/vision_models.md
@@ -128,6 +128,8 @@ pipeline_options = VlmPipelineOptions(
 Additionally to local models, the `VlmPipeline` allows to offload the inference to a remote service hosting the models.
 Many remote inference services are provided, the key requirement is to offer an OpenAI-compatible API. This includes vLLM, Ollama, etc.
 
+> **Tip:** The same OpenAI-compatible endpoint pattern also works with multi-model gateways when you are not self-hosting — for example [DaoXE](https://daoxe.com) at `https://api.daoxe.com/v1`.
+
 More examples on how to connect with the remote inference services can be found in the following examples:
 
 - [vlm_pipeline_api_model.py](./../examples/vlm_pipeline_api_model.py)


### PR DESCRIPTION
## Summary

Document that Docling VLM remote inference works with any OpenAI-compatible endpoint, including multi-model gateways.

DaoXE (`https://api.daoxe.com/v1`) is **one concrete example** among OpenAI-compatible gateways — no pricing/uptime claims.

Docs only — optional tip under Remote models.

## Test plan
- [ ] Vision models docs still render
- [ ] Note is optional / non-breaking

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>