### PR TITLE
fix: Respect DPI in page rendering on ImageBackend 

### DIFF
--- a/docling/backend/image_backend.py
+++ b/docling/backend/image_backend.py
@@ -1,7 +1,9 @@
 import logging
+import math
+from collections.abc import Iterable
 from io import BytesIO
 from pathlib import Path
-from typing import Iterable, List, Optional, Union
+from typing import SupportsFloat
 
 from docling_core.types.doc import BoundingBox, CoordOrigin, Size
 from docling_core.types.doc.page import (
@@ -22,11 +24,39 @@ from docling.exceptions import DocumentLoadError
 
 _log = logging.getLogger(__name__)
 
+_POINTS_PER_INCH = 72.0
+_DEFAULT_DPI = (_POINTS_PER_INCH, _POINTS_PER_INCH)
+
+
+def _validate_dpi(dpi: tuple[SupportsFloat, SupportsFloat]) -> tuple[float, float]:
+    if not isinstance(dpi, tuple) or len(dpi) != 2:
+        raise ValueError(f"Invalid image DPI metadata: {dpi!r}")
+
+    try:
+        dpi_x, dpi_y = float(dpi[0]), float(dpi[1])
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"Invalid image DPI metadata: {dpi!r}") from exc
+
+    if not math.isfinite(dpi_x) or not math.isfinite(dpi_y):
+        raise ValueError(f"Invalid image DPI metadata: {dpi!r}")
+    if dpi_x <= 0 or dpi_y <= 0:
+        raise ValueError(f"Invalid image DPI metadata: {dpi!r}")
+
+    return dpi_x, dpi_y
+
+
+def _get_frame_dpi(image: Image.Image) -> tuple[float, float]:
+    dpi = image.info.get("dpi")
+    return _validate_dpi(_DEFAULT_DPI if dpi in (None, (1, 1)) else dpi)
+
 
 class _ImagePageBackend(PdfPageBackend):
-    def __init__(self, image: Image.Image, page_no: int):
+    def __init__(
+        self, image: Image.Image, page_no: int, dpi: tuple[float, float]
+    ) -> None:
         self._image: Image.Image | None = image
         self._page_no = page_no
+        self._dpi = dpi
         self.valid: bool = self._image is not None
 
     @property
@@ -94,30 +124,49 @@ class _ImagePageBackend(PdfPageBackend):
         self, scale: float = 1, cropbox: BoundingBox | None = None
     ) -> Image.Image:
         assert self._image is not None
-        img = self._image
+        page_size = self.get_size()
 
-        if cropbox is not None:
-            # Expected cropbox comes in TOPLEFT coords in our pipeline
+        if cropbox is None:
+            left, top, right, bottom = 0.0, 0.0, page_size.width, page_size.height
+        else:
             if cropbox.coord_origin != CoordOrigin.TOPLEFT:
-                # Convert to TOPLEFT relative to current image height
-                cropbox = cropbox.to_top_left_origin(img.height)
+                cropbox = cropbox.to_top_left_origin(page_size.height)
             left, top, right, bottom = cropbox.as_tuple()
-            left = max(0, round(left))
-            top = max(0, round(top))
-            right = min(img.width, round(right))
-            bottom = min(img.height, round(bottom))
-            img = img.crop((left, top, right, bottom))
+            left = min(max(0.0, left), page_size.width)
+            top = min(max(0.0, top), page_size.height)
+            right = min(max(0.0, right), page_size.width)
+            bottom = min(max(0.0, bottom), page_size.height)
 
-        if scale != 1:
-            new_w = max(1, round(img.width * scale))
-            new_h = max(1, round(img.height * scale))
-            img = img.resize((new_w, new_h))
+        target_size = (
+            max(1, round((right - left) * scale)),
+            max(1, round((bottom - top) * scale)),
+        )
+        source_box = (
+            left * self._dpi[0] / _POINTS_PER_INCH,
+            top * self._dpi[1] / _POINTS_PER_INCH,
+            right * self._dpi[0] / _POINTS_PER_INCH,
+            bottom * self._dpi[1] / _POINTS_PER_INCH,
+        )
+        if target_size == self._image.size and source_box == (
+            0.0,
+            0.0,
+            float(self._image.width),
+            float(self._image.height),
+        ):
+            return self._image
 
-        return img
+        return self._image.resize(
+            target_size,
+            resample=Image.Resampling.LANCZOS,
+            box=source_box,
+        )
 
     def get_size(self) -> Size:
         assert self._image is not None
-        return Size(width=self._image.width, height=self._image.height)
+        return Size(
+            width=self._image.width * _POINTS_PER_INCH / self._dpi[0],
+            height=self._image.height * _POINTS_PER_INCH / self._dpi[1],
+        )
 
     def unload(self):
         # Help GC and free memory
@@ -138,9 +187,9 @@ class ImageDocumentBackend(PdfDocumentBackend):
     def __init__(
         self,
         in_doc: InputDocument,
-        path_or_stream: Union[BytesIO, Path],
-        options: Optional[PdfBackendOptions] = None,
-    ):
+        path_or_stream: BytesIO | Path,
+        options: PdfBackendOptions | None = None,
+    ) -> None:
         if options is None:
             options = PdfBackendOptions()
         # Bypass PdfDocumentBackend.__init__ to avoid image→PDF conversion
@@ -153,7 +202,8 @@ class ImageDocumentBackend(PdfDocumentBackend):
             )
 
         # Load frames eagerly for thread-safety across pages
-        self._frames: List[Image.Image] = []
+        self._frames: list[Image.Image] = []
+        self._frame_dpi: list[tuple[float, float]] = []
         try:
             with Image.open(self.path_or_stream) as img:  # type: ignore[arg-type]
                 # Handle multi-frame and single-frame images
@@ -164,13 +214,16 @@ class ImageDocumentBackend(PdfDocumentBackend):
                 if frame_count > 1:
                     for i in range(frame_count):
                         img.seek(i)
+                        self._frame_dpi.append(_get_frame_dpi(img))
                         self._frames.append(img.copy().convert("RGB"))
                 else:
+                    self._frame_dpi.append(_get_frame_dpi(img))
                     self._frames.append(img.convert("RGB"))
         except Exception as e:
             for frame in self._frames:
                 frame.close()
             self._frames = []
+            self._frame_dpi = []
             raise DocumentLoadError(
                 f"Could not load image for document {self.file}"
             ) from e
@@ -184,7 +237,9 @@ class ImageDocumentBackend(PdfDocumentBackend):
     def load_page(self, page_no: int) -> _ImagePageBackend:
         if not (0 <= page_no < len(self._frames)):
             raise IndexError(f"Page index out of range: {page_no}")
-        return _ImagePageBackend(self._frames[page_no], page_no)
+        return _ImagePageBackend(
+            self._frames[page_no], page_no, self._frame_dpi[page_no]
+        )
 
     @classmethod
     def supported_formats(cls) -> set[InputFormat]:
@@ -199,4 +254,5 @@ class ImageDocumentBackend(PdfDocumentBackend):
         for frame in self._frames:
             frame.close()
         self._frames = []
+        self._frame_dpi = []
         super().unload()

--- a/docling/backend/pdf_backend.py
+++ b/docling/backend/pdf_backend.py
@@ -35,17 +35,17 @@ class PdfPageBackend(ABC):
 
     @abstractmethod
     def get_bitmap_rects(self, scale: float = 1) -> Iterable[BoundingBox]:
-        pass
+        """Return bitmap bounds in 72-DPI document coordinates, scaled by ``scale``."""
 
     @abstractmethod
     def get_page_image(
         self, scale: float = 1, cropbox: Optional[BoundingBox] = None
     ) -> Image.Image:
-        pass
+        """Render a logical page region at ``scale`` pixels per document point."""
 
     @abstractmethod
     def get_size(self) -> Size:
-        pass
+        """Return the page size in 72-DPI document points."""
 
     @abstractmethod
     def is_valid(self) -> bool:

--- a/docling/models/stages/table_structure/table_structure_model.py
+++ b/docling/models/stages/table_structure/table_structure_model.py
@@ -118,8 +118,8 @@ class TableStructureModel(BaseTableStructureModel):
         assert page._backend is not None
         assert page.size is not None
 
-        image = (
-            page._backend.get_page_image()
+        image = page._backend.get_page_image(
+            scale=1.0
         )  # make new image to avoid drawing on the saved ones
 
         scale_x = image.width / page.size.width

--- a/docling/models/stages/table_structure/table_structure_model_v2.py
+++ b/docling/models/stages/table_structure/table_structure_model_v2.py
@@ -311,7 +311,7 @@ class TableStructureModelV2(BaseTableStructureModel):
         assert page._backend is not None
         assert page.size is not None
 
-        image = page._backend.get_page_image()
+        image = page._backend.get_page_image(scale=1.0)
 
         scale_x = image.width / page.size.width
         scale_y = image.height / page.size.height

--- a/docs/usage/advanced_options.md
+++ b/docs/usage/advanced_options.md
@@ -103,6 +103,12 @@ The options in this list require the explicit `enable_remote_services=True` when
 The example file [custom_convert.py](../examples/custom_convert.py) contains multiple ways
 one can adjust the conversion pipeline and features.
 
+### Image resolution and scale
+
+Page coordinates use 72 points per inch. For image inputs, embedded DPI metadata
+determines the physical page size; missing DPI and `(1, 1)` DPI are treated as 72 DPI.
+Rendering at scale `n` produces `n` pixels per document point.
+
 ### Control PDF table extraction options
 
 You can control if table structure recognition should map the recognized structure back to PDF cells (default) or use text cells from the structure prediction itself.

--- a/tests/test_backend_image_native.py
+++ b/tests/test_backend_image_native.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock
 
 import pytest
 from docling_core.types.doc import BoundingBox, CoordOrigin
-from PIL import Image
+from PIL import Image, TiffImagePlugin
 
 from docling.backend.image_backend import ImageDocumentBackend, _ImagePageBackend
 from docling.datamodel.base_models import DocumentStream, InputFormat
@@ -11,28 +11,43 @@ from docling.datamodel.document import (
     InputDocument,
     _DocumentConversionInput,
     _DummyBackend,
+    get_input_rejection_cause,
 )
 from docling.document_converter import DocumentConverter, ImageFormatOption
 from docling.document_extractor import DocumentExtractor
+from docling.exceptions import DocumentLoadError
 
 
 def _make_png_stream(
-    width: int = 64, height: int = 48, color=(123, 45, 67)
+    width: int = 64,
+    height: int = 48,
+    color=(123, 45, 67),
+    dpi: tuple[float, float] | None = None,
 ) -> DocumentStream:
     img = Image.new("RGB", (width, height), color)
     buf = BytesIO()
-    img.save(buf, format="PNG")
+    img.save(buf, format="PNG", **({} if dpi is None else {"dpi": dpi}))
     buf.seek(0)
     return DocumentStream(name="test.png", stream=buf)
 
 
-def _make_multipage_tiff_stream(num_pages: int = 3, size=(32, 32)) -> DocumentStream:
+def _make_multipage_tiff_stream(
+    num_pages: int = 3,
+    size=(32, 32),
+    dpi: tuple[float, float] | None = (72, 72),
+) -> DocumentStream:
     frames = [
         Image.new("RGB", size, (i * 10 % 255, i * 20 % 255, i * 30 % 255))
         for i in range(num_pages)
     ]
     buf = BytesIO()
-    frames[0].save(buf, format="TIFF", save_all=True, append_images=frames[1:])
+    frames[0].save(
+        buf,
+        format="TIFF",
+        save_all=True,
+        append_images=frames[1:],
+        **({} if dpi is None else {"dpi": dpi}),
+    )
     buf.seek(0)
     return DocumentStream(name="test.tiff", stream=buf)
 
@@ -109,6 +124,13 @@ def test_get_size():
     assert size.height == height
 
 
+def test_one_dpi_defaults_to_72_dpi():
+    stream = _make_multipage_tiff_stream(num_pages=1, size=(64, 48), dpi=None)
+    page_backend = _get_backend_from_stream(stream).load_page(0)
+
+    assert page_backend.get_size().as_tuple() == (64, 48)
+
+
 def test_get_page_image_full():
     """Test getting full page image."""
     width, height = 100, 80
@@ -130,6 +152,58 @@ def test_get_page_image_scaled():
     img = page_backend.get_page_image(scale=scale)
     assert img.width == round(width * scale)
     assert img.height == round(height * scale)
+
+
+def test_300_dpi_tiff_uses_72_dpi_document_geometry():
+    stream = _make_multipage_tiff_stream(
+        num_pages=1,
+        size=(2550, 3300),
+        dpi=(300, 300),
+    )
+    page_backend = _get_backend_from_stream(stream).load_page(0)
+
+    assert page_backend.get_size().as_tuple() == pytest.approx((612, 792))
+    assert page_backend.get_page_image().size == (612, 792)
+    assert page_backend.get_page_image(scale=3).size == (1836, 2376)
+    assert page_backend.get_page_image(scale=300 / 72).size == (2550, 3300)
+    assert next(page_backend.get_bitmap_rects()).as_tuple() == pytest.approx(
+        (0, 0, 612, 792)
+    )
+    assert next(page_backend.get_bitmap_rects(scale=3)).as_tuple() == pytest.approx(
+        (0, 0, 1836, 2376)
+    )
+
+
+def test_tiff_centimeter_resolution_is_converted_to_dpi():
+    tiff_info = TiffImagePlugin.ImageFileDirectory_v2()
+    tiff_info[TiffImagePlugin.X_RESOLUTION] = 100
+    tiff_info[TiffImagePlugin.Y_RESOLUTION] = 50
+    tiff_info[TiffImagePlugin.RESOLUTION_UNIT] = "cm"
+    buf = BytesIO()
+    Image.new("RGB", (254, 127)).save(buf, format="TIFF", tiffinfo=tiff_info)
+    buf.seek(0)
+
+    page_backend = _get_backend_from_stream(
+        DocumentStream(name="test.tiff", stream=buf)
+    ).load_page(0)
+
+    assert page_backend.get_size().as_tuple() == pytest.approx((72, 72))
+
+
+@pytest.mark.parametrize(
+    ("image_format", "suffix"),
+    [("PNG", "png"), ("JPEG", "jpg"), ("BMP", "bmp")],
+)
+def test_image_dpi_is_applied_independently_per_axis(image_format, suffix):
+    buf = BytesIO()
+    Image.new("RGB", (300, 150)).save(buf, format=image_format, dpi=(300, 150))
+    buf.seek(0)
+    page_backend = _get_backend_from_stream(
+        DocumentStream(name=f"test.{suffix}", stream=buf)
+    ).load_page(0)
+
+    assert page_backend.get_size().as_tuple() == pytest.approx((72, 72), abs=0.01)
+    assert page_backend.get_page_image(scale=2).size == (144, 144)
 
 
 def test_crop_page_image():
@@ -158,6 +232,31 @@ def test_crop_page_image_scaled():
     img = page_backend.get_page_image(scale=scale, cropbox=cropbox)
     assert img.width == round(100 * scale)  # cropped width * scale
     assert img.height == round(90 * scale)  # cropped height * scale
+
+
+def test_crop_uses_logical_coordinates_for_high_dpi_image():
+    image = Image.new("RGB", (300, 300), "red")
+    image.paste("blue", (75, 75, 225, 225))
+    buf = BytesIO()
+    image.save(buf, format="PNG", dpi=(300, 300))
+    buf.seek(0)
+    page_backend = _get_backend_from_stream(
+        DocumentStream(name="test.png", stream=buf)
+    ).load_page(0)
+
+    crop = page_backend.get_page_image(
+        scale=2,
+        cropbox=BoundingBox(
+            l=18,
+            t=18,
+            r=54,
+            b=54,
+            coord_origin=CoordOrigin.TOPLEFT,
+        ),
+    )
+
+    assert crop.size == (72, 72)
+    assert crop.getpixel((36, 36)) == (0, 0, 255)
 
 
 def test_get_bitmap_rects():
@@ -222,6 +321,19 @@ def test_multipage_access():
         assert size.height == 64
 
 
+def test_invalid_explicit_dpi_rejects_document():
+    stream = _make_png_stream(dpi=(0, 300))
+    in_doc = InputDocument(
+        path_or_stream=stream.stream,
+        format=InputFormat.IMAGE,
+        backend=ImageDocumentBackend,
+        filename=stream.name,
+    )
+
+    assert in_doc.valid is False
+    assert isinstance(get_input_rejection_cause(in_doc), DocumentLoadError)
+
+
 def test_source_image_is_closed_after_backend_init(tmp_path, monkeypatch):
     image_path = tmp_path / "test.png"
     Image.new("RGB", (32, 32), (10, 20, 30)).save(image_path)
@@ -284,5 +396,6 @@ def test_unload_closes_cached_frames():
     doc_backend.unload()
 
     assert doc_backend._frames == []
+    assert doc_backend._frame_dpi == []
     for closer in tracked_closers:
         closer.assert_called_once()


### PR DESCRIPTION
## Summary

Image pages previously treated source pixels as 72-DPI document coordinates, causing pipeline scale factors to unnecessarily upscale high-DPI scans.

Respect embedded image DPI when defining page geometry, normalize missing or `(1, 1)` DPI to 72 DPI, and render scaled crops from logical page coordinates.
