### PR TITLE
fix: Do not torch compile models by default

### DIFF
--- a/docling/datamodel/settings.py
+++ b/docling/datamodel/settings.py
@@ -52,7 +52,7 @@ class DebugSettings(BaseModel):
 
 
 class InferenceSettings(BaseModel):
-    compile_torch_models: bool = True
+    compile_torch_models: bool = False
 
 
 class AppSettings(BaseSettings):


### PR DESCRIPTION
Reinstates `compile_torch_models=False` as the default on inference settings.

Setting this to `True` has shown to be fragile and unsafe in several environments.

**Issue resolved by this Pull Request:**
Resolves #3956 #3986

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.
