### PR TITLE
fix(layout): sort cells by position, dedupe overlapping OCR passes

### DIFF
--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -3,7 +3,7 @@ import logging
 import sys
 from collections import defaultdict
 
-from docling_core.types.doc import BoundingBox, DocItemLabel, Size
+from docling_core.types.doc import BoundingBox, CoordOrigin, DocItemLabel, Size
 from docling_core.types.doc.page import TextCell
 from rtree import index
 
@@ -589,15 +589,45 @@ class LayoutPostprocessor:
 
         return current_best if current_best else clusters[0]
 
+    _OVERLAPPING_CELL_IOU_THRESHOLD = 0.5
+
     def _deduplicate_cells(self, cells: list[TextCell]) -> list[TextCell]:
-        """Ensure each cell appears only once, maintaining order of first appearance."""
+        """Ensure each cell appears only once, maintaining order of first appearance.
+
+        Two passes: exact `cell.index` repeats (the same cell reappearing in a
+        combined list, e.g. after a cluster merge), then bbox-IoU overlap. The
+        second pass matters because two different OCR detection passes over the
+        same cluster (e.g. a low-confidence-region retry) index their cells
+        independently of each other — an index-only check never catches a retry
+        pass re-detecting a line the first pass already got, and the cluster's
+        assembled text ends up with that line's content twice.
+        """
         seen_ids = set()
         unique_cells = []
         for cell in cells:
             if cell.index not in seen_ids:
                 seen_ids.add(cell.index)
                 unique_cells.append(cell)
-        return unique_cells
+
+        keep = [True] * len(unique_cells)
+        for i in range(len(unique_cells)):
+            if not keep[i]:
+                continue
+            for j in range(i + 1, len(unique_cells)):
+                if not keep[j]:
+                    continue
+                iou = (
+                    unique_cells[i]
+                    .rect.to_bounding_box()
+                    .intersection_over_union(unique_cells[j].rect.to_bounding_box())
+                )
+                if iou > self._OVERLAPPING_CELL_IOU_THRESHOLD:
+                    if unique_cells[i].confidence >= unique_cells[j].confidence:
+                        keep[j] = False
+                    else:
+                        keep[i] = False
+                        break
+        return [cell for cell, k in zip(unique_cells, keep) if k]
 
     def _assign_cells_to_clusters(
         self, clusters: list[Cluster], min_overlap: float = 0.2
@@ -669,8 +699,67 @@ class LayoutPostprocessor:
         return clusters
 
     def _sort_cells(self, cells: list[TextCell]) -> list[TextCell]:
-        """Sort cells in native reading order."""
-        return sorted(cells, key=lambda c: c.index)
+        """Sort cells in reading order: top-to-bottom rows, left-to-right within a row.
+
+        A cluster's cells aren't necessarily the product of one OCR pass — an engine's
+        low-confidence-region retry (e.g. a rescan of text over a busy background) can
+        emit a second, independently-indexed batch of cells overlapping the same
+        cluster. `c.index` is detection order *within whichever pass produced a cell*,
+        not reading order across passes, so sorting by it can interleave passes
+        nonsensically: an earlier pass's partial-line fragment sorting ahead of (or
+        alongside) the fuller text a later pass recovered for those same lines,
+        assembling into a paragraph with a fragment duplicated at the front and the
+        real text truncated where the fragment's content began.
+
+        Sorting by raw (top, left) position fixes that but overcorrects: two cells on
+        the same visual line almost never share the exact same top coordinate (normal
+        per-glyph/per-word bbox jitter), so a naive position sort can still place a
+        later word ahead of an earlier one on the same row. Cells are bucketed into
+        rows by vertical-center overlap first — same convention as _sort_clusters's
+        "tblr" mode, just tolerant of that jitter — then sorted left-to-right within
+        each row, with `index` only as the final tie-break for cells whose bboxes
+        coincide (or are degenerate), rather than a primary ordering key.
+
+        A bbox's `t`/`b` are only comparable as "top-to-bottom ascending" within one
+        `coord_origin`: TOPLEFT's `t` grows downward (smaller = higher on the page),
+        BOTTOMLEFT's grows upward (larger = higher on the page) — mixing them without
+        normalizing would treat a BOTTOMLEFT cell's top edge as its bottom. `_row_bounds`
+        below negates BOTTOMLEFT's t/b so the same "ascending, top <= bottom" comparisons
+        used for TOPLEFT work for either origin without needing page_height to fully
+        convert coordinate systems.
+        """
+        if not cells:
+            return []
+
+        def _row_bounds(cell: TextCell) -> tuple[float, float]:
+            bbox = cell.rect.to_bounding_box()
+            if bbox.coord_origin == CoordOrigin.BOTTOMLEFT:
+                return -bbox.t, -bbox.b
+            return bbox.t, bbox.b
+
+        by_top = sorted(
+            cells,
+            key=lambda c: (*_row_bounds(c), c.rect.to_bounding_box().l, c.index),
+        )
+
+        rows: list[list[TextCell]] = []
+        row_top = row_bottom = None
+        for cell in by_top:
+            top, bottom = _row_bounds(cell)
+            center = (top + bottom) / 2
+            if row_top is None or not (row_top <= center <= row_bottom):
+                rows.append([])
+                row_top, row_bottom = top, bottom
+            else:
+                row_top = min(row_top, top)
+                row_bottom = max(row_bottom, bottom)
+            rows[-1].append(cell)
+
+        sorted_cells: list[TextCell] = []
+        for row in rows:
+            row.sort(key=lambda c: (c.rect.to_bounding_box().l, c.index))
+            sorted_cells.extend(row)
+        return sorted_cells
 
     def _sort_clusters(
         self, clusters: list[Cluster], mode: str = "id"

--- a/tests/test_layout_postprocessor.py
+++ b/tests/test_layout_postprocessor.py
@@ -1,4 +1,4 @@
-from docling_core.types.doc import DocItemLabel
+from docling_core.types.doc import CoordOrigin, DocItemLabel
 from docling_core.types.doc.page import BoundingRectangle, TextCell
 
 from docling.datamodel.base_models import BoundingBox, Cluster
@@ -44,6 +44,135 @@ def test_sort_cells_uses_native_cell_index_order() -> None:
 
     assert [cell.index for cell in sorted_cells] == [1, 2, 3]
     assert [cell.index for cell in cells] == [3, 1, 2]
+
+
+def _positioned_text_cell(
+    index: int,
+    bbox: tuple,
+    *,
+    text: str = "",
+    confidence: float = 1.0,
+    coord_origin: CoordOrigin = CoordOrigin.TOPLEFT,
+) -> TextCell:
+    left, top, right, bottom = bbox
+    return TextCell(
+        index=index,
+        rect=BoundingRectangle.from_bounding_box(
+            BoundingBox(l=left, t=top, r=right, b=bottom, coord_origin=coord_origin)
+        ),
+        text=text or str(index),
+        orig=text or str(index),
+        confidence=confidence,
+        from_ocr=True,
+    )
+
+
+def test_sort_cells_orders_two_ocr_passes_by_position_not_index() -> None:
+    # Reproduces the real bug: a low-confidence-region retry re-OCRs part of a
+    # paragraph, emitting cells indexed independently of the first pass. Pass A
+    # (indices 0-1) only caught two scattered lines; pass B (higher indices,
+    # 18-26) caught the whole paragraph in the correct top-to-bottom order.
+    # Sorting by index alone put pass A's fragment first regardless of where it
+    # physically belongs; sorting by position must interleave/order by row instead.
+    processor = object.__new__(LayoutPostprocessor)
+    cells = [
+        _positioned_text_cell(0, (35, 577, 341, 586), text="pass-a-line-2-tail"),
+        _positioned_text_cell(1, (35, 629, 195, 638), text="pass-a-last-line"),
+        _positioned_text_cell(18, (35, 562, 350, 576), text="pass-b-line-1"),
+        _positioned_text_cell(21, (35, 588, 360, 601), text="pass-b-line-3"),
+        _positioned_text_cell(23, (35, 601, 341, 614), text="pass-b-line-4"),
+        _positioned_text_cell(26, (35, 614, 332, 627), text="pass-b-line-5"),
+    ]
+
+    sorted_cells = processor._sort_cells(cells)
+
+    assert [cell.text for cell in sorted_cells] == [
+        "pass-b-line-1",
+        "pass-a-line-2-tail",
+        "pass-b-line-3",
+        "pass-b-line-4",
+        "pass-b-line-5",
+        "pass-a-last-line",
+    ]
+
+
+def test_sort_cells_groups_same_row_by_left_x_despite_top_jitter() -> None:
+    # Real per-word bboxes on one visual line never share the exact same top
+    # coordinate. A naive sort by (top, left) would place "beta" before "alpha"
+    # here since 100.4 < 100.6 even though alpha is to the left of beta.
+    processor = object.__new__(LayoutPostprocessor)
+    cells = [
+        _positioned_text_cell(0, (60, 100.6, 100, 110), text="alpha"),
+        _positioned_text_cell(1, (10, 100.4, 55, 110), text="beta"),
+    ]
+
+    sorted_cells = processor._sort_cells(cells)
+
+    assert [cell.text for cell in sorted_cells] == ["beta", "alpha"]
+
+
+def test_sort_cells_orders_rows_top_to_bottom() -> None:
+    processor = object.__new__(LayoutPostprocessor)
+    cells = [
+        _positioned_text_cell(0, (10, 200, 100, 210), text="row-2"),
+        _positioned_text_cell(1, (10, 10, 100, 20), text="row-1"),
+    ]
+
+    sorted_cells = processor._sort_cells(cells)
+
+    assert [cell.text for cell in sorted_cells] == ["row-1", "row-2"]
+
+
+def test_sort_cells_handles_bottomleft_origin() -> None:
+    # BOTTOMLEFT's t grows upward (larger t = higher on the page), the opposite
+    # of TOPLEFT. A sort that assumes TOPLEFT's convention unconditionally would
+    # emit these in reverse.
+    processor = object.__new__(LayoutPostprocessor)
+    cells = [
+        _positioned_text_cell(
+            0,
+            (10, 20, 100, 30),
+            text="lower-on-page",
+            coord_origin=CoordOrigin.BOTTOMLEFT,
+        ),
+        _positioned_text_cell(
+            1,
+            (10, 200, 100, 210),
+            text="higher-on-page",
+            coord_origin=CoordOrigin.BOTTOMLEFT,
+        ),
+    ]
+
+    sorted_cells = processor._sort_cells(cells)
+
+    assert [cell.text for cell in sorted_cells] == ["higher-on-page", "lower-on-page"]
+
+
+def test_deduplicate_cells_drops_overlapping_cell_keeping_higher_confidence() -> None:
+    # Two OCR passes detecting the same physical line produce cells with
+    # near-identical, overlapping bboxes but different (independent) indices.
+    # Only cell.index-based dedup can't catch this; overlap-based dedup must.
+    processor = object.__new__(LayoutPostprocessor)
+    cells = [
+        _positioned_text_cell(0, (35, 577, 341, 586), text="pass-a", confidence=0.4),
+        _positioned_text_cell(20, (35, 574, 338, 589), text="pass-b", confidence=0.9),
+    ]
+
+    result = processor._deduplicate_cells(cells)
+
+    assert [cell.text for cell in result] == ["pass-b"]
+
+
+def test_deduplicate_cells_keeps_non_overlapping_cells() -> None:
+    processor = object.__new__(LayoutPostprocessor)
+    cells = [
+        _positioned_text_cell(0, (10, 10, 100, 20), text="line-1"),
+        _positioned_text_cell(1, (10, 30, 100, 40), text="line-2"),
+    ]
+
+    result = processor._deduplicate_cells(cells)
+
+    assert [cell.text for cell in result] == ["line-1", "line-2"]
 
 
 def test_cross_type_overlaps_removes_picture_coinciding_with_table() -> None:


### PR DESCRIPTION
Body:
Cluster cells were sorted by `c.index` (OCR detection order), which breaks across a low-confidence-region retry's independently-indexed second pass — reproduced on a real scanned doc as a duplicated/displaced fragment in the assembled text.

- `_sort_cells`: bucket into rows by vertical-center overlap, sort left-to-right within each row; `index` only as tie-break. Handles TOPLEFT/BOTTOMLEFT origins.
- `_deduplicate_cells`: also drop re-detected lines via bbox IoU > 0.5, keeping higher-confidence cell.

Unit tests added for both. Reference test data regenerated for all affected test files (layout/OCR-utils) — no reference docs changed.

**Checklist:**
- [x] Tests have been added
- [ ] Documentation — n/a
- [ ] Examples — n/a
