### PR TITLE
fix: update release CI

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -45,7 +45,7 @@ jobs:
           name: dist
           path: dist/
       - name: Publish docling-slim to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           attestations: true
           packages-dir: dist/docling-slim/
@@ -72,7 +72,7 @@ jobs:
           echo "Waiting 60 seconds for docling-slim to propagate on PyPI..."
           sleep 60
       - name: Publish docling to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           attestations: true
           packages-dir: dist/docling/
@@ -99,7 +99,7 @@ jobs:
           echo "Waiting 60 seconds for docling-slim to propagate on PyPI..."
           sleep 60
       - name: Publish docling-client to PyPI
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           attestations: true
           packages-dir: dist/docling-client/


### PR DESCRIPTION
Fixing the release error

```
Checking dist/docling-slim/docling_slim-2.120.0-py3-none-any.whl: ERROR
InvalidDistribution: Invalid distribution metadata: '2.5' is not a valid metadata version
```

See notes in https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.14.2

**Checklist:**

- [x] Documentation has been updated, if necessary. (n/a — CI-only change)
- [x] Examples have been added, if necessary. (n/a)
- [x] Tests have been added, if necessary. (n/a — verified by reproducing the twine check locally)

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
