### PR TITLE
fix(layout): fall back to the uncompiled model when torch.compile fails (#3956)

### DIFF
--- a/docling/models/inference_engines/object_detection/transformers_engine.py
+++ b/docling/models/inference_engines/object_detection/transformers_engine.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import sys
 from pathlib import Path
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import TYPE_CHECKING, Any, List, Optional, Union
 
 from packaging import version
 
@@ -63,6 +63,7 @@ class TransformersObjectDetectionEngine(HfObjectDetectionEngineBase):
         )
         self.options: TransformersObjectDetectionEngineOptions = options
         self._model: Optional[AutoModelForObjectDetection] = None
+        self._uncompiled_model: Optional[AutoModelForObjectDetection] = None
         self._device: Optional[torch.device] = None
 
     def _resolve_device(self) -> torch.device:
@@ -155,9 +156,11 @@ class TransformersObjectDetectionEngine(HfObjectDetectionEngineBase):
             # Works for Python >= 3.14 with torch >= 2.10
             if self.options.compile_model:
                 if sys.version_info < (3, 14):
+                    self._uncompiled_model = self._model
                     self._model = torch.compile(self._model)  # type: ignore[arg-type,assignment]
                     _log.debug("Model compiled with torch.compile()")
                 elif version.parse(torch.__version__) >= version.parse("2.10"):
+                    self._uncompiled_model = self._model
                     self._model = torch.compile(self._model)  # type: ignore[arg-type,assignment]
                     _log.debug("Model compiled with torch.compile()")
                 else:
@@ -172,6 +175,30 @@ class TransformersObjectDetectionEngine(HfObjectDetectionEngineBase):
         _log.info(
             f"Transformers engine ready (device={self._device}, dtype={self._model.dtype})"  # type: ignore[union-attr]
         )
+
+    def _forward(self, **inputs: torch.Tensor) -> Any:
+        """Run the model, degrading to the uncompiled one if compilation fails.
+
+        ``torch.compile()`` is lazy: the backend only builds a kernel on the
+        first forward pass, so a machine without a working C++ compiler raises
+        here rather than in ``initialize()``. Compilation is an optimization,
+        so fall back to the uncompiled model instead of failing the conversion.
+        """
+        import torch
+
+        try:
+            return self._model(**inputs)  # type: ignore[operator]
+        except torch._dynamo.exc.TorchDynamoException as exc:
+            if self._uncompiled_model is None:
+                raise
+            _log.warning(
+                "torch.compile() failed (%s); falling back to the uncompiled model. "
+                "Set DOCLING_INFERENCE_COMPILE_TORCH_MODELS=false to skip compilation.",
+                type(exc).__name__,
+            )
+            self._model = self._uncompiled_model
+            self._uncompiled_model = None
+            return self._model(**inputs)  # type: ignore[operator]
 
     def predict_batch(
         self, input_batch: List[ObjectDetectionEngineInput]
@@ -202,7 +229,7 @@ class TransformersObjectDetectionEngine(HfObjectDetectionEngineBase):
 
         # Run inference
         with torch.inference_mode():
-            outputs = self._model(**inputs)  # type: ignore[operator]
+            outputs = self._forward(**inputs)
 
         # Post-process using HuggingFace processor
         results = self._processor.post_process_object_detection(  # type: ignore[attr-defined]

--- a/tests/test_object_detection_compile_fallback.py
+++ b/tests/test_object_detection_compile_fallback.py
@@ -1,0 +1,62 @@
+"""Regression test: a failing torch.compile() must not fail the conversion."""
+
+import pytest
+import torch
+import torch._dynamo
+
+from docling.models.inference_engines.object_detection.transformers_engine import (
+    TransformersObjectDetectionEngine,
+)
+
+
+class _CompileFailure(torch._dynamo.exc.TorchDynamoException):
+    """Stands in for the backend failure raised on the first compiled forward."""
+
+
+class _FailingCompiledModel(torch.nn.Module):
+    def forward(self, **kwargs):
+        raise _CompileFailure("No working C++ compiler found")
+
+
+class _EagerModel(torch.nn.Module):
+    def forward(self, **kwargs):
+        return "eager-output"
+
+
+class _BrokenModel(torch.nn.Module):
+    def forward(self, **kwargs):
+        raise ValueError("a genuine model error")
+
+
+def _engine(model, uncompiled):
+    engine = object.__new__(TransformersObjectDetectionEngine)
+    engine._model = model
+    engine._uncompiled_model = uncompiled
+    return engine
+
+
+def test_forward_falls_back_to_the_uncompiled_model():
+    eager = _EagerModel()
+    engine = _engine(_FailingCompiledModel(), eager)
+
+    assert engine._forward(pixel_values=None) == "eager-output"
+    # the swap is permanent, so later batches do not retry compilation
+    assert engine._model is eager
+    assert engine._uncompiled_model is None
+    assert engine._forward(pixel_values=None) == "eager-output"
+
+
+def test_forward_reraises_when_there_is_nothing_to_fall_back_to():
+    engine = _engine(_FailingCompiledModel(), None)
+
+    with pytest.raises(_CompileFailure):
+        engine._forward(pixel_values=None)
+
+
+def test_forward_does_not_mask_genuine_model_errors():
+    engine = _engine(_BrokenModel(), _EagerModel())
+
+    with pytest.raises(ValueError, match="a genuine model error"):
+        engine._forward(pixel_values=None)
+    # the uncompiled model is still held, since no fallback happened
+    assert engine._uncompiled_model is not None


### PR DESCRIPTION
Related to #3956 (and complementary to #3962, which changes the default rather than the failure mode).

### The problem

`torch.compile()` is lazy. It returns an `OptimizedModule` immediately and the backend only builds a kernel on the **first forward pass**. In `TransformersObjectDetectionEngine` the compile call sits inside `initialize()`'s `try/except`, but the first forward happens in `predict_batch()`:

```python
with torch.inference_mode():
    outputs = self._model(**inputs)
```

Nothing catches it there, so on a machine without a working C++ compiler the conversion dies with `torch._dynamo.exc.BackendCompilerFailed` wrapping `InvalidCxxCompiler`, surfaced to the user as a `ConversionError`.

Since #3914 made `LayoutObjectDetectionOptions` the default and `compile_torch_models` defaults to `True`, this sits on the **default PDF path** — a plain `DocumentConverter().convert(...)` raises. It is not Windows-specific: it reproduces the same way on a slim Linux image with no `g++` (reported against `python:3.12-slim` in [neuml/txtai#1176](https://github.com/neuml/txtai/issues/1176), where it also broke that project's Windows CI).

### The change

Compilation is an optimization, not a correctness requirement, so keep a handle on the uncompiled module and degrade to it with a warning instead of failing the conversion:

- `initialize()` records `self._uncompiled_model` before handing the model to `torch.compile()`.
- A small `_forward()` helper wraps the call. On `torch._dynamo.exc.TorchDynamoException` it logs a warning naming the env var, swaps `_model` back to the uncompiled module, and retries once.
- The swap is permanent, so subsequent batches do not pay the failed-compile cost again.

Deliberately narrow: if no uncompiled handle was recorded (`compile_model=False`, so nothing was compiled), the error propagates unchanged; anything that is not a `TorchDynamoException` propagates unchanged, so a genuine model error is never masked as a compile problem.

### Verification

`torch.compile()` really does defer the failure to the first forward — confirmed on torch 2.5.1, Python 3.12, Windows with no `cl`/`g++` on `PATH`:

```
compile() returned OK: OptimizedModule
FORWARD FAILED at first call -> torch._dynamo.exc.BackendCompilerFailed
MRO: [BackendCompilerFailed, TorchDynamoException, RuntimeError, Exception, ...]
```

Against a genuinely failing compile on that machine:

| | before | after |
| --- | --- | --- |
| first forward | raises `BackendCompilerFailed` → `ConversionError` | warns, falls back, returns output |
| genuine model error | propagates | propagates (unchanged) |
| nothing to fall back to | raises | raises (unchanged) |

`tests/test_object_detection_compile_fallback.py` covers those three rows and needs no model download. It fails 3/3 against the code before this change and passes 3/3 after.

`ruff==0.15.12` `check` and `format --check` clean with the repo config.

### Notes

- The sibling `image_classification` and `vlm` transformers engines share the same shape. I left them alone to keep this focused on the default layout path that #3914 turned on; happy to extend if you'd prefer one pass.
- This is orthogonal to #3962: that one decides *whether* to compile, this one decides what happens *when compiling fails anyway* — including on Linux, and on Windows machines that do have MSVC but hit some other backend failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
