### PR TITLE
feat: add opt-in table cell formula enrichment stage

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1944,6 +1944,18 @@ class PdfPipelineOptions(PaginatedPipelineOptions):
             )
         ),
     ] = False
+
+    do_table_cell_formula_enrichment: Annotated[
+        bool,
+        Field(
+            description=(
+                "If enabled, formula recognition is run over table cells, "
+                "emitting rich table cells whose `ref` points to the recognised "
+                "content. Requires do_formula_enrichment. Disabled by default: "
+                "adds per-cell inference cost."
+            )
+        ),
+    ] = False
     force_backend_text: Annotated[
         bool,
         Field(

--- a/docling/models/stages/code_formula/table_cell_formula_vlm_model.py
+++ b/docling/models/stages/code_formula/table_cell_formula_vlm_model.py
@@ -1,0 +1,83 @@
+import logging
+from collections.abc import Iterable
+from typing import List, Optional, Tuple
+
+from docling_core.types.doc import DoclingDocument, NodeItem, TableItem
+from PIL import Image
+from pydantic import BaseModel, ConfigDict
+
+from docling.datamodel.document import ConversionResult
+from docling.models.base_model import GenericEnrichmentModel
+
+_log = logging.getLogger(__name__)
+
+
+class TableFormulaEnrichmentElement(BaseModel):
+    """A table together with the cell images that may contain formulas."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    item: TableItem
+    cell_crops: List[Tuple[int, Image.Image]]
+
+
+class TableCellFormulaVlmModel(GenericEnrichmentModel[TableFormulaEnrichmentElement]):
+    """Runs formula recognition over PDF table cells.
+
+    ``TableItem`` is yielded by ``DoclingDocument.iterate_items()``, so this
+    stage receives the table and descends into ``data.table_cells`` itself.
+    No change to the enrichment loop or to existing models is required.
+
+    Cell crops cannot reuse ``BaseItemAndImageEnrichmentModel``: a ``TableCell``
+    carries a ``bbox`` but no ``prov``, and is not a ``DocItem``.
+    """
+
+    # Aligned with CodeFormulaVlmModel so crops match the model's training data.
+    images_scale = 1.67  # 120 dpi
+    expansion_factor = 0.18
+    elements_batch_size = 2
+
+    def __init__(self, *, enabled: bool) -> None:
+        self.enabled = enabled
+
+    def is_processable(self, doc: DoclingDocument, element: NodeItem) -> bool:
+        return self.enabled and isinstance(element, TableItem)
+
+    def prepare_element(
+        self, conv_res: ConversionResult, element: NodeItem
+    ) -> Optional[TableFormulaEnrichmentElement]:
+        if not self.is_processable(doc=conv_res.document, element=element):
+            return None
+        assert isinstance(element, TableItem)
+
+        if not element.prov:
+            return None  # no page geometry: nothing to crop
+
+        page_no = element.prov[0].page_no
+        page_ix = page_no - conv_res.pages[0].page_no
+        page = conv_res.pages[page_ix]
+
+        crops: List[Tuple[int, Image.Image]] = []
+        for idx, cell in enumerate(element.data.table_cells):
+            if cell.bbox is None:
+                continue
+            bbox = cell.bbox.expand_by_scale(
+                self.expansion_factor, self.expansion_factor
+            )
+            image = page.get_image(scale=self.images_scale, cropbox=bbox)
+            if image is not None:
+                crops.append((idx, image))
+
+        if not crops:
+            return None
+        return TableFormulaEnrichmentElement(item=element, cell_crops=crops)
+
+    def __call__(
+        self,
+        doc: DoclingDocument,
+        element_batch: Iterable[TableFormulaEnrichmentElement],
+    ) -> Iterable[NodeItem]:
+        # Plumbing only: formula detection and rich-cell construction are not
+        # implemented yet, pending design confirmation on the linked issue.
+        for element in element_batch:
+            yield element.item

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -59,6 +59,9 @@ from docling.models.factories import (
 from docling.models.stages.code_formula.code_formula_vlm_model import (
     CodeFormulaVlmModel,
 )
+from docling.models.stages.code_formula.table_cell_formula_vlm_model import (
+    TableCellFormulaVlmModel,
+)
 from docling.models.stages.heading_hierarchy.heading_hierarchy_model import (
     HeadingHierarchyModel,
 )
@@ -661,6 +664,9 @@ class StandardPdfPipeline(ConvertPipeline):
                 accelerator_options=self.pipeline_options.accelerator_options,
                 enable_remote_services=self.pipeline_options.enable_remote_services,
             ),
+            TableCellFormulaVlmModel(
+                enabled=self.pipeline_options.do_table_cell_formula_enrichment,
+            ),
             *self.enrichment_pipe,
         ]
 
@@ -671,6 +677,7 @@ class StandardPdfPipeline(ConvertPipeline):
                 self.pipeline_options.do_picture_classification,
                 self.pipeline_options.do_picture_description,
                 self.pipeline_options.do_chart_extraction,
+                self.pipeline_options.do_table_cell_formula_enrichment,
             )
         )
 


### PR DESCRIPTION
Draft for #3828. Plumbing only — seeking design confirmation before implementing detection and rich-cell construction.

What's here

TableCellFormulaVlmModel, a new GenericEnrichmentModel that accepts TableItem from iterate_items() and descends into data.table_cells in its own prepare_element.
do_table_cell_formula_enrichment pipeline option, default off.
Wired into StandardPdfPipeline.enrichment_pipe and added to the keep_backend set.

What's deliberately not here

The VLM call and the pre-filter that gates it.
Rich-cell construction (RichTableCell + group + ref).

Why this shape

TableItem is already yielded by iterate_items(), so descending into cells inside a dedicated stage needs no change to _enrich_document and doesn't widen the contract for existing enrichment models. Cell crops can't reuse BaseItemAndImageEnrichmentModel, since a TableCell has a bbox but no prov and isn't a DocItem — hence the separate prepared-element type.

Open questions (from the issue thread)

Measuring the layout stage on TR 38.901 Table 7.4.1-1 showed 0 formula clusters — the whole region is labelled table — so cluster-overlap detection isn't available and a text pre-filter is required. @Thecave3 has argued for recall over precision given the option is opt-in, and confirmed a ref pointing at a group with ordered children (mirroring html_backend.py) is what downstream consumers want, rather than a single FormulaItem.

Before implementing that, I'd like confirmation that this is the shape you want — separate opt-in stage vs. generalising the enrichment descent.

Local test run matches the pre-change baseline on Windows (6 pre-existing failures, unrelated: path-separator assertions and one MSVC dependency).