### PR TITLE
fix(csv): detect the dialect when a quoted field spans several lines

### DIFF
--- a/docling/backend/csv_backend.py
+++ b/docling/backend/csv_backend.py
@@ -1,6 +1,7 @@
 import csv
 import logging
 import warnings
+from collections.abc import Callable
 from io import BytesIO, StringIO
 from pathlib import Path
 from typing import Final, Set, Union
@@ -14,25 +15,27 @@ from docling.exceptions import DocumentLoadError
 
 _log = logging.getLogger(__name__)
 
-# Characters of the file handed to csv.Sniffer to detect the dialect.
-_SNIFF_SAMPLE_SIZE: Final[int] = 65536
+# Characters of the file handed to csv.Sniffer when the first line alone
+# cannot be sniffed.
+_SNIFF_SAMPLE_SIZE: Final[int] = 4096
 _DELIMITERS: Final[str] = ",;\t|:"
 
 
-def _sniff_dialect(head: str, sample: str) -> type[csv.Dialect]:
+def _sniff_dialect(head: str, read_sample: Callable[[], str]) -> type[csv.Dialect]:
     """Detect the dialect from the first line, falling back to a larger sample.
 
     The first line is enough for most files and is what the sniffer reads best:
     it rejects samples whose rows hold different numbers of delimiters. It is
     not enough when a quoted field spans several lines, because the line is cut
     mid-quote; retrying with a sample that closes the quote recovers those.
+    `read_sample` is only called on that fallback path.
 
     Raises csv.Error if neither can be detected.
     """
     try:
         return csv.Sniffer().sniff(head, _DELIMITERS)
     except csv.Error:
-        return csv.Sniffer().sniff(sample, _DELIMITERS)
+        return csv.Sniffer().sniff(read_sample(), _DELIMITERS)
 
 
 class CsvDocumentBackend(DeclarativeDocumentBackend):
@@ -75,12 +78,16 @@ class CsvDocumentBackend(DeclarativeDocumentBackend):
         Parses the CSV data into a structured document model.
         """
 
-        # Detect CSV dialect
+        # Detect CSV dialect. The larger sample is only read when the first
+        # line fails to sniff.
         head = self.content.readline()
-        self.content.seek(0)
-        sample = self.content.read(_SNIFF_SAMPLE_SIZE)
+
+        def read_sample() -> str:
+            self.content.seek(0)
+            return self.content.read(_SNIFF_SAMPLE_SIZE)
+
         try:
-            dialect: type[csv.Dialect] = _sniff_dialect(head, sample)
+            dialect: type[csv.Dialect] = _sniff_dialect(head, read_sample)
             if dialect.delimiter not in _DELIMITERS:
                 raise RuntimeError(
                     f"Cannot convert csv with unknown delimiter {dialect.delimiter}."

--- a/docling/backend/csv_backend.py
+++ b/docling/backend/csv_backend.py
@@ -3,7 +3,7 @@ import logging
 import warnings
 from io import BytesIO, StringIO
 from pathlib import Path
-from typing import Set, Union
+from typing import Final, Set, Union
 
 from docling_core.types.doc import DoclingDocument, DocumentOrigin, TableCell, TableData
 
@@ -13,6 +13,26 @@ from docling.datamodel.document import InputDocument
 from docling.exceptions import DocumentLoadError
 
 _log = logging.getLogger(__name__)
+
+# Characters of the file handed to csv.Sniffer to detect the dialect.
+_SNIFF_SAMPLE_SIZE: Final[int] = 65536
+_DELIMITERS: Final[str] = ",;\t|:"
+
+
+def _sniff_dialect(head: str, sample: str) -> type[csv.Dialect]:
+    """Detect the dialect from the first line, falling back to a larger sample.
+
+    The first line is enough for most files and is what the sniffer reads best:
+    it rejects samples whose rows hold different numbers of delimiters. It is
+    not enough when a quoted field spans several lines, because the line is cut
+    mid-quote; retrying with a sample that closes the quote recovers those.
+
+    Raises csv.Error if neither can be detected.
+    """
+    try:
+        return csv.Sniffer().sniff(head, _DELIMITERS)
+    except csv.Error:
+        return csv.Sniffer().sniff(sample, _DELIMITERS)
 
 
 class CsvDocumentBackend(DeclarativeDocumentBackend):
@@ -57,9 +77,11 @@ class CsvDocumentBackend(DeclarativeDocumentBackend):
 
         # Detect CSV dialect
         head = self.content.readline()
+        self.content.seek(0)
+        sample = self.content.read(_SNIFF_SAMPLE_SIZE)
         try:
-            dialect: type[csv.Dialect] = csv.Sniffer().sniff(head, ",;\t|:")
-            if dialect.delimiter not in {",", ";", "\t", "|", ":"}:
+            dialect: type[csv.Dialect] = _sniff_dialect(head, sample)
+            if dialect.delimiter not in _DELIMITERS:
                 raise RuntimeError(
                     f"Cannot convert csv with unknown delimiter {dialect.delimiter}."
                 )

--- a/tests/test_backend_csv.py
+++ b/tests/test_backend_csv.py
@@ -89,6 +89,22 @@ def test_e2e_invalid_csv_conversions():
         converter.convert(csv_inconsistent_header)
 
 
+def test_quoted_newline_in_first_field():
+    """A quoted field spanning several lines must not break delimiter sniffing.
+
+    Reading a single line split the field mid-quote, so the sniffer saw an
+    unterminated quote and the conversion failed outright.
+    """
+    csv_bytes = b'"line one\nstill line one";b;c\n1;2;3\n'
+    conv_result = get_converter().convert(
+        DocumentStream(name="quoted.csv", stream=BytesIO(csv_bytes)),
+        raises_on_error=True,
+    )
+    table = conv_result.document.tables[0]
+    assert table.data.num_cols == 3
+    assert table.data.table_cells[0].text == "line one\nstill line one"
+
+
 def test_empty_csv():
     """Regression test: converting an empty CSV file should not raise an IndexError."""
     conv_result = get_converter().convert(


### PR DESCRIPTION
## Problem

A CSV whose first field is quoted and contains a newline fails to convert:

```python
DocumentConverter(allowed_formats=[InputFormat.CSV]).convert(
    DocumentStream(name="quoted.csv",
                   stream=BytesIO(b'"line one\nstill line one";b;c\n1;2;3\n')),
    raises_on_error=True,
)
# RuntimeError: Pipeline SimplePipeline failed
#   _csv.Error: ',' expected after '"'
```

`convert()` sniffs the dialect from `self.content.readline()`. That read stops at the newline inside the quoted field, so the sniffer gets `'"line one'` — an unterminated quote — and raises `csv.Error`. The handler falls back to `csv.excel`, and reading a semicolon file as comma-delimited under `strict=True` aborts the conversion.

## Fix

Retry the sniff on a larger sample when the first line fails; the sample closes the quote and the dialect is detected.

The first line is still tried first, deliberately. Sniffing the larger sample unconditionally regresses existing fixtures: `csv.Sniffer` rejects samples whose rows carry different numbers of delimiters (`csv-inconsistent-header`, `csv-too-many-columns`), and it also infers `quotechar` from what it is given — on `csv-too-few-columns` it picks `'` and strips the quotes from a `'b'` cell, changing that file's groundtruth. Falling back only on failure leaves every currently-detected dialect untouched.

## Tests

`test_quoted_newline_in_first_field` in `tests/test_backend_csv.py`. Against unfixed code:

```
FAILED tests/test_backend_csv.py::test_quoted_newline_in_first_field
  - RuntimeError: Pipeline SimplePipeline failed
```

`tests/test_backend_csv.py` goes 3 passed → 4 passed; no groundtruth was regenerated. `ruff check` and `ruff format --check` are clean.

Found while reading the backend, so there is no tracking issue. Related but distinct: #1716 is the single-column sniff failure already handled by the comma fallback.
