### PR TITLE
fix(docx): prevent KeyError in _manage_list_structure when use_level …

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -2543,7 +2543,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             list_gr = self._get_or_create_list_group(
                 doc=doc,
                 numid=numid,
-                parent=self.parents[use_level - 1],
+                parent=self.parents.get(use_level - 1),
                 elem_ref=elem_ref,
             )
 

--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -2496,7 +2496,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             ):
                 list_gr1 = doc.add_list_group(
                     name="list",
-                    parent=self.parents[i - 1],
+                    parent=self.parents.get(i - 1),
                     content_layer=self.content_layer,
                 )
                 self.parents[i] = list_gr1

--- a/tests/test_backend_msword_lists.py
+++ b/tests/test_backend_msword_lists.py
@@ -4,7 +4,9 @@ Kept separate from ``test_backend_msword.py`` so that file stays under the
 repository's per-file line limit.
 """
 
-from docling_core.types.doc import ListItem
+from io import BytesIO
+
+from docling_core.types.doc import DoclingDocument, DocumentOrigin, ListGroup, ListItem
 from docx import Document
 from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
@@ -94,3 +96,69 @@ def test_ordered_list_resumes_numbering_after_intervening_list(tmp_path):
         ("bullet two", ""),
         ("Third ordered item", "3."),
     ]
+
+
+def test_manage_list_structure_no_keyerror_when_use_level_exceeds_parents(tmp_path):
+    """_manage_list_structure must not raise KeyError when use_level exceeds parents.
+
+    The pathological state is:
+      - parents has keys 0..11, with key 0 set to None (cleared) and others
+        holding NodeItems from headings / earlier lists.
+      - level_at_new_list is 11 (set by the previous list item of the same numId).
+      - A second item for the same numId arrives with ilevel=2, which triggers
+        the "New list sequence" branch and computes use_level = 11 + 2 = 13.
+      - parents.get(12) is not a key at all → previously raised KeyError: 12.
+    """
+
+    docx_io = _make_empty_docx()
+    docx_path = tmp_path / "empty.docx"
+    docx_path.write_bytes(docx_io.getvalue())
+
+    in_doc = InputDocument(
+        path_or_stream=docx_path,
+        format=InputFormat.DOCX,
+        backend=MsWordDocumentBackend,
+        filename=docx_path.name,
+    )
+    backend = MsWordDocumentBackend(in_doc=in_doc, path_or_stream=docx_path)
+
+    out_doc = DoclingDocument(
+        name="test",
+        origin=DocumentOrigin(
+            filename="test.docx",
+            mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            binary_hash="0",
+        ),
+    )
+
+    body_node = out_doc.body
+    first_list_gr = out_doc.add_list_group(name="list", parent=body_node)
+    backend.parents = dict.fromkeys(range(12), body_node)
+    backend.parents[0] = None  # gap that makes _get_level() return 0
+    backend.parents[11] = first_list_gr
+
+    # Simulate history: the immediately previous item was numid=27, ilevel=2.
+    backend.history = {
+        "names": [None, "list"],
+        "levels": [None, 11],
+        "numids": [None, 27],
+        "indents": [None, 2],
+    }
+    backend.level_at_new_list = 11
+    backend.last_numid = 27
+
+    # This must not raise KeyError.
+    elem_ref, use_level = backend._manage_list_structure(
+        doc=out_doc, numid=27, ilevel=2
+    )
+
+    assert isinstance(backend.parents.get(use_level), ListGroup)
+
+
+def _make_empty_docx():
+    """Return an in-memory .docx with no content."""
+
+    buf = BytesIO()
+    Document().save(buf)
+    buf.seek(0)
+    return buf

--- a/tests/test_backend_msword_lists.py
+++ b/tests/test_backend_msword_lists.py
@@ -155,6 +155,58 @@ def test_manage_list_structure_no_keyerror_when_use_level_exceeds_parents(tmp_pa
     assert isinstance(backend.parents.get(use_level), ListGroup)
 
 
+def test_manage_list_structure_no_keyerror_open_indented_list_exceeds_parents(tmp_path):
+    """_manage_list_structure must not raise KeyError in the "Open indented list" branch.
+
+    The pathological state is:
+      - parents has keys 0..11, with keys 0..10 holding body nodes and key 11
+        holding a ListGroup.
+      - level_at_new_list is 11, prev_indent is 2, ilevel is 4.
+      - The "Open indented list" loop runs for i in range(14, 16), accessing
+        parents[i - 1] where i - 1 = 13 is not a key in parents.
+    """
+    docx_path = tmp_path / "empty.docx"
+    docx_path.write_bytes(_make_empty_docx().getvalue())
+
+    in_doc = InputDocument(
+        path_or_stream=docx_path,
+        format=InputFormat.DOCX,
+        backend=MsWordDocumentBackend,
+        filename=docx_path.name,
+    )
+    backend = MsWordDocumentBackend(in_doc=in_doc, path_or_stream=docx_path)
+
+    out_doc = DoclingDocument(
+        name="test",
+        origin=DocumentOrigin(
+            filename="test.docx",
+            mimetype="application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+            binary_hash="0",
+        ),
+    )
+
+    body_node = out_doc.body
+    first_list_gr = out_doc.add_list_group(name="list", parent=body_node)
+    backend.parents = dict.fromkeys(range(12), body_node)
+    backend.parents[11] = first_list_gr
+
+    # Simulate history: same numId, previous item was at ilevel=2.
+    backend.history = {
+        "names": [None, "list"],
+        "levels": [None, 11],
+        "numids": [None, 27],
+        "indents": [None, 2],
+    }
+    backend.level_at_new_list = 11
+    backend.last_numid = 27
+
+    elem_ref, use_level = backend._manage_list_structure(
+        doc=out_doc, numid=27, ilevel=4
+    )
+
+    assert isinstance(backend.parents.get(use_level), ListGroup)
+
+
 def _make_empty_docx():
     """Return an in-memory .docx with no content."""
 


### PR DESCRIPTION
## Problem

Converting certain `.docx` files failed with `RuntimeError: Pipeline SimplePipeline failed`
caused by a `KeyError` raised from `_manage_list_structure`. The whole document was lost.

The "New list sequence" branch computed `use_level = level_at_new_list + ilevel` and then
looked up the parent node with a direct dict index:

```python
parent=self.parents[use_level - 1],   # raised KeyError
```

`use_level` is derived from accumulated list state (`level_at_new_list`) and the DOCX
indentation level (`ilevel`), neither of which is bounded by the keys that happen to exist in
`parents`. When a document contains deep heading structure followed by a list whose first item
extends the `parents` dict and sets `level_at_new_list` to a high value, the next item of the
same list computes an index that was never inserted.

The existing guard immediately above the failing line already used `.get()` to probe the same
slot safely, making the direct index an oversight.

## Fix

Replace the direct index with `.get()`:

```python
parent=self.parents.get(use_level - 1),
```

`_get_or_create_list_group` already accepts `parent: NodeItem | None` — a `None` parent
attaches the new list group at the document body level, which is the same behaviour used
everywhere else in the backend when no enclosing node is available.

## Test

A focused unit test constructs the exact `parents` and history state that triggered the
failure and asserts that `_manage_list_structure` completes without raising and places a
`ListGroup` at the returned `use_level`.

Resolves #3971

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
