### PR TITLE
feat(pdf): infer heading levels from font weight, slant and case

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1852,12 +1852,38 @@ class HeadingHierarchyOptions(BaseModel):
         bool,
         Field(
             description=(
-                "Use font size (approximated from parsed PDF cell heights) as a fallback for "
-                "headings without recognizable numbering. Requires "
-                "`generate_parsed_pages=True`."
+                "Use the visual style of the heading (font size, and with `use_font_style` also "
+                "weight, slant and letter case) as a fallback for headings without recognizable "
+                "numbering. Requires `generate_parsed_pages=True`."
             )
         ),
     ] = True
+    use_font_style: Annotated[
+        bool,
+        Field(
+            description=(
+                "Refine the style fallback with the font weight and slant read from the embedded "
+                "PDF font names, plus all-caps detection, so that headings sharing a font size "
+                "are still ranked (bold above regular, upright above italic, all-caps above "
+                "mixed case). Ignored when `use_style` is disabled; font names that carry no "
+                "recognizable styling fall back to font size alone."
+            )
+        ),
+    ] = True
+    style_size_tolerance: Annotated[
+        float,
+        Field(
+            ge=0.0,
+            le=1.0,
+            description=(
+                "Relative difference below which two heading font sizes are treated as one size "
+                "by the style fallback. The size of a heading is measured from its cells, so the "
+                "same font measures a little taller on a heading that has descenders; without "
+                "this tolerance such headings would land on different levels. Higher = more "
+                "sizes collapse into one level."
+            ),
+        ),
+    ] = 0.05
     numbering_schemes: Annotated[
         list[str] | None,
         Field(

--- a/docling/models/stages/heading_hierarchy/heading_hierarchy_model.py
+++ b/docling/models/stages/heading_hierarchy/heading_hierarchy_model.py
@@ -15,8 +15,12 @@ produced by the PDF path defaults to ``level=1`` and the document hierarchy is f
 2. **numbering** -- legal/outline numbering such as ``PART I -> 1. -> 1.1 -> (a) -> (i)``.
    The primary signal for headings without a bookmark match: on legal/regulatory documents
    numbering is far more reliable than styling, which is often uniform.
-3. **style** -- font size approximated from the parsed PDF cells, used only for headings
-   that have neither a bookmark match nor recognizable numbering.
+3. **style** -- the heading's visual style, read from the parsed PDF cells, used only for
+   headings that have neither a bookmark match nor recognizable numbering. Headings are ranked
+   by font size first -- with near-equal sizes merged, since the size is measured from the cells
+   and the same font measures taller on a heading that has descenders -- and then by font weight,
+   slant and letter case, so that headings sharing a size are still separated (bold above
+   regular, upright above italic, all-caps above mixed).
 
 Apart from promoting a confidently bookmark-matched list-item, the model only rewrites heading
 levels -- it never adds, removes or reorders items. The core
@@ -26,16 +30,18 @@ drive the style fallback.
 """
 
 import re
+from collections import Counter
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 from statistics import median
 
 from docling_core.types.doc import DoclingDocument
 from docling_core.types.doc.document import ListItem, SectionHeaderItem
-from docling_core.types.doc.page import SegmentedPdfPage
+from docling_core.types.doc.page import PdfTextCell, SegmentedPdfPage
 
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import HeadingHierarchyOptions
+from docling.utils.font_style import parse_font_style, weight_class
 from docling.utils.pdf_outline import _PdfOutlineItem
 
 # Default precedence of numbering schemes, highest hierarchy level first. ``dotted`` shares
@@ -198,10 +204,38 @@ def _infer_from_numbering(
     return {i: key_to_level[key] for i, key in keys.items()}
 
 
-def _heading_font_size(
-    item: SectionHeaderItem, parsed_pages: dict[int, SegmentedPdfPage]
-) -> float | None:
-    """Median height of parsed PDF cells overlapping the heading, as a font-size proxy."""
+@dataclass(frozen=True)
+class _HeadingStyle:
+    """The visual style of a heading, used as the ranking key of the style fallback."""
+
+    size: float  # median height of the underlying cells, as a font-size proxy
+    weight_cls: int = 0  # 0 light/regular, 1 medium/semibold, 2 bold and above
+    italic: bool = False
+    caps: bool = False
+
+
+# Share of the heading's characters that must be italic for the heading to count as italic.
+_ITALIC_RATIO = 0.6
+
+
+def _is_all_caps(text: str) -> bool:
+    """Whether the text is written in capitals (ignoring digits and punctuation)."""
+    letters = [char for char in text if char.isalpha()]
+    return len(letters) >= 4 and all(char.isupper() for char in letters)
+
+
+def _heading_style(
+    item: SectionHeaderItem,
+    parsed_pages: dict[int, SegmentedPdfPage],
+    options: HeadingHierarchyOptions,
+) -> _HeadingStyle | None:
+    """Style of a heading, derived from the parsed PDF cells overlapping it.
+
+    Weight and slant are a character-weighted vote across those cells, since a heading can mix
+    fonts (a regular "1.1 " in front of a bold title). Cells without font information -- OCR
+    output, the pypdfium2 backend, or names that carry no recognizable styling -- contribute
+    their size but leave the heading at the regular weight, so the ranking degrades to font size.
+    """
     if not item.prov:
         return None
     prov = item.prov[0]
@@ -212,15 +246,61 @@ def _heading_font_size(
     page_height = parsed.dimension.height
     hbox = prov.bbox.to_top_left_origin(page_height)
     heights: list[float] = []
+    weights: Counter[int] = Counter()
+    styled_chars = 0
+    italic_chars = 0
     for cell in parsed.textline_cells:
         if not cell.text or not cell.text.strip():
             continue
         cbox = cell.rect.to_bounding_box().to_top_left_origin(page_height)
-        if hbox.overlaps(cbox):
-            heights.append(cell.rect.height)
+        if not hbox.overlaps(cbox):
+            continue
+        heights.append(cell.rect.height)
+
+        if not options.use_font_style or not isinstance(cell, PdfTextCell):
+            continue
+        style = parse_font_style(cell.font_name)
+        if not style.known:
+            continue
+        chars = len(cell.text.strip())
+        weights[weight_class(style.weight)] += chars
+        styled_chars += chars
+        if style.italic:
+            italic_chars += chars
+
     if not heights:
         return None
-    return median(heights)
+    size = median(heights)
+    if not options.use_font_style:
+        return _HeadingStyle(size=size)
+    return _HeadingStyle(
+        size=size,
+        # On a tie, the heavier class wins: emphasis is what makes a heading stand out.
+        weight_cls=max(weights, key=lambda cls: (weights[cls], cls), default=0),
+        italic=bool(styled_chars) and italic_chars / styled_chars >= _ITALIC_RATIO,
+        caps=_is_all_caps(item.text),
+    )
+
+
+def _cluster_sizes(sizes: set[float], tolerance: float) -> dict[float, int]:
+    """Group font sizes into clusters, largest first, and map each size to its cluster index.
+
+    The size of a heading is the median height of its cells, which measures the glyphs that are
+    actually on the line rather than the font size: a heading with descenders ("Securing and
+    protecting") measures a couple of points taller than one without ("Contents") in the very same
+    font. Treating every distinct height as its own level therefore invents levels and, because
+    each level then holds a single heading, leaves no headings for weight or slant to separate.
+    Consecutive sizes within ``tolerance`` (relative) are merged to absorb that measurement noise.
+    """
+    clusters: dict[float, int] = {}
+    index = 0
+    previous: float | None = None
+    for size in sorted(sizes, reverse=True):
+        if previous is not None and (previous - size) > tolerance * previous:
+            index += 1
+        clusters[size] = index
+        previous = size
+    return clusters
 
 
 def _infer_from_style(
@@ -228,24 +308,30 @@ def _infer_from_style(
     parsed_pages: dict[int, SegmentedPdfPage],
     options: HeadingHierarchyOptions,
 ) -> dict[int, int]:
-    """Map heading index -> level from font size buckets (larger size = higher level)."""
+    """Map heading index -> level from the heading styles (most prominent style = level 1)."""
     if not parsed_pages:
         return {}
-    sizes: dict[int, float] = {}
+    styles: dict[int, _HeadingStyle] = {}
     for i, heading in enumerate(headings):
-        size = _heading_font_size(heading, parsed_pages)
-        if size is not None:
-            sizes[i] = size
-    if not sizes:
+        style = _heading_style(heading, parsed_pages, options)
+        if style is not None:
+            styles[i] = style
+    if not styles:
         return {}
 
-    # Bucket by rounded point size; the largest size becomes level 1.
-    rounded = {i: round(size) for i, size in sizes.items()}
-    ranked = {
-        size: lvl
-        for lvl, size in enumerate(sorted(set(rounded.values()), reverse=True), start=1)
+    clusters = _cluster_sizes(
+        {style.size for style in styles.values()}, options.style_size_tolerance
+    )
+    # Order by size first, then by how much the heading stands out within its size: heavier before
+    # lighter, upright before italic (italic sits lighter on the page), capitals before mixed case.
+    keys = {
+        i: (clusters[style.size], -style.weight_cls, style.italic, not style.caps)
+        for i, style in styles.items()
     }
-    return {i: ranked[size] for i, size in rounded.items()}
+    # Compress the distinct keys actually present into contiguous levels, so a signal that does
+    # not vary across the document's headings (e.g. all of them bold) adds no levels.
+    ranked = {key: lvl for lvl, key in enumerate(sorted(set(keys.values())), start=1)}
+    return {i: ranked[key] for i, key in keys.items()}
 
 
 # --------------------------------------------------------------------------------- bookmarks

--- a/docling/utils/font_style.py
+++ b/docling/utils/font_style.py
@@ -1,0 +1,167 @@
+"""Read weight and slant out of a PDF font name.
+
+PDF font names are the only styling metadata Docling gets from the digital text layer:
+``PdfTextCell.font_name`` carries the font dictionary's name (e.g. ``/Helvetica-Bold``,
+``/NKDKGK+HelveticaNeueLTPro-Bd``, ``/KIDKQO+Times-Italic``). There is no standard for encoding
+weight and slant in that string -- only foundry conventions -- so :func:`parse_font_style`
+recognizes the common ones and reports everything else as *unknown* rather than guessing.
+
+Two rules keep the parser conservative, because a false "bold" silently rewrites a heading level
+while a miss only falls back to the previous behavior:
+
+1. **Style words are matched as whole tokens**, after splitting the name on separators and
+   camel-case boundaries. ``Avenir-Book`` is a regular weight, but the family ``Bookman`` is not.
+2. **Abbreviations are only honored as a whole separator-delimited part.** ``-Bd`` is bold, but
+   the ``TB`` in ``LinLibertineTB`` and the ``LT`` in ``HelveticaNeueLTPro`` are not read as
+   styles -- foundry tags glued onto a family name look exactly like weight abbreviations.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+
+# Weight of text whose font name says nothing about weight.
+REGULAR_WEIGHT = 400
+
+# Subset-embedded fonts are prefixed with six uppercase letters and a plus (PDF 32000-1 9.6.4).
+_SUBSET_PREFIX = re.compile(r"^[A-Z]{6}\+")
+_SEPARATORS = re.compile(r"[-_,+ ]+")
+# camelCase / digit boundaries: "HelveticaNeueLTPro" -> Helvetica, Neue, LT, Pro
+_TOKENS = re.compile(r"[A-Z]+(?![a-z])|[A-Z][a-z]+|[a-z]+|\d+")
+
+# Whole style words. Deliberately excludes short foundry tags (LT, MT, PS, Std, Pro, Com).
+_WEIGHT_TOKENS = {
+    "thin": 100,
+    "hairline": 100,
+    "extralight": 200,
+    "ultralight": 200,
+    "light": 300,
+    "book": REGULAR_WEIGHT,
+    "normal": REGULAR_WEIGHT,
+    "plain": REGULAR_WEIGHT,
+    "regular": REGULAR_WEIGHT,
+    "roman": REGULAR_WEIGHT,  # upright, as in Times-Roman -- not a Roman numeral, not italic
+    "medium": 500,
+    "demi": 600,
+    "demibold": 600,
+    "semi": 600,
+    "semibold": 600,
+    "bold": 700,
+    "extrabold": 800,
+    "ultrabold": 800,
+    "black": 900,
+    "fat": 900,
+    "heavy": 900,
+    "poster": 900,
+    "ultra": 900,
+}
+
+_ITALIC_TOKENS = frozenset(
+    {"italic", "ital", "inclined", "kursiv", "oblique", "slanted"}
+)
+
+# Camel-case splitting separates the modifier from the weight ("SemiBold" -> semi, bold), so
+# recombine the pairs before looking tokens up individually.
+_WEIGHT_MODIFIERS = {
+    "semi": {"bold": 600, "light": 350},
+    "demi": {"bold": 600, "light": 350},
+    "extra": {"bold": 800, "light": 200, "black": 900},
+    "ultra": {"bold": 800, "light": 200, "black": 900},
+    "x": {"bold": 800, "light": 200},
+}
+
+# Abbreviations, honored only when they form a complete separator-delimited part.
+# Values are ``(weight, italic)``; ``None`` leaves that aspect unset.
+_PART_ABBREVIATIONS: dict[str, tuple[int | None, bool | None]] = {
+    "b": (700, None),
+    "bd": (700, None),
+    "bi": (700, True),
+    "bdit": (700, True),
+    "blk": (900, None),
+    "i": (None, True),
+    "ita": (None, True),
+    "it": (None, True),
+    "lt": (300, None),
+    "md": (500, None),
+    "obl": (None, True),
+    "reg": (REGULAR_WEIGHT, None),
+    "rg": (REGULAR_WEIGHT, None),
+    "rom": (REGULAR_WEIGHT, None),
+    "sb": (600, None),
+}
+
+
+@dataclass(frozen=True)
+class _FontStyle:
+    """Weight and slant read from a font name (internal)."""
+
+    weight: int = REGULAR_WEIGHT
+    italic: bool = False
+    known: bool = False  # False when the name carried no recognizable style
+
+
+def weight_class(weight: int) -> int:
+    """Bucket a numeric weight into ``0`` (light/regular), ``1`` (medium/semibold), ``2`` (bold+).
+
+    Coarse on purpose: heading levels are derived from the distinct classes present in a document,
+    so a finer scale would split near-identical styles into separate levels.
+    """
+    if weight >= 700:
+        return 2
+    if weight >= 500:
+        return 1
+    return 0
+
+
+@lru_cache(maxsize=1024)
+def parse_font_style(font_name: str) -> _FontStyle:
+    """Read weight and slant from a PDF font name.
+
+    Returns a regular, upright style with ``known=False`` when the name carries no recognizable
+    styling -- an unstyled family, a foundry-tagged name, or a bare resource key such as ``/F1``
+    (docling-parse falls back to the key, or to the literal ``"null"``, when the font dictionary
+    has no descriptive name).
+    """
+    name = _SUBSET_PREFIX.sub("", (font_name or "").lstrip("/"), count=1)
+    if not name:
+        return _FontStyle()
+
+    weight: int | None = None
+    italic: bool | None = None
+
+    for part in _SEPARATORS.split(name):
+        if not part:
+            continue
+        abbreviation = _PART_ABBREVIATIONS.get(part.lower())
+        if abbreviation is not None:
+            part_weight, part_italic = abbreviation
+            weight = part_weight if part_weight is not None else weight
+            italic = part_italic if part_italic is not None else italic
+            continue
+
+        tokens = [token.lower() for token in _TOKENS.findall(part)]
+        index = 0
+        while index < len(tokens):
+            token = tokens[index]
+            modifier = _WEIGHT_MODIFIERS.get(token)
+            if modifier is not None and index + 1 < len(tokens):
+                combined = modifier.get(tokens[index + 1])
+                if combined is not None:
+                    weight = combined
+                    index += 2
+                    continue
+            if token in _WEIGHT_TOKENS:
+                weight = _WEIGHT_TOKENS[token]
+            elif token in _ITALIC_TOKENS:
+                italic = True
+            index += 1
+
+    if weight is None and italic is None:
+        return _FontStyle()
+    return _FontStyle(
+        weight=weight if weight is not None else REGULAR_WEIGHT,
+        italic=bool(italic),
+        known=True,
+    )

--- a/tests/test_font_style.py
+++ b/tests/test_font_style.py
@@ -1,0 +1,90 @@
+"""Tests for reading font weight and slant out of PDF font names."""
+
+import pytest
+
+from docling.utils.font_style import parse_font_style, weight_class
+
+# Names harvested from the PDFs under tests/data/pdf/sources/, plus the foundry conventions they
+# represent. The expectations pin how each convention is read, since there is no standard for
+# encoding weight and slant in a font name.
+_REAL_FONT_NAMES = [
+    # (font name, weight, italic)
+    ("/AAAAAC+Verdana-Bold", 700, False),
+    ("/NKDKGK+HelveticaNeueLTPro-Bd", 700, False),  # abbreviation as a whole part
+    ("/HelveticaNeue-BoldCond", 700, False),  # camel-cased width suffix
+    ("/NKDKHL+LubalinGraphStd-Demi", 600, False),  # demi alone means semibold
+    ("/AAAAAV+FoundrySterling-Medium", 500, False),  # must not round up to bold
+    ("/NKDKFH+HelveticaNeueLTPro-Md", 500, False),
+    ("/WACECQ+Times-Roman", 400, False),  # "Roman" is upright regular, not italic
+    (
+        "/AAAAAR+Avenir-Book",
+        400,
+        False,
+    ),  # "Book" is a weight, unlike the family "Bookman"
+    ("/JRMZCQ+MyriadPro-Regular", 400, False),
+    ("/KIDKQO+Times-Italic", 400, True),
+    ("/BLKGOW+Helvetica-Oblique", 400, True),
+    (
+        "Arial-BoldItalicMT",
+        700,
+        True,
+    ),  # weight and slant in one part, plus a foundry tag
+]
+
+# Names whose styling cannot be read. They must resolve to regular and upright so the heading
+# ranking falls back to font size instead of inventing a level.
+_UNREADABLE_FONT_NAMES = [
+    "/F1",  # resource key: docling-parse reports it when the font dict has no name
+    "null",  # docling-parse's placeholder when no name is found at all
+    "/AAAAAJ+ArialMT",  # MT is a foundry tag, not a style
+    "/NKDKLM+HelveticaNeueLTCom",  # LT/Com are foundry tags
+    "/AAAAAE+Verdana",  # bare family name
+    "",
+]
+
+
+@pytest.mark.parametrize(("font_name", "weight", "italic"), _REAL_FONT_NAMES)
+def test_real_font_names(font_name: str, weight: int, italic: bool):
+    style = parse_font_style(font_name)
+
+    assert (style.weight, style.italic) == (weight, italic)
+    assert style.known
+
+
+@pytest.mark.parametrize("font_name", _UNREADABLE_FONT_NAMES)
+def test_unreadable_font_names_resolve_to_regular(font_name: str):
+    style = parse_font_style(font_name)
+
+    assert (style.weight, style.italic, style.known) == (400, False, False)
+
+
+@pytest.mark.parametrize(
+    "font_name", ["/RWPIRK+LinLibertineTB", "/TKQZJF+LinLibertineTI"]
+)
+def test_glued_single_letter_suffixes_are_not_read(font_name: str):
+    # Linux Libertine encodes bold/italic as a T{B,I} suffix glued to the family name. Reading
+    # single letters without a separator would also turn foundry tags into styles, so this
+    # regular-and-upright result is a deliberate miss: a wrong bold silently rewrites a heading
+    # level, while a miss only falls back to font size.
+    assert not parse_font_style(font_name).known
+
+
+@pytest.mark.parametrize(
+    ("font_name", "weight"),
+    [
+        ("Foo-SemiBold", 600),
+        ("Foo-ExtraBold", 800),
+        ("Foo-UltraLight", 200),
+        ("Foo-Black", 900),
+    ],
+)
+def test_camel_cased_modifiers_combine_with_the_weight(font_name: str, weight: int):
+    # Camel-case splitting separates "Semi" from "Bold"; the pair must not be read as plain bold.
+    assert parse_font_style(font_name).weight == weight
+
+
+def test_weight_classes_group_neighbouring_weights():
+    # Bold and heavier share a class, medium and semibold share one, everything lighter is regular.
+    assert [weight_class(w) for w in (100, 300, 400)] == [0, 0, 0]
+    assert [weight_class(w) for w in (500, 600)] == [1, 1]
+    assert [weight_class(w) for w in (700, 800, 900)] == [2, 2, 2]

--- a/tests/test_heading_hierarchy.py
+++ b/tests/test_heading_hierarchy.py
@@ -144,7 +144,7 @@ def _bbox(left, top, right, bottom):
     )
 
 
-def _cell(text, left, top, right, bottom):
+def _cell(text, left, top, right, bottom, font_name="Helvetica"):
     return PdfTextCell(
         index=0,
         rect=BoundingRectangle.from_bounding_box(_bbox(left, top, right, bottom)),
@@ -153,7 +153,7 @@ def _cell(text, left, top, right, bottom):
         rendering_mode=PdfCellRenderingMode.FILL_TEXT,
         widget=False,
         font_key="F1",
-        font_name="Helvetica",
+        font_name=font_name,
     )
 
 
@@ -209,3 +209,165 @@ def test_style_fallback_assigns_levels_by_font_size():
     model.assign_heading_levels(doc, parsed_pages={1: page})
 
     assert [h.level for h in doc.texts] == [1, 2]
+
+
+def _style_levels(rows, **opts) -> list[int]:
+    """Level of each heading, from ``(text, top, bottom, font name)`` rows on a single page.
+
+    Each row becomes both a heading and the parsed cell it was extracted from, so the cell height
+    (``bottom - top``) acts as the font size and the font name carries weight and slant.
+    """
+    doc = DoclingDocument(name="t")
+    cells = []
+    for text, top, bottom, font_name in rows:
+        doc.add_heading(
+            text=text,
+            prov=ProvenanceItem(
+                page_no=1, charspan=(0, len(text)), bbox=_bbox(100, top, 300, bottom)
+            ),
+        )
+        cells.append(_cell(text, 100, top, 300, bottom, font_name=font_name))
+
+    model = HeadingHierarchyModel(
+        options=HeadingHierarchyOptions(use_numbering=False, use_style=True, **opts)
+    )
+    model.assign_heading_levels(doc, parsed_pages={1: _segmented_page(cells)})
+    return [heading.level for heading in doc.texts]
+
+
+def test_close_font_sizes_are_one_level():
+    # Heading size is measured from the cells, so the same font measures taller on a heading that
+    # has descenders ("Securing and protecting" vs "Contents" in redp5110_sampled.pdf). Splitting
+    # on that difference invents a level and leaves each level holding a single heading.
+    levels = _style_levels(
+        [
+            ("Securing and protecting data", 50, 74, "/Helvetica-Bold"),  # height 24
+            ("Contents", 100, 123, "/Helvetica-Bold"),  # height 23
+            ("1.1 Security fundamentals", 150, 162, "/Helvetica-Bold"),  # height 12
+        ]
+    )
+
+    assert levels == [1, 1, 2]
+
+
+def test_style_size_tolerance_zero_keeps_every_size_apart():
+    rows = [
+        ("Securing and protecting data", 50, 74, "/Helvetica-Bold"),
+        ("Contents", 100, 123, "/Helvetica-Bold"),
+    ]
+
+    assert _style_levels(rows, style_size_tolerance=0.0) == [1, 2]
+
+
+def test_weight_separates_headings_inside_one_size_cluster():
+    # Once near-identical sizes share a level, weight and slant are what tell them apart.
+    levels = _style_levels(
+        [
+            ("Securing and protecting data", 50, 74, "/Helvetica-Bold"),  # height 24
+            ("DB2 for i Center of Excellence", 100, 123, "/Times-Italic"),  # height 23
+        ]
+    )
+
+    assert levels == [1, 2]
+
+
+def test_style_ranks_bold_above_regular_at_the_same_size():
+    # The case font size alone cannot separate: a section head set in the body size, distinguished
+    # only by its weight (as in tests/data/pdf/sources/redp5110_sampled.pdf).
+    levels = _style_levels(
+        [
+            ("Notices", 50, 62, "/Helvetica-Bold"),
+            ("Trademarks", 80, 92, "/Helvetica"),
+        ]
+    )
+
+    assert levels == [1, 2]
+
+
+def test_uniform_weight_adds_no_levels():
+    # A signal that does not vary must not split anything: three bold headings at two sizes still
+    # produce the two levels that font size alone would.
+    levels = _style_levels(
+        [
+            ("Preface", 50, 72, "/Helvetica-Bold"),
+            ("Authors", 100, 112, "/Helvetica-Bold"),
+            ("Comments", 130, 142, "/Helvetica-Bold"),
+        ]
+    )
+
+    assert levels == [1, 2, 2]
+
+
+def test_style_ranks_weight_then_slant():
+    # At one size: bold is the most prominent, italic the least (italic sits lighter on the page
+    # than upright text, so italic subheads rank below plain ones).
+    levels = _style_levels(
+        [
+            ("Scope", 50, 62, "/Helvetica-Bold"),
+            ("Definitions", 80, 92, "/Helvetica"),
+            ("Remarks", 110, 122, "/Helvetica-Oblique"),
+        ]
+    )
+
+    assert levels == [1, 2, 3]
+
+
+def test_all_caps_outranks_mixed_case():
+    levels = _style_levels(
+        [
+            ("OVERVIEW", 50, 62, "/Helvetica-Bold"),
+            ("Details", 80, 92, "/Helvetica-Bold"),
+        ]
+    )
+
+    assert levels == [1, 2]
+
+
+def test_weight_is_voted_across_the_cells_of_a_heading():
+    # A heading can mix fonts -- a regular numbering marker in front of a bold title. The bold
+    # title carries more characters, so the heading counts as bold and outranks the plain one.
+    doc = DoclingDocument(name="t")
+    for text, top in [("1.1 Scope", 50), ("Definitions", 80)]:
+        doc.add_heading(
+            text=text,
+            prov=ProvenanceItem(
+                page_no=1, charspan=(0, len(text)), bbox=_bbox(100, top, 300, top + 12)
+            ),
+        )
+    page = _segmented_page(
+        [
+            _cell("1.1", 100, 50, 124, 62, font_name="/Helvetica"),
+            _cell("Scope", 128, 50, 300, 62, font_name="/Helvetica-Bold"),
+            _cell("Definitions", 100, 80, 300, 92, font_name="/Helvetica"),
+        ]
+    )
+
+    model = HeadingHierarchyModel(
+        options=HeadingHierarchyOptions(use_numbering=False, use_style=True)
+    )
+    model.assign_heading_levels(doc, parsed_pages={1: page})
+
+    assert [heading.level for heading in doc.texts] == [1, 2]
+
+
+def test_use_font_style_false_ranks_by_size_only():
+    rows = [
+        ("Notices", 50, 62, "/Helvetica-Bold"),
+        ("Trademarks", 80, 92, "/Helvetica"),
+    ]
+
+    assert _style_levels(rows, use_font_style=False) == [1, 1]
+
+
+def test_font_names_without_styling_rank_by_size_only():
+    # Some PDFs report a resource key instead of a font name; those headings must fall back to
+    # font size rather than being split apart.
+    levels = _style_levels(
+        [
+            ("Overview", 50, 70, "/F1"),
+            ("Details", 88, 100, "/F2"),
+            ("Remarks", 120, 132, "/F3"),
+        ]
+    )
+
+    assert levels == [1, 2, 2]


### PR DESCRIPTION
Hi maintainers, this PR is to further follow-up to #3633 (numbering/style heading inference) and #3688 (bookmarks/ToC).

The style fallback of `HeadingHierarchyModel`, the only signal that fires for unnumbered headings in PDFs without an outline, ranked headings by *exact rounded font size*. Two problems, both measured on the PDFs in `tests/data/pdf/sources/`:

1. **The size proxy is noisy, and exact bucketing turns that noise into levels.** A heading's size
   is the median height of the cells overlapping it, which measures the glyphs actually on the
   line rather than the font size. In `redp5110_sampled.pdf`, `Securing and protecting IBM DB2
   data` measures 24 and `Contents` measures 22 *in the same font* — descenders. Every heading
   therefore landed in its own bucket: 10 distinct sizes over 20 headings, 12 of them clamped to
   the maximum level.
2. **Weight, slant and letter case were not read at all**, although `PdfTextCell.font_name`
   carries them (`/Helvetica-Bold`, `/NKDKGK+HelveticaNeueLTPro-Bd`, `/KIDKQO+Times-Italic`).

Because of (1), fixing (2) alone is a no-op: with every heading alone in its size bucket, a tie-breaker never gets consulted. Both change together here.

## Changes

- **`docling/utils/font_style.py`** (new, pure): `parse_font_style()` reads weight and slant from a PDF font name; `weight_class()` buckets to light/regular, medium/semibold, bold+. Two rules keep it conservative, since a false "bold" silently rewrites a heading level while a miss only falls back to font size:
  - style words match as **whole tokens** after splitting on separators and camel case (`Avenir-Book` is a weight; the family `Bookman` is not; `HelveticaNeue-BoldCond` is bold);
  - abbreviations count **only as a complete separator-delimited part** (`-Bd` is bold; the `TB` in `LinLibertineTB` and the `LT` in `HelveticaNeueLTPro` are not, since foundry tags glued to a family name are indistinguishable from weight abbreviations).

  Names that carry no recognizable styling — `/F1`, `"null"`, `ArialMT`, bare families, resolve to regular and upright, so those documents keep the previous font-size behavior.

- **`heading_hierarchy_model.py`**: `_heading_font_size` becomes `_heading_style`, returning size, weight class, italic and all-caps. Weight and slant are a character-weighted vote across the cells of the heading, since a heading can mix a regular `1.1` marker with a bold title; cells with no font information (OCR, the pypdfium2 backend) contribute their size only.
  `_cluster_sizes` merges near-equal sizes, and headings are then ranked by `(size cluster, weight, upright before italic, capitals before mixed case)`. A signal that does not vary across a document's headings adds no levels.

- **`HeadingHierarchyOptions`**: `use_font_style` (default `True`, sub-switch of `use_style`) and `style_size_tolerance` (default `0.05`). Both are exposed by the service API automatically, since `docling/datamodel/service/options.py` embeds the model directly.

No pipeline change: the model already receives the parsed pages, and the same cells carry the font names. No new dependency 

## Usage

The stage stays opt-in. `generate_parsed_pages=True` is what makes the parsed cells — and
therefore the fonts — available to it:

```python
from docling.datamodel.base_models import InputFormat
from docling.datamodel.pipeline_options import (
    HeadingHierarchyOptions,
    PdfPipelineOptions,
)
from docling.document_converter import DocumentConverter, PdfFormatOption

pipeline_options = PdfPipelineOptions(generate_parsed_pages=True)
pipeline_options.heading_hierarchy_options = HeadingHierarchyOptions(
    enabled=True,
    # use_font_style=False,      # rank by font size alone, as before this PR
    # style_size_tolerance=0.0,  # never merge two measured sizes
)

converter = DocumentConverter(
    format_options={
        InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)
    }
)
print(converter.convert("report.pdf").document.export_to_markdown())
```

Through the service API, where the new fields need no separate wiring:

```json
{
  "do_pdf_heading_hierarchy": true,
  "pdf_heading_hierarchy_options": {
    "use_font_style": true,
    "style_size_tolerance": 0.05
  }
}
```

## Measured effect

Isolating the signal (`use_bookmarks=False, use_numbering=False, use_style=True`), against `main`:

**`2206.01062.pdf`** (DocLayNet, ACM template) — 7 of 18 headings change, all corrections:

| heading | main | this PR |
| --- | --- | --- |
| `1 INTRODUCTION`, `2 RELATED WORK`, … `REFERENCES` | 2 | 2 |
| `Baselines for Object Detection`, `Learning Curve`, `Impact of Class Labels`, … | 2 | **3** |
| `ACMReference Format:` | 3 | 4 |

The mixed-case subsection heads were being flattened into their all-caps parent sections. The discriminator here is letter case, not weight: this document is set in Linux Libertine, i.e. the `LinLibertineTB` convention the parser deliberately declines to read.

**`redp5110_sampled.pdf`** (IBM Redbook, Helvetica) — 11 of 20 change; headings pinned at the level cap drop from 12/20 to 8/20. `1.1 Security fundamentals` now sits above `1.3.1 Existing row and column control`; both were at the cap before. The italic
`DB2 for i Center of Excellence` now ranks below the same-size bold `Contents`/`Preface`.

**`amt_handbook_sample.pdf`**, **`2305.03393v1-pg9.pdf`** — no changes: uniform heading styling, nothing to separate.

## Compatibility

The stage is opt-in and off by default (`heading_hierarchy_options.enabled=False`), so no reference data changed. For users who had enabled it, `use_font_style=False` restores the previous ranking, and `style_size_tolerance=0.0` restores exact size bucketing, worth noting that size clustering applies regardless of `use_font_style`, because it is a correctness fix for the size
proxy rather than a new signal.

Known gap: some PDFs report a font resource key (`/F1`) instead of a font name, so weight is unavailable there and the ranking falls back to size. The root cause is upstream in docling-parse (`init_font_name()` prefers the deprecated `/Name` key over `/BaseFont`) and is left for a separate fix.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
