### PR TITLE
fix: Fixed HTML render to stop implicit file requests.

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -11,6 +11,7 @@ from io import BytesIO
 from pathlib import Path
 from typing import Any, Final, Iterator, Literal, Optional, Union, cast
 from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 from docling_core.types.doc import (
     BoundingBox,
@@ -590,10 +591,43 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
             return value
         return Path(value).resolve().as_uri()
 
+    def _get_browser_local_base_path(self) -> Optional[Path]:
+        if isinstance(self.path_or_stream, Path):
+            return self.path_or_stream.resolve()
+
+        if self.base_path and ImageResourceLoader.is_local_path(self.base_path):
+            return Path(self.base_path).resolve()
+
+        return None
+
+    def _is_allowed_browser_file_request(self, request_url: str) -> bool:
+        local_base_path = self._get_browser_local_base_path()
+        if local_base_path is not None and request_url == local_base_path.as_uri():
+            return True
+
+        if not self.options.enable_local_fetch or local_base_path is None:
+            return False
+
+        requested_path = Path(url2pathname(urlparse(request_url).path)).resolve()
+        return requested_path.is_relative_to(local_base_path.parent)
+
     def _get_browser_request_block_reason(self, request_url: str) -> Optional[str]:
         parsed = urlparse(request_url)
         scheme = (parsed.scheme or "").lower()
-        if scheme in {"file", "data", "about", "blob"}:
+        if scheme == "file":
+            if self._is_allowed_browser_file_request(request_url):
+                return None
+            if not self.options.enable_local_fetch:
+                return (
+                    "local fetch is disabled "
+                    "(set options.enable_local_fetch=True to allow)"
+                )
+            return (
+                "local file access is limited to the source document directory "
+                "during HTML rendering"
+            )
+
+        if scheme in {"data", "about", "blob"}:
             return None
 
         if ImageResourceLoader.is_remote_url(request_url):

--- a/tests/test_backend_html.py
+++ b/tests/test_backend_html.py
@@ -1207,12 +1207,15 @@ def _make_html_backend(options=None):
 def test_browser_request_block_reason_policy():
     """Render-mode request filtering: scheme allow-list plus remote-fetch gating."""
     backend = _make_html_backend(HTMLBackendOptions(enable_remote_fetch=False))
+    source_file_url = Path(backend.path_or_stream).resolve().as_uri()
 
-    # data:/file: schemes are always allowed during rendering
+    # data: remains allow-listed, and the source document itself must remain renderable
     assert (
         backend._get_browser_request_block_reason("data:image/png;base64,AAAA") is None
     )
-    assert backend._get_browser_request_block_reason("file:///tmp/page.html") is None
+    assert backend._get_browser_request_block_reason(source_file_url) is None
+    reason = backend._get_browser_request_block_reason("file:///tmp/page.html")
+    assert reason is not None and "local fetch is disabled" in reason
 
     # remote requests are blocked while remote fetch is disabled
     reason = backend._get_browser_request_block_reason("http://example.com/img.png")
@@ -1228,6 +1231,20 @@ def test_browser_request_block_reason_policy():
     assert (
         backend._get_browser_request_block_reason("http://example.com/img.png") is None
     )
+
+
+def test_browser_request_block_reason_local_fetch_confined_to_source_directory():
+    html_path = Path("./tests/data/html/sources/example_01.html").resolve()
+    backend = _make_html_backend(
+        HTMLBackendOptions(enable_local_fetch=True, source_uri=html_path)
+    )
+
+    allowed_file_url = (html_path.parent / "example_image_01.png").resolve().as_uri()
+    assert backend._get_browser_request_block_reason(allowed_file_url) is None
+
+    blocked_file_url = (html_path.parent.parent.parent / "README.md").resolve().as_uri()
+    reason = backend._get_browser_request_block_reason(blocked_file_url)
+    assert reason is not None and "source document directory" in reason
 
 
 def test_coerce_base_url():


### PR DESCRIPTION
HTML render fix to stop implicitly allowing arbitrary file requests.
Render mode now:
- Always allows the main local HTML document itself to load
- Blocks other local file requests unless enable_local_fetch=True
- When local fetch is enabled, confines file sub-resources to the source document’s directory

<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
