### PR TITLE
feat(pdf): recover bold and italic text from the embedded font names

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1917,6 +1917,49 @@ class HeadingHierarchyOptions(BaseModel):
     ] = 0.8
 
 
+class TextFormattingOptions(BaseModel):
+    """Options for recovering character formatting in the PDF/image pipeline.
+
+    The PDF path never sets ``TextItem.formatting``, so bold and italic text converts
+    indistinguishably from body text, unlike the Word, HTML, Markdown and ODF backends. When
+    ``enabled``, the reading-order stage reads the weight and slant of the embedded PDF font
+    names and sets ``formatting`` on the text items whose cells agree on it. Only ``bold`` and
+    ``italic`` are set; underline, strikethrough and script leave no trace in a font name.
+
+    Notes:
+        - Formatting describes a whole text item, while a PDF carries a font per cell. An item
+          whose cells disagree -- a bold "Figure 7." in front of an italic caption -- is left
+          unformatted rather than emphasized as a whole.
+        - Section headers, titles, code and formulas are never formatted: heading markup already
+          conveys prominence, and emphasis markers around a code fence corrupt it.
+        - Items with no digital text layer (OCR results, the pypdfium2 backend) carry no font
+          information and are left unformatted.
+    """
+
+    enabled: Annotated[
+        bool,
+        Field(
+            description=(
+                "Enable recovery of bold and italic text for the PDF/image pipeline. When "
+                "disabled (default), TextItem.formatting is left unset and emphasis is dropped "
+                "from the converted document (unchanged behavior)."
+            )
+        ),
+    ] = False
+    use_rendering_mode: Annotated[
+        bool,
+        Field(
+            description=(
+                "Also read text drawn with a stroked outline as bold, which is how a PDF fakes a "
+                "bold face when no bold font is embedded. Applies only to text whose font name "
+                "carries no recognizable weight, so an explicit regular weight is never "
+                "overridden. Most PDFs never record a rendering mode, in which case this has no "
+                "effect."
+            )
+        ),
+    ] = True
+
+
 class PdfPipelineOptions(PaginatedPipelineOptions):
     """Configuration options for the PDF document processing pipeline.
 
@@ -2077,6 +2120,16 @@ class PdfPipelineOptions(PaginatedPipelineOptions):
             )
         ),
     ] = HeadingHierarchyOptions()
+    text_formatting_options: Annotated[
+        TextFormattingOptions,
+        Field(
+            description=(
+                "Configuration for recovering bold and italic text from the embedded PDF font "
+                "names. Disabled by default; when enabled, the reading-order stage sets "
+                "TextItem.formatting instead of dropping emphasis."
+            )
+        ),
+    ] = TextFormattingOptions()
 
     ### Arguments for threaded PDF pipeline with batching and backpressure control
 

--- a/docling/datamodel/service/options.py
+++ b/docling/datamodel/service/options.py
@@ -28,6 +28,7 @@ from docling.datamodel.pipeline_options import (
     ProcessingPipeline,
     TableFormerMode,
     TableStructureOptions,
+    TextFormattingOptions,
     VlmConvertOptions,
 )
 
@@ -520,6 +521,32 @@ class ConvertDocumentsOptions(BaseModel):
             ],
         ),
     ] = HeadingHierarchyOptions()
+
+    do_pdf_text_formatting: Annotated[
+        bool,
+        Field(
+            description=(
+                "If enabled, bold and italic text is recovered for PDF and image inputs "
+                "processed by the standard pipeline, by reading the weight and slant of the "
+                "embedded PDF font names. When disabled, emphasis is dropped and the text "
+                "converts indistinguishably from body text. Boolean. Optional, defaults to "
+                "false."
+            ),
+            examples=[False],
+        ),
+    ] = False
+
+    pdf_text_formatting_options: Annotated[
+        TextFormattingOptions,
+        Field(
+            description=(
+                "Fine-tuning of the character-formatting recovery, applied when "
+                "do_pdf_text_formatting is enabled. The nested enabled flag is set "
+                "automatically from do_pdf_text_formatting and does not need to be provided."
+            ),
+            examples=[TextFormattingOptions(use_rendering_mode=False)],
+        ),
+    ] = TextFormattingOptions()
 
     include_images: Annotated[
         bool,

--- a/docling/models/base_layout_model.py
+++ b/docling/models/base_layout_model.py
@@ -30,6 +30,15 @@ TABLE_LABELS = [DocItemLabel.TABLE, DocItemLabel.DOCUMENT_INDEX]
 FIGURE_LABEL = DocItemLabel.PICTURE
 FORMULA_LABEL = DocItemLabel.FORMULA
 CONTAINER_LABELS = [DocItemLabel.FORM, DocItemLabel.KEY_VALUE_REGION]
+# Labels whose items never carry character formatting: heading markup already conveys prominence,
+# and code and formulas are serialized inside their own delimiters, where emphasis markers would
+# end up wrapping the fence rather than the text.
+UNSTYLED_LABELS = [
+    DocItemLabel.SECTION_HEADER,
+    DocItemLabel.TITLE,
+    DocItemLabel.CODE,
+    DocItemLabel.FORMULA,
+]
 
 
 class BaseLayoutModel(BasePageModel, BaseModelWithOptions, ABC):

--- a/docling/models/stages/heading_hierarchy/heading_hierarchy_model.py
+++ b/docling/models/stages/heading_hierarchy/heading_hierarchy_model.py
@@ -30,18 +30,17 @@ drive the style fallback.
 """
 
 import re
-from collections import Counter
 from dataclasses import dataclass
 from difflib import SequenceMatcher
 from statistics import median
 
 from docling_core.types.doc import DoclingDocument
 from docling_core.types.doc.document import ListItem, SectionHeaderItem
-from docling_core.types.doc.page import PdfTextCell, SegmentedPdfPage
+from docling_core.types.doc.page import SegmentedPdfPage
 
 from docling.datamodel.document import ConversionResult
 from docling.datamodel.pipeline_options import HeadingHierarchyOptions
-from docling.utils.font_style import parse_font_style, weight_class
+from docling.utils.font_style import tally_cell_styles
 from docling.utils.pdf_outline import _PdfOutlineItem
 
 # Default precedence of numbering schemes, highest hierarchy level first. ``dotted`` shares
@@ -245,39 +244,25 @@ def _heading_style(
 
     page_height = parsed.dimension.height
     hbox = prov.bbox.to_top_left_origin(page_height)
-    heights: list[float] = []
-    weights: Counter[int] = Counter()
-    styled_chars = 0
-    italic_chars = 0
-    for cell in parsed.textline_cells:
-        if not cell.text or not cell.text.strip():
-            continue
-        cbox = cell.rect.to_bounding_box().to_top_left_origin(page_height)
-        if not hbox.overlaps(cbox):
-            continue
-        heights.append(cell.rect.height)
-
-        if not options.use_font_style or not isinstance(cell, PdfTextCell):
-            continue
-        style = parse_font_style(cell.font_name)
-        if not style.known:
-            continue
-        chars = len(cell.text.strip())
-        weights[weight_class(style.weight)] += chars
-        styled_chars += chars
-        if style.italic:
-            italic_chars += chars
-
-    if not heights:
+    overlapping = [
+        cell
+        for cell in parsed.textline_cells
+        if cell.text
+        and cell.text.strip()
+        and hbox.overlaps(cell.rect.to_bounding_box().to_top_left_origin(page_height))
+    ]
+    if not overlapping:
         return None
-    size = median(heights)
+
+    size = median(cell.rect.height for cell in overlapping)
     if not options.use_font_style:
         return _HeadingStyle(size=size)
+    tally = tally_cell_styles(overlapping)
     return _HeadingStyle(
         size=size,
         # On a tie, the heavier class wins: emphasis is what makes a heading stand out.
-        weight_cls=max(weights, key=lambda cls: (weights[cls], cls), default=0),
-        italic=bool(styled_chars) and italic_chars / styled_chars >= _ITALIC_RATIO,
+        weight_cls=tally.dominant_weight_class(),
+        italic=tally.italic_share >= _ITALIC_RATIO,
         caps=_is_all_caps(item.text),
     )
 

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -13,6 +13,7 @@ from docling_core.types.doc import (
     TableData,
     TableItem,
 )
+from docling_core.types.doc.common.formatting import Formatting
 from docling_core.types.doc.document import ContentLayer
 from docling_ibm_models.list_item_normalizer.list_marker_processor import (
     ListItemMarkerProcessor,
@@ -32,6 +33,9 @@ from docling.datamodel.base_models import (
     TextElement,
 )
 from docling.datamodel.document import ConversionResult
+from docling.datamodel.pipeline_options import TextFormattingOptions
+from docling.models.base_layout_model import UNSTYLED_LABELS
+from docling.utils.font_style import formatting_from_cells
 from docling.utils.profiling import ProfilingScope, TimeRecorder
 
 
@@ -39,6 +43,7 @@ class ReadingOrderOptions(BaseModel):
     model_config = ConfigDict(protected_namespaces=())
 
     model_names: str = ""  # e.g. "language;term;reference"
+    text_formatting: TextFormattingOptions = TextFormattingOptions()
 
 
 class ReadingOrderModel:
@@ -48,6 +53,15 @@ class ReadingOrderModel:
         self.options = options
         self.ro_model = ReadingOrderPredictor()
         self.list_item_processor = ListItemMarkerProcessor()
+
+    def _cluster_formatting(self, cluster: Cluster) -> Formatting | None:
+        """Bold/italic of a cluster's text, or None when it is not determined."""
+        options = self.options.text_formatting
+        if not options.enabled or cluster.label in UNSTYLED_LABELS:
+            return None
+        return formatting_from_cells(
+            cluster.cells, use_rendering_mode=options.use_rendering_mode
+        )
 
     def _assembled_to_readingorder_elements(
         self, conv_res: ConversionResult
@@ -100,7 +114,12 @@ class ReadingOrderModel:
             )
             if c_label == DocItemLabel.LIST_ITEM:
                 # TODO: Infer if this is a numbered or a bullet list item
-                l_item = doc.add_list_item(parent=doc_item, text=c_text, prov=c_prov)
+                l_item = doc.add_list_item(
+                    parent=doc_item,
+                    text=c_text,
+                    prov=c_prov,
+                    formatting=self._cluster_formatting(child),
+                )
                 self.list_item_processor.process_list_item(l_item)
             elif c_label == DocItemLabel.SECTION_HEADER:
                 doc.add_heading(parent=doc_item, text=c_text, prov=c_prov)
@@ -117,6 +136,7 @@ class ReadingOrderModel:
                     text=c_text,
                     prov=c_prov,
                     content_layer=content_layer,
+                    formatting=self._cluster_formatting(child),
                 )
 
     def _create_rich_cell_group(
@@ -532,6 +552,7 @@ class ReadingOrderModel:
             prov=prov,
             parent=parent,
             hyperlink=elem.hyperlink,
+            formatting=self._cluster_formatting(elem.cluster),
         )
         return new_item
 
@@ -555,12 +576,14 @@ class ReadingOrderModel:
                 prov=prov,
                 parent=current_list,
                 hyperlink=element.hyperlink,
+                formatting=self._cluster_formatting(element.cluster),
             )
             self.list_item_processor.process_list_item(new_item)
 
         elif label == DocItemLabel.SECTION_HEADER:
             current_list = None
 
+            # No formatting: the heading markup already conveys the emphasis.
             new_item = out_doc.add_heading(
                 text=cap_text, prov=prov, hyperlink=element.hyperlink
             )
@@ -583,6 +606,7 @@ class ReadingOrderModel:
                 prov=prov,
                 content_layer=content_layer,
                 hyperlink=element.hyperlink,
+                formatting=self._cluster_formatting(element.cluster),
             )
         return new_item, current_list
 
@@ -619,6 +643,11 @@ class ReadingOrderModel:
 
         if new_item.hyperlink != merged_elem.hyperlink:
             new_item.hyperlink = None
+
+        # The halves of a paragraph split across columns or pages are one item; if they are not
+        # emphasized alike, the concatenation is not uniformly emphasized either.
+        if new_item.formatting != self._cluster_formatting(merged_elem.cluster):
+            new_item.formatting = None
 
     def __call__(self, conv_res: ConversionResult) -> DoclingDocument:
         with TimeRecorder(conv_res, "reading_order", scope=ProfilingScope.DOCUMENT):

--- a/docling/pipeline/legacy_standard_pdf_pipeline.py
+++ b/docling/pipeline/legacy_standard_pdf_pipeline.py
@@ -63,7 +63,11 @@ class LegacyStandardPdfPipeline(PaginatedPipeline):
                 or self.pipeline_options.generate_table_images
             )
 
-        self.reading_order_model = ReadingOrderModel(options=ReadingOrderOptions())
+        self.reading_order_model = ReadingOrderModel(
+            options=ReadingOrderOptions(
+                text_formatting=self.pipeline_options.text_formatting_options
+            )
+        )
         self.heading_hierarchy_model = HeadingHierarchyModel(
             options=self.pipeline_options.heading_hierarchy_options
         )

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -636,7 +636,11 @@ class StandardPdfPipeline(ConvertPipeline):
             enable_remote_services=self.pipeline_options.enable_remote_services,
         )
         self.assemble_model = PageAssembleModel(options=PageAssembleOptions())
-        self.reading_order_model = ReadingOrderModel(options=ReadingOrderOptions())
+        self.reading_order_model = ReadingOrderModel(
+            options=ReadingOrderOptions(
+                text_formatting=self.pipeline_options.text_formatting_options
+            )
+        )
         self.heading_hierarchy_model = HeadingHierarchyModel(
             options=self.pipeline_options.heading_hierarchy_options
         )

--- a/docling/utils/font_style.py
+++ b/docling/utils/font_style.py
@@ -14,16 +14,27 @@ while a miss only falls back to the previous behavior:
 2. **Abbreviations are only honored as a whole separator-delimited part.** ``-Bd`` is bold, but
    the ``TB`` in ``LinLibertineTB`` and the ``LT`` in ``HelveticaNeueLTPro`` are not read as
    styles -- foundry tags glued onto a family name look exactly like weight abbreviations.
+
+:func:`tally_cell_styles` lifts the same reading from one font name to the cells of one layout
+cluster, and :func:`formatting_from_cells` turns that tally into the item-level
+:class:`~docling_core.types.doc.common.formatting.Formatting` of a text item.
 """
 
 from __future__ import annotations
 
 import re
-from dataclasses import dataclass
+from collections import Counter
+from collections.abc import Iterable
+from dataclasses import dataclass, field
 from functools import lru_cache
+
+from docling_core.types.doc.common.formatting import Formatting
+from docling_core.types.doc.page import PdfCellRenderingMode, PdfTextCell, TextCell
 
 # Weight of text whose font name says nothing about weight.
 REGULAR_WEIGHT = 400
+# Lightest weight that reads as bold.
+BOLD_WEIGHT = 700
 
 # Subset-embedded fonts are prefixed with six uppercase letters and a plus (PDF 32000-1 9.6.4).
 _SUBSET_PREFIX = re.compile(r"^[A-Z]{6}\+")
@@ -48,7 +59,7 @@ _WEIGHT_TOKENS = {
     "demibold": 600,
     "semi": 600,
     "semibold": 600,
-    "bold": 700,
+    "bold": BOLD_WEIGHT,
     "extrabold": 800,
     "ultrabold": 800,
     "black": 900,
@@ -165,3 +176,112 @@ def parse_font_style(font_name: str) -> _FontStyle:
         italic=bool(italic),
         known=True,
     )
+
+
+# Share of an item's characters that must come from cells with a readable style before the
+# item's styling counts as determined at all.
+_STYLE_COVERAGE = 0.8
+# Share of those characters that must agree before the attribute is set on the item.
+_STYLE_AGREEMENT = 0.8
+
+# Rendering modes that stroke the glyph outline, the classic way of faking a bold face when no
+# bold font is embedded (PDF 32000-1 9.3.6).
+_STROKED_MODES = frozenset(
+    {PdfCellRenderingMode.STROKE_TEXT, PdfCellRenderingMode.FILL_THEN_STROKE}
+)
+
+
+@dataclass(frozen=True)
+class _StyleTally:
+    """Character-weighted styling of a set of cells (internal)."""
+
+    chars: int = 0  # characters in cells that carry text
+    styled_chars: int = 0  # of those, characters whose styling could be read
+    italic_chars: int = 0  # of styled_chars, characters in an italic font
+    weight_chars: Counter[int] = field(
+        default_factory=Counter
+    )  # weight class -> characters
+
+    @property
+    def coverage(self) -> float:
+        return self.styled_chars / self.chars if self.chars else 0.0
+
+    @property
+    def italic_share(self) -> float:
+        return self.italic_chars / self.styled_chars if self.styled_chars else 0.0
+
+    @property
+    def bold_share(self) -> float:
+        if not self.styled_chars:
+            return 0.0
+        return self.weight_chars[weight_class(BOLD_WEIGHT)] / self.styled_chars
+
+    def dominant_weight_class(self) -> int:
+        """The weight class carrying the most characters; on a tie the heavier class wins."""
+        return max(
+            self.weight_chars, key=lambda cls: (self.weight_chars[cls], cls), default=0
+        )
+
+
+def tally_cell_styles(
+    cells: Iterable[TextCell], *, use_rendering_mode: bool = False
+) -> _StyleTally:
+    """Weigh the styling of ``cells`` by the number of characters each one contributes.
+
+    Cells whose styling cannot be read -- OCR output, the pypdfium2 backend, or font names that
+    carry no recognizable styling -- still count towards ``chars``, so that a caller can tell a
+    confidently plain run from one that was simply never legible.
+
+    With ``use_rendering_mode``, a cell whose font name says nothing but which is drawn with a
+    stroked outline is read as bold. It is a fallback for silent font names only: an explicit
+    ``-Regular`` is never overridden.
+    """
+    chars = styled_chars = italic_chars = 0
+    weight_chars: Counter[int] = Counter()
+    for cell in cells:
+        text = (cell.text or "").strip()
+        if not text:
+            continue
+        chars += len(text)
+        if not isinstance(cell, PdfTextCell):
+            continue
+        style = parse_font_style(cell.font_name)
+        if style.known:
+            styled_chars += len(text)
+            weight_chars[weight_class(style.weight)] += len(text)
+            if style.italic:
+                italic_chars += len(text)
+        elif use_rendering_mode and cell.rendering_mode in _STROKED_MODES:
+            styled_chars += len(text)
+            weight_chars[weight_class(BOLD_WEIGHT)] += len(text)
+    return _StyleTally(
+        chars=chars,
+        styled_chars=styled_chars,
+        italic_chars=italic_chars,
+        weight_chars=weight_chars,
+    )
+
+
+def formatting_from_cells(
+    cells: Iterable[TextCell], *, use_rendering_mode: bool = False
+) -> Formatting | None:
+    """Item-level bold/italic for the cells of one layout cluster, or ``None`` when undetermined.
+
+    ``Formatting`` describes a whole text item, while a PDF carries a font per cell, so an
+    attribute is only reported when the cells agree on it. Two gates, both character-weighted:
+    most of the item must be legible at all, and most of the legible part must share the
+    attribute. Anything less returns ``None`` -- an emphasis that is wrong is written verbatim
+    into the exported text as ``**`` or ``*``, while a miss merely reproduces the behavior of a
+    pipeline that reads no styling.
+
+    ``None`` rather than an all-false ``Formatting`` for the same reason: the field is serialized
+    with ``exclude_none``, and "not determined" is what actually happened.
+
+    Underline, strikethrough and script stay unset -- a font name carries no signal for them.
+    """
+    tally = tally_cell_styles(cells, use_rendering_mode=use_rendering_mode)
+    if tally.coverage < _STYLE_COVERAGE:
+        return None
+    bold = tally.bold_share >= _STYLE_AGREEMENT
+    italic = tally.italic_share >= _STYLE_AGREEMENT
+    return Formatting(bold=bold, italic=italic) if (bold or italic) else None

--- a/tests/test_font_style.py
+++ b/tests/test_font_style.py
@@ -1,8 +1,21 @@
 """Tests for reading font weight and slant out of PDF font names."""
 
 import pytest
+from docling_core.types.doc import CoordOrigin
+from docling_core.types.doc.common.formatting import Formatting
+from docling_core.types.doc.page import (
+    BoundingRectangle,
+    PdfCellRenderingMode,
+    PdfTextCell,
+    TextCell,
+)
 
-from docling.utils.font_style import parse_font_style, weight_class
+from docling.utils.font_style import (
+    formatting_from_cells,
+    parse_font_style,
+    tally_cell_styles,
+    weight_class,
+)
 
 # Names harvested from the PDFs under tests/data/pdf/sources/, plus the foundry conventions they
 # represent. The expectations pin how each convention is read, since there is no standard for
@@ -88,3 +101,133 @@ def test_weight_classes_group_neighbouring_weights():
     assert [weight_class(w) for w in (100, 300, 400)] == [0, 0, 0]
     assert [weight_class(w) for w in (500, 600)] == [1, 1]
     assert [weight_class(w) for w in (700, 800, 900)] == [2, 2, 2]
+
+
+def _rect() -> BoundingRectangle:
+    return BoundingRectangle(
+        r_x0=0.0,
+        r_y0=0.0,
+        r_x1=10.0,
+        r_y1=0.0,
+        r_x2=10.0,
+        r_y2=5.0,
+        r_x3=0.0,
+        r_y3=5.0,
+        coord_origin=CoordOrigin.TOPLEFT,
+    )
+
+
+def _pdf_cell(
+    text: str,
+    font_name: str,
+    rendering_mode: PdfCellRenderingMode = PdfCellRenderingMode.FILL_TEXT,
+) -> PdfTextCell:
+    return PdfTextCell(
+        rect=_rect(),
+        text=text,
+        orig=text,
+        font_key="F0",
+        font_name=font_name,
+        widget=False,
+        rendering_mode=rendering_mode,
+    )
+
+
+def _ocr_cell(text: str) -> TextCell:
+    return TextCell(rect=_rect(), text=text, orig=text, from_ocr=True)
+
+
+_BOLD = Formatting(bold=True)
+_ITALIC = Formatting(italic=True)
+
+_FORMATTING_CASES = [
+    # (case id, cells, expected formatting)
+    ("uniform bold", [_pdf_cell("Lorem", "Times-Bold")] * 2, _BOLD),
+    ("uniform italic", [_pdf_cell("Lorem", "Times-Italic")], _ITALIC),
+    (
+        "bold italic",
+        [_pdf_cell("Lorem", "Arial-BoldItalicMT")],
+        Formatting(bold=True, italic=True),
+    ),
+    # Semibold is emphasis in the heading ranking but not bold text.
+    ("semibold is not bold", [_pdf_cell("Lorem", "LubalinGraphStd-Demi")], None),
+    # A readable, plain run stays None rather than an all-false Formatting: the field is
+    # serialized with exclude_none, so all-false would bloat every text item.
+    ("readable and plain", [_pdf_cell("Lorem", "Times-Roman")] * 2, None),
+    (
+        # The real caption of tests/data/pdf/sources/amt_handbook_sample.pdf.
+        "mixed bold label and italic caption",
+        [
+            _pdf_cell("Figure 7-26.", "Helvetica-Bold"),
+            _pdf_cell("Self-locking nuts.", "Times-Italic"),
+        ],
+        None,
+    ),
+    (
+        "dominant bold outweighs a short unreadable run",
+        [_pdf_cell("L" * 90, "Times-Bold"), _pdf_cell("L" * 5, "ArialMT")],
+        _BOLD,
+    ),
+    (
+        "short bold run does not carry an unreadable item",
+        [_pdf_cell("L" * 5, "Times-Bold"), _pdf_cell("L" * 90, "ArialMT")],
+        None,
+    ),
+    ("ocr cells carry no font", [_ocr_cell("Lorem")] * 2, None),
+    (
+        "one bold cell among ocr cells",
+        [_pdf_cell("Lorem", "Times-Bold")] + [_ocr_cell("Lorem")] * 3,
+        None,
+    ),
+    ("no cells", [], None),
+    (
+        "whitespace only",
+        [_pdf_cell(" ", "Times-Bold"), _pdf_cell("\n", "Times-Bold")],
+        None,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("cells", "expected"),
+    [(cells, expected) for _, cells, expected in _FORMATTING_CASES],
+    ids=[case_id for case_id, _, _ in _FORMATTING_CASES],
+)
+def test_formatting_from_cells(cells: list[TextCell], expected: Formatting | None):
+    assert formatting_from_cells(cells) == expected
+
+
+@pytest.mark.parametrize(
+    ("font_name", "rendering_mode", "use_rendering_mode", "expected"),
+    [
+        # A stroked outline is how a PDF fakes bold when no bold font is embedded, so it is read
+        # as bold -- but only where the font name itself says nothing.
+        ("ArialMT", PdfCellRenderingMode.FILL_THEN_STROKE, True, _BOLD),
+        ("ArialMT", PdfCellRenderingMode.STROKE_TEXT, True, _BOLD),
+        ("ArialMT", PdfCellRenderingMode.FILL_THEN_STROKE, False, None),
+        ("Times-Roman", PdfCellRenderingMode.STROKE_TEXT, True, None),
+        ("ArialMT", PdfCellRenderingMode.FILL_TEXT, True, None),
+        # Most PDFs never issue a Tr operator, and docling-parse reports UNKNOWN for those.
+        ("ArialMT", PdfCellRenderingMode.UNKNOWN, True, None),
+    ],
+)
+def test_stroked_text_is_read_as_bold_only_when_the_name_is_silent(
+    font_name: str,
+    rendering_mode: PdfCellRenderingMode,
+    use_rendering_mode: bool,
+    expected: Formatting | None,
+):
+    cells = [_pdf_cell("Lorem", font_name, rendering_mode)]
+
+    assert (
+        formatting_from_cells(cells, use_rendering_mode=use_rendering_mode) == expected
+    )
+
+
+def test_dominant_weight_class_breaks_ties_towards_the_heavier_class():
+    # The heading ranking depends on this: emphasis is what makes a heading stand out.
+    tally = tally_cell_styles(
+        [_pdf_cell("Lorem", "Times-Bold"), _pdf_cell("Lorem", "Times-Roman")]
+    )
+
+    assert tally.dominant_weight_class() == 2

--- a/tests/test_pdf_formatting.py
+++ b/tests/test_pdf_formatting.py
@@ -27,10 +27,9 @@ def _convert(
     *,
     enabled: bool = True,
     page_range: tuple[int, int] | None = None,
-    do_ocr: bool = False,
 ) -> ConversionResult:
     pipeline_options = PdfPipelineOptions()
-    pipeline_options.do_ocr = do_ocr
+    pipeline_options.do_ocr = False
     pipeline_options.do_table_structure = False
     pipeline_options.accelerator_options.device = AcceleratorDevice.CPU
     if enabled:
@@ -83,15 +82,4 @@ def test_formatting_is_not_recovered_unless_enabled(pipeline_cls) -> None:
         pipeline_cls, "tests/data/pdf/sources/amt_handbook_sample.pdf", enabled=False
     )
 
-    assert all(t.formatting is None for t in result.document.texts)
-
-
-@pytest.mark.ml_ocr
-def test_scanned_pages_carry_no_formatting() -> None:
-    # OCR produces cells without font information, so nothing is claimed about their styling.
-    result = _convert(
-        StandardPdfPipeline, "tests/data/ocr/sources/ocr_test.pdf", do_ocr=True
-    )
-
-    assert result.document.texts
     assert all(t.formatting is None for t in result.document.texts)

--- a/tests/test_pdf_formatting.py
+++ b/tests/test_pdf_formatting.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+
+import pytest
+from docling_core.types.doc.common.formatting import Formatting
+from docling_core.types.doc.document import SectionHeaderItem
+
+from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
+from docling.datamodel.accelerator_options import AcceleratorDevice
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.document import ConversionResult, InputDocument
+from docling.datamodel.pipeline_options import (
+    PdfPipelineOptions,
+    TextFormattingOptions,
+)
+from docling.datamodel.settings import DocumentLimits
+from docling.pipeline.legacy_standard_pdf_pipeline import LegacyStandardPdfPipeline
+from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline
+
+pytestmark = pytest.mark.ml_pdf_model
+
+PIPELINES = [StandardPdfPipeline, LegacyStandardPdfPipeline]
+
+
+def _convert(
+    pipeline_cls,
+    source: str,
+    *,
+    enabled: bool = True,
+    page_range: tuple[int, int] | None = None,
+    do_ocr: bool = False,
+) -> ConversionResult:
+    pipeline_options = PdfPipelineOptions()
+    pipeline_options.do_ocr = do_ocr
+    pipeline_options.do_table_structure = False
+    pipeline_options.accelerator_options.device = AcceleratorDevice.CPU
+    if enabled:
+        pipeline_options.text_formatting_options = TextFormattingOptions(enabled=True)
+
+    limits = DocumentLimits(page_range=page_range) if page_range else DocumentLimits()
+    input_document = InputDocument(
+        path_or_stream=Path(source),
+        format=InputFormat.PDF,
+        backend=DoclingParseDocumentBackend,
+        limits=limits,
+    )
+    return pipeline_cls(pipeline_options).execute(input_document, raises_on_error=True)
+
+
+@pytest.mark.parametrize("pipeline_cls", PIPELINES)
+def test_italic_body_text_is_recovered(pipeline_cls) -> None:
+    result = _convert(
+        pipeline_cls, "tests/data/pdf/sources/2203.01017v2.pdf", page_range=(1, 1)
+    )
+    texts = result.document.texts
+
+    # The abstract is set in NimbusRomNo9L-ReguItal, the body around it is not.
+    abstract = next(t for t in texts if t.text.startswith("Tables organize valuable"))
+    assert abstract.formatting == Formatting(italic=True)
+    assert all(
+        t.formatting is None
+        for t in texts
+        if t.text.startswith("Tables are widely used")
+    )
+    # Heading markup already conveys prominence, so headings are never formatted.
+    assert all(t.formatting is None for t in texts if isinstance(t, SectionHeaderItem))
+
+
+@pytest.mark.parametrize("pipeline_cls", PIPELINES)
+def test_bold_text_inside_a_picture_is_recovered(pipeline_cls) -> None:
+    result = _convert(pipeline_cls, "tests/data/pdf/sources/amt_handbook_sample.pdf")
+    formatting = {t.text: t.formatting for t in result.document.texts}
+
+    # Labels inside the figure, reached through the picture-child path.
+    assert formatting["Tightened nut"] == Formatting(bold=True)
+    assert formatting["Untightened nut"] == Formatting(bold=True)
+    # A bold label in front of an italic caption: the item is not uniformly emphasized.
+    assert formatting["Figure 7-26. Self-locking nuts."] is None
+
+
+@pytest.mark.parametrize("pipeline_cls", PIPELINES)
+def test_formatting_is_not_recovered_unless_enabled(pipeline_cls) -> None:
+    result = _convert(
+        pipeline_cls, "tests/data/pdf/sources/amt_handbook_sample.pdf", enabled=False
+    )
+
+    assert all(t.formatting is None for t in result.document.texts)
+
+
+@pytest.mark.ml_ocr
+def test_scanned_pages_carry_no_formatting() -> None:
+    # OCR produces cells without font information, so nothing is claimed about their styling.
+    result = _convert(
+        StandardPdfPipeline, "tests/data/ocr/sources/ocr_test.pdf", do_ocr=True
+    )
+
+    assert result.document.texts
+    assert all(t.formatting is None for t in result.document.texts)

--- a/tests/test_pdf_formatting_ocr.py
+++ b/tests/test_pdf_formatting_ocr.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+
+import pytest
+
+from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
+from docling.datamodel.accelerator_options import AcceleratorDevice
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.document import InputDocument
+from docling.datamodel.pipeline_options import (
+    PdfPipelineOptions,
+    TextFormattingOptions,
+)
+from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline
+
+# Lives apart from tests/test_pdf_formatting.py because CI selects whole modules by their
+# module-level marker, and this case needs the OCR lane rather than the PDF-model one.
+pytestmark = pytest.mark.ml_ocr
+
+
+def test_scanned_pages_carry_no_formatting() -> None:
+    # OCR produces cells without font information, so nothing is claimed about their styling.
+    pipeline_options = PdfPipelineOptions()
+    pipeline_options.do_ocr = True
+    pipeline_options.do_table_structure = False
+    pipeline_options.accelerator_options.device = AcceleratorDevice.CPU
+    pipeline_options.text_formatting_options = TextFormattingOptions(enabled=True)
+
+    input_document = InputDocument(
+        path_or_stream=Path("tests/data/ocr/sources/ocr_test.pdf"),
+        format=InputFormat.PDF,
+        backend=DoclingParseDocumentBackend,
+    )
+    result = StandardPdfPipeline(pipeline_options).execute(
+        input_document, raises_on_error=True
+    )
+
+    assert result.document.texts
+    assert all(t.formatting is None for t in result.document.texts)


### PR DESCRIPTION
Hi maintainers, i think this feature is worth adding after i do #3984, so i open this PR. Thanks a lot!

## What's added in
PDF conversion never sets `TextItem.formatting`, so bold and italic text converts indistinguishably from body text. Every other text backend already populates it in Word, HTML, Markdown, ODF, JATS, LaTeX, BoxNote, WebVTT and the whole downstream stack is in place: `DocSerializer.post_process` applies the field with `include_formatting=True` by default, and the
markdown serializer emits `**`/`*`. Only the producer side is missing on the PDF path.

The signal is already in the pipeline. `PdfTextCell.font_name` carries the embedded font name, and `docling/utils/font_style.py` (added in #3984) already reads weight and slant out of it but the result is consumed only to rank heading levels and is never written into the document.

This adds an opt-in stage that reads it into `TextItem.formatting`.

## Changes

- **`docling/utils/font_style.py`**: `tally_cell_styles()` lifts `parse_font_style` from one font
  name to the cells of one layout cluster, weighing each cell by its character count.
  `formatting_from_cells()` turns that tally into an item-level `Formatting`.

  `Formatting` describes a whole text item, while a PDF carries a font per cell, so an attribute is
  only reported when the cells agree. Two character-weighted gates, both at 0.8: most of the item
  must be legible at all (**coverage**), and most of the legible part must share the attribute
  (**agreement**). Anything less returns `None`, never an all-false `Formatting` — the field is
  serialized with `exclude_none`, and "not determined" is what actually happened.

  The threshold is deliberately stricter than the heading ranking's `_ITALIC_RATIO = 0.6`, because
  the two do different jobs: that one feeds a *relative* ranking that level-compression often
  absorbs, while this one is written verbatim into the exported text, where a wrong `**` corrupts
  the string for chunking and diffing. A miss just reproduces today's behavior.

- **`readingorder_model.py`**: `_cluster_formatting()` applied at every text call site. This is the
  only stage that reaches both sources of text items — `_handle_text_element` for the main path and
  `_add_child_elements` for text nested inside picture/form clusters. The latter carries 174 of the
  190 affected items, so hooking page assembly instead would have missed most of the signal.
  `cluster.cells` are still live at this point, so no `generate_parsed_pages=True` is needed.

  `_merge_elements` nulls conflicting formatting, exactly as it already does for `hyperlink`: the
  halves of a paragraph split across columns or pages are one item, and if they are not emphasized
  alike, the concatenation is not either.

- **`UNSTYLED_LABELS`** (`base_layout_model.py`): section headers, titles, code and formulas are
  never formatted. Heading markup already conveys prominence — matching `msword_backend._add_heading`,
  which deliberately omits `formatting` while `_add_paragraph` passes it. For code and formulas it is
  a correctness matter: `MarkdownTextSerializer` post-processes a `CodeItem` *after* fencing, so a
  bold code block would serialize as ``**```…```**``.

- **`TextFormattingOptions`**: `enabled` (default `False`) and `use_rendering_mode` (default `True`),
  on `PdfPipelineOptions.text_formatting_options`, mirrored in the service API as
  `do_pdf_text_formatting` / `pdf_text_formatting_options`.

- **`heading_hierarchy_model._heading_style`** now delegates its per-cell arithmetic to
  `tally_cell_styles` instead of repeating it. Behavior-identical — `dominant_weight_class()` and
  `italic_share` reproduce the previous expressions exactly, and the existing heading tests pin it.

Only `bold` and `italic` are set. Underline and strikethrough would need line geometry, and script needs per-cell baseline offsets that docling-parse does not expose; no other backend asserts what it cannot see.

## Measured effect

Simulating the rule against the committed groundtruth for the 14 PDFs in `tests/data/pdf/sources/`:

- **190 of 2014** text items (9.4%) gain formatting; 129 more are excluded by the label gate.
- 16 land on the markdown-visible main path (13 bold, 3 italic); 174 are nested inside pictures.
- Per document: `redp5110_sampled` 52, `2305.03393v1` 48, `2206.01062` 44, `2203.01017v2` 31,
  `right_to_left_03` 13, `amt_handbook_sample` 2, and 0 for the other eight.

Threshold sensitivity, same corpus:

| coverage / agreement | items formatted |
| --- | --- |
| 1.0 (unanimous) | 184 |
| **0.8 (this PR)** | **190** |
| 0.6 | 198 |
| 0.5 | 198 |

Loosening to 0.5 buys 8 items (0.4%), and those 8 are exactly the mixed-font items where uniform emphasis is wrong 

Sample of the change in markdown: the `2203.01017v2` abstract becomes `*Tables organize valuable content…*`, and `redp5110_sampled`'s `Front cover` becomes `**Front cover**`.


## Compatibility

Off by default, so no reference data changed and the PDF, OCR and webp groundtruth bundles are
byte-identical. A test pins that.

Even with the flag on, the OCR and webp groundtruth would not move: all six OCR source PDFs have no
digital text layer, so every cell is an OCR `TextCell` and the coverage gate returns `None`.

Known gap, left for a follow-up: TeX/Computer Modern names (`CMBX12`, `SFBX1000`, `CMTI`) are not
recognized by `parse_font_style`, which is why `code_and_formula`, `picture_classification` and
`2305.03393v1-pg9` get nothing. That is correct under the module's existing "abbreviations only as a
whole separator-delimited part" rule, and adding CM conventions would also shift heading levels, so
it belongs in its own change.

## Usage

```python
from docling.datamodel.base_models import InputFormat
from docling.datamodel.pipeline_options import PdfPipelineOptions, TextFormattingOptions
from docling.document_converter import DocumentConverter, PdfFormatOption

pipeline_options = PdfPipelineOptions()
pipeline_options.text_formatting_options = TextFormattingOptions(
    enabled=True,
    # use_rendering_mode=False,  # ignore stroked text, read font names only
)

converter = DocumentConverter(
    format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options)}
)
print(converter.convert("report.pdf").document.export_to_markdown())
```


**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
