### PR TITLE
fix(ocr): recover mixed native/OCR content dropped by region selection

### DIFF
--- a/docling/models/base_ocr_model.py
+++ b/docling/models/base_ocr_model.py
@@ -45,6 +45,11 @@ class BaseOcrModel(BasePageModel, BaseModelWithOptions):
 
     DEFAULT_DILATION_SIZE = 20
 
+    # A layout cluster is skipped for OCR only once native PDF text covers at least
+    # this fraction of its area. Below that, the cluster is treated as needing OCR
+    # even though some native text overlaps it (see `_find_pdf_aware_layout_ocr_rects`).
+    NATIVE_TEXT_COVERAGE_SKIP_THRESHOLD = 0.9
+
     def __init__(
         self,
         *,
@@ -108,10 +113,19 @@ class BaseOcrModel(BasePageModel, BaseModelWithOptions):
         Compute the OCR rects from the layout clusters of a programmatic PDF.
 
         1. Start from the layout clusters.
-        2. Eliminate clusters that intersect exclusively with programmatic text PDF cells
-           The following clusters therefore remain:
-           - Clusters without any overlapping PDF cell.
+        2. Eliminate clusters that are (almost) fully covered by programmatic text PDF
+           cells. The following clusters therefore remain and get OCR'd:
+           - Clusters without any overlapping PDF text cell.
            - Clusters with at least one overlapping non-text region (e.g. bitmap, shape).
+           - Clusters where native PDF text covers only part of the cluster's area
+             (below `NATIVE_TEXT_COVERAGE_SKIP_THRESHOLD`) - e.g. a list item whose
+             bullet is native text but whose label is a separately rasterized or
+             stamped image with no native text of its own. Skipping the whole
+             cluster just because *some* native text overlaps it would silently
+             drop that image-only content, since it has no native text and would
+             never be OCR'd otherwise. Re-including such a cluster is safe:
+             `_merge_ocr_and_pdf_cells` already prefers native PDF cells over OCR
+             cells wherever they overlap, so this only recovers the gap.
         3. Deduplicate the remaining cluster bboxes.
         """
         if page.predictions.layout is None:
@@ -123,7 +137,8 @@ class BaseOcrModel(BasePageModel, BaseModelWithOptions):
         p = index.Property()
         p.dimension = 2
         text_index = index.Index(properties=p)
-        for i, text_cell in enumerate(page._backend.get_text_cells()):
+        text_cells = list(page._backend.get_text_cells())
+        for i, text_cell in enumerate(text_cells):
             text_index.insert(i, text_cell.rect.to_bounding_box().as_tuple())
 
         # Create index for the non-text PDF cells
@@ -135,14 +150,35 @@ class BaseOcrModel(BasePageModel, BaseModelWithOptions):
         ocr_rects: list[BoundingBox] = []
         for cluster in page.predictions.layout.clusters:
             cluster_bbox_tuple = cluster.bbox.as_tuple()
-            text_overlaps = list(text_index.intersection(cluster_bbox_tuple))
+            text_overlap_ids = list(text_index.intersection(cluster_bbox_tuple))
             non_text_overlaps = list(non_text_index.intersection(cluster_bbox_tuple))
 
-            # Get the clusters that overlap with non-txt PDF cells
+            # Get the clusters that overlap with non-text PDF cells
             if len(non_text_overlaps) > 0:
                 ocr_rects.append(cluster.bbox)
-            # And the ones that don't overlap with any PDF cells
-            elif len(text_overlaps) == 0:
+                continue
+
+            # And the ones that don't overlap with any PDF text cells
+            if len(text_overlap_ids) == 0:
+                ocr_rects.append(cluster.bbox)
+                continue
+
+            # Some native PDF text overlaps this cluster. Only skip OCR once that
+            # text covers most of the cluster's area - otherwise any uncovered
+            # portion has no native text and no OCR, and is silently lost.
+            cluster_area = cluster.bbox.area()
+            if cluster_area <= 0:
+                continue
+            covered_area = sum(
+                cluster.bbox.intersection_area_with(
+                    text_cells[i].rect.to_bounding_box()
+                )
+                for i in text_overlap_ids
+            )
+            if (
+                covered_area / cluster_area
+                < BaseOcrModel.NATIVE_TEXT_COVERAGE_SKIP_THRESHOLD
+            ):
                 ocr_rects.append(cluster.bbox)
 
         # Deduplicate the surviving cluster bboxes.

--- a/tests/test_base_ocr_model.py
+++ b/tests/test_base_ocr_model.py
@@ -1,0 +1,150 @@
+from collections.abc import Iterable
+from typing import Type
+
+from docling_core.types.doc import CoordOrigin, DocItemLabel
+
+from docling.datamodel.base_models import (
+    BoundingBox,
+    Cluster,
+    LayoutPrediction,
+    Page,
+    Size,
+)
+from docling.datamodel.document import ConversionResult
+from docling.datamodel.pipeline_options import OcrOptions
+from docling.models.base_ocr_model import BaseOcrModel
+
+
+class _DummyOcrModel(BaseOcrModel):
+    """Minimal concrete subclass, only to satisfy ABC instantiation."""
+
+    def __call__(
+        self, conv_res: ConversionResult, page_batch: Iterable[Page]
+    ) -> Iterable[Page]:
+        yield from page_batch
+
+    @classmethod
+    def get_options_type(cls) -> Type[OcrOptions]:
+        return OcrOptions
+
+
+class _FakeRect:
+    def __init__(self, bbox: BoundingBox) -> None:
+        self._bbox = bbox
+
+    def to_bounding_box(self) -> BoundingBox:
+        return self._bbox
+
+
+class _FakeTextCell:
+    def __init__(self, bbox: BoundingBox) -> None:
+        self.rect = _FakeRect(bbox)
+        self.text = "x"
+
+
+class _FakeBackend:
+    def __init__(
+        self, text_cells: list[_FakeTextCell], bitmap_rects: list[BoundingBox]
+    ) -> None:
+        self._text_cells = text_cells
+        self._bitmap_rects = bitmap_rects
+
+    def is_valid(self) -> bool:
+        return True
+
+    def get_text_cells(self) -> list[_FakeTextCell]:
+        return self._text_cells
+
+    def get_bitmap_rects(self) -> list[BoundingBox]:
+        return self._bitmap_rects
+
+
+def _cluster(cid: int, bbox: tuple, confidence: float = 0.8) -> Cluster:
+    left, top, right, bottom = bbox
+    return Cluster(
+        id=cid,
+        label=DocItemLabel.TEXT,
+        bbox=BoundingBox(
+            l=left, t=top, r=right, b=bottom, coord_origin=CoordOrigin.TOPLEFT
+        ),
+        confidence=confidence,
+    )
+
+
+def _bbox(coords: tuple) -> BoundingBox:
+    left, top, right, bottom = coords
+    return BoundingBox(
+        l=left, t=top, r=right, b=bottom, coord_origin=CoordOrigin.TOPLEFT
+    )
+
+
+def _make_model() -> _DummyOcrModel:
+    model = object.__new__(_DummyOcrModel)
+    # Bypass `_deduplicate_rects`'s dilation/rasterization: this test targets the
+    # per-cluster inclusion decision in `_find_pdf_aware_layout_ocr_rects`, not the
+    # separate blob-merging step, so an identity passthrough keeps the returned
+    # rects directly comparable to the input clusters.
+    model._deduplicate_rects = lambda size, rects, dilation_size=0: (0.0, list(rects))  # type: ignore[method-assign]
+    return model
+
+
+def _make_page(clusters: list[Cluster], backend: _FakeBackend) -> Page:
+    page = Page(page_no=1)
+    page.size = Size(width=600, height=800)
+    page.predictions.layout = LayoutPrediction(clusters=clusters)
+    page._backend = backend  # type: ignore[assignment]
+    return page
+
+
+def test_cluster_mostly_covered_by_native_text_is_excluded() -> None:
+    # A cluster whose native PDF text spans (almost) its whole area needs no OCR.
+    cluster = _cluster(1, (10, 10, 190, 30))
+    text_cell = _FakeTextCell(_bbox((10, 10, 190, 30)))
+    backend = _FakeBackend(text_cells=[text_cell], bitmap_rects=[])
+    page = _make_page([cluster], backend)
+
+    model = _make_model()
+    ocr_rects = model._find_pdf_aware_layout_ocr_rects(page)
+
+    assert ocr_rects == []
+
+
+def test_cluster_partially_covered_by_native_text_is_still_ocrd() -> None:
+    # Regression test for the "silent complete drop" / "missing mid-paragraph
+    # clause" bugs: a list item whose bullet is native PDF text but whose
+    # remaining label is a separately rasterized/stamped image (no native text of
+    # its own) must still be sent to OCR for the uncovered portion, instead of
+    # being excluded wholesale just because *some* native text overlaps it.
+    cluster = _cluster(1, (10, 60, 190, 80))
+    bullet_cell = _FakeTextCell(_bbox((10, 60, 30, 80)))  # covers ~11% of the area
+    backend = _FakeBackend(text_cells=[bullet_cell], bitmap_rects=[])
+    page = _make_page([cluster], backend)
+
+    model = _make_model()
+    ocr_rects = model._find_pdf_aware_layout_ocr_rects(page)
+
+    assert ocr_rects == [cluster.bbox]
+
+
+def test_cluster_without_any_native_text_is_ocrd() -> None:
+    cluster = _cluster(1, (10, 110, 190, 130))
+    backend = _FakeBackend(text_cells=[], bitmap_rects=[])
+    page = _make_page([cluster], backend)
+
+    model = _make_model()
+    ocr_rects = model._find_pdf_aware_layout_ocr_rects(page)
+
+    assert ocr_rects == [cluster.bbox]
+
+
+def test_cluster_overlapping_bitmap_is_ocrd_even_with_full_text_coverage() -> None:
+    cluster = _cluster(1, (10, 160, 190, 180))
+    text_cell = _FakeTextCell(_bbox((10, 160, 190, 180)))
+    bitmap = _bbox((10, 160, 190, 180))
+    backend = _FakeBackend(text_cells=[text_cell], bitmap_rects=[bitmap])
+    page = _make_page([cluster], backend)
+
+    model = _make_model()
+    ocr_rects = model._find_pdf_aware_layout_ocr_rects(page)
+
+    assert ocr_rects == [cluster.bbox]


### PR DESCRIPTION
`_find_pdf_aware_layout_ocr_rects` excluded an entire layout cluster from OCR whenever it overlapped *any* native PDF text cell, even if that text covered only a small part of the cluster. This silently drops content in clusters that mix native PDF text with separately rasterized or stamped regions — for example a list item whose bullet is native text but whose label is an image with no native text of its own, or a paragraph where one line is native and another isn't.

This PR replaces the any-overlap check with an area-coverage-fraction threshold: a cluster is now skipped only once native text covers most of its area (90%+). Below that, the cluster is still sent to OCR. This is safe because `_merge_ocr_and_pdf_cells` already prefers native PDF cells over OCR cells wherever they overlap, so recovering these clusters only fills the previously-dropped gap — it doesn't introduce duplicate content.

**How this was found and verified:**
Traced from a real-world PDF where 4 of 8 list items and a mid-paragraph clause were silently dropped from the recovered text. Confirmed via direct instrumentation that:
- The layout model *did* propose correctly-sized cluster bboxes (not a layout/detection issue).
- OCR was never invoked on the affected region at all, because `_find_pdf_aware_layout_ocr_rects` excluded the whole cluster due to a single small native-text overlap (the bullet character, or one native line in a multi-line paragraph cluster).
- Raising `EasyOcrOptions.confidence_threshold` to 0 made no difference, ruling out an OCR-quality/confidence explanation.

Checked docling's own reference test documents for regressions: `ocr_test.pdf` and `webp-test.webp` are the only two fixtures in the test suite that exercise `easyocr` + `PDF_AWARE_LAYOUT_REGIONS` (the affected mode) — both produce byte-identical output before and after this change, so no reference data needed regenerating.

**Checklist:**

- [ ] Documentation has been updated, if necessary. — not applicable, no public API change.
- [ ] Examples have been added, if necessary. — not applicable.
- [x] Tests have been added, if necessary. — `tests/test_base_ocr_model.py`, 4 unit tests covering full/partial/zero native-text coverage and the bitmap-overlap case.