### PR TITLE
fix: Surface VLM API call failures as PARTIAL_SUCCESS instead of silent empty pages

### DIFF
--- a/docling/pipeline/vlm_pipeline.py
+++ b/docling/pipeline/vlm_pipeline.py
@@ -66,7 +66,7 @@ from docling.utils.deepseekocr_utils import parse_deepseekocr_markdown
 from docling.utils.profiling import ProfilingScope, TimeRecorder
 
 _log = logging.getLogger(__name__)
-_DOCLANG_OPEN_RE = re.compile(r"<doclang(?:\s[^>]*)?>")
+_DOCLANG_OPEN_RE = re.compile(r"<doclang(?:\s[^>]*)?>") 
 
 
 def _raise_if_unsupported_threaded_backend(
@@ -237,8 +237,8 @@ class VlmPipeline(PaginatedPipeline):
         """Determine conversion status accounting for VLM stop reasons.
 
         Extends the base implementation to detect partial failures from VLM
-        inference, such as truncated output (LENGTH) or filtered content
-        (CONTENT_FILTERED).
+        inference, such as truncated output (LENGTH), filtered content
+        (CONTENT_FILTERED), or a swallowed API error (UNSPECIFIED + empty text).
         """
         status = super()._determine_status(conv_res)
 
@@ -265,6 +265,18 @@ class VlmPipeline(PaginatedPipeline):
                         module_name=self.__class__.__name__,
                         error_message="VLM output incomplete "
                         f"(stop_reason={vlm_response.stop_reason.value}).",
+                        category=FailureCategory.INFERENCE_FAILURE,
+                        page_no=page.page_no,
+                    )
+                )
+                status = ConversionStatus.PARTIAL_SUCCESS
+            elif vlm_response.stop_reason == VlmStopReason.UNSPECIFIED and not vlm_response.text:
+                conv_res.errors.append(
+                    ErrorItem(
+                        component_type=DoclingComponentType.PIPELINE,
+                        module_name=self.__class__.__name__,
+                        error_message="VLM returned empty output with UNSPECIFIED stop reason; "
+                        "the API call likely failed (timeout, connection error, or gateway error).",
                         category=FailureCategory.INFERENCE_FAILURE,
                         page_no=page.page_no,
                     )

--- a/docling/pipeline/vlm_pipeline.py
+++ b/docling/pipeline/vlm_pipeline.py
@@ -66,7 +66,7 @@ from docling.utils.deepseekocr_utils import parse_deepseekocr_markdown
 from docling.utils.profiling import ProfilingScope, TimeRecorder
 
 _log = logging.getLogger(__name__)
-_DOCLANG_OPEN_RE = re.compile(r"<doclang(?:\s[^>]*)?>") 
+_DOCLANG_OPEN_RE = re.compile(r"<doclang(?:\s[^>]*)?>")
 
 
 def _raise_if_unsupported_threaded_backend(


### PR DESCRIPTION
### Problem\n\nWhen `api_image_request()` fails due to a timeout, connection error, or gateway error, it catches the exception and returns `ApiImageRequestResult(\"\", 0, VlmStopReason.UNSPECIFIED)`. The `_determine_status()` override in `VlmPipeline` only checked for `LENGTH` and `CONTENT_FILTERED` stop reasons, so an `UNSPECIFIED` stop reason with an empty text response was treated as full `SUCCESS` with no errors recorded.\n\nThis made it impossible for callers to distinguish a genuine blank page from a completely failed API call. `raises_on_error=True` never fired, and `conv_res.errors` stayed empty.\n\n### Fix\n\nAdd an `elif` branch to `_determine_status` that checks for `VlmStopReason.UNSPECIFIED` combined with an empty text response and downgrades the result to `PARTIAL_SUCCESS` with an `ErrorItem`, consistent with how `LENGTH` and `CONTENT_FILTERED` are already handled.\n\nA non-empty response with `UNSPECIFIED` stop reason is left untouched — that represents a normal completion where the model stopped for an unspecified reason but did produce output.\n\nFixes #4009