### PR TITLE
fix(pptx): keep the bbox of shapes positioned at x = 0 EMU

### DIFF
--- a/docling/backend/mspowerpoint_backend.py
+++ b/docling/backend/mspowerpoint_backend.py
@@ -226,7 +226,7 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
     def _generate_prov(
         self, shape, slide_ind, text="", slide_size=Size(width=1, height=1)
     ):
-        if shape.left:
+        if None not in (shape.left, shape.top, shape.width, shape.height):
             left = shape.left
             top = shape.top
             width = shape.width

--- a/tests/test_backend_pptx.py
+++ b/tests/test_backend_pptx.py
@@ -272,6 +272,32 @@ def test_pptx_malformed_picture_shapes():
     assert "Slide With Wrong Content Type" in pred_md
 
 
+def test_pptx_left_flush_shape_keeps_own_bbox(tmp_path: Path):
+    """A shape positioned at x = 0 EMU must keep its own bounding box.
+
+    shape.left is an Emu, an int subclass, so a left-flush shape made the
+    old truthiness check fall into the position-unknown fallback and its
+    provenance bbox covered the entire slide.
+    """
+    from pptx import Presentation
+    from pptx.util import Inches
+
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[6])
+    flush = slide.shapes.add_textbox(Inches(0), Inches(1), Inches(3), Inches(1))
+    flush.text_frame.text = "flush left"
+    pptx_path = tmp_path / "flush_left.pptx"
+    prs.save(pptx_path)
+
+    doc = get_converter().convert(pptx_path).document
+
+    item = next(t for t in doc.texts if t.text == "flush left")
+    bbox = item.prov[0].bbox
+    assert (bbox.l, bbox.r) == (0, Inches(3))
+    assert abs(bbox.t - bbox.b) == Inches(1)
+    assert bbox.r != prs.slide_width
+
+
 def test_pptx_page_range():
     converter = get_converter()
     pptx_path = Path("./tests/data/pptx/sources/powerpoint_sample.pptx")


### PR DESCRIPTION
### What's broken

`_generate_prov` in the PPTX backend uses `if shape.left:` to decide whether a shape has a known position. `shape.left` is a `pptx.util.Emu` — an `int` subclass — so a shape flush against the left slide edge (`left == 0`) takes the position-unknown fallback: its real `top`/`width`/`height` are discarded and its provenance bbox becomes the entire slide. Affects every shape type routed through this helper (text, pictures, tables, charts), and collapses all left-flush shapes on a slide to the same bbox.

### Why

The fallback exists for placeholder shapes that inherit geometry from the layout and return `None` (#584, #868). `0` is a legitimate position, not a missing one — the guard needs an identity check, not truthiness.

### The fix

One line: `if None not in (shape.left, shape.top, shape.width, shape.height):`. Checking all four coordinates (instead of just `left is not None`) also covers a shape that has `a:off` but no `a:ext`, which today passes the truthy guard and crashes at `left + width` with a `TypeError`; it now takes the fallback as intended.

### Repro

```python
prs = Presentation()
slide = prs.slides.add_slide(prs.slide_layouts[6])
tb = slide.shapes.add_textbox(Inches(0), Inches(1), Inches(3), Inches(1))
tb.text_frame.text = "flush left"
# before: bbox l=0.0 t=6858000.0 r=9144000.0 b=0.0  (the whole slide)
# after:  bbox l=0.0 r=2743200.0, height 914400     (the textbox)
```

### The test

`tests/test_backend_pptx.py::test_pptx_left_flush_shape_keeps_own_bbox` builds the deck above with python-pptx in `tmp_path` (same pattern as `test_backend_msexcel.py`) and asserts the shape keeps its own rectangle. It fails on main and passes with the fix; the full `tests/test_backend_pptx.py` suite passes (13 passed) with no groundtruth changes — no committed fixture contains a left-flush shape, which is why this went unnoticed.

Pre-commit (ruff, formatter, ty, tach) is green on the changed files.

Closes #3989