### PR TITLE
fix(pypdfium2): apply page rotation to text-cell coordinates

### DIFF
--- a/docling/backend/pypdfium2_backend.py
+++ b/docling/backend/pypdfium2_backend.py
@@ -99,6 +99,76 @@ def get_pdf_page_geometry(
         )
 
 
+def _rect_to_display_frame(
+    rect: tuple[float, float, float, float],
+    rotation: int,
+    page_size: Size,
+) -> tuple[float, float, float, float]:
+    """Map a rect from the page's unrotated frame to its rotated display frame.
+
+    PDFium reports page-object and text coordinates in the unrotated (MediaBox)
+    frame, ignoring the page's ``/Rotate`` entry. ``PdfPage.get_size()`` and the
+    rendered page bitmap, on the other hand, are already in the rotated display
+    frame. Applying the rotation here puts everything the backend returns into
+    that single frame.
+
+    Args:
+        rect: ``(x0, y0, x1, y1)`` in the unrotated frame, bottom-left origin.
+        rotation: page rotation in degrees (``PdfPage.get_rotation()``).
+        page_size: page size in the display frame (``get_size()``).
+
+    Returns:
+        ``(x0, y0, x1, y1)`` in the display frame, bottom-left origin.
+    """
+    x0, y0, x1, y1 = rect
+    if rotation == 90:
+        return (y0, page_size.height - x1, y1, page_size.height - x0)
+    elif rotation == 180:
+        return (
+            page_size.width - x1,
+            page_size.height - y1,
+            page_size.width - x0,
+            page_size.height - y0,
+        )
+    elif rotation == 270:
+        return (page_size.width - y1, x0, page_size.width - y0, x1)
+    return (x0, y0, x1, y1)
+
+
+def _rect_to_pdf_frame(
+    rect: tuple[float, float, float, float],
+    rotation: int,
+    page_size: Size,
+) -> tuple[float, float, float, float]:
+    """Map a rect from the rotated display frame back to the unrotated frame.
+
+    Inverse of :func:`_rect_to_display_frame`, needed whenever coordinates are
+    handed back to PDFium (e.g. ``PdfTextPage.get_text_bounded()``), which only
+    understands the unrotated frame.
+
+    Args:
+        rect: ``(x0, y0, x1, y1)`` in the display frame, bottom-left origin.
+        rotation: page rotation in degrees (``PdfPage.get_rotation()``).
+        page_size: page size in the display frame (``get_size()``).
+
+    Returns:
+        ``(x0, y0, x1, y1)`` in the unrotated frame, bottom-left origin.
+    """
+    x0, y0, x1, y1 = rect
+    if rotation == 90:
+        return (page_size.height - y1, x0, page_size.height - y0, x1)
+    elif rotation == 180:
+        return (
+            page_size.width - x1,
+            page_size.height - y1,
+            page_size.width - x0,
+            page_size.height - y0,
+        )
+    elif rotation == 270:
+        return (y0, page_size.width - x1, y1, page_size.width - x0)
+    return (x0, y0, x1, y1)
+
+
 if TYPE_CHECKING:
     from docling.datamodel.document import InputDocument
 
@@ -146,8 +216,10 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
     def _compute_text_cells(self) -> List[TextCell]:
         """Compute text cells from pypdfium."""
         with pypdfium2_lock:
+            page = self._require_page()
             if not self.text_page:
-                self.text_page = self._require_page().get_textpage()
+                self.text_page = page.get_textpage()
+            rotation = page.get_rotation()
 
         cells = []
         cell_counter = 0
@@ -158,7 +230,9 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
             for i in range(self.text_page.count_rects()):
                 rect = self.text_page.get_rect(i)
                 text_piece = self.text_page.get_text_bounded(*rect)
-                x0, y0, x1, y1 = rect
+                # `rect` is in the unrotated frame, `page_size` in the rotated
+                # display frame: bring the rect over before converting origin.
+                x0, y0, x1, y1 = _rect_to_display_frame(rect, rotation, page_size)
                 cells.append(
                     TextCell(
                         index=cell_counter,
@@ -256,8 +330,11 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
 
                 assert self.text_page is not None
                 bbox = merged_bbox.to_bottom_left_origin(page_size.height)
+                # Cells are stored in the display frame; PDFium only understands
+                # the unrotated one, so undo the rotation before querying it.
+                pdf_rect = _rect_to_pdf_frame(bbox.as_tuple(), rotation, page_size)
                 with pypdfium2_lock:
-                    merged_text = self.text_page.get_text_bounded(*bbox.as_tuple())
+                    merged_text = self.text_page.get_text_bounded(*pdf_rect)
 
                 return TextCell(
                     index=group[0].index,
@@ -289,27 +366,7 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
                     pos = obj.get_bounds()  # pypdfium2 >= 5.x
                 else:
                     pos = obj.get_pos()  # pypdfium2 <= 4.x
-                if rotation == 90:
-                    pos = (
-                        pos[1],
-                        page_size.height - pos[2],
-                        pos[3],
-                        page_size.height - pos[0],
-                    )
-                elif rotation == 180:
-                    pos = (
-                        page_size.width - pos[2],
-                        page_size.height - pos[3],
-                        page_size.width - pos[0],
-                        page_size.height - pos[1],
-                    )
-                elif rotation == 270:
-                    pos = (
-                        page_size.width - pos[3],
-                        pos[0],
-                        page_size.width - pos[1],
-                        pos[2],
-                    )
+                pos = _rect_to_display_frame(pos, rotation, page_size)
 
                 cropbox = BoundingBox.from_tuple(
                     pos, origin=CoordOrigin.BOTTOMLEFT
@@ -320,14 +377,22 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
 
     def get_text_in_rect(self, bbox: BoundingBox) -> str:
         with pypdfium2_lock:
+            page = self._require_page()
             if not self.text_page:
-                self.text_page = self._require_page().get_textpage()
+                self.text_page = page.get_textpage()
+            rotation = page.get_rotation()
+
+        page_size = self.get_size()
 
         if bbox.coord_origin != CoordOrigin.BOTTOMLEFT:
-            bbox = bbox.to_bottom_left_origin(self.get_size().height)
+            bbox = bbox.to_bottom_left_origin(page_size.height)
+
+        # `bbox` is expressed in the rotated display frame, PDFium expects the
+        # unrotated one.
+        pdf_rect = _rect_to_pdf_frame(bbox.as_tuple(), rotation, page_size)
 
         with pypdfium2_lock:
-            text_piece = self.text_page.get_text_bounded(*bbox.as_tuple())
+            text_piece = self.text_page.get_text_bounded(*pdf_rect)
 
         return text_piece
 

--- a/tests/test_backend_pdfium_rotation.py
+++ b/tests/test_backend_pdfium_rotation.py
@@ -1,0 +1,219 @@
+"""Text-cell geometry for pages carrying a ``/Rotate`` entry.
+
+PDFium reports text coordinates in the page's unrotated (MediaBox) frame and
+ignores ``/Rotate``, while ``PdfPage.get_size()`` and the rendered page bitmap
+are already in the rotated *display* frame. These tests pin down that the
+pypdfium2 backend hands back a single, consistent frame.
+
+The fixtures are built as raw PDF bytes so the tests need no models, no GPU and
+no extra dependency: the same three words are drawn at the same *displayed*
+position four times, once with a plain landscape MediaBox and once for each of
+``/Rotate 90``, ``180`` and ``270``. All four documents look identical to a
+reader, so the text cells the backend extracts from them must match too.
+"""
+
+from pathlib import Path
+
+import pypdfium2 as pdfium
+import pytest
+from docling_core.types.doc import BoundingBox, CoordOrigin
+from docling_core.types.doc.page import TextCell
+
+from docling.backend.pypdfium2_backend import (
+    PyPdfiumDocumentBackend,
+    PyPdfiumPageBackend,
+)
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.document import InputDocument
+
+# The page every variant *displays*: US Letter, landscape.
+DISPLAY_WIDTH = 792.0
+DISPLAY_HEIGHT = 612.0
+
+FONT_SIZE = 24
+WORDS = ("ALPHA", "BRAVO", "CHARLIE")
+# Left edge of each word and the shared baseline, in the display frame
+# (bottom-left origin). The gaps are small enough that the backend's horizontal
+# merging collapses the three words into a single cell.
+WORD_X = (50.0, 130.0, 215.0)
+BASELINE_Y = 512.0
+
+# Rects come straight from the same glyph metrics in every variant, so the only
+# difference is floating-point noise from the rotation arithmetic.
+TOLERANCE = 0.5
+
+
+def _media_box(rotation: int) -> tuple[float, float]:
+    """Size of the MediaBox needed to display as ``DISPLAY_WIDTH x DISPLAY_HEIGHT``."""
+    if rotation in (90, 270):
+        return DISPLAY_HEIGHT, DISPLAY_WIDTH
+    return DISPLAY_WIDTH, DISPLAY_HEIGHT
+
+
+def _text_matrix(rotation: int, x: float) -> tuple[float, ...]:
+    """Text matrix placing a word at ``(x, BASELINE_Y)`` of the *displayed* page.
+
+    ``/Rotate`` turns the page clockwise for display, so the content stream has
+    to counter-rotate for the text to come out upright and in the same place.
+    """
+    if rotation == 90:
+        return (0.0, 1.0, -1.0, 0.0, DISPLAY_HEIGHT - BASELINE_Y, x)
+    elif rotation == 180:
+        return (-1.0, 0.0, 0.0, -1.0, DISPLAY_WIDTH - x, DISPLAY_HEIGHT - BASELINE_Y)
+    elif rotation == 270:
+        return (0.0, -1.0, 1.0, 0.0, BASELINE_Y, DISPLAY_WIDTH - x)
+    return (1.0, 0.0, 0.0, 1.0, x, BASELINE_Y)
+
+
+def _build_pdf(rotation: int) -> bytes:
+    """A one-page PDF with the three words, stored with the given ``/Rotate``."""
+    media_width, media_height = _media_box(rotation)
+    blocks = [
+        "BT /F1 {size} Tf {matrix} Tm ({word}) Tj ET".format(
+            size=FONT_SIZE,
+            matrix=" ".join(f"{v:g}" for v in _text_matrix(rotation, x)),
+            word=word,
+        )
+        for x, word in zip(WORD_X, WORDS, strict=True)
+    ]
+    content = ("\n".join(blocks) + "\n").encode("ascii")
+
+    rotate_entry = f" /Rotate {rotation}" if rotation else ""
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        (
+            f"<< /Type /Page /Parent 2 0 R "
+            f"/MediaBox [0 0 {media_width:g} {media_height:g}]{rotate_entry} "
+            f"/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>"
+        ).encode("ascii"),
+        b"<< /Length "
+        + str(len(content)).encode("ascii")
+        + b" >>\nstream\n"
+        + content
+        + b"endstream",
+        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica "
+        b"/Encoding /WinAnsiEncoding >>",
+    ]
+
+    out = bytearray(b"%PDF-1.7\n%\xe2\xe3\xcf\xd3\n")
+    offsets = []
+    for number, body in enumerate(objects, start=1):
+        offsets.append(len(out))
+        out += f"{number} 0 obj\n".encode("ascii") + body + b"\nendobj\n"
+
+    startxref = len(out)
+    out += f"xref\n0 {len(objects) + 1}\n".encode("ascii")
+    out += b"0000000000 65535 f \n"
+    for offset in offsets:
+        out += f"{offset:010d} 00000 n \n".encode("ascii")
+    out += (
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+        f"startxref\n{startxref}\n%%EOF\n"
+    ).encode("ascii")
+    return bytes(out)
+
+
+def _write_pdf(tmp_path: Path, rotation: int) -> Path:
+    path = tmp_path / f"rotate_{rotation}.pdf"
+    path.write_bytes(_build_pdf(rotation))
+    return path
+
+
+def _page_backend(tmp_path: Path, rotation: int) -> PyPdfiumPageBackend:
+    in_doc = InputDocument(
+        path_or_stream=_write_pdf(tmp_path, rotation),
+        format=InputFormat.PDF,
+        backend=PyPdfiumDocumentBackend,
+    )
+    return in_doc._backend.load_page(0)
+
+
+def _union(cells: list[TextCell]) -> tuple[float, float, float, float]:
+    """``(l, t, r, b)`` covering every cell, in top-left origin."""
+    boxes = [cell.rect.to_bounding_box() for cell in cells]
+    assert boxes, "no text cells were extracted"
+    assert all(box.coord_origin == CoordOrigin.TOPLEFT for box in boxes)
+    return (
+        min(box.l for box in boxes),
+        min(box.t for box in boxes),
+        max(box.r for box in boxes),
+        max(box.b for box in boxes),
+    )
+
+
+@pytest.mark.parametrize("rotation", [90, 180, 270])
+def test_text_cells_match_unrotated_twin(tmp_path: Path, rotation: int) -> None:
+    """A rotated page and its flat twin display alike, so their cells must agree."""
+    flat = list(_page_backend(tmp_path, 0).get_text_cells())
+    rotated = list(_page_backend(tmp_path, rotation).get_text_cells())
+
+    assert [cell.text for cell in rotated] == [cell.text for cell in flat]
+    assert _union(rotated) == pytest.approx(_union(flat), abs=TOLERANCE)
+
+
+@pytest.mark.parametrize("rotation", [0, 90, 180, 270])
+def test_text_cells_lie_inside_the_page(tmp_path: Path, rotation: int) -> None:
+    """Cells must sit within the page as ``get_size()`` reports it."""
+    page_backend = _page_backend(tmp_path, rotation)
+    size = page_backend.get_size()
+    assert (size.width, size.height) == (DISPLAY_WIDTH, DISPLAY_HEIGHT)
+
+    for cell in page_backend.get_text_cells():
+        box = cell.rect.to_bounding_box()
+        assert 0 <= box.l <= box.r <= size.width
+        assert 0 <= box.t <= box.b <= size.height
+
+
+def test_unrotated_page_geometry_is_unchanged(tmp_path: Path) -> None:
+    """Without ``/Rotate`` the cells stay exactly what PDFium reports."""
+    path = _write_pdf(tmp_path, 0)
+
+    pdf = pdfium.PdfDocument(path)
+    try:
+        text_page = pdf[0].get_textpage()
+        rects = [text_page.get_rect(i) for i in range(text_page.count_rects())]
+    finally:
+        pdf.close()
+    assert rects
+
+    expected = (
+        min(rect[0] for rect in rects),
+        DISPLAY_HEIGHT - max(rect[3] for rect in rects),
+        max(rect[2] for rect in rects),
+        DISPLAY_HEIGHT - min(rect[1] for rect in rects),
+    )
+
+    in_doc = InputDocument(
+        path_or_stream=path, format=InputFormat.PDF, backend=PyPdfiumDocumentBackend
+    )
+    cells = list(in_doc._backend.load_page(0).get_text_cells())
+    assert _union(cells) == pytest.approx(expected, abs=1e-6)
+
+
+@pytest.mark.parametrize("rotation", [0, 90, 180, 270])
+def test_get_text_in_rect_accepts_display_coordinates(
+    tmp_path: Path, rotation: int
+) -> None:
+    """Re-extraction must undo the rotation before querying PDFium again."""
+    page_backend = _page_backend(tmp_path, rotation)
+    left, top, right, bottom = _union(list(page_backend.get_text_cells()))
+
+    text = page_backend.get_text_in_rect(
+        BoundingBox(l=left - 2, t=top - 2, r=right + 2, b=bottom + 2)
+    )
+
+    for word in WORDS:
+        assert word in text
+
+
+@pytest.mark.parametrize("rotation", [0, 90, 180, 270])
+def test_merged_cell_text_survives_rotation(tmp_path: Path, rotation: int) -> None:
+    """Merging re-reads the text through PDFium, which needs the unrotated frame."""
+    cells = list(_page_backend(tmp_path, rotation).get_text_cells())
+
+    # The three words sit on one row with sub-word gaps, so they merge into one
+    # cell whose text is re-extracted from the merged bounding box.
+    assert len(cells) == 1
+    for word in WORDS:
+        assert word in cells[0].text


### PR DESCRIPTION
Fixes #4007

### The bug

For a page carrying a `/Rotate` entry, the pypdfium2 backend describes it from two different coordinate frames:

| method | frame |
|---|---|
| `get_size()` | rotated display frame — PDFium swaps width/height for 90/270 |
| `get_page_image()` | rotated — the bitmap is rendered upright |
| `get_text_cells()` / `get_segmented_page()` | unrotated MediaBox frame — `FPDFText_GetRect` values used as-is |

`_compute_text_cells()` then calls `to_top_left_origin(page_size.height)`, applying the *rotated* height to coordinates still in the *unrotated* frame. Text cells come back transposed 90° against the page image they are meant to describe, frequently with a negative `t`. Downstream, layout clusters (predicted on the correctly-oriented image) and text cells no longer overlap, so items get emitted from both frames and can be duplicated.

`get_bitmap_rects()` has corrected for this since #2039; the text path never got the equivalent, so within one backend image rects were rotation-corrected and text cells were not.

### Minimal repro

```python
import pypdfium2 as pdfium

# same page content, saved once flat and once portrait + /Rotate 90
for path in ("flat_landscape.pdf", "portrait_rotate90.pdf"):
    pdf = pdfium.PdfDocument(path)
    page = pdf[0]
    w, h = page.get_size()
    rect = page.get_textpage().get_rect(0)   # (l, b, r, t), unrotated frame
    print(path, (w, h), tuple(round(v, 1) for v in rect),
          "t after to_top_left_origin ->", round(h - rect[3], 1))
    pdf.close()
```

```
flat_landscape.pdf     (792.0, 612.0)  (50.3, 512.0, 128.4, 529.2)  t after to_top_left_origin -> 82.8
portrait_rotate90.pdf  (792.0, 612.0)  (82.8,  50.3, 100.0, 128.4)  t after to_top_left_origin -> 483.6
```

The two files display identically, `get_size()` agrees, the render agrees — only the text rect is in the other frame, and the top-left conversion then subtracts from the wrong dimension. On `/Rotate 270` the same page yields a negative `t`.

### What changed

- Extracted the per-angle transform into `_rect_to_display_frame()` and added its inverse, `_rect_to_pdf_frame()`.
- `_compute_text_cells()` reads `page.get_rotation()` and maps each rect into the display frame before `to_top_left_origin()`.
- `merge_group()` and `get_text_in_rect()` apply the inverse before `get_text_bounded()`: cells are now stored in the display frame, while PDFium still only understands the unrotated one. Without this, text re-extraction on rotated pages silently returns nothing.
- `get_bitmap_rects()` now calls the shared helper instead of its own copy of the same arithmetic. The arithmetic is identical, so the image path is behaviour-preserving.

Out of scope, worth a follow-up: `get_pdf_page_geometry()` still reports `SegmentedPdfPage.dimension` in the unrotated frame, so `dimension.height` and the text cells describe different frames on a rotated page. The boxes it exposes are named after PDF boxes (`media_bbox`, `crop_bbox`, …), so normalising them looked like a separate decision rather than part of this fix.

### Tests

New `tests/test_backend_pdfium_rotation.py` — no models, no GPU, no new dependency. Fixtures are built as raw PDF bytes in the test: the same three words are drawn at the same *displayed* position four times, once with a landscape MediaBox and once each for `/Rotate 90`, `180` and `270` (with a counter-rotating text matrix), so all four documents render identically. It asserts that

- a rotated page's cells match its flat twin's, in both text and geometry (abs tolerance 0.5),
- cells lie inside the page as `get_size()` reports it, for all four rotations,
- an unrotated page is untouched — cells still equal the raw pdfium rects through `to_top_left_origin()` to 1e-6,
- `get_text_in_rect()` accepts display-frame coordinates on a rotated page,
- a merged cell — whose text is re-extracted through PDFium from the merged box — still reads correctly on a rotated page.

Against the unpatched backend, 6 of the 16 cases fail; with the fix, all 16 pass. The existing pypdfium2 backend tests that don't require models (`test_get_text_from_rect`, `test_merge_row`, `test_text_cell_counts`, `test_crop_page_image`, `test_num_pages`) pass unchanged before and after.
