### PR TITLE
fix(settings): disable torch compilation by default on Windows

### DIFF
--- a/tests/test_settings_load.py
+++ b/tests/test_settings_load.py
@@ -54,6 +54,34 @@ def test_compile_model_defaults_from_settings(monkeypatch):
     assert TransformersVlmEngineOptions().compile_model is True
 
 
+def test_compile_model_defaults_to_false_on_windows(monkeypatch):
+    import importlib
+    import sys
+
+    import docling.datamodel.settings as settings_module
+    from docling.datamodel.object_detection_engine_options import (
+        TransformersObjectDetectionEngineOptions,
+    )
+
+    monkeypatch.delenv("DOCLING_INFERENCE_COMPILE_TORCH_MODELS", raising=False)
+    original_platform = sys.platform
+    monkeypatch.setattr(sys, "platform", "win32")
+    importlib.reload(settings_module)
+
+    try:
+        assert settings_module.settings.inference.compile_torch_models is False
+        assert TransformersObjectDetectionEngineOptions().compile_model is False
+
+        monkeypatch.setenv("DOCLING_INFERENCE_COMPILE_TORCH_MODELS", "True")
+        importlib.reload(settings_module)
+        assert settings_module.settings.inference.compile_torch_models is True
+        assert TransformersObjectDetectionEngineOptions().compile_model is True
+    finally:
+        monkeypatch.setattr(sys, "platform", original_platform)
+        monkeypatch.delenv("DOCLING_INFERENCE_COMPILE_TORCH_MODELS", raising=False)
+        importlib.reload(settings_module)
+
+
 def test_scoped_settings_restores_state():
     import importlib
 


### PR DESCRIPTION
Resolves #3956

### Summary

- Disable `torch.compile()` by default on Windows, where TorchInductor requires an MSVC compiler that may not be installed.
- Preserve explicit opt-in through `DOCLING_INFERENCE_COMPILE_TORCH_MODELS=true` and per-engine `compile_model=True`.
- Add a regression test covering the Windows default and the environment-variable override.

### Testing

- `python3 -m py_compile docling/datamodel/settings.py tests/test_settings_load.py`
- `python3 scripts/check_tach_module_coverage.py`
- `python3 scripts/check_max_lines.py --max-lines=1500`
- Import smoke: `python3 -c "import docling"`
- Not run locally: the repository uv-managed pytest and Ruff checks; `uv`, pytest, and Ruff are unavailable in this environment.

### Checklist

- [x] Tests added for the behavior change.
- [x] Documentation is not required for this internal default change.
- [x] Commit includes the required DCO sign-off.