### PR TITLE
fix(reading-order): register captions absorbed into a picture region

### DIFF
--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -4,6 +4,7 @@ from docling_core.types.doc import (
     DocItemLabel,
     DoclingDocument,
     DocumentOrigin,
+    FloatingItem,
     GroupLabel,
     NodeItem,
     ProvenanceItem,
@@ -107,13 +108,18 @@ class ReadingOrderModel:
                     DocItemLabel.PAGE_FOOTER,
                 ):
                     content_layer = ContentLayer.FURNITURE
-                doc.add_text(
+                new_item = doc.add_text(
                     parent=doc_item,
                     label=c_label,
                     text=c_text,
                     prov=c_prov,
                     content_layer=content_layer,
                 )
+                # Serializers reach captions via `captions`, never by walking children.
+                if c_label == DocItemLabel.CAPTION and isinstance(
+                    doc_item, FloatingItem
+                ):
+                    doc_item.captions.append(new_item.get_ref())
 
     def _create_rich_cell_group(
         self, element: BasePageElement, doc: DoclingDocument, table_item: NodeItem

--- a/tests/test_readingorder_caption_backref.py
+++ b/tests/test_readingorder_caption_backref.py
@@ -1,0 +1,107 @@
+from docling_core.types.doc import (
+    BoundingBox,
+    DocItemLabel,
+    DoclingDocument,
+    GroupLabel,
+    Size,
+)
+from docling_core.types.doc.page import BoundingRectangle, TextCell
+
+from docling.datamodel.base_models import BasePageElement, Cluster, FigureElement
+from docling.models.stages.reading_order.readingorder_model import (
+    ReadingOrderModel,
+    ReadingOrderOptions,
+)
+
+PAGE_NO = 1
+PAGE_HEIGHT = 100.0
+
+
+def _child(cluster_id: int, label: DocItemLabel, text: str) -> Cluster:
+    cell = TextCell(
+        index=cluster_id,
+        rect=BoundingRectangle(
+            r_x0=0, r_y0=0, r_x1=10, r_y1=0, r_x2=10, r_y2=5, r_x3=0, r_y3=5
+        ),
+        text=text,
+        orig=text,
+        from_ocr=False,
+    )
+    return Cluster(
+        id=cluster_id,
+        label=label,
+        bbox=BoundingBox(l=0, t=0, r=10, b=5),
+        cells=[cell],
+    )
+
+
+def _element_with(children: list[Cluster]) -> BasePageElement:
+    return FigureElement(
+        label=DocItemLabel.PICTURE,
+        id=1,
+        page_no=PAGE_NO,
+        cluster=Cluster(
+            id=1,
+            label=DocItemLabel.PICTURE,
+            bbox=BoundingBox(l=0, t=0, r=20, b=20),
+            children=children,
+        ),
+    )
+
+
+def _doc() -> DoclingDocument:
+    doc = DoclingDocument(name="test")
+    doc.add_page(page_no=PAGE_NO, size=Size(width=100.0, height=PAGE_HEIGHT))
+    return doc
+
+
+def _model() -> ReadingOrderModel:
+    return ReadingOrderModel(options=ReadingOrderOptions())
+
+
+def test_caption_child_is_registered_on_the_picture():
+    doc = _doc()
+    picture = doc.add_picture()
+    element = _element_with([_child(2, DocItemLabel.CAPTION, "Figure 1. A caption")])
+
+    _model()._add_child_elements(element, picture, doc)
+
+    assert len(picture.captions) == 1
+    assert picture.captions[0].resolve(doc).text == "Figure 1. A caption"
+
+
+def test_caption_child_survives_markdown_export():
+    doc = _doc()
+    picture = doc.add_picture()
+    element = _element_with([_child(2, DocItemLabel.CAPTION, "Figure 1. A caption")])
+
+    _model()._add_child_elements(element, picture, doc)
+
+    assert "Figure 1. A caption" in doc.export_to_markdown()
+
+
+def test_non_caption_children_are_not_registered_as_captions():
+    doc = _doc()
+    picture = doc.add_picture()
+    element = _element_with(
+        [
+            _child(2, DocItemLabel.TEXT, "axis label noise"),
+            _child(3, DocItemLabel.PAGE_FOOTER, "page 4"),
+        ]
+    )
+
+    _model()._add_child_elements(element, picture, doc)
+
+    assert picture.captions == []
+
+
+def test_caption_child_under_a_group_needs_no_back_reference():
+    # Groups are walked by the serializers, so a caption parented to one is
+    # already reachable. Only floating items need the back-reference.
+    doc = _doc()
+    group = doc.add_group(label=GroupLabel.UNSPECIFIED)
+    element = _element_with([_child(2, DocItemLabel.CAPTION, "Figure 1. A caption")])
+
+    _model()._add_child_elements(element, group, doc)
+
+    assert "Figure 1. A caption" in doc.export_to_markdown()


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

When the layout model places a caption inside a figure region rather than beside it, `_add_child_elements` attaches the caption with `parent` set but never adds it to the picture's `captions` list. Serializers reach captions only through that list — `serialize_captions()` iterates `item.captions`, and nothing walks a floating item's children — so the caption is dropped from Markdown and HTML while still present in the JSON export. There is no warning.

Both kinds occur in the same document:

```
texts[14]  label=caption  parent=#/pictures/1   pictures[1].captions=[#/texts/14]   → emitted
texts[28]  label=caption  parent=#/pictures/2   pictures[2].captions=[]             → dropped
```

## Fix

```python
if c_label == DocItemLabel.CAPTION and isinstance(doc_item, FloatingItem):
    doc_item.captions.append(new_item.get_ref())
```

The `CAPTION` check keeps it narrow: figure regions also absorb OCR fragments of axis labels and in-chart text, all labelled `text`, and those stay excluded. On the document above the change recovers exactly one item and nothing else.

`FloatingItem` scopes it to the only parent whose children are otherwise unreachable. The other two callers of `_add_child_elements` pass a group — the rich-cell fallback for structureless tables, and form/key-value regions — and groups are walked by the serializers, so their children already reach the output either way.

Output is unchanged on all 16 PDFs under `tests/data/pdf/sources/`, so no reference test data needed regeneration.

A caption the layout model labels `text` instead of `caption` is still dropped; that is a classification problem, and widening this condition to reach it would pull the in-chart noise into the body.

## Related

#3708 fixes a neighbouring symptom by reclassifying pictures that are mostly text. I ran that branch here: with `recover_text_in_pictures` on and off the output is identical, since this picture is a genuine chart with a small caption, which that heuristic deliberately leaves alone. The two changes are independent.

**Checklist:**

- [X] Documentation has been updated, if necessary.
- [X] Examples have been added, if necessary.
- [X] Tests have been added, if necessary.
