### PR TITLE
fix: transformers warnings

### DIFF
--- a/docling/models/inference_engines/image_classification/transformers_engine.py
+++ b/docling/models/inference_engines/image_classification/transformers_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.metadata
 import logging
 import sys
 from pathlib import Path
@@ -121,10 +122,23 @@ class TransformersImageClassificationEngine(HfImageClassificationEngineBase):
         self._id_to_label = self._load_label_mapping(model_folder)
 
         _log.debug("Loading model from %s to device %s", model_folder, self._device)
+        # transformers>=5 renamed the `torch_dtype` kwarg to `dtype`. Passing
+        # `torch_dtype=None` is not a no-op there: the None survives into the
+        # config kwargs and hits the deprecated `PretrainedConfig.torch_dtype`
+        # setter, which warns. Only pass the kwarg when a dtype was resolved.
+        dtype_kwargs = {}
+        if torch_dtype is not None:
+            dtype_arg_name = (
+                "dtype"
+                if version.parse(importlib.metadata.version("transformers")).major >= 5
+                else "torch_dtype"
+            )
+            dtype_kwargs[dtype_arg_name] = torch_dtype
+
         try:
             self._model = AutoModelForImageClassification.from_pretrained(
                 str(model_folder),
-                torch_dtype=torch_dtype,
+                **dtype_kwargs,
             )
             self._model.to(self._device)  # type: ignore[union-attr]
             self._model.eval()  # type: ignore[union-attr]

--- a/docling/models/inference_engines/object_detection/transformers_engine.py
+++ b/docling/models/inference_engines/object_detection/transformers_engine.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import importlib.metadata
 import logging
 import sys
 from pathlib import Path
@@ -145,10 +146,23 @@ class TransformersObjectDetectionEngine(HfObjectDetectionEngineBase):
 
         # Load model
         _log.debug(f"Loading model from {model_folder} to device {self._device}")
+        # transformers>=5 renamed the `torch_dtype` kwarg to `dtype`. Passing
+        # `torch_dtype=None` is not a no-op there: the None survives into the
+        # config kwargs and hits the deprecated `PretrainedConfig.torch_dtype`
+        # setter, which warns. Only pass the kwarg when a dtype was resolved.
+        dtype_kwargs = {}
+        if torch_dtype is not None:
+            dtype_arg_name = (
+                "dtype"
+                if version.parse(importlib.metadata.version("transformers")).major >= 5
+                else "torch_dtype"
+            )
+            dtype_kwargs[dtype_arg_name] = torch_dtype
+
         try:
             self._model = AutoModelForObjectDetection.from_pretrained(
                 str(model_folder),
-                torch_dtype=torch_dtype,
+                **dtype_kwargs,
             )
             self._model.to(self._device)  # type: ignore[union-attr]
             self._model.eval()  # type: ignore[union-attr]
@@ -156,6 +170,12 @@ class TransformersObjectDetectionEngine(HfObjectDetectionEngineBase):
             # Optionally compile model for better performance (model must be in eval mode first)
             # Works for Python < 3.14 with any torch 2.x
             # Works for Python >= 3.14 with torch >= 2.10
+            #
+            # Note: RT-DETRv2 in transformers 5.x validates its encoder spatial
+            # shapes with a tensor condition, which makes dynamo break the graph
+            # once per compiled region ("Graph break from Tensor.item()"). This is
+            # noisy but harmless; setting TRANSFORMERS_DISABLE_TORCH_CHECK=1 in the
+            # environment skips the check (safe for our fixed-resolution exports).
             if self.options.compile_model:
                 if sys.version_info < (3, 14):
                     self._model = torch.compile(self._model)  # type: ignore[arg-type,assignment]


### PR DESCRIPTION
fix: avoid deprecated `torch_dtype` warnings on transformers 5.x

  ## Description

  `transformers` 5.x renamed the `from_pretrained` keyword `torch_dtype` to `dtype`.
  Both Transformers-backed inference engines still passed `torch_dtype=torch_dtype`
  unconditionally, including when the dtype resolved to `None`.

  That is not a no-op on transformers 5.x: the `None` value is forwarded into the
  config kwargs and reaches the deprecated `PretrainedConfig.torch_dtype` setter,
  which emits a deprecation warning on every model load. Users converting documents
  with the layout / image-classification stages saw this warning repeatedly in
  otherwise clean output.

  This PR:

  - Only passes a dtype kwarg when a dtype was actually resolved (`torch_dtype is not None`),
    so the default path no longer touches the deprecated setter at all.
  - Picks the correct keyword name at runtime based on the installed `transformers`
    major version (`dtype` for >= 5, `torch_dtype` otherwise), keeping both
    transformers 4.x and 5.x working from the same code path.
  - Adds a comment documenting a second, unrelated source of noise: RT-DETRv2 on
    transformers 5.x validates encoder spatial shapes with a tensor condition, which
    causes a `torch.compile` graph break ("Graph break from `Tensor.item()`") once per
    compiled region. It is noisy but harmless, and can be silenced with
    `TRANSFORMERS_DISABLE_TORCH_CHECK=1` — safe for our fixed-resolution exports.

  Files touched:

  - `docling/models/inference_engines/image_classification/transformers_engine.py`
  - `docling/models/inference_engines/object_detection/transformers_engine.py`

  No behavior change for users on transformers 4.x, and no change to the resolved
  dtype in any case — only how (and whether) it is handed to `from_pretrained`.