### PR TITLE
fix: missing dclx in response ArtifactRef

### DIFF
--- a/docling/datamodel/service/responses.py
+++ b/docling/datamodel/service/responses.py
@@ -123,7 +123,14 @@ class RemoteTargetResult(BaseModel):
 
 class ArtifactRef(BaseModel):
     artifact_type: Literal[
-        "json", "html", "markdown", "text", "doctags", "doclang", "dclx", "resource_bundle"
+        "json",
+        "html",
+        "markdown",
+        "text",
+        "doctags",
+        "doclang",
+        "dclx",
+        "resource_bundle",
     ]
     mime_type: str
     uri: AnyUrl

--- a/docling/datamodel/service/responses.py
+++ b/docling/datamodel/service/responses.py
@@ -123,7 +123,7 @@ class RemoteTargetResult(BaseModel):
 
 class ArtifactRef(BaseModel):
     artifact_type: Literal[
-        "json", "html", "markdown", "text", "doctags", "doclang", "resource_bundle"
+        "json", "html", "markdown", "text", "doctags", "doclang", "dclx", "resource_bundle"
     ]
     mime_type: str
     uri: AnyUrl


### PR DESCRIPTION
docling_jobkit expects `dclx` to be present in `ArtifactRef` but it wasn't.

