### PR TITLE
feat(cli): add --page-range to convert

### DIFF
--- a/docling/.agents/skills/docling/references/cli.md
+++ b/docling/.agents/skills/docling/references/cli.md
@@ -93,6 +93,7 @@ docling report.pdf --enrich-picture-description --output /tmp/
 | Scanned / image-only PDF | Standard with OCR, or `--pipeline vlm` |
 | Password-protected PDF | `--pdf-password PASSWORD` (raises `ConversionError` if wrong) |
 | Very large document (500+ pages) | Standard, add `--no-tables` for speed; set `--device` / `--num-threads` |
+| Only part of a document is needed | `--page-range 1-4` (or a single page, `--page-range 4`); page numbers start at 1 |
 | Complex / multi-column layout | `--pipeline vlm` (standard may misorder reading flow) |
 | Handwriting or formulas | `--pipeline vlm` only |
 | Output near-empty | Enable OCR, or switch to `--pipeline vlm` |

--- a/docling/cli/export_utils.py
+++ b/docling/cli/export_utils.py
@@ -1,9 +1,11 @@
 import re
 from pathlib import Path
 
+import typer
 from docling_core.types.doc import ImageRefMode
 
 from docling.datamodel.base_models import OutputFormat
+from docling.datamodel.settings import PageRange
 
 _OUTPUT_FORMATS_NOT_SUPPORTING_IMAGE_EMBEDDING = frozenset(
     {
@@ -47,6 +49,34 @@ def _export_flags_from_formats(to_formats: list[OutputFormat]) -> dict[str, bool
         "export_dclx": OutputFormat.DCLX in to_formats,
         "export_chunks": OutputFormat.CHUNKS in to_formats,
     }
+
+
+def _parse_page_range(raw: str | None) -> PageRange | None:
+    """Parse a ``--page-range`` value like ``1-4`` (or a single page ``4``).
+
+    Page numbers start at 1. Returns ``None`` when no range is given so the
+    caller's default (all pages) applies. Shared by the local ``convert``
+    command and the remote ``convert-remote`` command.
+    """
+    if raw is None:
+        return None
+    text = raw.strip()
+    try:
+        if "-" in text:
+            start_str, end_str = text.split("-", 1)
+            start, end = int(start_str), int(end_str)
+        else:
+            start = end = int(text)
+    except ValueError:
+        raise typer.BadParameter(
+            f"Invalid --page-range {raw!r}. Use START-END (e.g. 1-4) or a single page.",
+        )
+    if start < 1 or end < start:
+        raise typer.BadParameter(
+            f"Invalid --page-range {raw!r}. Page numbers start at 1 and END must be "
+            ">= START.",
+        )
+    return (start, end)
 
 
 def _split_list(raw: str | None) -> list[str] | None:

--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -46,6 +46,7 @@ from rich.console import Console
 from docling.cli.export_utils import (
     _export_flags_from_formats,
     _is_empty_output,
+    _parse_page_range,
     _should_generate_export_images,
     _split_list,
 )
@@ -128,7 +129,7 @@ from docling.datamodel.pipeline_options import (
     normalize_pdf_backend,
 )
 from docling.datamodel.pipeline_options_asr_model import InlineAsrOptions
-from docling.datamodel.settings import settings
+from docling.datamodel.settings import DEFAULT_PAGE_RANGE, settings
 from docling.document_converter import (
     AudioFormatOption,
     DocumentConverter,
@@ -871,6 +872,14 @@ def convert(  # noqa: C901
     pdf_password: Annotated[
         str | None, typer.Option(..., help="Password for protected PDF documents")
     ] = None,
+    page_range: Annotated[
+        str | None,
+        typer.Option(
+            "--page-range",
+            help="Only convert a range of pages, e.g. 1-4 (page numbers start at 1). "
+            "Honored by the PDF, XLSX and PPTX backends.",
+        ),
+    ] = None,
     table_mode: Annotated[
         TableFormerMode,
         typer.Option(..., help="The mode to use in the table structure model."),
@@ -1086,6 +1095,8 @@ def convert(  # noqa: C901
     if headers is not None:
         headers_t = TypeAdapter(dict[str, str])
         parsed_headers = headers_t.validate_json(headers)
+
+    parsed_page_range = _parse_page_range(page_range) or DEFAULT_PAGE_RANGE
 
     parsed_html_image_headers: dict[str, str] | None = None
     if html_image_headers is not None:
@@ -1440,7 +1451,10 @@ def convert(  # noqa: C901
 
         _log.info(f"paths: {input_doc_paths}")
         conv_results = doc_converter.convert_all(
-            input_doc_paths, headers=parsed_headers, raises_on_error=abort_on_error
+            input_doc_paths,
+            headers=parsed_headers,
+            raises_on_error=abort_on_error,
+            page_range=parsed_page_range,
         )
 
         output.mkdir(parents=True, exist_ok=True)

--- a/docling/cli/remote.py
+++ b/docling/cli/remote.py
@@ -17,14 +17,17 @@ from typing import Annotated, Optional
 import typer
 from docling_core.types.doc import ImageRefMode
 
-from docling.cli.export_utils import _export_flags_from_formats, _split_list
+from docling.cli.export_utils import (
+    _export_flags_from_formats,
+    _parse_page_range,
+    _split_list,
+)
 from docling.cli.main import ChunkerType
 from docling.datamodel.base_models import InputFormat, OutputFormat
 from docling.datamodel.pipeline_options import ProcessingPipeline
 from docling.datamodel.service.options import (
     ConvertDocumentsOptions as ConvertDocumentsRequestOptions,
 )
-from docling.datamodel.settings import PageRange
 from docling.service_client import (
     DEFAULT_MAX_CONCURRENCY,
     DoclingServiceClient,
@@ -65,33 +68,6 @@ Examples:
   # Whole directory, only PDFs and DOCX, no OCR
   docling convert-remote --from pdf --from docx --no-ocr ./inbox
 """
-
-
-def _parse_page_range(raw: Optional[str]) -> Optional[PageRange]:
-    """Parse a ``--page-range`` value like ``1-4`` (or a single page ``4``).
-
-    Page numbers start at 1. Returns ``None`` when no range is given so the
-    service default (all pages) applies.
-    """
-    if raw is None:
-        return None
-    text = raw.strip()
-    try:
-        if "-" in text:
-            start_str, end_str = text.split("-", 1)
-            start, end = int(start_str), int(end_str)
-        else:
-            start = end = int(text)
-    except ValueError:
-        raise typer.BadParameter(
-            f"Invalid --page-range {raw!r}. Use START-END (e.g. 1-4) or a single page.",
-        )
-    if start < 1 or end < start:
-        raise typer.BadParameter(
-            f"Invalid --page-range {raw!r}. Page numbers start at 1 and END must be "
-            ">= START.",
-        )
-    return (start, end)
 
 
 def _collect_sources(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,21 +1,28 @@
 import base64
+import json
 import re
 import zipfile
 from io import BytesIO
 from pathlib import Path
 from typing import Any
 
+import click
 import pytest
 from docling_core.types.doc import ImageRefMode
 from PIL import Image
 from typer.testing import CliRunner
 
-from docling.cli.export_utils import _should_generate_export_images, _split_list
+from docling.cli.export_utils import (
+    _parse_page_range,
+    _should_generate_export_images,
+    _split_list,
+)
 from docling.cli.main import app
 from docling.datamodel.accelerator_options import AcceleratorDevice
 from docling.datamodel.backend_options import ThreadedDoclingParseBackendOptions
 from docling.datamodel.base_models import InputFormat, OutputFormat
 from docling.datamodel.pipeline_options import OcrMode, PdfBackend, VlmPipelineOptions
+from docling.datamodel.settings import DEFAULT_PAGE_RANGE, PageRange
 from docling.document_converter import PdfFormatOption
 
 runner = CliRunner()
@@ -166,6 +173,7 @@ def test_cli_from_odf_expands_to_open_document_formats(
             input_doc_paths: list[Path],
             headers: dict[str, str] | None = None,
             raises_on_error: bool = False,
+            page_range: PageRange = DEFAULT_PAGE_RANGE,
         ) -> list[Any]:
             assert input_doc_paths
             return []
@@ -669,6 +677,7 @@ def test_cli_accepts_threaded_docling_parse_backend(
             input_doc_paths: list[Path],
             headers: dict[str, str] | None = None,
             raises_on_error: bool = False,
+            page_range: PageRange = DEFAULT_PAGE_RANGE,
         ) -> list[Any]:
             assert len(input_doc_paths) == 1
             return []
@@ -712,7 +721,13 @@ def _capture_cli_ocr_options(monkeypatch, extra_args, tmp_path):
             pdf_option = format_options[InputFormat.PDF]
             captured["ocr_options"] = pdf_option.pipeline_options.ocr_options
 
-        def convert_all(self, input_doc_paths, headers=None, raises_on_error=False):
+        def convert_all(
+            self,
+            input_doc_paths,
+            headers=None,
+            raises_on_error=False,
+            page_range=DEFAULT_PAGE_RANGE,
+        ):
             return []
 
     monkeypatch.setattr(
@@ -773,6 +788,99 @@ def test_cli_invalid_ocr_mode_is_rejected(tmp_path):
     assert result.exit_code != 0
 
 
+def _capture_cli_page_range(monkeypatch, extra_args, tmp_path):
+    """Invoke `docling convert` with a fake converter and return the page_range it got."""
+    captured: dict[str, Any] = {}
+
+    class _FakeDocumentConverter:
+        def __init__(self, *, allowed_formats, format_options):
+            pass
+
+        def convert_all(
+            self,
+            input_doc_paths,
+            headers=None,
+            raises_on_error=False,
+            page_range=DEFAULT_PAGE_RANGE,
+        ):
+            captured["page_range"] = page_range
+            return []
+
+    monkeypatch.setattr(
+        "docling.document_converter.DocumentConverter", _FakeDocumentConverter
+    )
+    source = "./tests/data/pdf/sources/2305.03393v1-pg9.pdf"
+    result = runner.invoke(
+        app, [source, "--output", str(tmp_path / "out"), *extra_args]
+    )
+    return result, captured.get("page_range")
+
+
+def test_cli_page_range_reaches_convert_all(tmp_path, monkeypatch):
+    result, page_range = _capture_cli_page_range(
+        monkeypatch, ["--page-range", "2-4"], tmp_path
+    )
+    assert result.exit_code == 0
+    assert page_range == (2, 4)
+
+
+def test_cli_page_range_accepts_single_page(tmp_path, monkeypatch):
+    result, page_range = _capture_cli_page_range(
+        monkeypatch, ["--page-range", "3"], tmp_path
+    )
+    assert result.exit_code == 0
+    assert page_range == (3, 3)
+
+
+def test_cli_page_range_defaults_to_all_pages(tmp_path, monkeypatch):
+    result, page_range = _capture_cli_page_range(monkeypatch, [], tmp_path)
+    assert result.exit_code == 0
+    assert page_range == DEFAULT_PAGE_RANGE
+
+
+@pytest.mark.parametrize("raw", ["4-2", "0-3", "abc", "1-", "-3"])
+def test_cli_invalid_page_range_is_rejected(tmp_path, monkeypatch, raw):
+    result, page_range = _capture_cli_page_range(
+        monkeypatch, ["--page-range", raw], tmp_path
+    )
+    assert result.exit_code != 0
+    assert page_range is None
+
+
+def test_cli_page_range_limits_converted_pages(tmp_path):
+    """`--page-range 2-3` must convert only those slides of a 3-slide deck.
+
+    Uses PPTX because its backend honors ``page_range`` without needing the
+    layout model, keeping the end-to-end assertion cheap.
+    """
+    output = tmp_path / "out"
+    result = runner.invoke(
+        app,
+        [
+            "./tests/data/pptx/sources/powerpoint_sample.pptx",
+            "--output",
+            str(output),
+            "--to",
+            "json",
+            "--page-range",
+            "2-3",
+        ],
+    )
+    assert result.exit_code == 0
+
+    doc = json.loads((output / "powerpoint_sample.json").read_text(encoding="utf-8"))
+    assert sorted(int(page_no) for page_no in doc["pages"]) == [2, 3]
+
+
+def test_parse_page_range_is_shared_with_convert_remote():
+    """`convert` and `convert-remote` must parse --page-range identically."""
+    assert _parse_page_range(None) is None
+    assert _parse_page_range("1-4") == (1, 4)
+    assert _parse_page_range(" 7 ") == (7, 7)
+    with pytest.raises(click.exceptions.UsageError):
+        _parse_page_range("4-2")
+
+
 def test_cli_passes_accelerator_options_to_vlm_pipeline(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -796,6 +904,7 @@ def test_cli_passes_accelerator_options_to_vlm_pipeline(
             input_doc_paths: list[Path],
             headers: dict[str, str] | None = None,
             raises_on_error: bool = False,
+            page_range: PageRange = DEFAULT_PAGE_RANGE,
         ) -> list[Any]:
             assert len(input_doc_paths) == 1
             return []


### PR DESCRIPTION
`DocumentConverter.convert` and `convert_all` have accepted a `page_range` argument for a long time, and `docling convert-remote` already exposes it as `--page-range`. The local `docling convert` command never did, it called `convert_all()` with only `headers` and `raises_on_error`, so the same flag worked remotely and silently did not exist locally.

This adds `--page-range` to `docling convert`, with the same syntax, the same validation, and the same help wording as `convert-remote`:

```bash
docling convert report.pdf --page-range 1-4    # pages 1 through 4
docling convert report.pdf --page-range 4      # just page 4
```

Page numbers start at 1. The range is honored by the PDF, XLSX and PPTX backends, which already read `in_doc.limits.page_range`.

### Changes

- `docling/cli/export_utils.py` — moved `_parse_page_range` here from
  `cli/remote.py`, unchanged. This module is the existing home for helpers
  shared by `convert` and `convert-remote` (`_split_list`,
  `_export_flags_from_formats`, `_should_generate_export_images`), so both
  commands now parse `--page-range` through one implementation and cannot drift.
- `docling/cli/remote.py` — imports the helper instead of defining it. No
  behavior change; `convert-remote --page-range` works exactly as before.
- `docling/cli/main.py` — new `--page-range` option on `convert`, parsed once
  and passed to `convert_all(page_range=...)`. Omitting the flag passes
  `DEFAULT_PAGE_RANGE`, so the default (all pages) is unchanged.
- `docling/.agents/skills/docling/references/cli.md` — one row in the "Common
  situations" table, per the AGENTS.md requirement to keep the shipped usage
  skill in sync with the CLI.

`docs/reference/cli.md` is generated by `scripts/render_cli_reference.py` and
gitignored, so it is not part of this diff; the new option shows up there
automatically.

### Tests

Ten new tests in `tests/test_cli.py`:

- `--page-range 2-4` reaches `convert_all` as `(2, 4)`; a bare `--page-range 3`
  becomes `(3, 3)`; omitting it passes `DEFAULT_PAGE_RANGE`.
- `4-2`, `0-3`, `abc`, `1-` and `-3` are all rejected with a non-zero exit.
- End-to-end: converting a 3-slide deck with `--page-range 2-3` yields exactly
  pages 2 and 3. This uses PPTX rather than PDF deliberately — the PPTX backend
  honors `page_range` without loading the layout model, so the assertion stays
  in the core test lane instead of an ML lane.
- `_parse_page_range` is exercised directly to lock in that `convert` and
  `convert-remote` parse the flag identically after the move.

Four existing fake `DocumentConverter.convert_all` signatures in `tests/test_cli.py` gained the new keyword argument.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
