### PR TITLE
fix(cli): propagate service flags to AsrPipelineOptions

### DIFF
--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -1434,7 +1434,8 @@ def convert(  # noqa: C901
                 device=device,
                 num_threads=num_threads,
             ),
-            # enable_remote_services=enable_remote_services,
+            allow_external_plugins=allow_external_plugins,
+            enable_remote_services=enable_remote_services,
             # artifacts_path = artifacts_path
         )
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1044,3 +1044,66 @@ def test_cli_invalid_ocr_engine_is_rejected(tmp_path):
         ],
     )
     assert result.exit_code != 0
+
+
+def _capture_cli_asr_pipeline_options(monkeypatch, extra_args, tmp_path):
+    """Invoke `docling convert` with a fake converter and return the
+    AsrPipelineOptions built alongside the requested (non-audio) pipeline.
+
+    The CLI always constructs `AsrPipelineOptions` regardless of the input
+    format, so this can be observed without converting an audio file.
+    """
+    captured: dict[str, Any] = {}
+
+    class _FakeDocumentConverter:
+        def __init__(self, *, allowed_formats, format_options):
+            audio_option = format_options[InputFormat.AUDIO]
+            captured["asr_pipeline_options"] = audio_option.pipeline_options
+
+        def convert_all(
+            self,
+            input_doc_paths,
+            headers=None,
+            raises_on_error=False,
+            page_range=DEFAULT_PAGE_RANGE,
+        ):
+            return []
+
+    monkeypatch.setattr(
+        "docling.document_converter.DocumentConverter", _FakeDocumentConverter
+    )
+    source = "./tests/data/pdf/sources/2305.03393v1-pg9.pdf"
+    result = runner.invoke(
+        app, [source, "--output", str(tmp_path / "out"), *extra_args]
+    )
+    return result, captured.get("asr_pipeline_options")
+
+
+def test_cli_allow_external_plugins_reaches_asr_pipeline_options(tmp_path, monkeypatch):
+    """Regression test for #3284: `--allow-external-plugins` and
+    `--enable-remote-services` were parsed correctly but never passed into
+    the (always-constructed) `AsrPipelineOptions`, which silently kept
+    reporting `allow_external_plugins=False` / `enable_remote_services=False`
+    regardless of the flags actually passed on the command line.
+    """
+    result, asr_pipeline_options = _capture_cli_asr_pipeline_options(
+        monkeypatch,
+        ["--allow-external-plugins", "--enable-remote-services"],
+        tmp_path,
+    )
+    assert result.exit_code == 0, result.output
+    assert asr_pipeline_options is not None
+    assert asr_pipeline_options.allow_external_plugins is True
+    assert asr_pipeline_options.enable_remote_services is True
+
+
+def test_cli_asr_pipeline_options_default_to_false(tmp_path, monkeypatch):
+    """Companion to the regression test above: without the flags, the
+    ASR pipeline options should still default to False."""
+    result, asr_pipeline_options = _capture_cli_asr_pipeline_options(
+        monkeypatch, [], tmp_path
+    )
+    assert result.exit_code == 0, result.output
+    assert asr_pipeline_options is not None
+    assert asr_pipeline_options.allow_external_plugins is False
+    assert asr_pipeline_options.enable_remote_services is False


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Closes #3284

## Summary

`AsrPipelineOptions` created by the CLI did not receive the parsed `allow_external_plugins` and `enable_remote_services` values. As a result, the `ASR pipeline_options` debug output always reported both options as `False`, even when the corresponding CLI flags were enabled.

This does not affect Surya or external plugin loading. In the reproduction from #3284, `surya-ocr` is loaded successfully and conversion completes. The inconsistency is limited to the separately constructed ASR pipeline options.

## Fix

Pass `allow_external_plugins` and `enable_remote_services` into `AsrPipelineOptions`, consistent with the other pipeline option construction paths in the CLI.

## Tests

Added model-free CLI regression coverage that verifies:
- both values propagate when the corresponding CLI flags are enabled;
- both values remain `False` by default.

The new regression test fails without this change and passes with it. The tests use a fake `DocumentConverter`, so no OCR model, PDF backend, external plugin, or network access is required.

`ruff check`, `ruff format --check`, `ty check`, and `prek` pass for the change.

**Checklist:**
- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
