### PR TITLE
fix(odf): resolve 'draw:image' 'xlink:href' through ImageResourceLoader

### DIFF
--- a/docling/backend/opendocument_backend.py
+++ b/docling/backend/opendocument_backend.py
@@ -888,7 +888,8 @@ def _odf_image_can_be_bitmap(image: Any, image_url: str | None) -> bool:
     suffix = Path(image_url).suffix.lower()
     if suffix in {".pdf", ".svg", ".emf", ".wmf"}:
         return False
-    # Empty suffix is intentionally excluded: extension-less paths are typical of system files (e.g. /etc/passwd) and are not valid ODF image references.
+    # Empty suffix is intentionally excluded: extension-less paths are typical of
+    # system files (e.g. /etc/passwd) and are not valid ODF image references.
     return suffix in {
         ".bmp",
         ".gif",

--- a/docling/backend/opendocument_backend.py
+++ b/docling/backend/opendocument_backend.py
@@ -57,6 +57,7 @@ from docling.backend.abstract_backend import (
     DeclarativeDocumentBackend,
     PaginatedDocumentBackend,
 )
+from docling.backend.utils.image_resource_loader import ImageResourceLoader
 from docling.datamodel.backend_options import OdsBackendOptions
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
@@ -171,6 +172,10 @@ class _OdfBaseBackend(DeclarativeDocumentBackend):
                 f"{self.odf_obj.get_type()!r}"
             )
         self.valid = True
+        self._image_loader = ImageResourceLoader(
+            enable_local_fetch=self.options.enable_local_fetch,
+            enable_remote_fetch=self.options.enable_remote_fetch,
+        )
 
     @override
     def is_valid(self) -> bool:
@@ -537,6 +542,7 @@ def _add_odf_paragraph(
     parent: NodeItem | None,
     content_layer: ContentLayer | None,
     odf_obj: OdfDocument | None,
+    image_loader: ImageResourceLoader | None = None,
 ) -> None:
     chart_count = _add_odf_charts(doc, element, parent, content_layer, odf_obj)
     images = element.get_images()
@@ -546,6 +552,7 @@ def _add_odf_paragraph(
         parent,
         content_layer,
         odf_obj,
+        image_loader=image_loader,
         skip_object_replacements=chart_count > 0,
     )
     runs = _odf_text_runs(element, odf_obj)
@@ -831,7 +838,10 @@ def _odf_cell_is_rich(cell: Any) -> bool:
 
 
 def _image_ref_from_odf_image(
-    odf_obj: OdfDocument | None, image: Any
+    odf_obj: OdfDocument | None,
+    image: Any,
+    *,
+    image_loader: ImageResourceLoader | None = None,
 ) -> ImageRef | None:
     image_url = _odf_image_href(image)
     if not _odf_image_can_be_bitmap(image, image_url):
@@ -848,10 +858,10 @@ def _image_ref_from_odf_image(
         except Exception:
             image_data = None
 
-    if image_data is None and image_url:
-        image_path = Path(image_url)
-        if image_path.is_file():
-            image_data = image_path.read_bytes()
+    # External xlink:href values (remote URLs or local paths) are resolved through
+    # ImageResourceLoader, governed by enable_remote_fetch / enable_local_fetch.
+    if image_data is None and image_url and image_loader is not None:
+        image_data = image_loader.load_image_data(image_url, base_path=None)
 
     if image_data is None:
         return None
@@ -878,8 +888,8 @@ def _odf_image_can_be_bitmap(image: Any, image_url: str | None) -> bool:
     suffix = Path(image_url).suffix.lower()
     if suffix in {".pdf", ".svg", ".emf", ".wmf"}:
         return False
+    # Empty suffix is intentionally excluded: extension-less paths are typical of system files (e.g. /etc/passwd) and are not valid ODF image references.
     return suffix in {
-        "",
         ".bmp",
         ".gif",
         ".jpeg",
@@ -916,6 +926,7 @@ def _add_odf_images(
     content_layer: ContentLayer | None,
     odf_obj: OdfDocument | None,
     *,
+    image_loader: ImageResourceLoader | None = None,
     skip_object_replacements: bool = False,
 ) -> int:
     image_count = 0
@@ -925,7 +936,11 @@ def _add_odf_images(
             if image_url.removeprefix("./").startswith("ObjectReplacements/"):
                 continue
         try:
-            image_ref = _image_ref_from_odf_image(odf_obj, image)
+            image_ref = _image_ref_from_odf_image(
+                odf_obj,
+                image,
+                image_loader=image_loader,
+            )
         except Exception as e:
             _log.debug("Could not extract OpenDocument image: %s", e)
             image_ref = None
@@ -943,6 +958,7 @@ def _add_odf_child(
     parent: NodeItem | None,
     content_layer: ContentLayer | None,
     odf_obj: OdfDocument | None,
+    image_loader: ImageResourceLoader | None = None,
 ) -> _OdfListState | None:
     if isinstance(element, Header):
         _add_odf_heading(
@@ -959,6 +975,7 @@ def _add_odf_child(
             parent=parent,
             content_layer=content_layer,
             odf_obj=odf_obj,
+            image_loader=image_loader,
         )
     elif isinstance(element, OdfList):
         return _add_odf_list(
@@ -977,6 +994,7 @@ def _add_odf_child(
             parent=parent,
             content_layer=content_layer,
             odf_obj=odf_obj,
+            image_loader=image_loader,
         )
     elif isinstance(element, Section):
         _add_odf_children(
@@ -985,6 +1003,7 @@ def _add_odf_child(
             parent=parent,
             content_layer=content_layer,
             odf_obj=odf_obj,
+            image_loader=image_loader,
         )
     elif isinstance(element, Frame):
         chart_count = _add_odf_charts(doc, element, parent, content_layer, odf_obj)
@@ -994,12 +1013,20 @@ def _add_odf_child(
             parent,
             content_layer,
             odf_obj,
+            image_loader=image_loader,
             skip_object_replacements=chart_count > 0,
         )
     else:
         get_images = getattr(element, "get_images", None)
         if callable(get_images):
-            _add_odf_images(doc, get_images(), parent, content_layer, odf_obj)
+            _add_odf_images(
+                doc,
+                get_images(),
+                parent,
+                content_layer,
+                odf_obj,
+                image_loader=image_loader,
+            )
         else:
             _log.debug(
                 "Ignoring ODF element with tag: %s", getattr(element, "tag", None)
@@ -1014,6 +1041,7 @@ def _add_odf_children(
     parent: NodeItem | None,
     content_layer: ContentLayer | None,
     odf_obj: OdfDocument | None,
+    image_loader: ImageResourceLoader | None = None,
 ) -> None:
     previous_list_state: _OdfListState | None = None
     for element in elements:
@@ -1036,6 +1064,7 @@ def _add_odf_children(
                 parent=parent,
                 content_layer=content_layer,
                 odf_obj=odf_obj,
+                image_loader=image_loader,
             )
 
 
@@ -1287,6 +1316,7 @@ def _add_rich_cell_children(
     parent: NodeItem,
     content_layer: ContentLayer | None,
     odf_obj: OdfDocument | None,
+    image_loader: ImageResourceLoader | None = None,
 ) -> None:
     for child in cell.children:
         _add_odf_child(
@@ -1295,6 +1325,7 @@ def _add_rich_cell_children(
             parent=parent,
             content_layer=content_layer,
             odf_obj=odf_obj,
+            image_loader=image_loader,
         )
 
 
@@ -1310,6 +1341,7 @@ def _add_table_from_odf(
     prov: ProvenanceItem | None = None,
     content_layer: ContentLayer | None = None,
     odf_obj: OdfDocument | None = None,
+    image_loader: ImageResourceLoader | None = None,
 ) -> TableItem | None:
     if min_row is None or max_row is None or min_col is None or max_col is None:
         min_row, max_row, min_col, max_col = _find_true_data_bounds(table)
@@ -1369,6 +1401,7 @@ def _add_table_from_odf(
                     parent=group,
                     content_layer=content_layer,
                     odf_obj=odf_obj,
+                    image_loader=image_loader,
                 )
                 table_cell = RichTableCell(**cell_kwargs, ref=group.get_ref())
             else:
@@ -1514,6 +1547,7 @@ class OdtDocumentBackend(_OdfBaseBackend):
             parent=parent,
             content_layer=None,
             odf_obj=self.odf_obj,
+            image_loader=self._image_loader,
         )
 
 
@@ -1640,6 +1674,7 @@ class OdpDocumentBackend(_OdfBaseBackend, PaginatedDocumentBackend):
                 tbl,
                 parent=parent,
                 odf_obj=self.odf_obj,
+                image_loader=self._image_loader,
             )
 
         _add_odf_images(
@@ -1648,6 +1683,7 @@ class OdpDocumentBackend(_OdfBaseBackend, PaginatedDocumentBackend):
             parent,
             None,
             self.odf_obj,
+            image_loader=self._image_loader,
             skip_object_replacements=chart_count > 0,
         )
 

--- a/docling/backend/utils/image_resource_loader.py
+++ b/docling/backend/utils/image_resource_loader.py
@@ -1,14 +1,9 @@
 """Shared image-resource loading for declarative backends.
 
-Turns an image source (a ``data:`` URI, a local file, or a remote URL) into a
-Docling :class:`~docling_core.types.doc.document.ImageRef`, enforcing the
-relevant safety limits: a path-traversal guard when resolving relative paths,
-the ``enable_local_fetch`` / ``enable_remote_fetch`` toggles, and the base64 and
-remote download size caps.
-
-This logic originated in the HTML backend. It is factored out here so the HTML
-and Markdown backends can share a single implementation instead of duplicating
-it (or constructing one backend from inside the other).
+Turns an image source (a URI, a local file, or a remote URL) into a DoclingDocument
+`ImageRef`, enforcing the relevant safety limits: a path-traversal guard when resolving
+relative paths, the `enable_local_fetch` / `enable_remote_fetch` toggles, and the
+base64 and remote download size caps.
 """
 
 import base64
@@ -79,7 +74,7 @@ def validate_url_safety(url: str) -> None:
 class ImageResourceLoader:
     """Resolve and load image resources for declarative document backends.
 
-    The ``base_path`` against which relative locations are resolved is supplied
+    The `base_path` against which relative locations are resolved is supplied
     per call rather than stored, so a backend that mutates its base path between
     calls always uses the current value.
     """
@@ -179,7 +174,7 @@ class ImageResourceLoader:
         return None
 
     def load_image_ref(self, src: str, base_path: Optional[str]) -> Optional[ImageRef]:
-        """Resolve ``src`` against ``base_path`` and decode it into an ImageRef."""
+        """Resolve `src` against `base_path` and decode it into an ImageRef."""
         return self.create_image_ref(
             self.resolve_relative_path(src, base_path), base_path
         )

--- a/tests/test_backend_opendocument.py
+++ b/tests/test_backend_opendocument.py
@@ -10,6 +10,8 @@ This module includes two types of tests:
 from __future__ import annotations
 
 import logging
+import sys
+import zipfile
 from io import BytesIO
 from pathlib import Path
 
@@ -1373,3 +1375,82 @@ def test_ods_sheet_names_filter(tmp_path: Path):
         f"Should have 1 group, got {len(doc_single.groups)}"
     )
     assert doc_single.groups[0].name == "sheet: Sheet2", "Should only have Sheet2"
+
+
+def _build_odt_with_external_image_href(path: Path, href: str) -> Path:
+    """Build a minimal ODT whose only draw:image points at *href* (not embedded)."""
+    content_xml = (
+        '<?xml version="1.0"?>'
+        "<office:document-content"
+        ' xmlns:office="urn:oasis:names:tc:opendocument:xmlns:office:1.0"'
+        ' xmlns:text="urn:oasis:names:tc:opendocument:xmlns:text:1.0"'
+        ' xmlns:draw="urn:oasis:names:tc:opendocument:xmlns:drawing:1.0"'
+        ' xmlns:xlink="http://www.w3.org/1999/xlink" office:version="1.2">'
+        "<office:body><office:text><text:p>"
+        f'<draw:frame><draw:image xlink:href="{href}"/></draw:frame>'
+        "</text:p></office:text></office:body>"
+        "</office:document-content>"
+    )
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+        zi = zipfile.ZipInfo("mimetype")
+        zi.compress_type = zipfile.ZIP_STORED
+        z.writestr(zi, "application/vnd.oasis.opendocument.text")
+        z.writestr("content.xml", content_xml)
+    return path
+
+
+def test_odt_local_filesystem_path_is_not_read(tmp_path: Path):
+    """Crafted ODT with an absolute xlink:href must not read from the local filesystem.
+
+    Regression test for the security advisory: the ODF backend previously fell
+    back to Path(image_url).read_bytes() when the part was not found inside the
+    archive, allowing arbitrary local-file reads from document-supplied paths.
+    """
+    canary = tmp_path / "canary.png"
+    Image.new("RGB", (4, 4), "blue").save(canary)
+
+    odt_path = tmp_path / "trigger.odt"
+    _build_odt_with_external_image_href(odt_path, str(canary))
+
+    files_opened: list[str] = []
+
+    def _audit(event: str, args: tuple) -> None:
+        if event == "open":
+            files_opened.append(str(args[0]))
+
+    sys.addaudithook(_audit)
+
+    res = DocumentConverter(allowed_formats=[InputFormat.ODT]).convert(odt_path)
+
+    # The canary must not have been opened.
+    assert str(canary) not in files_opened, (
+        "ODF backend read a local filesystem path supplied via xlink:href"
+    )
+    # The document converts successfully but contains no picture (no embedded image).
+    assert res.document.pictures == [], (
+        "No picture should appear when the xlink:href points outside the archive"
+    )
+
+
+def test_odt_extensionless_path_is_not_read(tmp_path: Path):
+    """Extension-less absolute paths (e.g. /etc/passwd) must be rejected early.
+
+    _odf_image_can_be_bitmap previously allowed the empty-suffix case, which
+    admitted any extension-less system path before the filesystem fallback ran.
+    """
+    odt_path = tmp_path / "trigger_noext.odt"
+    _build_odt_with_external_image_href(odt_path, "/etc/passwd")
+
+    files_opened: list[str] = []
+
+    def _audit(event: str, args: tuple) -> None:
+        if event == "open":
+            files_opened.append(str(args[0]))
+
+    sys.addaudithook(_audit)
+
+    DocumentConverter(allowed_formats=[InputFormat.ODT]).convert(odt_path)
+
+    assert "/etc/passwd" not in files_opened, (
+        "ODF backend attempted to open an extension-less system path"
+    )


### PR DESCRIPTION
## Summary

Fixes an arbitrary local-file read in the ODF backend (`OdtDocumentBackend`, `OdsDocumentBackend`, `OdpDocumentBackend`).

A crafted `.odt` / `.ods` / `.odp` containing a `draw:image` element whose `xlink:href` points to an absolute filesystem path (e.g. `/etc/passwd`, `/tmp/canary.png`) caused Docling to open and embed that file in the conversion output, with no authentication or permission check beyond normal OS file access. The trigger archive is 452 bytes and requires no manifest or embedded image part.

The root cause was a fallback in `_image_ref_from_odf_image` that called `Path(image_url).read_bytes()` directly, without consulting the `enable_local_fetch` / `enable_remote_fetch` controls that the HTML, Markdown, EPUB and XBRL backends all enforce through `ImageResourceLoader`.

## Impact

- Arbitrary local file read: any file readable by the converting process could be opened by supplying its absolute path as `xlink:href`.
- Silent file-existence oracle: absent and present paths were distinguishable by side-channel while conversion reported success either way.
- Full content disclosure: where the target decoded as an image, its bytes were embedded verbatim in the `DoclingDocument` and base64-encoded in HTML, Markdown and JSON exports.

## Changes

### `docling/backend/opendocument_backend.py`

- Remove the filesystem fallback (`Path(image_url).read_bytes()`) from `_image_ref_from_odf_image`. ODF images must be embedded in the ZIP archive; the fallback was an unintended escape hatch with no equivalent in any other backend.
- Route external `xlink:href` values through `ImageResourceLoader` so `enable_remote_fetch` and `enable_local_fetch` govern this backend identically to HTML/Markdown. The loader is constructed once in `_OdfBaseBackend.__init__` from `self.options` and propagated through the call chain.
- Pass `base_path=None` unconditionally. Conforming ODF producers never write relative external paths (per ODF 1.3 §2.2.1.1 — all external references are absolute IRIs); the loader's local-path branch requires a non-`None` `base_path`, providing an additional hard stop even if `enable_local_fetch=True`.
- Remove `""` from `_odf_image_can_be_bitmap`'s suffix allow list. Extension-less paths (`/etc/passwd`, `/proc/self/environ`, …) are now rejected before any I/O is attempted, closing the file-existence oracle for that class of path entirely.

### `tests/test_backend_opendocument.py`

Two regression tests using `sys.addaudithook` to verify at the OS syscall level that:
- A crafted ODT referencing an absolute `.png` path outside the archive does not open that file and produces no picture item.
- A crafted ODT referencing `/etc/passwd` (extension-less) is rejected before any I/O.

## Testing

```
uv run pytest tests/test_backend_opendocument.py   # 46 passed
make validate                                       # all hooks pass
```

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
