### PR TITLE
fix(vlm): record MLX generated token counts

### DIFF
--- a/docling/models/inference_engines/vlm/mlx_engine.py
+++ b/docling/models/inference_engines/vlm/mlx_engine.py
@@ -203,6 +203,7 @@ class MlxVlmEngine(BaseVlmEngine, HuggingFaceModelDownloadMixin):
                 _log.debug("Starting MLX generation...")
 
                 output_text = ""
+                num_tokens = 0
                 stop_reason = "unspecified"
 
                 # Use stream_generate for proper stop string handling
@@ -216,6 +217,7 @@ class MlxVlmEngine(BaseVlmEngine, HuggingFaceModelDownloadMixin):
                     temp=input_data.temperature,
                 ):
                     output_text += token.text
+                    num_tokens += 1
 
                     # Check for configured stop strings
                     if input_data.stop_strings:
@@ -270,6 +272,7 @@ class MlxVlmEngine(BaseVlmEngine, HuggingFaceModelDownloadMixin):
                         stop_reason=stop_reason,
                         metadata={
                             "generation_time": generation_time,
+                            "num_tokens": num_tokens,
                             "model": self.model_config.repo_id
                             if self.model_config
                             else "unknown",

--- a/tests/test_api_usage_propagation.py
+++ b/tests/test_api_usage_propagation.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -11,11 +12,15 @@ from docling.datamodel.base_models import (
 )
 from docling.datamodel.pipeline_options import PictureDescriptionApiOptions
 from docling.datamodel.pipeline_options_vlm_model import ApiVlmOptions, ResponseFormat
-from docling.datamodel.vlm_engine_options import ApiVlmEngineOptions
+from docling.datamodel.vlm_engine_options import (
+    ApiVlmEngineOptions,
+    MlxVlmEngineOptions,
+)
 from docling.models.inference_engines.vlm.api_openai_compatible_engine import (
     ApiVlmEngine,
 )
 from docling.models.inference_engines.vlm.base import VlmEngineInput
+from docling.models.inference_engines.vlm.mlx_engine import MlxVlmEngine
 from docling.models.stages.picture_description.picture_description_api_model import (
     PictureDescriptionApiModel,
 )
@@ -113,6 +118,28 @@ def test_api_vlm_engine_preserves_usage_on_output_metadata(
     assert output.stop_reason == expected_stop_reason
     assert output.metadata["num_tokens"] == api_result.num_tokens
     assert output.metadata["usage"] == api_result.usage
+
+
+def test_mlx_vlm_engine_records_generated_token_count() -> None:
+    engine = MlxVlmEngine(options=MlxVlmEngineOptions(), artifacts_path=None)
+    engine._initialized = True
+    engine.vlm_model = object()
+    engine.processor = object()
+    engine.config = object()
+    engine.apply_chat_template = lambda *_args, **_kwargs: "formatted prompt"
+    engine.stream_generate = lambda *_args, **_kwargs: iter(
+        [
+            SimpleNamespace(text="first "),
+            SimpleNamespace(text="second "),
+            SimpleNamespace(text="third"),
+        ]
+    )
+
+    input_data = VlmEngineInput(image=Image.new("RGB", (8, 8)), prompt="Describe")
+    output = engine.predict_batch([input_data])[0]
+
+    assert output.text == "first second third"
+    assert output.metadata["num_tokens"] == 3
 
 
 def test_picture_description_api_model_forwards_usage_response_key() -> None:


### PR DESCRIPTION
## Summary

- record the number of tokens emitted by the MLX streaming loop in `VlmEngineOutput.metadata["num_tokens"]`
- keep MLX runtime metadata aligned with the Transformers, vLLM, and API runtimes
- add a focused cross-platform regression that uses mocked stream tokens and needs no MLX model or Apple Silicon

Closes #3953.

## Validation

- `uv run pytest tests/test_api_usage_propagation.py -q -rA` — 6 passed
- `make validate` — passed
- `make check` — reached the repository-wide maximum-line check; it reports three unchanged existing upstream-main files above the configured limit (`mspowerpoint_backend.py`, `jats_backend.py`, and `datamodel/document.py`). No unrelated formatting or line-count cleanup is included.