### PR TITLE
fix(pdf): normalize Arabic presentation forms in extracted text

### DIFF
--- a/docling/models/stages/page_assemble/page_assemble_model.py
+++ b/docling/models/stages/page_assemble/page_assemble_model.py
@@ -27,6 +27,7 @@ from docling.models.base_layout_model import (
 )
 from docling.models.base_model import BasePageModel
 from docling.utils.profiling import TimeRecorder
+from docling.utils.text_normalization import normalize_arabic_presentation_forms
 
 _log = logging.getLogger(__name__)
 
@@ -153,6 +154,9 @@ class PageAssembleModel(BasePageModel):
             ),
             sanitized_text,
         )
+        # Arabic shaping normalization: fold contextual presentation forms back to
+        # their canonical Arabic letters, so the extracted text is searchable.
+        sanitized_text = normalize_arabic_presentation_forms(sanitized_text)
 
         return sanitized_text.strip()  # Strip any leading or trailing whitespace
 

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -31,6 +31,7 @@ from docling.datamodel.base_models import (
 )
 from docling.datamodel.document import ConversionResult
 from docling.utils.profiling import ProfilingScope, TimeRecorder
+from docling.utils.text_normalization import normalize_arabic_presentation_forms
 
 
 class ReadingOrderOptions(BaseModel):
@@ -83,12 +84,14 @@ class ReadingOrderModel:
             c_bbox = child.bbox.to_bottom_left_origin(
                 doc.pages[element.page_no].size.height
             )
-            c_text = " ".join(
-                [
-                    cell.text.replace("\x02", "-").strip()
-                    for cell in child.cells
-                    if len(cell.text.strip()) > 0
-                ]
+            c_text = normalize_arabic_presentation_forms(
+                " ".join(
+                    [
+                        cell.text.replace("\x02", "-").strip()
+                        for cell in child.cells
+                        if len(cell.text.strip()) > 0
+                    ]
+                )
             )
 
             c_prov = ProvenanceItem(

--- a/docling/models/stages/table_structure/table_structure_model.py
+++ b/docling/models/stages/table_structure/table_structure_model.py
@@ -25,6 +25,7 @@ from docling.models.base_table_model import BaseTableStructureModel
 from docling.models.utils.hf_model_download import download_hf_model
 from docling.utils.accelerator_utils import decide_device
 from docling.utils.profiling import TimeRecorder
+from docling.utils.text_normalization import normalize_arabic_presentation_forms
 
 _log = logging.getLogger(__name__)
 
@@ -271,6 +272,7 @@ class TableStructureModel(BaseTableStructureModel):
                         tc = TableCell.model_validate(element)
                         if tc.bbox is not None:
                             tc.bbox = tc.bbox.scaled(1 / self.scale)
+                        tc.text = normalize_arabic_presentation_forms(tc.text)
                         table_cells.append(tc)
 
                     assert "predict_details" in table_out

--- a/docling/utils/text_normalization.py
+++ b/docling/utils/text_normalization.py
@@ -1,0 +1,24 @@
+"""Character-level normalization applied to text extracted from documents."""
+
+import re
+import unicodedata
+
+# Arabic Presentation Forms-A (U+FB50-U+FDFF) and Forms-B (U+FE70-U+FEFF).
+# Some PDF fonts encode Arabic with these compatibility codepoints, which carry
+# one codepoint per contextual letter shape (initial/medial/final/isolated)
+# instead of the canonical letter. Text stored that way is not searchable or
+# comparable against normally-encoded Arabic, since a shaped codepoint never
+# matches its U+0600 block equivalent.
+_ARABIC_PRESENTATION_RE = re.compile(r"[ﭐ-﷿ﹰ-﻿]+")
+
+
+def normalize_arabic_presentation_forms(text: str) -> str:
+    """Fold Arabic presentation forms back to canonical Arabic letters.
+
+    NFKC is applied per matched run rather than to the whole string, so it can
+    never rewrite other scripts: a global NFKC would also fold superscripts,
+    subscripts and full-width forms (e.g. "x²" -> "x2").
+    """
+    return _ARABIC_PRESENTATION_RE.sub(
+        lambda m: unicodedata.normalize("NFKC", m.group(0)), text
+    )

--- a/docling/utils/text_normalization.py
+++ b/docling/utils/text_normalization.py
@@ -9,7 +9,7 @@ import unicodedata
 # instead of the canonical letter. Text stored that way is not searchable or
 # comparable against normally-encoded Arabic, since a shaped codepoint never
 # matches its U+0600 block equivalent.
-_ARABIC_PRESENTATION_RE = re.compile(r"[ﭐ-﷿ﹰ-﻿]+")
+_ARABIC_PRESENTATION_RE = re.compile("[\ufb50-\ufdff\ufe70-\ufeff]+")
 
 
 def normalize_arabic_presentation_forms(text: str) -> str:

--- a/tests/test_page_assemble_model.py
+++ b/tests/test_page_assemble_model.py
@@ -260,3 +260,50 @@ class TestMatchHyperlink:
         page.parsed_page = pp
         bbox = BoundingBox(l=10, t=10, r=90, b=20)
         assert PageAssembleModel._match_hyperlink(bbox, page) is None
+
+
+class TestSanitizeTextArabicPresentationForms:
+    """Tests for Arabic presentation-form normalization in sanitize_text()."""
+
+    def test_isolated_and_shaped_letters_are_folded(self, model):
+        """Shaped Arabic (U+FE70-U+FEFF) folds to the canonical U+0600 letters."""
+        # meem initial, alef final, reh final, seen isolated -> "مارس" (March)
+        shaped = "ﻣﺎﺮﺱ"
+        assert model.sanitize_text([shaped]) == "مارس"
+
+    def test_lam_alef_ligature_expands_to_two_letters(self, model):
+        """U+FEFB (lam-alef ligature) expands to lam + alef, not a single glyph."""
+        assert model.sanitize_text(["ﻻ"]) == "لا"
+
+    def test_forms_a_range_is_folded(self, model):
+        """Presentation Forms-A (U+FB50-U+FDFF) is normalized too."""
+        # U+FEDF is lam initial form; U+FB58 is peh initial form.
+        assert model.sanitize_text(["ﭘ"]) == "پ"
+
+    def test_shaped_text_becomes_searchable(self, model):
+        """The fold makes extracted Arabic match normally-encoded Arabic."""
+        # alef isolated, lam initial, hah medial, reh final, seen isolated
+        shaped = "ﺍﻟﺤﺮﺱ"
+        assert "الحرس" in model.sanitize_text([shaped])
+
+    def test_canonical_arabic_is_unchanged(self, model):
+        """Arabic already in the U+0600 block passes through untouched."""
+        assert model.sanitize_text(["مرحبا"]) == "مرحبا"
+
+    def test_superscript_is_not_normalized(self, model):
+        """NFKC is scoped to Arabic runs: superscripts must survive."""
+        assert model.sanitize_text(["x²"]) == "x²"
+
+    def test_subscript_is_not_normalized(self, model):
+        """NFKC is scoped to Arabic runs: subscripts must survive."""
+        assert model.sanitize_text(["H₂O"]) == "H₂O"
+
+    def test_fullwidth_is_not_normalized(self, model):
+        """NFKC is scoped to Arabic runs: full-width forms must survive."""
+        # FULLWIDTH LATIN SMALL LETTERS F, U, L, L (U+FF46, U+FF55, U+FF4C)
+        fullwidth = "".join(chr(cp) for cp in (0xFF46, 0xFF55, 0xFF4C, 0xFF4C))
+        assert model.sanitize_text([fullwidth]) == fullwidth
+
+    def test_mixed_arabic_and_latin(self, model):
+        """Only the Arabic run is folded; surrounding Latin is untouched."""
+        assert model.sanitize_text(["2024 ﻣﺎﺮﺱ x²"]) == "2024 مارس x²"


### PR DESCRIPTION
## Problem

Some PDF fonts encode Arabic using Unicode **presentation forms** (Forms-A
`U+FB50-U+FDFF`, Forms-B `U+FE70-U+FEFF`) — compatibility codepoints that carry
one codepoint per contextual letter shape (initial/medial/final/isolated) rather
than the canonical letter.

Docling passed these through unchanged. The extracted text *renders* correctly,
so the problem is invisible on inspection, but it is a different byte sequence
from normally-encoded Arabic and therefore **not searchable or comparable**:

```python
md = converter.convert("arabic_report.pdf").document.export_to_markdown()
"الاستراتيجيات" in md        # False — the document contains this word
```

For any downstream index, retrieval or LLM pipeline, the Arabic content is
effectively unreachable.

## Fix

Fold presentation-form runs back to canonical Arabic letters with NFKC, via a
small shared helper (`docling/utils/text_normalization.py`).

The substitution is applied **per matched run**, scoped to the two Arabic ranges,
never to the whole string. That is deliberate: a global NFKC would also rewrite
other scripts — `x²` → `x2`, `H₂O` → `H2O`, and full-width forms. Three tests pin
that those survive.

Applied on all three paths that build text from cells, since each one leaked
independently:

| Path | Content |
|---|---|
| `page_assemble_model.sanitize_text()` | body text |
| `readingorder_model.py` | list items, headings (had no normalization at all) |
| `table_structure_model.py` | table cells |

## Verification

Measured on 25 unique PDFs, A/B against the same branch with the fix on vs off.

**No regressions** — 19 documents that contain no presentation forms produce
**byte-identical output** (SHA-256) with and without the fix, including docling's
16 test PDFs and the three `right_to_left_*` fixtures. The normalization is a
no-op unless the broken encoding is actually present.

**Fixes the affected documents** — 3 Arabic PDFs:

| Document | presentation forms before | after |
|---|---|---|
| corporate strategy report | 2331 | 0 |
| services revenue report | 708 | 0 |
| services performance report | 78 | 0 |



I also audited NFKC behaviour across all 832 codepoints in the two ranges: 488
fold to canonical letters, 101 are left unchanged (Arabic symbols), and 2 are
honorific ligatures that expand to their full phrase (`U+FDFA`, `U+FDFB`), which
is the intended Unicode mapping. `U+FEFF` (BOM), which sits inside the Forms-B
range, is left untouched.

## Notes

- Positive cases came from Arabic documents produced by one organisation, so the
  affected-PDF sample is narrow; the unit tests cover the Unicode mechanics
  generically. Persian/Urdu use the same ranges and should behave identically,
  but I have not tested one.
- Output bytes now differ from the PDF's raw bytes for affected documents.
  `sanitize_text()` already does this for quotes, bullets and Latin ligatures, so
  this does not introduce a new property.
- Related: the output pasted in #2179 exhibits this encoding, though the
  reading-order issue reported there is separate and not addressed here.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.