### PR TITLE
feat(cli): add --layout-engine and --table-structure-engine

### DIFF
--- a/docling/.agents/skills/docling/references/cli.md
+++ b/docling/.agents/skills/docling/references/cli.md
@@ -80,6 +80,8 @@ OCR engines are optional dependencies — see
 ```bash
 docling report.pdf --no-tables --output /tmp/            # skip table structure (faster)
 docling report.pdf --table-mode accurate --output /tmp/  # vs. fast
+docling report.pdf --layout-engine docling_layout_default --output /tmp/  # choose layout engine
+docling report.pdf --table-structure-engine docling_tableformer_v2 --output /tmp/  # choose table engine
 docling report.pdf --enrich-code --output /tmp/          # code understanding
 docling report.pdf --enrich-formula --output /tmp/       # formula understanding
 docling report.pdf --enrich-picture-classes --output /tmp/

--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -112,7 +112,11 @@ from docling.datamodel.base_models import (
 from docling.datamodel.document import ConversionResult, DoclingVersion
 from docling.datamodel.pipeline_options import (
     AsrPipelineOptions,
+    BaseLayoutOptions,
+    BaseTableStructureOptions,
     ConvertPipelineOptions,
+    LayoutObjectDetectionOptions,
+    LayoutOptions,
     OcrAutoOptions,
     OcrMode,
     OcrOptions,
@@ -242,6 +246,14 @@ def _expand_from_formats(from_formats: list[str] | None) -> list[InputFormat]:
 
 ocr_factory_internal = get_ocr_factory(allow_external_plugins=False)
 ocr_engines_enum_internal = ocr_factory_internal.get_enum()
+
+layout_factory_internal = get_layout_factory(allow_external_plugins=False)
+layout_engines_enum_internal = layout_factory_internal.get_enum()
+
+table_structure_factory_internal = get_table_structure_factory(
+    allow_external_plugins=False
+)
+table_structure_engines_enum_internal = table_structure_factory_internal.get_enum()
 
 # Get available VLM presets from the registry
 vlm_preset_ids = VlmConvertOptions.list_preset_ids()
@@ -841,6 +853,28 @@ def convert(  # noqa: C901
             help="If enabled, the table structure model will be used to extract table information.",
         ),
     ] = True,
+    layout_engine: Annotated[
+        str,
+        typer.Option(
+            ...,
+            help=(
+                f"The layout engine to use. When --allow-external-plugins is *not* set, the available values are: "
+                f"{', '.join(o.value for o in layout_engines_enum_internal)}. "
+                f"Use the option --show-external-plugins to see the options allowed with external plugins."
+            ),
+        ),
+    ] = LayoutObjectDetectionOptions.kind,
+    table_structure_engine: Annotated[
+        str,
+        typer.Option(
+            ...,
+            help=(
+                f"The table structure engine to use. When --allow-external-plugins is *not* set, the available values are: "
+                f"{', '.join(o.value for o in table_structure_engines_enum_internal)}. "
+                f"Use the option --show-external-plugins to see the options allowed with external plugins."
+            ),
+        ),
+    ] = TableStructureOptions.kind,
     ocr_engine: Annotated[
         str,
         typer.Option(
@@ -1215,6 +1249,20 @@ def convert(  # noqa: C901
             password=pdf_password
         )
 
+        layout_factory = get_layout_factory(
+            allow_external_plugins=allow_external_plugins
+        )
+        layout_options: BaseLayoutOptions = layout_factory.create_options(  # type: ignore
+            kind=layout_engine
+        )
+
+        table_structure_factory = get_table_structure_factory(
+            allow_external_plugins=allow_external_plugins
+        )
+        table_structure_options: BaseTableStructureOptions = (  # type: ignore
+            table_structure_factory.create_options(kind=table_structure_engine)
+        )
+
         if pipeline == ProcessingPipeline.STANDARD:
             pipeline_options = PdfPipelineOptions(
                 allow_external_plugins=allow_external_plugins,
@@ -1223,6 +1271,8 @@ def convert(  # noqa: C901
                 do_ocr=ocr,
                 ocr_options=ocr_options,
                 do_table_structure=tables,
+                layout_options=layout_options,
+                table_structure_options=table_structure_options,
                 do_code_enrichment=enrich_code,
                 do_formula_enrichment=enrich_formula,
                 do_picture_description=enrich_picture_description,

--- a/docs/concepts/plugins.md
+++ b/docs/concepts/plugins.md
@@ -62,7 +62,43 @@ def ocr_engines():
     }
 ```
 
-where `YourOcrModel` must implement the [`BaseOcrModel`](https://github.com/docling-project/docling/blob/main/docling/models/base_ocr_model.py#L23) and provide an options class derived from [`OcrOptions`](https://github.com/docling-project/docling/blob/main/docling/datamodel/pipeline_options.py#L105).
+where `YourOcrModel` must implement the [`BaseOcrModel`](https://github.com/docling-project/docling/blob/main/docling/models/base_ocr_model.py#L40) and provide an options class derived from [`OcrOptions`](https://github.com/docling-project/docling/blob/main/docling/datamodel/pipeline_options.py#L184).
+
+### Layout engine factory
+
+The layout engine factory allows to provide more layout engines to the Docling users.
+
+The content of `your_package.module` registers the layout engines with a code similar to:
+
+```py
+# Factory registration
+def layout_engines():
+    return {
+        "layout_engines": [
+            YourLayoutModel,
+        ]
+    }
+```
+
+where `YourLayoutModel` must implement the [`BaseLayoutModel`](https://github.com/docling-project/docling/blob/main/docling/models/base_layout_model.py#L35) and provide an options class derived from [`BaseLayoutOptions`](https://github.com/docling-project/docling/blob/main/docling/datamodel/pipeline_options.py#L1454).
+
+### Table structure engine factory
+
+The table structure engine factory allows to provide more table structure recognition engines to the Docling users.
+
+The content of `your_package.module` registers the table structure engines with a code similar to:
+
+```py
+# Factory registration
+def table_structure_engines():
+    return {
+        "table_structure_engines": [
+            YourTableStructureModel,
+        ]
+    }
+```
+
+where `YourTableStructureModel` must implement the [`BaseTableStructureModel`](https://github.com/docling-project/docling/blob/main/docling/models/base_table_model.py#L13) and provide an options class derived from [`BaseTableStructureOptions`](https://github.com/docling-project/docling/blob/main/docling/datamodel/pipeline_options.py#L130).
 
 If you look for an example, the [default Docling plugins](https://github.com/docling-project/docling/blob/main/docling/models/plugins/defaults.py) is a good starting point.
 
@@ -76,8 +112,10 @@ from docling.datamodel.pipeline_options import PdfPipelineOptions
 from docling.document_converter import DocumentConverter, PdfFormatOption
 
 pipeline_options = PdfPipelineOptions()
-pipeline_options.allow_external_plugins = True  # <-- enabled the external plugins
-pipeline_options.ocr_options = YourOptions  # <-- your options here
+pipeline_options.allow_external_plugins = True  # <-- enable external plugins
+pipeline_options.ocr_options = YourOptions  # <-- your OCR options here
+pipeline_options.layout_options = YourLayoutOptions  # <-- your layout options here
+pipeline_options.table_structure_options = YourTableStructureOptions  # <-- your table structure options here
 
 doc_converter = DocumentConverter(
     format_options={
@@ -90,12 +128,18 @@ doc_converter = DocumentConverter(
 
 ### Using the `docling` CLI
 
-Similarly, when using the `docling` users have to enable external plugins before selecting the new one.
+Similarly, when using the `docling` CLI, users have to enable external plugins before selecting the new one.
 
 ```sh
 # Show the external plugins
 docling --show-external-plugins
 
-# Run docling with the new plugin
+# Run docling with a custom OCR engine
 docling --allow-external-plugins --ocr-engine=NAME
+
+# Run docling with a custom layout engine
+docling --allow-external-plugins --layout-engine=NAME
+
+# Run docling with a custom table structure engine
+docling --allow-external-plugins --table-structure-engine=NAME
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -61,11 +61,14 @@ docling convert [OPTIONS] source
 | `--force-ocr` / `--no-force-ocr` | flag | `false` | DEPRECATED: use `--ocr-mode full_page` instead. Replace any existing text with OCR generated text over the full content. |
 | `--ocr-mode` | `full_page`, `layout_regions`, `pdf_aware_layout_regions`, `default` | `default` | Which document regions are fed to the OCR engine. |
 | `--tables` / `--no-tables` | flag | `true` | If enabled, the table structure model will be used to extract table information. |
+| `--layout-engine` | `text` | `layout_object_detection` | The layout engine to use. When --allow-external-plugins is *not* set, the available values are: layout_object_detection, docling_layout_default, docling_experimental_table_crops_layout. Use the option --show-external-plugins to see the options allowed with external plugins. |
+| `--table-structure-engine` | `text` | `docling_tableformer` | The table structure engine to use. When --allow-external-plugins is *not* set, the available values are: docling_tableformer, docling_tableformer_v2, granite_vision_table. Use the option --show-external-plugins to see the options allowed with external plugins. |
 | `--ocr-engine` | `text` | `auto` | The OCR engine to use. When --allow-external-plugins is *not* set, the available values are: auto, easyocr, kserve_v2_ocr, nemotron-ocr, ocrmac, rapidocr, tesserocr, tesseract. Use the option --show-external-plugins to see the options allowed with external plugins. |
 | `--ocr-lang` | `text` |  | Provide a comma-separated list of languages used by the OCR engine. Note that each OCR engine has different values for the language names. |
 | `--psm` | `integer` |  | Page Segmentation Mode for the OCR engine (0-13). |
 | `--pdf-backend` | `pypdfium2`, `docling_parse`, `threaded_docling_parse`, `dlparse_v1`, `dlparse_v2`, `dlparse_v4` | `docling_parse` | The PDF backend to use. |
 | `--pdf-password` | `text` |  | Password for protected PDF documents |
+| `--page-range` | `text` |  | Only convert a range of pages, e.g. 1-4 (page numbers start at 1). Honored by the PDF, XLSX and PPTX backends. |
 | `--table-mode` | `fast`, `accurate` | `accurate` | The mode to use in the table structure model. |
 | `--enrich-code` / `--no-enrich-code` | flag | `false` | Enable the code enrichment model in the pipeline. |
 | `--enrich-formula` / `--no-enrich-formula` | flag | `false` | Enable the formula enrichment model in the pipeline. |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -935,3 +935,112 @@ def test_cli_passes_accelerator_options_to_vlm_pipeline(
     assert captured_pipeline_options is not None
     assert captured_pipeline_options.accelerator_options.device == AcceleratorDevice.CPU
     assert captured_pipeline_options.accelerator_options.num_threads == 7
+
+
+def _capture_cli_engine_options(monkeypatch, extra_args, tmp_path, option_name):
+    """Helper to capture layout/table/ocr engine options from CLI."""
+    captured: dict[str, Any] = {}
+
+    class _FakeDocumentConverter:
+        def __init__(self, *, allowed_formats, format_options):
+            pdf_option = format_options[InputFormat.PDF]
+            captured["option"] = getattr(pdf_option.pipeline_options, option_name)
+
+        def convert_all(
+            self,
+            input_doc_paths,
+            headers=None,
+            raises_on_error=False,
+            page_range=DEFAULT_PAGE_RANGE,
+        ):
+            return []
+
+    monkeypatch.setattr(
+        "docling.document_converter.DocumentConverter", _FakeDocumentConverter
+    )
+    source = "./tests/data/pdf/sources/2305.03393v1-pg9.pdf"
+    result = runner.invoke(
+        app, [source, "--output", str(tmp_path / "out"), *extra_args]
+    )
+    return result, captured.get("option")
+
+
+def test_cli_layout_engine_can_be_set(tmp_path, monkeypatch):
+    """Test that --layout-engine sets layout options correctly."""
+    result, layout_options = _capture_cli_engine_options(
+        monkeypatch,
+        ["--layout-engine", "docling_layout_default"],
+        tmp_path,
+        "layout_options",
+    )
+    assert result.exit_code == 0
+    assert layout_options is not None
+    assert layout_options.kind == "docling_layout_default"
+
+
+def test_cli_table_structure_engine_can_be_set(tmp_path, monkeypatch):
+    """Test that --table-structure-engine sets table structure options correctly."""
+    result, table_options = _capture_cli_engine_options(
+        monkeypatch,
+        ["--table-structure-engine", "docling_tableformer_v2"],
+        tmp_path,
+        "table_structure_options",
+    )
+    assert result.exit_code == 0
+    assert table_options is not None
+    assert table_options.kind == "docling_tableformer_v2"
+
+
+def test_cli_ocr_engine_can_be_set(tmp_path, monkeypatch):
+    """Test that --ocr-engine sets OCR options correctly."""
+    result, ocr_options = _capture_cli_engine_options(
+        monkeypatch, ["--ocr-engine", "easyocr"], tmp_path, "ocr_options"
+    )
+    assert result.exit_code == 0
+    assert ocr_options is not None
+    assert ocr_options.kind == "easyocr"
+
+
+def test_cli_invalid_layout_engine_is_rejected(tmp_path):
+    """Test that invalid --layout-engine is rejected."""
+    result = runner.invoke(
+        app,
+        [
+            "./tests/data/pdf/sources/2305.03393v1-pg9.pdf",
+            "--output",
+            str(tmp_path / "out"),
+            "--layout-engine",
+            "invalid_engine",
+        ],
+    )
+    assert result.exit_code != 0
+
+
+def test_cli_invalid_table_structure_engine_is_rejected(tmp_path):
+    """Test that invalid --table-structure-engine is rejected."""
+    result = runner.invoke(
+        app,
+        [
+            "./tests/data/pdf/sources/2305.03393v1-pg9.pdf",
+            "--output",
+            str(tmp_path / "out"),
+            "--table-structure-engine",
+            "invalid_engine",
+        ],
+    )
+    assert result.exit_code != 0
+
+
+def test_cli_invalid_ocr_engine_is_rejected(tmp_path):
+    """Test that invalid --ocr-engine is rejected."""
+    result = runner.invoke(
+        app,
+        [
+            "./tests/data/pdf/sources/2305.03393v1-pg9.pdf",
+            "--output",
+            str(tmp_path / "out"),
+            "--ocr-engine",
+            "invalid_engine",
+        ],
+    )
+    assert result.exit_code != 0


### PR DESCRIPTION
Adds `--layout-engine` and `--table-structure-engine` to the `docling convert` CLI. Intentionally similar to the existing `--ocr-engine`. Makes it easier to test and use custom plugins.

Manually tested with `docling_tableformer_v2` and custom plugins. Updated documentation and added tests with the help of an AI agent (GitHub Copilot).

Helps a bit with #2402.
Intensifies the somewhat misleading error messages noticed in #1444.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
