### PR TITLE
feat(email): parse email attachments

### DIFF
--- a/docling/backend/email_backend.py
+++ b/docling/backend/email_backend.py
@@ -1,20 +1,27 @@
 from __future__ import annotations
 
+import base64
+import binascii
 import logging
+import quopri
 import re
 from datetime import datetime
 from email.message import EmailMessage
 from email.utils import format_datetime, formataddr
 from io import BytesIO
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 from docling_core.types.doc import DocItemLabel, DoclingDocument, DocumentOrigin
 
 from docling.backend.abstract_backend import DeclarativeDocumentBackend
 from docling.backend.html_backend import HTMLDocumentBackend
 from docling.datamodel.backend_options import EmailBackendOptions, HTMLBackendOptions
-from docling.datamodel.base_models import InputFormat
+from docling.datamodel.base_models import ConversionStatus, DocumentStream, InputFormat
 from docling.datamodel.document import InputDocument
+
+if TYPE_CHECKING:
+    from docling.document_converter import DocumentConverter
 from docling.exceptions import DocumentLoadError
 
 # mail-parser is only installed by the `format-email` extra, but
@@ -264,22 +271,142 @@ class EmailDocumentBackend(DeclarativeDocumentBackend):
             return mail_date.strip()
         return ""
 
-    def _get_attachment_labels(self) -> list[str]:
-        """Return one display label per attachment (name, optional content type).
+    @staticmethod
+    def _attachment_filename(index: int, attachment: dict[str, Any]) -> str:
+        filename = (attachment.get("filename") or "").strip()
+        return filename or f"attachment-{index + 1}"
 
-        Only attachment metadata is surfaced; the encoded payload is never
-        included, matching how ``.eml`` attachment content is excluded.
+    @staticmethod
+    def _attachment_label(index: int, attachment: dict[str, Any]) -> str:
+        filename = EmailDocumentBackend._attachment_filename(index, attachment)
+        content_type = (attachment.get("mail_content_type") or "").strip()
+        return f"{filename} ({content_type})" if content_type else filename
+
+    @staticmethod
+    def _get_attachment_bytes(attachment: dict[str, Any]) -> bytes | None:
+        """Decode an attachment's payload into raw bytes.
+
+        mailparser exposes the payload as it appeared in the MIME part together
+        with its transfer encoding, so we reverse that encoding here. Returns
+        ``None`` when the payload is missing or cannot be decoded.
         """
+        payload = attachment.get("payload")
+        if payload is None:
+            return None
+
+        encoding = (attachment.get("content_transfer_encoding") or "").lower()
+        try:
+            if encoding == "base64":
+                return base64.b64decode(payload)
+            if encoding == "quoted-printable":
+                data = payload.encode("utf-8") if isinstance(payload, str) else payload
+                return quopri.decodestring(data)
+        except (ValueError, binascii.Error):
+            return None
+
+        if isinstance(payload, bytes):
+            return payload
+        if isinstance(payload, str):
+            charset = attachment.get("charset") or "utf-8"
+            try:
+                return payload.encode(charset, errors="replace")
+            except LookupError:
+                return payload.encode("utf-8", errors="replace")
+        return None
+
+    def _build_attachment_converter(self) -> DocumentConverter:
+        # Imported lazily: document_converter imports this module, so a
+        # module-level import would create a circular import. One converter is
+        # built per email and reused across its attachments (pipelines are cached
+        # per converter instance). It uses default options, so a nested email
+        # attachment is parsed but its own attachments are not recursed.
+        from docling.document_converter import DocumentConverter
+
+        return DocumentConverter()
+
+    def _convert_attachment(
+        self, converter: DocumentConverter, filename: str, data: bytes
+    ) -> DoclingDocument | None:
+        """Convert one attachment via Docling, or ``None`` if it cannot be parsed."""
+        stream = DocumentStream(name=filename, stream=BytesIO(data))
+        try:
+            result = converter.convert(stream, raises_on_error=False)
+        except Exception as exc:  # unsupported format, missing extra, bad bytes
+            _log.info("Could not convert email attachment %r: %s", filename, exc)
+            return None
+        if result.status not in (
+            ConversionStatus.SUCCESS,
+            ConversionStatus.PARTIAL_SUCCESS,
+        ):
+            _log.info(
+                "Skipped email attachment %r (conversion status: %s)",
+                filename,
+                result.status,
+            )
+            return None
+        return result.document
+
+    def _add_attachments(self, doc: DoclingDocument) -> None:
+        """Append the attachments section, listing or parsing per the options."""
         assert self.mail is not None
 
-        labels: list[str] = []
-        for index, attachment in enumerate(self.mail.attachments or []):
-            filename = (attachment.get("filename") or "").strip()
-            if not filename:
-                filename = f"attachment-{index + 1}"
-            content_type = (attachment.get("mail_content_type") or "").strip()
-            labels.append(f"{filename} ({content_type})" if content_type else filename)
-        return labels
+        attachments = self.mail.attachments or []
+        if not attachments:
+            return
+        if not (self.options.process_attachments or self.options.list_attachments):
+            return
+
+        doc.add_heading(text="Attachments", level=2)
+
+        if not self.options.process_attachments:
+            attachments_group = doc.add_list_group(name="attachments")
+            for index, attachment in enumerate(attachments):
+                doc.add_list_item(
+                    text=self._attachment_label(index, attachment),
+                    parent=attachments_group,
+                )
+            return
+
+        converter: DocumentConverter | None = None
+        total_bytes = 0
+        for index, attachment in enumerate(attachments):
+            if index >= self.options.max_attachments:
+                break
+            filename = self._attachment_filename(index, attachment)
+            label = self._attachment_label(index, attachment)
+            section = doc.add_heading(text=filename, level=3)
+
+            data = self._get_attachment_bytes(attachment)
+            if not data:
+                doc.add_text(
+                    label=DocItemLabel.TEXT,
+                    text=f"{label}: attachment content could not be read.",
+                )
+                continue
+            if len(data) > self.options.max_attachment_bytes:
+                doc.add_text(
+                    label=DocItemLabel.TEXT,
+                    text=f"{label}: skipped (exceeds max_attachment_bytes).",
+                )
+                continue
+            if total_bytes + len(data) > self.options.max_attachment_total_bytes:
+                doc.add_text(
+                    label=DocItemLabel.TEXT,
+                    text=f"{label}: skipped (attachment size budget exceeded).",
+                )
+                continue
+            total_bytes += len(data)
+
+            if converter is None:
+                converter = self._build_attachment_converter()
+            child = self._convert_attachment(converter, filename, data)
+            if child is None:
+                doc.add_text(
+                    label=DocItemLabel.TEXT,
+                    text=f"{label}: could not be parsed by Docling.",
+                )
+            else:
+                doc.add_document(child, parent=section)
 
     def convert(self) -> DoclingDocument:
         if not self.is_valid() or self.mail is None:
@@ -317,12 +444,6 @@ class EmailDocumentBackend(DeclarativeDocumentBackend):
         for body_paragraph in body_paragraphs:
             doc.add_text(label=DocItemLabel.TEXT, text=body_paragraph)
 
-        if self.options.list_attachments:
-            attachment_labels = self._get_attachment_labels()
-            if attachment_labels:
-                doc.add_heading(text="Attachments", level=2)
-                attachments_group = doc.add_list_group(name="attachments")
-                for label in attachment_labels:
-                    doc.add_list_item(text=label, parent=attachments_group)
+        self._add_attachments(doc)
 
         return doc

--- a/docling/backend/email_backend.py
+++ b/docling/backend/email_backend.py
@@ -5,6 +5,7 @@ import binascii
 import logging
 import quopri
 import re
+from collections.abc import Callable
 from datetime import datetime
 from email.message import EmailMessage
 from email.utils import format_datetime, formataddr
@@ -19,10 +20,10 @@ from docling.backend.html_backend import HTMLDocumentBackend
 from docling.datamodel.backend_options import EmailBackendOptions, HTMLBackendOptions
 from docling.datamodel.base_models import ConversionStatus, DocumentStream, InputFormat
 from docling.datamodel.document import InputDocument
+from docling.exceptions import DocumentLoadError
 
 if TYPE_CHECKING:
     from docling.document_converter import DocumentConverter
-from docling.exceptions import DocumentLoadError
 
 # mail-parser is only installed by the `format-email` extra, but
 # DocumentConverter imports every backend eagerly. Importing it at module load
@@ -54,6 +55,22 @@ except ImportError as e:  # pragma: no cover - import-time guard
     _OXMSG_IMPORT_ERROR = e
 
 _log = logging.getLogger(__name__)
+
+# DocumentConverter lives in the entrypoints layer, which the backend (core)
+# layer must not import (enforced by Tach). Instead, docling.document_converter
+# injects a factory here at import time, inverting the dependency. When the
+# factory is unset (e.g. the converter module was never imported), attachment
+# processing gracefully degrades to listing.
+_attachment_converter_factory: Callable[[], DocumentConverter] | None = None
+
+
+def register_attachment_converter_factory(
+    factory: Callable[[], DocumentConverter],
+) -> None:
+    """Register the factory used to build a converter for email attachments."""
+    global _attachment_converter_factory
+    _attachment_converter_factory = factory
+
 
 # OLE2 / Compound File Binary signature that prefixes every Outlook .msg file.
 _MSG_MAGIC = b"\xd0\xcf\x11\xe0\xa1\xb1\x1a\xe1"
@@ -314,15 +331,18 @@ class EmailDocumentBackend(DeclarativeDocumentBackend):
                 return payload.encode("utf-8", errors="replace")
         return None
 
-    def _build_attachment_converter(self) -> DocumentConverter:
-        # Imported lazily: document_converter imports this module, so a
-        # module-level import would create a circular import. One converter is
-        # built per email and reused across its attachments (pipelines are cached
-        # per converter instance). It uses default options, so a nested email
+    @staticmethod
+    def _build_attachment_converter() -> DocumentConverter | None:
+        # The converter (entrypoints layer) is injected via
+        # register_attachment_converter_factory so this core-layer backend never
+        # imports it. Returns None when no factory has been registered, in which
+        # case attachments are listed instead of parsed. One converter is built
+        # per email and reused across its attachments (pipelines are cached per
+        # converter instance); it uses default options, so a nested email
         # attachment is parsed but its own attachments are not recursed.
-        from docling.document_converter import DocumentConverter
-
-        return DocumentConverter()
+        if _attachment_converter_factory is None:
+            return None
+        return _attachment_converter_factory()
 
     def _convert_attachment(
         self, converter: DocumentConverter, filename: str, data: bytes
@@ -346,28 +366,22 @@ class EmailDocumentBackend(DeclarativeDocumentBackend):
             return None
         return result.document
 
-    def _add_attachments(self, doc: DoclingDocument) -> None:
-        """Append the attachments section, listing or parsing per the options."""
-        assert self.mail is not None
+    def _list_attachments(
+        self, doc: DoclingDocument, attachments: list[dict[str, Any]]
+    ) -> None:
+        attachments_group = doc.add_list_group(name="attachments")
+        for index, attachment in enumerate(attachments):
+            doc.add_list_item(
+                text=self._attachment_label(index, attachment),
+                parent=attachments_group,
+            )
 
-        attachments = self.mail.attachments or []
-        if not attachments:
-            return
-        if not (self.options.process_attachments or self.options.list_attachments):
-            return
-
-        doc.add_heading(text="Attachments", level=2)
-
-        if not self.options.process_attachments:
-            attachments_group = doc.add_list_group(name="attachments")
-            for index, attachment in enumerate(attachments):
-                doc.add_list_item(
-                    text=self._attachment_label(index, attachment),
-                    parent=attachments_group,
-                )
-            return
-
-        converter: DocumentConverter | None = None
+    def _process_attachments(
+        self,
+        doc: DoclingDocument,
+        attachments: list[dict[str, Any]],
+        converter: DocumentConverter,
+    ) -> None:
         total_bytes = 0
         for index, attachment in enumerate(attachments):
             if index >= self.options.max_attachments:
@@ -397,8 +411,6 @@ class EmailDocumentBackend(DeclarativeDocumentBackend):
                 continue
             total_bytes += len(data)
 
-            if converter is None:
-                converter = self._build_attachment_converter()
             child = self._convert_attachment(converter, filename, data)
             if child is None:
                 doc.add_text(
@@ -407,6 +419,30 @@ class EmailDocumentBackend(DeclarativeDocumentBackend):
                 )
             else:
                 doc.add_document(child, parent=section)
+
+    def _add_attachments(self, doc: DoclingDocument) -> None:
+        """Append the attachments section, listing or parsing per the options."""
+        assert self.mail is not None
+
+        attachments = self.mail.attachments or []
+        if not attachments:
+            return
+        if not (self.options.process_attachments or self.options.list_attachments):
+            return
+
+        # Fall back to listing when parsing is off, or when no converter factory
+        # was registered (the entrypoints layer was never imported).
+        converter = (
+            self._build_attachment_converter()
+            if self.options.process_attachments
+            else None
+        )
+
+        doc.add_heading(text="Attachments", level=2)
+        if converter is None:
+            self._list_attachments(doc, attachments)
+        else:
+            self._process_attachments(doc, attachments, converter)
 
     def convert(self) -> DoclingDocument:
         if not self.is_valid() or self.mail is None:

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -403,6 +403,46 @@ class EmailBackendOptions(BaseBackendOptions):
             "is never embedded. Opt-in (default False)."
         ),
     )
+    process_attachments: bool = Field(
+        False,
+        description=(
+            "Whether to parse the email's attachments with Docling and embed "
+            "their converted content under an 'Attachments' section, each "
+            "attachment as its own subsection. Every supported format is routed "
+            "through Docling's own DocumentConverter, so PDF/DOCX/PPTX/XLSX/"
+            "images/HTML/... are handled the same way as standalone documents. "
+            "Attachments whose format is unsupported, whose backend dependency "
+            "is missing, or that fail to convert fall back to a name/type note. "
+            "Opt-in (default False) because it runs the full conversion pipeline "
+            "per attachment. Takes precedence over list_attachments."
+        ),
+    )
+    max_attachments: int = Field(
+        32,
+        ge=0,
+        description=(
+            "Maximum number of attachments to process when process_attachments "
+            "is enabled. Attachments beyond this count are ignored."
+        ),
+    )
+    max_attachment_bytes: int = Field(
+        25 * 1024 * 1024,  # 25 MB
+        ge=0,
+        description=(
+            "Maximum size in bytes of a single attachment to process when "
+            "process_attachments is enabled. Larger attachments are skipped with "
+            "a note instead of being converted."
+        ),
+    )
+    max_attachment_total_bytes: int = Field(
+        100 * 1024 * 1024,  # 100 MB
+        ge=0,
+        description=(
+            "Maximum cumulative size in bytes of all attachments processed for a "
+            "single email when process_attachments is enabled. Once the budget is "
+            "exhausted, remaining attachments are skipped with a note."
+        ),
+    )
 
 
 class XBRLBackendOptions(BaseBackendOptions):

--- a/docling/document_converter.py
+++ b/docling/document_converter.py
@@ -23,7 +23,10 @@ from docling.backend.boxnote_backend import BoxNoteDocumentBackend
 from docling.backend.csv_backend import CsvDocumentBackend
 from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
 from docling.backend.ebcdic_backend import EbcdicDocumentBackend
-from docling.backend.email_backend import EmailDocumentBackend
+from docling.backend.email_backend import (
+    EmailDocumentBackend,
+    register_attachment_converter_factory,
+)
 from docling.backend.epub_backend import EpubDocumentBackend
 from docling.backend.html_backend import HTMLDocumentBackend
 from docling.backend.image_backend import ImageDocumentBackend
@@ -798,3 +801,10 @@ class DocumentConverter:
                 self._unload_input_document(in_doc)
 
         return conv_res
+
+
+# The email backend can parse attachments with Docling, but it lives in a lower
+# architecture layer and must not import DocumentConverter directly. Inject a
+# factory here (entrypoints layer) so EmailBackendOptions.process_attachments
+# works while keeping the module-boundary rules satisfied.
+register_attachment_converter_factory(lambda: DocumentConverter())

--- a/docs/usage/supported_formats.md
+++ b/docs/usage/supported_formats.md
@@ -23,7 +23,7 @@ Below you can find a listing of all supported input and output formats.
 | MP4, AVI, MOV | Video formats — audio track is extracted and transcribed (requires `asr` extra and `ffmpeg`) |
 | WebVTT | Web Video Text Tracks format for displaying timed text |
 | BoxNote | Box Notes collaborative note format |
-| Email | MIME (`.eml`) and Outlook (`.msg`) email messages; attachment names can optionally be listed via `EmailBackendOptions` |
+| Email | MIME (`.eml`) and Outlook (`.msg`) email messages; via `EmailBackendOptions`, attachment names can optionally be listed (`list_attachments`) or attachments parsed with Docling and embedded (`process_attachments`) |
 
 Schema-specific support:
 

--- a/tests/data/email/sources/eml_with_html_attachment.eml
+++ b/tests/data/email/sources/eml_with_html_attachment.eml
@@ -1,0 +1,23 @@
+From: Alice Example <alice@example.com>
+To: Bob Example <bob@example.com>
+Subject: Email with HTML attachment
+Date: Wed, 20 May 2026 10:30:00 +0000
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="===============6542120918356800943=="
+
+--===============6542120918356800943==
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: 7bit
+
+Please see the attached quarterly report.
+
+--===============6542120918356800943==
+Content-Type: text/html
+Content-Transfer-Encoding: base64
+Content-Disposition: attachment; filename="report.html"
+MIME-Version: 1.0
+
+PGh0bWw+PGJvZHk+PGgxPlF1YXJ0ZXJseSBSZXBvcnQ8L2gxPjxwPlJldmVudWUgcm9zZSB0byAx
+MiBtaWxsaW9uIGRvbGxhcnMuPC9wPjwvYm9keT48L2h0bWw+
+
+--===============6542120918356800943==--

--- a/tests/test_backend_email.py
+++ b/tests/test_backend_email.py
@@ -279,3 +279,82 @@ def test_msg_document_converter_lists_attachments_via_format_option():
     assert "Attachments" in markdown
     assert "test.txt" in markdown
     assert "report.pdf" in markdown
+
+
+def _email_backend(path: Path, options: EmailBackendOptions) -> EmailDocumentBackend:
+    in_doc = InputDocument(
+        path_or_stream=path,
+        format=InputFormat.EMAIL,
+        backend=EmailDocumentBackend,
+    )
+    return EmailDocumentBackend(in_doc=in_doc, path_or_stream=path, options=options)
+
+
+def test_email_process_attachments_embeds_converted_content():
+    in_path = Path("tests/data/email/sources/eml_with_html_attachment.eml")
+    backend = _email_backend(in_path, EmailBackendOptions(process_attachments=True))
+
+    markdown = backend.convert().export_to_markdown()
+
+    # The email's own content is still present ...
+    assert "Please see the attached quarterly report." in markdown
+    # ... and the HTML attachment was parsed and embedded under its own subsection.
+    assert "report.html" in markdown
+    assert "Quarterly Report" in markdown
+    assert "Revenue rose to 12 million dollars." in markdown
+
+
+def test_email_process_attachments_via_document_converter():
+    converter = DocumentConverter(
+        allowed_formats=[InputFormat.EMAIL],
+        format_options={
+            InputFormat.EMAIL: EmailFormatOption(
+                backend_options=EmailBackendOptions(process_attachments=True)
+            )
+        },
+    )
+    result = converter.convert(
+        Path("tests/data/email/sources/eml_with_html_attachment.eml")
+    )
+
+    markdown = result.document.export_to_markdown()
+    assert "Quarterly Report" in markdown
+    assert "Revenue rose to 12 million dollars." in markdown
+
+
+def test_email_attachments_not_processed_by_default():
+    in_path = Path("tests/data/email/sources/eml_with_html_attachment.eml")
+    backend = _email_backend(in_path, EmailBackendOptions())
+
+    markdown = backend.convert().export_to_markdown()
+
+    assert "Attachments" not in markdown
+    assert "Quarterly Report" not in markdown
+
+
+def test_email_process_attachments_falls_back_to_listing_when_unparseable():
+    # msg_with_attachment.msg carries a text attachment (parseable) and a
+    # deliberately invalid application/pdf attachment (unparseable), so this
+    # exercises both the embed path and the name/type fallback in one document.
+    in_path = Path("tests/data/email/sources/msg_with_attachment.msg")
+    backend = _email_backend(in_path, EmailBackendOptions(process_attachments=True))
+
+    markdown = backend.convert().export_to_markdown()
+
+    # Parseable attachment content is embedded.
+    assert "This is a test attachment file." in markdown
+    # Unparseable attachment is still listed by name/type (never dropped).
+    assert "report.pdf" in markdown
+    assert "could not be parsed" in markdown
+
+
+def test_email_process_attachments_respects_max_attachments():
+    in_path = Path("tests/data/email/sources/eml_with_html_attachment.eml")
+    backend = _email_backend(
+        in_path, EmailBackendOptions(process_attachments=True, max_attachments=0)
+    )
+
+    markdown = backend.convert().export_to_markdown()
+
+    # No attachment is processed, so the converted attachment content is absent.
+    assert "Revenue rose to 12 million dollars." not in markdown


### PR DESCRIPTION
Hi maintainers, this PR is to follow-up to #3873 and #3909 to now actually parse the attachment instead of just listing it. 
#3873 added `.eml`/`.msg` parsing and optional listing of attachment **names**, this PR optionally parses the attachments themselves.

With `EmailBackendOptions(process_attachments=True)`, each attachment is routed through Docling's own `DocumentConverter` and its converted content is embedded under an "Attachments" section, one subsection per attachment. So a PDF/DOCX/ PPTX/XLSX/image/HTML attachment is parsed exactly like a standalone document (tables, layout, OCR, ...). Attachments that can't be parsed because of unsupported format, a missing optional dependency, or corrupt bytes will fall back to a `name (content_type)` note, so nothing is silently dropped.

### How it works

- Attachment bytes are decoded from the same `mail-parser` representation used for both `.eml` and `.msg`, so both formats share one path.
- The backend builds one `DocumentConverter` per email (imported lazily to avoid the `document_converter` ↔ `email_backend` import cycle) and reuses it across attachments. The converted sub-document is merged in with `DoclingDocument.add_document(child, parent=<subsection>)`.
- The internal converter uses default options, so an attached `.eml`/`.msg` is parsed but its own attachments are not recursed.
- Opt-in (default off) since it runs the full pipeline per attachment. Guard rails: `max_attachments`, `max_attachment_bytes`, `max_attachment_total_bytes`.

### Usage

```python
from docling.datamodel.base_models import InputFormat
from docling.datamodel.backend_options import EmailBackendOptions
from docling.document_converter import DocumentConverter, EmailFormatOption

converter = DocumentConverter(
    format_options={
        InputFormat.EMAIL: EmailFormatOption(
            backend_options=EmailBackendOptions(process_attachments=True)
        )
    }
)

# Works for .eml and .msg; attachment content is embedded in the result.
doc = converter.convert("message.eml").document
print(doc.export_to_markdown())
```

Set `list_attachments=True` instead to only list attachment names/types without parsing them (the previous behavior).


**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
