### PR TITLE
fix(odt): populate TextItem.hyperlink for anchor elements

### DIFF
--- a/docling/backend/opendocument_backend.py
+++ b/docling/backend/opendocument_backend.py
@@ -48,6 +48,7 @@ from docling_core.types.doc import (
     TabularChartMetaField,
 )
 from PIL import Image as PILImage
+from pydantic import AnyUrl, ValidationError
 from typing_extensions import override
 
 from docling.backend.abstract_backend import (
@@ -105,6 +106,16 @@ class _OdfListState:
 class _OdfTextRun:
     text: str
     formatting: Formatting | None = None
+    hyperlink: AnyUrl | Path | None = None
+
+
+def _odf_hyperlink_from_href(href: str | None) -> AnyUrl | Path | None:
+    if not href:
+        return None
+    try:
+        return AnyUrl(href)
+    except ValidationError:
+        return Path(href)
 
 
 def _load_odf_document(
@@ -302,32 +313,46 @@ def _odf_text_runs(
     element: Any,
     odf_obj: OdfDocument | None,
     inherited_formatting: Formatting | None = None,
+    inherited_hyperlink: AnyUrl | Path | None = None,
 ) -> list[_OdfTextRun]:
     style_name = element.attributes.get("text:style-name")
     formatting = _formatting_from_odf_text_style(
         odf_obj, style_name, inherited_formatting
     )
     tag = element.tag
+    hyperlink = (
+        _odf_hyperlink_from_href(element.attributes.get("xlink:href"))
+        if tag == "text:a"
+        else inherited_hyperlink
+    )
     if tag == "text:line-break":
-        return [_OdfTextRun(text=element.text or "\n", formatting=formatting)]
+        return [
+            _OdfTextRun(
+                text=element.text or "\n", formatting=formatting, hyperlink=hyperlink
+            )
+        ]
     if tag == "text:tab":
-        return [_OdfTextRun(text="\t", formatting=formatting)]
+        return [_OdfTextRun(text="\t", formatting=formatting, hyperlink=hyperlink)]
 
     runs: list[_OdfTextRun] = []
     children = element.children
     text = element.text
     if text:
-        runs.append(_OdfTextRun(text=text, formatting=formatting))
+        runs.append(_OdfTextRun(text=text, formatting=formatting, hyperlink=hyperlink))
 
     for child in children:
-        runs.extend(_odf_text_runs(child, odf_obj, formatting))
+        runs.extend(_odf_text_runs(child, odf_obj, formatting, hyperlink))
         if child.tail:
-            runs.append(_OdfTextRun(text=child.tail, formatting=formatting))
+            runs.append(
+                _OdfTextRun(text=child.tail, formatting=formatting, hyperlink=hyperlink)
+            )
 
     if not runs and not children:
         inner_text = element.inner_text
         if inner_text:
-            runs.append(_OdfTextRun(text=inner_text, formatting=formatting))
+            runs.append(
+                _OdfTextRun(text=inner_text, formatting=formatting, hyperlink=hyperlink)
+            )
 
     return runs
 
@@ -337,10 +362,18 @@ def _normalize_odf_text_runs(runs: list[_OdfTextRun]) -> list[_OdfTextRun]:
     for run in runs:
         if run.text == "":
             continue
-        if merged_runs and merged_runs[-1].formatting == run.formatting:
+        if (
+            merged_runs
+            and merged_runs[-1].formatting == run.formatting
+            and merged_runs[-1].hyperlink == run.hyperlink
+        ):
             merged_runs[-1].text += run.text
         else:
-            merged_runs.append(_OdfTextRun(text=run.text, formatting=run.formatting))
+            merged_runs.append(
+                _OdfTextRun(
+                    text=run.text, formatting=run.formatting, hyperlink=run.hyperlink
+                )
+            )
 
     while merged_runs and merged_runs[0].text.strip() == "":
         merged_runs.pop(0)
@@ -378,6 +411,7 @@ def _add_odf_text_runs(
             text=runs[0].text,
             content_layer=content_layer,
             formatting=runs[0].formatting,
+            hyperlink=runs[0].hyperlink,
         )
 
     inline_group = doc.add_inline_group(parent=parent, content_layer=content_layer)
@@ -388,6 +422,7 @@ def _add_odf_text_runs(
             text=run.text,
             content_layer=content_layer,
             formatting=run.formatting,
+            hyperlink=run.hyperlink,
         )
     return inline_group
 
@@ -413,6 +448,7 @@ def _add_odf_heading(
             level=max(1, level),
             content_layer=content_layer,
             formatting=runs[0].formatting,
+            hyperlink=runs[0].hyperlink,
         )
         return
 
@@ -424,6 +460,7 @@ def _add_odf_heading(
             level=max(1, level),
             content_layer=content_layer,
             formatting=run.formatting,
+            hyperlink=run.hyperlink,
         )
 
 

--- a/docling/backend/opendocument_backend.py
+++ b/docling/backend/opendocument_backend.py
@@ -17,6 +17,8 @@ Known gaps to improve:
 from __future__ import annotations
 
 import logging
+import re
+from collections.abc import Callable
 from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
@@ -109,12 +111,23 @@ class _OdfTextRun:
     hyperlink: AnyUrl | Path | None = None
 
 
+_ODF_HREF_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
+
+
 def _odf_hyperlink_from_href(href: str | None) -> AnyUrl | Path | None:
+    if href is None:
+        return None
+    href = href.strip()
     if not href:
         return None
     try:
         return AnyUrl(href)
     except ValidationError:
+        if _ODF_HREF_SCHEME_RE.match(href):
+            # Looks like an attempted absolute URL (has a scheme) that failed
+            # to parse, e.g. a malformed host. Don't guess by treating it as
+            # a filesystem path.
+            return None
         return Path(href)
 
 
@@ -368,12 +381,18 @@ def _normalize_odf_text_runs(runs: list[_OdfTextRun]) -> list[_OdfTextRun]:
             and merged_runs[-1].hyperlink == run.hyperlink
         ):
             merged_runs[-1].text += run.text
-        else:
-            merged_runs.append(
-                _OdfTextRun(
-                    text=run.text, formatting=run.formatting, hyperlink=run.hyperlink
-                )
-            )
+            continue
+
+        text = run.text
+        if merged_runs and merged_runs[-1].hyperlink != run.hyperlink:
+            # A hyperlink boundary is a hard edge: strip the whitespace right
+            # at the boundary so it doesn't double up with the separator the
+            # markdown/inline serializer already inserts between runs.
+            merged_runs[-1].text = merged_runs[-1].text.rstrip()
+            text = text.lstrip()
+        merged_runs.append(
+            _OdfTextRun(text=text, formatting=run.formatting, hyperlink=run.hyperlink)
+        )
 
     while merged_runs and merged_runs[0].text.strip() == "":
         merged_runs.pop(0)
@@ -427,6 +446,47 @@ def _add_odf_text_runs(
     return inline_group
 
 
+def _add_odf_rich_block(
+    doc: DoclingDocument,
+    runs: list[_OdfTextRun],
+    *,
+    add_block: Callable[..., NodeItem],
+    parent: NodeItem | None,
+    content_layer: ContentLayer | None,
+) -> NodeItem | None:
+    """Add a heading/title-like block from text runs.
+
+    A single run becomes the block directly. Multiple runs (e.g. a heading
+    with a hyperlink or mixed formatting in the middle) become one empty
+    block wrapping an InlineGroup of TEXT runs, so the block stays a single
+    semantic item instead of fragmenting into several headings/titles.
+    """
+    runs = _normalize_odf_text_runs(runs)
+    if not runs:
+        return None
+    if len(runs) == 1:
+        return add_block(
+            text=runs[0].text,
+            parent=parent,
+            content_layer=content_layer,
+            formatting=runs[0].formatting,
+            hyperlink=runs[0].hyperlink,
+        )
+
+    block = add_block(text="", parent=parent, content_layer=content_layer)
+    inline_group = doc.add_inline_group(parent=block, content_layer=content_layer)
+    for run in runs:
+        doc.add_text(
+            label=DocItemLabel.TEXT,
+            parent=inline_group,
+            text=run.text,
+            content_layer=content_layer,
+            formatting=run.formatting,
+            hyperlink=run.hyperlink,
+        )
+    return block
+
+
 def _add_odf_heading(
     doc: DoclingDocument,
     element: Header,
@@ -435,33 +495,15 @@ def _add_odf_heading(
     content_layer: ContentLayer | None,
     odf_obj: OdfDocument | None,
 ) -> None:
-    level = element.get_attribute_integer("text:outline-level") or 1
+    level = max(1, element.get_attribute_integer("text:outline-level") or 1)
     runs = _odf_text_runs(element, odf_obj)
-    runs = _normalize_odf_text_runs(runs)
-    text = _odf_text_from_runs(runs)
-    if not text:
-        return
-    if len(runs) == 1:
-        doc.add_heading(
-            parent=parent,
-            text=text,
-            level=max(1, level),
-            content_layer=content_layer,
-            formatting=runs[0].formatting,
-            hyperlink=runs[0].hyperlink,
-        )
-        return
-
-    inline_group = doc.add_inline_group(parent=parent, content_layer=content_layer)
-    for run in runs:
-        doc.add_heading(
-            parent=inline_group,
-            text=run.text,
-            level=max(1, level),
-            content_layer=content_layer,
-            formatting=run.formatting,
-            hyperlink=run.hyperlink,
-        )
+    _add_odf_rich_block(
+        doc,
+        runs,
+        add_block=lambda **kwargs: doc.add_heading(level=level, **kwargs),
+        parent=parent,
+        content_layer=content_layer,
+    )
 
 
 def _odf_paragraph_style_names(
@@ -520,23 +562,21 @@ def _add_odf_paragraph(
 
     style_names = _odf_paragraph_style_names(odf_obj, element)
     if "Title" in style_names:
-        _add_odf_text_runs(
+        _add_odf_rich_block(
             doc,
             runs,
-            label=DocItemLabel.TITLE,
+            add_block=lambda **kwargs: doc.add_text(label=DocItemLabel.TITLE, **kwargs),
             parent=parent,
             content_layer=content_layer,
         )
     elif "Subtitle" in style_names:
-        text = _odf_text_from_runs(runs)
-        if text:
-            doc.add_heading(
-                parent=parent,
-                text=text,
-                level=1,
-                content_layer=content_layer,
-                formatting=runs[0].formatting if len(runs) == 1 else None,
-            )
+        _add_odf_rich_block(
+            doc,
+            runs,
+            add_block=lambda **kwargs: doc.add_heading(level=1, **kwargs),
+            parent=parent,
+            content_layer=content_layer,
+        )
     else:
         _add_odf_text_runs(
             doc,
@@ -1193,9 +1233,13 @@ def _add_odf_list(
                 marker=marker,
                 enumerated=current_enumerated,
                 parent=list_group,
-                text=text,
+                # Prefer the run-derived text: odfdo's own text_recursive
+                # renders hyperlinked children as "[text](href)" markdown,
+                # which would otherwise leak into the plain item text.
+                text=runs[0].text if runs else text,
                 content_layer=content_layer,
                 formatting=runs[0].formatting if runs else None,
+                hyperlink=runs[0].hyperlink if runs else None,
             )
         else:
             item = doc.add_list_item(
@@ -1215,6 +1259,7 @@ def _add_odf_list(
                     text=run.text,
                     content_layer=content_layer,
                     formatting=run.formatting,
+                    hyperlink=run.hyperlink,
                 )
         previous_item = item
         for nested_list in nested:

--- a/docling/backend/opendocument_backend.py
+++ b/docling/backend/opendocument_backend.py
@@ -111,7 +111,7 @@ class _OdfTextRun:
     hyperlink: AnyUrl | Path | None = None
 
 
-_ODF_HREF_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*://")
+_ODF_HREF_SCHEME_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9+.-]*:")
 
 
 def _odf_hyperlink_from_href(href: str | None) -> AnyUrl | Path | None:

--- a/tests/test_backend_opendocument.py
+++ b/tests/test_backend_opendocument.py
@@ -17,6 +17,7 @@ import pytest
 from docling_core.types.doc import (
     DocItemLabel,
     ImageRefMode,
+    InlineGroup,
     PictureClassificationLabel,
     PictureItem,
     RichTableCell,
@@ -571,15 +572,142 @@ def test_odt_hyperlink_preserved(tmp_path: Path):
     doc.save(str(path))
 
     res = DocumentConverter(allowed_formats=[InputFormat.ODT]).convert(path)
-    by_text = {item.text: item.hyperlink for item in res.document.texts}
 
-    assert str(by_text["the example talk"]) == "https://example.com/talk"
-    assert by_text["Watch "] is None
-    assert by_text[" for context."] is None
-
-    markdown = res.document.export_to_markdown()
-    assert "[the example talk](https://example.com/talk)" in markdown
+    assert [
+        (
+            item.text,
+            str(item.hyperlink) if item.hyperlink is not None else None,
+        )
+        for item in res.document.texts
+    ] == [
+        ("Watch", None),
+        ("the example talk", "https://example.com/talk"),
+        ("for context.", None),
+    ]
+    assert res.document.export_to_markdown().strip() == (
+        "Watch [the example talk](https://example.com/talk) for context."
+    )
     assert "example.com/talk" in res.document.model_dump_json()
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected_label", "expected_markdown"),
+    [
+        ("heading", DocItemLabel.SECTION_HEADER, "###"),
+        ("title", DocItemLabel.TITLE, "#"),
+        ("subtitle", DocItemLabel.SECTION_HEADER, "##"),
+    ],
+)
+def test_odt_preserves_hyperlinks_in_block_text(
+    tmp_path: Path,
+    kind: str,
+    expected_label: DocItemLabel,
+    expected_markdown: str,
+):
+    path = tmp_path / f"linked_{kind}.odt"
+    source = OdfDocument("text")
+    body = source.body
+    body.clear()
+
+    block = Header(2) if kind == "heading" else Paragraph(style=kind.capitalize())
+    block.append("Read ")
+    block.append(Link(url="#details", text="details"))
+    block.append(" now")
+    body.append(block)
+    source.save(str(path))
+
+    result = DocumentConverter(allowed_formats=[InputFormat.ODT]).convert(path)
+    semantic_items = [
+        item for item in result.document.texts if item.label == expected_label
+    ]
+
+    assert len(semantic_items) == 1
+    semantic_item = semantic_items[0]
+    assert semantic_item.text == ""
+    assert len(semantic_item.children) == 1
+
+    inline_group = semantic_item.children[0].resolve(result.document)
+    assert isinstance(inline_group, InlineGroup)
+    inline_items = [child.resolve(result.document) for child in inline_group.children]
+    assert [
+        (
+            item.text,
+            str(item.hyperlink) if item.hyperlink is not None else None,
+        )
+        for item in inline_items
+    ] == [("Read", None), ("details", "#details"), ("now", None)]
+    assert result.document.export_to_markdown().strip() == (
+        f"{expected_markdown} Read [details](#details) now"
+    )
+
+
+def test_odt_preserves_linked_list_item_target(tmp_path: Path):
+    path = tmp_path / "linked_list_item.odt"
+    source = OdfDocument("text")
+    body = source.body
+    body.clear()
+
+    paragraph = Paragraph()
+    paragraph.append(Link(url="list-target.odt#part", text="linked list item"))
+    list_item = ListItem()
+    list_item.append(paragraph)
+    odf_list = OdfList()
+    odf_list.append(list_item)
+    body.append(odf_list)
+    source.save(str(path))
+
+    result = DocumentConverter(allowed_formats=[InputFormat.ODT]).convert(path)
+    list_items = [
+        item for item in result.document.texts if item.label == DocItemLabel.LIST_ITEM
+    ]
+
+    assert [
+        (
+            item.text,
+            str(item.hyperlink) if item.hyperlink is not None else None,
+        )
+        for item in list_items
+    ] == [("linked list item", "list-target.odt#part")]
+    assert result.document.export_to_markdown().strip() == (
+        "- [linked list item](list-target.odt#part)"
+    )
+
+
+@pytest.mark.parametrize(
+    ("href", "expected_hyperlink", "expected_markdown"),
+    [
+        ("   ", None, "linked text"),
+        ("http://[::1", None, "linked text"),
+        ("http://", None, "linked text"),
+        ("guide.odt#part", "guide.odt#part", "[linked text](guide.odt#part)"),
+        ("#part", "#part", "[linked text](#part)"),
+    ],
+)
+def test_odt_classifies_hyperlink_targets(
+    tmp_path: Path,
+    href: str,
+    expected_hyperlink: str | None,
+    expected_markdown: str,
+):
+    path = tmp_path / "hyperlink_target.odt"
+    source = OdfDocument("text")
+    body = source.body
+    body.clear()
+
+    paragraph = Paragraph()
+    paragraph.append(Link(url=href, text="linked text"))
+    body.append(paragraph)
+    source.save(str(path))
+
+    result = DocumentConverter(allowed_formats=[InputFormat.ODT]).convert(path)
+
+    assert len(result.document.texts) == 1
+    text_item = result.document.texts[0]
+    assert text_item.text == "linked text"
+    assert (
+        str(text_item.hyperlink) if text_item.hyperlink is not None else None
+    ) == expected_hyperlink
+    assert result.document.export_to_markdown().strip() == expected_markdown
 
 
 def test_odt_text_document_script_formatting():

--- a/tests/test_backend_opendocument.py
+++ b/tests/test_backend_opendocument.py
@@ -679,6 +679,7 @@ def test_odt_preserves_linked_list_item_target(tmp_path: Path):
         ("   ", None, "linked text"),
         ("http://[::1", None, "linked text"),
         ("http://", None, "linked text"),
+        ("http:", None, "linked text"),
         ("guide.odt#part", "guide.odt#part", "[linked text](guide.odt#part)"),
         ("#part", "#part", "[linked text](#part)"),
     ],

--- a/tests/test_backend_opendocument.py
+++ b/tests/test_backend_opendocument.py
@@ -711,6 +711,55 @@ def test_odt_classifies_hyperlink_targets(
     assert result.document.export_to_markdown().strip() == expected_markdown
 
 
+def test_odt_link_without_href_does_not_crash(tmp_path: Path):
+    path = tmp_path / "link_without_href.odt"
+    source = OdfDocument("text")
+    body = source.body
+    body.clear()
+
+    paragraph = Paragraph("Before ")
+    # A text:a element missing xlink:href entirely (malformed/hand-edited
+    # markup) - odfdo's own Link always sets the attribute, so build the raw
+    # element to exercise the case where the attribute is absent.
+    raw_link = Element.from_tag("text:a")
+    raw_link.text = "malformed link"
+    paragraph.append(raw_link)
+    paragraph.append(" after")
+    body.append(paragraph)
+    source.save(str(path))
+
+    result = DocumentConverter(allowed_formats=[InputFormat.ODT]).convert(path)
+
+    assert [
+        (
+            item.text,
+            str(item.hyperlink) if item.hyperlink is not None else None,
+        )
+        for item in result.document.texts
+    ] == [("Before malformed link after", None)]
+
+
+def test_odt_empty_heading_produces_no_item(tmp_path: Path):
+    path = tmp_path / "empty_heading.odt"
+    source = OdfDocument("text")
+    body = source.body
+    body.clear()
+
+    body.append(Header(2))
+    body.append(Paragraph("Real content"))
+    source.save(str(path))
+
+    result = DocumentConverter(allowed_formats=[InputFormat.ODT]).convert(path)
+
+    headings = [
+        item
+        for item in result.document.texts
+        if item.label == DocItemLabel.SECTION_HEADER
+    ]
+    assert headings == []
+    assert [item.text for item in result.document.texts] == ["Real content"]
+
+
 def test_odt_text_document_script_formatting():
     path = Path("tests/data/odf/sources/text_document_01.odt")
 

--- a/tests/test_backend_opendocument.py
+++ b/tests/test_backend_opendocument.py
@@ -47,6 +47,7 @@ from odfdo import (
     Frame,
     Header,
     LineBreak,
+    Link,
     List as OdfList,
     ListItem,
     Paragraph,
@@ -555,6 +556,30 @@ def test_odt_text_document_text_formatting():
     assert "**Lorem Ipsum is not simply random text**" in markdown
     assert "*a Latin professor at Hampden-Sydney College in Virginia*" in markdown
     assert "~~The Extremes of Good and Evil~~" in markdown
+
+
+def test_odt_hyperlink_preserved(tmp_path: Path):
+    path = tmp_path / "hyperlink.odt"
+    doc = OdfDocument("text")
+    body = doc.body
+    body.clear()
+
+    paragraph = Paragraph("Watch ")
+    paragraph.append(Link(url="https://example.com/talk", text="the example talk"))
+    paragraph.append(Span(" for context."))
+    body.append(paragraph)
+    doc.save(str(path))
+
+    res = DocumentConverter(allowed_formats=[InputFormat.ODT]).convert(path)
+    by_text = {item.text: item.hyperlink for item in res.document.texts}
+
+    assert str(by_text["the example talk"]) == "https://example.com/talk"
+    assert by_text["Watch "] is None
+    assert by_text[" for context."] is None
+
+    markdown = res.document.export_to_markdown()
+    assert "[the example talk](https://example.com/talk)" in markdown
+    assert "example.com/talk" in res.document.model_dump_json()
 
 
 def test_odt_text_document_script_formatting():


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #3932

## What was broken

ODT documents containing hyperlinks (`<text:a xlink:href="...">`) lost the URL
entirely during conversion. The anchor text survived, but `TextItem.hyperlink`
was never populated and the URL appeared nowhere in the resulting
`DoclingDocument` — including its JSON serialization and Markdown export.

## Root cause

The ODT text-run pipeline had no concept of a hyperlink. `_OdfTextRun` carried
only `text` and `formatting`, and `_odf_text_runs()` special-cased
`text:line-break` and `text:tab` but let `text:a` fall through to the generic
recursive branch, which keeps the text and discards the `xlink:href`.

Even once the href was captured, `_normalize_odf_text_runs()` merged adjacent
runs on matching `formatting` alone, which would silently re-absorb a linked run
back into its plain-text neighbours and erase the link boundary again.

## Fix

Mirrors the existing HTML backend's `_use_hyperlink` pattern:

- add a `hyperlink` field to `_OdfTextRun`
- detect `text:a` in `_odf_text_runs()` and thread `xlink:href` down the
  recursion the same way `formatting` is already threaded
- require `hyperlink` to match (alongside `formatting`) before merging adjacent
  runs in `_normalize_odf_text_runs()`
- pass `hyperlink` through to `doc.add_text()` / `doc.add_heading()`

`AnyUrl` with a `Path` fallback on `ValidationError` matches how the HTML
backend handles relative hrefs.

## Scope

Paragraph text and headings only — the surfaces covered by the issue's
reproducer. List items and table cells reach the document through separate call
sites (`add_list_item`, `RichTableCell`); leaving those for a follow-up keeps
this diff reviewable.

## Verification

Using the reproducer from the issue — before:

    TextItem 'Watch the example talk for context.' hyperlink= None
    URL anywhere in the DoclingDocument JSON: False

after:

    TextItem 'Watch ' hyperlink= None
    TextItem 'the example talk' hyperlink= https://example.com/talk
    TextItem ' for context.' hyperlink= None
    URL anywhere in the DoclingDocument JSON: True

New test `test_odt_hyperlink_preserved` fails on `main` (KeyError — the anchor
text isn't a separate item there) and passes with this change.
`tests/test_backend_opendocument.py`: 32 passed.
`ruff format`, `ruff check`, `ty check` (no new diagnostics) and `tach check`
are clean.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.