### PR TITLE
fix(video): attach TrackSource via add_picture(source=...)

### DIFF
--- a/docling/pipeline/video_pipeline.py
+++ b/docling/pipeline/video_pipeline.py
@@ -275,17 +275,17 @@ class VideoPipeline(BasePipeline):
                 if event_type == 0:
                     frame = payload  # type: ignore[assignment]
                     try:
-                        picture = conv_res.document.add_picture(
+                        conv_res.document.add_picture(
                             image=ImageRef.from_pil(frame.image, dpi=72),
                             content_layer=ContentLayer.BODY,
-                        )
-                        picture.source = TrackSource(
-                            start_time=frame.timestamp,
-                            end_time=frame.timestamp + 0.001,
-                            identifier=(
-                                f"scene:{frame.scene_id}"
-                                if frame.scene_id is not None
-                                else None
+                            source=TrackSource(
+                                start_time=frame.timestamp,
+                                end_time=frame.timestamp + 0.001,
+                                identifier=(
+                                    f"scene:{frame.scene_id}"
+                                    if frame.scene_id is not None
+                                    else None
+                                ),
                             ),
                         )
                     except Exception as exc:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ requires-python = '>=3.10,<4.0'
 # MINIMAL BASE (8 packages) - ~50MB
 dependencies = [
   'pydantic>=2.0.0,<3.0.0',
-  'docling-core>=2.90.0,<3.0.0',
+  'docling-core>=2.91.0,<3.0.0',
   'pydantic-settings>=2.3.0,<3.0.0',
   'filetype>=1.2.0,<2.0.0',
   'requests>=2.32.2,<3.0.0',

--- a/uv.lock
+++ b/uv.lock
@@ -1547,7 +1547,7 @@ provides-extras = ["easyocr", "tesserocr", "ocrmac", "vlm", "rapidocr", "asr", "
 
 [[package]]
 name = "docling-core"
-version = "2.90.0"
+version = "2.91.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "defusedxml" },
@@ -1565,9 +1565,9 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a0/83/4e7169415904494d0bca8d10bbfbe7e626ff53834c7db86b06b32cfe7ce8/docling_core-2.90.0.tar.gz", hash = "sha256:55eda84a4a1822cca4c9259e0b7682477b56bd7db02763e4bccb9fafffe4e10b", size = 344122, upload-time = "2026-08-03T12:22:11.558Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e5/f5/5aaf6f1221242a4dd598b515786ffca796352a8d960a9c6a0deb614301f4/docling_core-2.91.0.tar.gz", hash = "sha256:dc40fe76524a2700f869265015a9ef86027888e73b5652f324b3b5c52a2df240", size = 344852, upload-time = "2026-08-06T14:23:07.919Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6b/9c/a2d9c4d733f16c93158c5c5bee134da10727a444dc7a5fe640bd13976c7c/docling_core-2.90.0-py3-none-any.whl", hash = "sha256:e8d739c51db4ea29d25217de1b1c3854dba9dd2483cd2f95aaafb09e4e52d3c5", size = 286436, upload-time = "2026-08-03T12:22:09.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/68/de7c0ba404d035afe78ae4e602290bb6c330b34cc53fd5f92c9950be4ac0/docling_core-2.91.0-py3-none-any.whl", hash = "sha256:4949a5dd77ae1daf4153c095897d3bdde1c870f2bbe401bf94d8834bef867998", size = 286832, upload-time = "2026-08-06T14:23:05.908Z" },
 ]
 
 [package.optional-dependencies]
@@ -2002,7 +2002,7 @@ requires-dist = [
     { name = "certifi", specifier = ">=2024.7.4" },
     { name = "defusedxml", marker = "extra == 'format-xml-uspto'", specifier = ">=0.7.1,<0.8.0" },
     { name = "defusedxml", marker = "extra == 'models-local'", specifier = ">=0.7.1,<0.8.0" },
-    { name = "docling-core", specifier = ">=2.90.0,<3.0.0" },
+    { name = "docling-core", specifier = ">=2.91.0,<3.0.0" },
     { name = "docling-core", extras = ["chunking"], marker = "extra == 'feat-chunking'", specifier = ">=2.73.0,<3.0.0" },
     { name = "docling-ibm-models", marker = "extra == 'models-local'", specifier = ">=3.13.0,<4" },
     { name = "docling-parse", marker = "extra == 'format-pdf-docling'", specifier = ">=7.0.0,<8.0.0" },


### PR DESCRIPTION
Supersedes #3925 (thanks @jackichen) by taking the cleaner fix that #3925's Note called for.

  docling-core 2.91.0 (docling-project/docling-core#711) added a keyword-only `source=` to every `add_*` helper, so the frame path can pass the
  `TrackSource` at construction instead of mutating `picture.source` afterwards — mirroring the transcript path. Bumps the `docling-core` floor to
  2.91.0, since `add_picture(source=...)` does not exist before that.

  Fixes #3924