### PR TITLE
fix(layout): normalize hyphenated labels in _build_label_map (#3936)

### DIFF
--- a/docling/models/stages/layout/layout_object_detection_model.py
+++ b/docling/models/stages/layout/layout_object_detection_model.py
@@ -59,8 +59,11 @@ class LayoutObjectDetectionModel(BaseLayoutModel):
         label_map = {}
 
         for label_id, label_name in id_to_label_str.items():
-            # Convert label name to uppercase to match DocItemLabel enum convention
-            label_enum_name = label_name.upper()
+            # Normalize to the DocItemLabel enum member convention: uppercase with
+            # underscores. Model configs emit hyphenated or spaced names such as
+            # "List-item", which .upper() alone leaves as "LIST-ITEM" and fails the
+            # enum name lookup (the member is LIST_ITEM).
+            label_enum_name = label_name.upper().replace("-", "_").replace(" ", "_")
             try:
                 label_map[label_id] = DocItemLabel[label_enum_name]
             except KeyError:

--- a/tests/test_layout_object_detection_labels.py
+++ b/tests/test_layout_object_detection_labels.py
@@ -1,0 +1,30 @@
+"""Regression coverage for LayoutObjectDetectionModel label normalization."""
+
+from docling_core.types.doc import DocItemLabel
+
+from docling.models.stages.layout.layout_object_detection_model import (
+    LayoutObjectDetectionModel,
+)
+
+
+class _HyphenatedLabelEngine:
+    """Engine stub whose config id2label uses hyphenated / spaced names."""
+
+    def get_label_mapping(self):
+        return {0: "List-item", 1: "Section-header", 2: "Key value region"}
+
+
+def test_build_label_map_normalizes_hyphenated_and_spaced_labels():
+    # Model configs expose labels like "List-item"; .upper() alone yields
+    # "LIST-ITEM", which is not a DocItemLabel member name (LIST_ITEM is), so
+    # the enum lookup used to raise. Hyphens and spaces must become underscores.
+    model = LayoutObjectDetectionModel.__new__(LayoutObjectDetectionModel)
+    model.engine = _HyphenatedLabelEngine()
+
+    label_map = model._build_label_map()
+
+    assert label_map == {
+        0: DocItemLabel.LIST_ITEM,
+        1: DocItemLabel.SECTION_HEADER,
+        2: DocItemLabel.KEY_VALUE_REGION,
+    }


### PR DESCRIPTION
Fixes #3936.

### Problem
`LayoutObjectDetectionModel._build_label_map` builds the id→`DocItemLabel` mapping by upper-casing each engine label name and looking it up as an enum **member name**:

```python
label_enum_name = label_name.upper()          # "List-item" -> "LIST-ITEM"
label_map[label_id] = DocItemLabel[label_enum_name]
```

Layout model configs expose hyphenated / spaced `id2label` names (`"List-item"`, `"Section-header"`, …). `.upper()` leaves the hyphen in place, so `DocItemLabel["LIST-ITEM"]` raises `KeyError` (the member is `LIST_ITEM`), which the `except` re-raises as a `RuntimeError` and aborts the whole conversion. This is the regression reported since v2.118:

```
KeyError: 'LIST-ITEM'
```

### Fix
Normalize hyphens and spaces to underscores before the enum lookup — the same normalization the pre-refactor `LayoutModel` path applied:

```python
label_enum_name = label_name.upper().replace("-", "_").replace(" ", "_")
```

### Test
Adds a focused regression test that drives `_build_label_map` with a stub engine returning hyphenated/spaced labels and asserts they resolve to `DocItemLabel.LIST_ITEM` / `SECTION_HEADER` / `KEY_VALUE_REGION`. It fails (`RuntimeError`) before the change and passes after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
