### PR TITLE
fix: lazy-load transformers/torch in VLM and ASR pipeline options

### DIFF
--- a/docling/datamodel/asr_model_specs.py
+++ b/docling/datamodel/asr_model_specs.py
@@ -1,5 +1,6 @@
 import logging
 from enum import Enum
+from typing import Any
 
 from pydantic import (
     AnyUrl,
@@ -85,10 +86,6 @@ def _get_whisper_tiny_model():
     )
 
 
-# Create the model instance
-WHISPER_TINY = _get_whisper_tiny_model()
-
-
 def _get_whisper_small_model():
     """
     Get the best Whisper Small model for the current hardware.
@@ -125,10 +122,6 @@ def _get_whisper_small_model():
         max_new_tokens=256,
         max_time_chunk=30.0,
     )
-
-
-# Create the model instance
-WHISPER_SMALL = _get_whisper_small_model()
 
 
 def _get_whisper_medium_model():
@@ -169,10 +162,6 @@ def _get_whisper_medium_model():
     )
 
 
-# Create the model instance
-WHISPER_MEDIUM = _get_whisper_medium_model()
-
-
 def _get_whisper_base_model():
     """
     Get the best Whisper Base model for the current hardware.
@@ -209,10 +198,6 @@ def _get_whisper_base_model():
         max_new_tokens=256,
         max_time_chunk=30.0,
     )
-
-
-# Create the model instance
-WHISPER_BASE = _get_whisper_base_model()
 
 
 def _get_whisper_large_model():
@@ -253,10 +238,6 @@ def _get_whisper_large_model():
     )
 
 
-# Create the model instance
-WHISPER_LARGE = _get_whisper_large_model()
-
-
 def _get_whisper_turbo_model():
     """
     Get the best Whisper Turbo model for the current hardware.
@@ -295,8 +276,38 @@ def _get_whisper_turbo_model():
     )
 
 
-# Create the model instance
-WHISPER_TURBO = _get_whisper_turbo_model()
+# `WHISPER_TINY`, `WHISPER_SMALL`, `WHISPER_MEDIUM`, `WHISPER_BASE`,
+# `WHISPER_LARGE` and `WHISPER_TURBO` are hardware-auto-detecting presets:
+# picking between MLX and native Whisper requires calling
+# `_detect_hardware_and_libraries()`, which does `import torch` to check
+# `torch.backends.mps.is_available()`. That import is guarded against
+# `torch` being *absent* (falls back to `has_mps=False`), but not against
+# the eager cost of running it merely because this module was imported —
+# so building these presets at module load time meant any consumer of
+# `docling.datamodel.pipeline_options` (which imports `asr_model_specs` for
+# unrelated ASR option types) paid that cost even when never touching ASR
+# at all. `__getattr__` (PEP 562) computes and caches each preset lazily,
+# on first real access, so importing this module never imports torch by
+# itself.
+_LAZY_AUTO_PRESET_FACTORIES = {
+    "WHISPER_TINY": _get_whisper_tiny_model,
+    "WHISPER_SMALL": _get_whisper_small_model,
+    "WHISPER_MEDIUM": _get_whisper_medium_model,
+    "WHISPER_BASE": _get_whisper_base_model,
+    "WHISPER_LARGE": _get_whisper_large_model,
+    "WHISPER_TURBO": _get_whisper_turbo_model,
+}
+_lazy_auto_preset_cache: dict[str, Any] = {}
+
+
+def __getattr__(name: str) -> Any:
+    factory = _LAZY_AUTO_PRESET_FACTORIES.get(name)
+    if factory is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    if name not in _lazy_auto_preset_cache:
+        _lazy_auto_preset_cache[name] = factory()
+    return _lazy_auto_preset_cache[name]
+
 
 # =============================================================================
 # Explicit MLX Whisper model options for users who want to force MLX usage

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1657,9 +1657,17 @@ class AsrPipelineOptions(PipelineOptions):
             description=(
                 "Automatic Speech Recognition (ASR) model configuration for audio transcription. Specifies which "
                 "ASR model to use (e.g., Whisper variants) and model-specific parameters for speech-to-text conversion."
-            )
+            ),
+            # `default_factory`, not a plain default: `asr_model_specs.WHISPER_TINY`
+            # is a hardware-auto-detecting preset (lazily computed via
+            # `asr_model_specs.__getattr__`, PEP 562). A plain `= ...` default
+            # is evaluated once at class-definition time — i.e. at import time,
+            # for every consumer of this module — which would defeat that
+            # laziness the moment this class body runs. `default_factory` defers
+            # it to actual instance construction instead.
+            default_factory=lambda: asr_model_specs.WHISPER_TINY,
         ),
-    ] = asr_model_specs.WHISPER_TINY
+    ]
 
 
 from docling.utils.video_frame_sampling import VideoFrameSamplingMode  # noqa: E402
@@ -1679,8 +1687,13 @@ class VideoPipelineOptions(PipelineOptions):
 
     asr_options: Annotated[
         InlineAsrOptions,
-        Field(description="ASR model configuration for the video audio track."),
-    ] = asr_model_specs.WHISPER_TINY
+        Field(
+            description="ASR model configuration for the video audio track.",
+            # See AsrPipelineOptions.asr_options above for why this must be
+            # a default_factory rather than a plain default.
+            default_factory=lambda: asr_model_specs.WHISPER_TINY,
+        ),
+    ]
 
     frame_sampling_mode: Annotated[
         VideoFrameSamplingMode,

--- a/docling/datamodel/pipeline_options_vlm_model.py
+++ b/docling/datamodel/pipeline_options_vlm_model.py
@@ -1,25 +1,22 @@
 from enum import Enum
-from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, Union
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional
 
 from docling_core.types.doc.page import SegmentedPage
-from pydantic import AnyUrl, BaseModel, ConfigDict, Field
+from pydantic import AnyUrl, BaseModel, ConfigDict, Field, field_validator
 from typing_extensions import deprecated
-
-try:
-    from transformers import StoppingCriteria
-except ImportError:
-    # `transformers` is optional for slim installs (e.g. `service-client`
-    # extra). The placeholder keeps the `custom_stopping_criteria` field
-    # annotation valid; pydantic accepts it via `arbitrary_types_allowed`.
-    class StoppingCriteria:  # type: ignore[no-redef]
-        pass
-
 
 from docling.datamodel.accelerator_options import AcceleratorDevice
 from docling.models.utils.generation_utils import GenerationStopper
 
 if TYPE_CHECKING:
     from docling_core.types.doc.page import SegmentedPage
+
+    # transformers.StoppingCriteria is only needed for static type checking
+    # and for validating actual custom_stopping_criteria values at runtime
+    # (see _validate_custom_stopping_criteria below) — never imported merely
+    # by loading this module, so a `models-onnxruntime`-only install never
+    # pulls in torch/transformers just to define these option classes.
+    from transformers import StoppingCriteria
 
     from docling.datamodel.base_models import Page
 
@@ -273,15 +270,64 @@ class InlineVlmOptions(BaseVlmOptions):
         ),
     ] = []
     custom_stopping_criteria: Annotated[
-        list[Union[StoppingCriteria, GenerationStopper]],
+        list[Any],
         Field(
             description=(
                 "Custom stopping criteria objects for fine-grained control "
                 "over generation termination. Allows implementing complex "
-                "stopping logic beyond simple string matching."
+                "stopping logic beyond simple string matching. Each item "
+                "must be a `GenerationStopper` instance, or — only if the "
+                "`transformers` package is installed — a "
+                "`transformers.StoppingCriteria` instance or subclass."
             )
         ),
     ] = []
+
+    @field_validator("custom_stopping_criteria")
+    @classmethod
+    def _validate_custom_stopping_criteria(cls, value: list[Any]) -> list[Any]:
+        """Validate stopping-criteria items without importing transformers
+        unless an item actually needs it (deferred, not at module load —
+        see the TYPE_CHECKING import above for the rationale). A pure
+        `GenerationStopper` list — the common case for ONNX-only pipelines
+        that never touch transformers-backed VLMs — never triggers the
+        import at all."""
+        if not value:
+            return value
+
+        def _is_generation_stopper(item: Any) -> bool:
+            return isinstance(item, GenerationStopper) or (
+                isinstance(item, type) and issubclass(item, GenerationStopper)
+            )
+
+        _stopping_criteria_type: type | None = None
+        for item in value:
+            if _is_generation_stopper(item):
+                continue
+            if _stopping_criteria_type is None:
+                try:
+                    from transformers import (
+                        StoppingCriteria as _stopping_criteria_type,  # type: ignore[assignment]
+                    )
+                except ImportError:
+                    raise ValueError(
+                        f"custom_stopping_criteria item {item!r} is not a "
+                        f"GenerationStopper instance, and the `transformers` "
+                        f"package (required for transformers.StoppingCriteria "
+                        f"items) is not installed."
+                    ) from None
+            is_valid_instance = isinstance(item, _stopping_criteria_type)
+            is_valid_subclass = isinstance(item, type) and issubclass(
+                item, _stopping_criteria_type
+            )
+            if not (is_valid_instance or is_valid_subclass):
+                raise ValueError(
+                    f"custom_stopping_criteria item {item!r} must be a "
+                    f"GenerationStopper instance, or a "
+                    f"transformers.StoppingCriteria instance/subclass."
+                )
+        return value
+
     extra_generation_config: Annotated[
         dict[str, Any],
         Field(


### PR DESCRIPTION
## Summary

Fixes #3997 — a `models-onnxruntime`-only install still pulled in `torch` and `transformers` merely by importing `docling.datamodel.pipeline_options` or `docling.document_converter`, via three independent eager-import paths. Continues the cleanup effort from #3805/#3837.

### 1. `pipeline_options_vlm_model.py`

`from transformers import StoppingCriteria` ran unconditionally at module load. The existing `try/except` only guarded against `transformers` being *absent* — when it's installed (e.g. transitively via `docling-ibm-models`), the import still executes and pulls in `torch` via `transformers/generation/stopping_criteria.py`. `StoppingCriteria` is deeply torch-native (every method operates on `torch.Tensor`), so this can't be made lazy on the `transformers` side.

Moved the import behind `TYPE_CHECKING`, loosened `custom_stopping_criteria` to `list[Any]`, and added a `field_validator` that only imports `transformers` when an item isn't already a (torch-free) `GenerationStopper` instance — so a pure-`GenerationStopper` list never touches `transformers` at all.

### 2. `asr_model_specs.py`

The six hardware-auto-detecting `WHISPER_*` presets (`TINY`/`SMALL`/`MEDIUM`/`BASE`/`LARGE`/`TURBO`) were built as module-level constants, each calling `_detect_hardware_and_libraries()`, which does `import torch` to check MPS availability. The `try/except` there guards against torch being *absent*, not against the cost of running it merely because the module was imported. Replaced the eager assignments with a PEP 562 `__getattr__` that computes and caches each preset lazily, on first real access.

### 3. `pipeline_options.py`

`AsrPipelineOptions.asr_options` and `VideoPipelineOptions.asr_options` had `= asr_model_specs.WHISPER_TINY` as a plain field default — evaluated at class-definition time (import time), which defeated fix #2 the moment either class body ran. Changed both to `default_factory=lambda: ...`.

## Verification

- Fresh subprocess: `import docling.datamodel.pipeline_options` / `docling.document_converter` no longer put `torch`/`torchvision`/`transformers` into `sys.modules`.
- Real `transformers.StoppingCriteria` subclasses and pure `GenerationStopper` subclasses both still validate correctly.
- `AsrPipelineOptions()` / `VideoPipelineOptions()` still resolve to the correct real default (`InlineAsrNativeWhisperOptions(repo_id='tiny')`) on actual construction.
- Invalid `custom_stopping_criteria` items still correctly rejected with `ValidationError`.
- `ruff check` / `ruff format` clean, `ty check` clean.
- Full relevant test suite (`test_asr_pipeline.py`, `test_asr_mlx_whisper.py`, `test_vlm_presets_and_runtime_options.py`): **52 passed, 12 failed, 1 skipped** — confirmed via `git stash` that **the same 12 tests fail identically on unpatched `main`** (missing ffmpeg / local Whisper weights in the test environment, unrelated to this change). Zero regressions.

## A related finding, not fixed here — flagging for visibility

While testing this against a real `DocumentConverter()` construction (not just module import), I found a third, independent eager-import path: `DocumentConverter.__init__` → `_get_default_option()` builds a dict literal containing **every** input format's default option unconditionally on every call — including `AudioFormatOption()` → `AsrPipeline.get_default_options()` → `AsrPipelineOptions()` — even when the caller only configures `PdfFormatOption` and never touches audio. With this PR's fix #3 in place, that `AsrPipelineOptions()` construction now correctly defers to instance-construction time via `default_factory` — but `DocumentConverter.__init__` unconditionally triggers that construction anyway, for every format, regardless of `allowed_formats`... actually, it *is* avoidable: passing `allowed_formats=[InputFormat.PDF]` explicitly (already a supported, documented parameter) means `_get_default_option` is never called for `AUDIO`, and the leak disappears — verified this live, `sys.modules` stays clean.

So this isn't a regression or a blocker — callers who care can already avoid it today by restricting `allowed_formats`. But `_get_default_option`'s dict-of-already-built-instances pattern means anyone who *doesn't* restrict `allowed_formats` pays the cost of constructing all ~25 formats' default options (including this one) just to look up one. Happy to open a separate, follow-up PR restructuring it into a dict of factory callables (grepped the repo: `_get_default_option`/`format_to_default_options` are referenced only inside `document_converter.py`, so it'd be a self-contained, single-file change) if that's of interest — didn't want to bundle an unrelated file into this PR's review surface.

## DCO

Signed off per CONTRIBUTING.md (`git commit -s`).
