### PR TITLE
fix(service client): serialize all the content of the engine options

### DIFF
--- a/docling/datamodel/vlm_engine_options.py
+++ b/docling/datamodel/vlm_engine_options.py
@@ -8,7 +8,7 @@ import logging
 from enum import Enum
 from typing import Any, Dict, Literal, Optional
 
-from pydantic import AnyUrl, Field
+from pydantic import AnyUrl, Field, model_validator
 
 from docling.datamodel.accelerator_options import AcceleratorDevice
 from docling.datamodel.settings import default_compile_model
@@ -205,9 +205,7 @@ class ApiVlmEngineOptions(BaseVlmEngineOptions):
     - OpenAI
     """
 
-    engine_type: VlmEngineType = Field(
-        default=VlmEngineType.API, description="API variant to use"
-    )
+    engine_type: VlmEngineType = Field(description="API variant to use")
 
     url: AnyUrl = Field(
         default=AnyUrl("http://localhost:11434/v1/chat/completions"),
@@ -227,15 +225,20 @@ class ApiVlmEngineOptions(BaseVlmEngineOptions):
 
     concurrency: int = Field(default=1, description="Number of concurrent requests")
 
-    def __init__(self, **data):
-        """Initialize with default URLs based on engine type."""
-        if "engine_type" in data and "url" not in data:
+    @model_validator(mode="before")
+    @classmethod
+    def _apply_defaults(cls, data: Any) -> Any:
+        """Supply default engine_type and URL when not explicitly provided."""
+        if not isinstance(data, dict):
+            return data
+        if "engine_type" not in data:
+            data = {**data, "engine_type": VlmEngineType.API}
+        if "url" not in data:
             engine_type = data["engine_type"]
             if engine_type == VlmEngineType.API_OLLAMA:
-                data["url"] = "http://localhost:11434/v1/chat/completions"
+                data = {**data, "url": "http://localhost:11434/v1/chat/completions"}
             elif engine_type == VlmEngineType.API_LMSTUDIO:
-                data["url"] = "http://localhost:1234/v1/chat/completions"
+                data = {**data, "url": "http://localhost:1234/v1/chat/completions"}
             elif engine_type == VlmEngineType.API_OPENAI:
-                data["url"] = "https://api.openai.com/v1/chat/completions"
-
-        super().__init__(**data)
+                data = {**data, "url": "https://api.openai.com/v1/chat/completions"}
+        return data

--- a/docling/models/inference_engines/vlm/base.py
+++ b/docling/models/inference_engines/vlm/base.py
@@ -17,7 +17,7 @@ from typing import (
 )
 
 from PIL.Image import Image
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, SerializeAsAny, field_validator
 from pydantic_core import PydanticUndefined
 
 if TYPE_CHECKING:
@@ -108,7 +108,7 @@ class BaseVlmEngineOptions(BaseModel):
 
 
 class VlmEngineOptionsMixin(BaseModel):
-    engine_options: BaseVlmEngineOptions = Field(
+    engine_options: SerializeAsAny[BaseVlmEngineOptions] = Field(
         description="Runtime configuration (transformers, mlx, api, etc.)"
     )
 


### PR DESCRIPTION
## Fix `ApiVlmEngineOptions` initialization and serialization

### Description

This PR addresses two related issues with `ApiVlmEngineOptions` and VLM engine options serialization:

1. **Replace `__init__` override with a Pydantic `model_validator`** in `ApiVlmEngineOptions`:
   - The custom `__init__` method used to apply default values for `engine_type` and `url` has been replaced with a proper `@model_validator(mode="before")` class method (`_apply_defaults`).
   - The `engine_type` field no longer carries a hardcoded default of `VlmEngineType.API` in the `Field(...)` definition; instead, the default is now applied within the validator when the field is absent from the input data.
   - Data mutations are done immutably (using dict unpacking `{**data, ...}`) to avoid in-place modification of the input.
   - This approach is more idiomatic for Pydantic v2 and avoids potential issues with the `__init__` override pattern.

2. **Fix serialization of subclassed engine options** in `VlmEngineOptionsMixin`:
   - The `engine_options` field type annotation has been updated from `BaseVlmEngineOptions` to `SerializeAsAny[BaseVlmEngineOptions]`.
   - This ensures that when a subclass instance (e.g., `ApiVlmEngineOptions`) is assigned to `engine_options`, Pydantic serializes the full subclass data rather than truncating it to only the fields defined on the base class.

---

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.