### PR TITLE
fix(markdown): preserve hard line breaks

### DIFF
--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -98,31 +98,29 @@ _CreationPayload = Annotated[
 ]
 
 
-def _only_plain_hard_breaks(children: list) -> bool:
+def _only_plain_line_breaks(children: list) -> bool:
     """Return True when children consist solely of RawText/Literal runs separated
-    by hard (non-soft) LineBreak nodes, with at least one such break present.
+    by LineBreak nodes (soft or hard), with at least one break present.
 
-    Such content is fully handled by the `_pending_hard_line_break` merge path
-    and does not need an inline_group wrapper.  Multiple plain runs without any
-    LineBreak (e.g. `RawText + Literal + RawText` from an escaped character)
-    return False so they still use the regular inline_group path.
+    Such content is fully handled by the pending-line-break merge paths and does
+    not need an inline_group wrapper.  Multiple plain runs without any LineBreak
+    (e.g. `RawText + Literal + RawText` from an escaped character) return False
+    so they still use the regular inline_group path.
 
     Args:
         children: Inline child nodes of a marko Paragraph, Heading, or ListItem
             paragraph to inspect.
 
     Returns:
-        True if all children are plain-text runs joined only by hard line breaks,
+        True if all children are plain-text runs joined only by line breaks,
         False otherwise.
     """
     if not _MARKO_AVAILABLE:
         return False
-    has_hard_break = any(
-        isinstance(c, marko.inline.LineBreak) and not c.soft for c in children
-    )
-    return has_hard_break and all(
+    has_break = any(isinstance(c, marko.inline.LineBreak) for c in children)
+    return has_break and all(
         isinstance(c, (marko.inline.RawText, marko.inline.Literal))
-        or (isinstance(c, marko.inline.LineBreak) and not c.soft)
+        or isinstance(c, marko.inline.LineBreak)
         for c in children
     )
 
@@ -275,6 +273,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         self.in_pipeless_table = False
         self.md_table_buffer: list[str] = []
         self._pending_hard_line_break = False
+        self._pending_soft_line_break = False
         self._html_blocks: int = 0
         self._image_loader: Optional[ImageResourceLoader] = None
 
@@ -548,9 +547,9 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                 if not isinstance(item, marko.block.ListItem)
             ]
             # Skip the inline_group path for items whose children are plain text
-            # runs separated solely by hard line breaks; _pending_hard_line_break
-            # will merge them into a single list_item with embedded '\n'.
-            if len(non_list_children) > 1 and not _only_plain_hard_breaks(
+            # runs separated by line breaks; the pending-line-break merge paths
+            # will produce a single list_item with the correct joined text.
+            if len(non_list_children) > 1 and not _only_plain_line_breaks(
                 non_list_children
             ):  # inline group will be created further down
                 parent_ref: Optional[str] = (
@@ -643,6 +642,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                         hyperlink=hyperlink,
                     )
                     self._pending_hard_line_break = False
+                    self._pending_soft_line_break = False
                 else:
                     if (
                         self._pending_hard_line_break
@@ -652,6 +652,14 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                     ):
                         doc.texts[-1].text += "\n" + snippet_text
                         doc.texts[-1].orig += "\n" + snippet_text
+                    elif (
+                        self._pending_soft_line_break
+                        and doc.texts
+                        and doc.texts[-1].formatting == formatting
+                        and doc.texts[-1].hyperlink == hyperlink
+                    ):
+                        doc.texts[-1].text += " " + snippet_text
+                        doc.texts[-1].orig += " " + snippet_text
                     else:
                         doc.add_text(
                             label=DocItemLabel.TEXT,
@@ -661,6 +669,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                             hyperlink=hyperlink,
                         )
                     self._pending_hard_line_break = False
+                    self._pending_soft_line_break = False
 
         elif isinstance(element, marko.inline.CodeSpan):
             self._close_table(doc)
@@ -708,7 +717,10 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
             if self.in_table:
                 _log.debug("Line break in a table")
                 self.md_table_buffer.append("")
-            elif not element.soft:
+            elif element.soft:
+                _log.debug("Soft line break")
+                self._pending_soft_line_break = True
+            else:
                 _log.debug("Hard line break")
                 self._pending_hard_line_break = True
 
@@ -745,7 +757,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         if (
             isinstance(element, marko.block.Paragraph | marko.block.Heading)
             and len(element_children) > 1
-            and not _only_plain_hard_breaks(element_children)
+            and not _only_plain_line_breaks(element_children)
         ):
             parent_item = doc.add_inline_group(parent=parent_item)
 

--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -661,10 +661,11 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                         doc.texts[-1].text += " " + snippet_text
                         doc.texts[-1].orig += " " + snippet_text
                     else:
+                        prefix = "\n" if self._pending_hard_line_break else ""
                         doc.add_text(
                             label=DocItemLabel.TEXT,
                             parent=parent_item,
-                            text=snippet_text,
+                            text=prefix + snippet_text,
                             formatting=formatting,
                             hyperlink=hyperlink,
                         )

--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -98,6 +98,35 @@ _CreationPayload = Annotated[
 ]
 
 
+def _only_plain_hard_breaks(children: list) -> bool:
+    """Return True when children consist solely of RawText/Literal runs separated
+    by hard (non-soft) LineBreak nodes, with at least one such break present.
+
+    Such content is fully handled by the `_pending_hard_line_break` merge path
+    and does not need an inline_group wrapper.  Multiple plain runs without any
+    LineBreak (e.g. `RawText + Literal + RawText` from an escaped character)
+    return False so they still use the regular inline_group path.
+
+    Args:
+        children: Inline child nodes of a marko Paragraph, Heading, or ListItem
+            paragraph to inspect.
+
+    Returns:
+        True if all children are plain-text runs joined only by hard line breaks,
+        False otherwise.
+    """
+    if not _MARKO_AVAILABLE:
+        return False
+    has_hard_break = any(
+        isinstance(c, marko.inline.LineBreak) and not c.soft for c in children
+    )
+    return has_hard_break and all(
+        isinstance(c, (marko.inline.RawText, marko.inline.Literal))
+        or (isinstance(c, marko.inline.LineBreak) and not c.soft)
+        for c in children
+    )
+
+
 class MarkdownDocumentBackend(DeclarativeDocumentBackend):
     _ENTITY_RE = re.compile(r"&(#\d+|#x[0-9a-fA-F]+|\w+);")
     _DELIMITER_CELL_RE = re.compile(r":?-+:?")
@@ -518,7 +547,12 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                 for item in child.children
                 if not isinstance(item, marko.block.ListItem)
             ]
-            if len(non_list_children) > 1:  # inline group will be created further down
+            # Skip the inline_group path for items whose children are plain text
+            # runs separated solely by hard line breaks; _pending_hard_line_break
+            # will merge them into a single list_item with embedded '\n'.
+            if len(non_list_children) > 1 and not _only_plain_hard_breaks(
+                non_list_children
+            ):  # inline group will be created further down
                 parent_ref: Optional[str] = (
                     parent_item.self_ref if parent_item else None
                 )
@@ -608,27 +642,16 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                         formatting=formatting,
                         hyperlink=hyperlink,
                     )
+                    self._pending_hard_line_break = False
                 else:
-                    if self._pending_hard_line_break and doc.texts:
-                        previous = doc.texts[-1]
-
-                        if (
-                            previous.parent
-                            and parent_item
-                            and previous.parent.cref == parent_item.self_ref
-                            and previous.formatting == formatting
-                            and previous.hyperlink == hyperlink
-                        ):
-                            previous.text += "\n" + snippet_text
-                            previous.orig += "\n" + snippet_text
-                        else:
-                            doc.add_text(
-                                label=DocItemLabel.TEXT,
-                                parent=parent_item,
-                                text=snippet_text,
-                                formatting=formatting,
-                                hyperlink=hyperlink,
-                            )
+                    if (
+                        self._pending_hard_line_break
+                        and doc.texts
+                        and doc.texts[-1].formatting == formatting
+                        and doc.texts[-1].hyperlink == hyperlink
+                    ):
+                        doc.texts[-1].text += "\n" + snippet_text
+                        doc.texts[-1].orig += "\n" + snippet_text
                     else:
                         doc.add_text(
                             label=DocItemLabel.TEXT,
@@ -637,7 +660,6 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                             formatting=formatting,
                             hyperlink=hyperlink,
                         )
-
                     self._pending_hard_line_break = False
 
         elif isinstance(element, marko.inline.CodeSpan):
@@ -719,9 +741,11 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                 element
             )
 
+        element_children = getattr(element, "children", [])
         if (
             isinstance(element, marko.block.Paragraph | marko.block.Heading)
-            and len(element.children) > 1
+            and len(element_children) > 1
+            and not _only_plain_hard_breaks(element_children)
         ):
             parent_item = doc.add_inline_group(parent=parent_item)
 

--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -245,6 +245,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         self.in_table = False
         self.in_pipeless_table = False
         self.md_table_buffer: list[str] = []
+        self._pending_hard_line_break = False
         self._html_blocks: int = 0
         self._image_loader: Optional[ImageResourceLoader] = None
 
@@ -608,13 +609,36 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                         hyperlink=hyperlink,
                     )
                 else:
-                    doc.add_text(
-                        label=DocItemLabel.TEXT,
-                        parent=parent_item,
-                        text=snippet_text,
-                        formatting=formatting,
-                        hyperlink=hyperlink,
-                    )
+                    if self._pending_hard_line_break and doc.texts:
+                        previous = doc.texts[-1]
+
+                        if (
+                            previous.parent
+                            and parent_item
+                            and previous.parent.cref == parent_item.self_ref
+                            and previous.formatting == formatting
+                            and previous.hyperlink == hyperlink
+                        ):
+                            previous.text += "\n" + snippet_text
+                            previous.orig += "\n" + snippet_text
+                        else:
+                            doc.add_text(
+                                label=DocItemLabel.TEXT,
+                                parent=parent_item,
+                                text=snippet_text,
+                                formatting=formatting,
+                                hyperlink=hyperlink,
+                            )
+                    else:
+                        doc.add_text(
+                            label=DocItemLabel.TEXT,
+                            parent=parent_item,
+                            text=snippet_text,
+                            formatting=formatting,
+                            hyperlink=hyperlink,
+                        )
+
+                    self._pending_hard_line_break = False
 
         elif isinstance(element, marko.inline.CodeSpan):
             self._close_table(doc)
@@ -662,6 +686,9 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
             if self.in_table:
                 _log.debug("Line break in a table")
                 self.md_table_buffer.append("")
+            elif not element.soft:
+                _log.debug("Hard line break")
+                self._pending_hard_line_break = True
 
         elif isinstance(element, marko.block.HTMLBlock):
             self._html_blocks += 1

--- a/tests/data/md/groundtruth/escaped_characters.md.json
+++ b/tests/data/md/groundtruth/escaped_characters.md.json
@@ -4,7 +4,7 @@
   "name": "escaped_characters",
   "origin": {
     "mimetype": "text/html",
-    "binary_hash": 4129962407829858370,
+    "binary_hash": 1704155112098845452,
     "filename": "escaped_characters.md"
   },
   "furniture": {

--- a/tests/data/md/groundtruth/line_breaks.md.json
+++ b/tests/data/md/groundtruth/line_breaks.md.json
@@ -1,0 +1,576 @@
+{
+  "schema_name": "DoclingDocument",
+  "version": "1.10.0",
+  "name": "line_breaks",
+  "origin": {
+    "mimetype": "text/markdown",
+    "binary_hash": 17013793482444672988,
+    "filename": "line_breaks.md"
+  },
+  "furniture": {
+    "self_ref": "#/furniture",
+    "children": [],
+    "content_layer": "furniture",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "body": {
+    "self_ref": "#/body",
+    "children": [
+      {
+        "$ref": "#/texts/0"
+      },
+      {
+        "$ref": "#/texts/1"
+      },
+      {
+        "$ref": "#/texts/2"
+      },
+      {
+        "$ref": "#/texts/3"
+      },
+      {
+        "$ref": "#/texts/4"
+      },
+      {
+        "$ref": "#/texts/5"
+      },
+      {
+        "$ref": "#/texts/6"
+      },
+      {
+        "$ref": "#/texts/7"
+      },
+      {
+        "$ref": "#/texts/8"
+      },
+      {
+        "$ref": "#/texts/9"
+      },
+      {
+        "$ref": "#/texts/10"
+      },
+      {
+        "$ref": "#/groups/0"
+      },
+      {
+        "$ref": "#/texts/12"
+      },
+      {
+        "$ref": "#/groups/1"
+      },
+      {
+        "$ref": "#/texts/16"
+      },
+      {
+        "$ref": "#/texts/17"
+      },
+      {
+        "$ref": "#/texts/18"
+      },
+      {
+        "$ref": "#/texts/19"
+      },
+      {
+        "$ref": "#/texts/20"
+      },
+      {
+        "$ref": "#/groups/2"
+      },
+      {
+        "$ref": "#/texts/23"
+      },
+      {
+        "$ref": "#/groups/3"
+      },
+      {
+        "$ref": "#/texts/26"
+      },
+      {
+        "$ref": "#/groups/4"
+      }
+    ],
+    "content_layer": "body",
+    "name": "_root_",
+    "label": "unspecified"
+  },
+  "groups": [
+    {
+      "self_ref": "#/groups/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/11"
+        }
+      ],
+      "content_layer": "body",
+      "name": "group",
+      "label": "inline"
+    },
+    {
+      "self_ref": "#/groups/1",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/13"
+        },
+        {
+          "$ref": "#/texts/14"
+        },
+        {
+          "$ref": "#/texts/15"
+        }
+      ],
+      "content_layer": "body",
+      "name": "group",
+      "label": "inline"
+    },
+    {
+      "self_ref": "#/groups/2",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/21"
+        },
+        {
+          "$ref": "#/texts/22"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/3",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/24"
+        },
+        {
+          "$ref": "#/texts/25"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list",
+      "label": "list"
+    },
+    {
+      "self_ref": "#/groups/4",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [
+        {
+          "$ref": "#/texts/27"
+        },
+        {
+          "$ref": "#/texts/28"
+        }
+      ],
+      "content_layer": "body",
+      "name": "list",
+      "label": "list"
+    }
+  ],
+  "texts": [
+    {
+      "self_ref": "#/texts/0",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "title",
+      "prov": [],
+      "orig": "Line breaks",
+      "text": "Line breaks"
+    },
+    {
+      "self_ref": "#/texts/1",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [],
+      "orig": "Soft break (bare newline)",
+      "text": "Soft break (bare newline)",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/2",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Author Affiliation",
+      "text": "Author Affiliation"
+    },
+    {
+      "self_ref": "#/texts/3",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [],
+      "orig": "Hard break (two trailing spaces)",
+      "text": "Hard break (two trailing spaces)",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/4",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Author\nAffiliation",
+      "text": "Author\nAffiliation"
+    },
+    {
+      "self_ref": "#/texts/5",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [],
+      "orig": "Hard break (backslash)",
+      "text": "Hard break (backslash)",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/6",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Author\nAffiliation",
+      "text": "Author\nAffiliation"
+    },
+    {
+      "self_ref": "#/texts/7",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [],
+      "orig": "Paragraph break (blank line)",
+      "text": "Paragraph break (blank line)",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/8",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Author",
+      "text": "Author"
+    },
+    {
+      "self_ref": "#/texts/9",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Affiliation",
+      "text": "Affiliation"
+    },
+    {
+      "self_ref": "#/texts/10",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [],
+      "orig": "Soft break between formatted runs",
+      "text": "Soft break between formatted runs",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/11",
+      "parent": {
+        "$ref": "#/groups/0"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Bold A Bold B",
+      "text": "Bold A Bold B",
+      "formatting": {
+        "bold": true,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "script": "baseline"
+      }
+    },
+    {
+      "self_ref": "#/texts/12",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [],
+      "orig": "Hard break between formatted runs (different formatting)",
+      "text": "Hard break between formatted runs (different formatting)",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/13",
+      "parent": {
+        "$ref": "#/groups/1"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Author",
+      "text": "Author"
+    },
+    {
+      "self_ref": "#/texts/14",
+      "parent": {
+        "$ref": "#/groups/1"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "John",
+      "text": "John",
+      "formatting": {
+        "bold": true,
+        "italic": false,
+        "underline": false,
+        "strikethrough": false,
+        "script": "baseline"
+      }
+    },
+    {
+      "self_ref": "#/texts/15",
+      "parent": {
+        "$ref": "#/groups/1"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "University XYZ",
+      "text": "University XYZ"
+    },
+    {
+      "self_ref": "#/texts/16",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [],
+      "orig": "Multiple hard breaks in one paragraph",
+      "text": "Multiple hard breaks in one paragraph",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/17",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Line 1\nLine 2\nLine 3",
+      "text": "Line 1\nLine 2\nLine 3"
+    },
+    {
+      "self_ref": "#/texts/18",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [],
+      "orig": "Mixed hard and soft breaks in one paragraph",
+      "text": "Mixed hard and soft breaks in one paragraph",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/19",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Line 1\nLine 2 Line 3",
+      "text": "Line 1\nLine 2 Line 3"
+    },
+    {
+      "self_ref": "#/texts/20",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [],
+      "orig": "Soft break in a list item",
+      "text": "Soft break in a list item",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/21",
+      "parent": {
+        "$ref": "#/groups/2"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "First Second",
+      "text": "First Second",
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/22",
+      "parent": {
+        "$ref": "#/groups/2"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Item 2",
+      "text": "Item 2",
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/23",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [],
+      "orig": "Hard break in a list item",
+      "text": "Hard break in a list item",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/24",
+      "parent": {
+        "$ref": "#/groups/3"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "First line\nSecond line",
+      "text": "First line\nSecond line",
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/25",
+      "parent": {
+        "$ref": "#/groups/3"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Item 2",
+      "text": "Item 2",
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/26",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "section_header",
+      "prov": [],
+      "orig": "Multiple hard breaks in a list item",
+      "text": "Multiple hard breaks in a list item",
+      "level": 1
+    },
+    {
+      "self_ref": "#/texts/27",
+      "parent": {
+        "$ref": "#/groups/4"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Line A\nLine B\nLine C",
+      "text": "Line A\nLine B\nLine C",
+      "enumerated": false,
+      "marker": ""
+    },
+    {
+      "self_ref": "#/texts/28",
+      "parent": {
+        "$ref": "#/groups/4"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "list_item",
+      "prov": [],
+      "orig": "Item 2",
+      "text": "Item 2",
+      "enumerated": false,
+      "marker": ""
+    }
+  ],
+  "pictures": [],
+  "tables": [],
+  "key_value_items": [],
+  "form_items": [],
+  "pages": {}
+}

--- a/tests/data/md/groundtruth/line_breaks.md.json
+++ b/tests/data/md/groundtruth/line_breaks.md.json
@@ -391,8 +391,8 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "University XYZ",
-      "text": "University XYZ"
+      "orig": "\nUniversity XYZ",
+      "text": "\nUniversity XYZ"
     },
     {
       "self_ref": "#/texts/16",

--- a/tests/data/md/groundtruth/line_breaks.md.md
+++ b/tests/data/md/groundtruth/line_breaks.md.md
@@ -26,7 +26,8 @@ Affiliation
 
 ## Hard break between formatted runs (different formatting)
 
-Author **John** University XYZ
+Author **John**   
+University XYZ
 
 ## Multiple hard breaks in one paragraph
 

--- a/tests/data/md/groundtruth/line_breaks.md.md
+++ b/tests/data/md/groundtruth/line_breaks.md.md
@@ -1,0 +1,58 @@
+# Line breaks
+
+## Soft break (bare newline)
+
+Author Affiliation
+
+## Hard break (two trailing spaces)
+
+Author  
+Affiliation
+
+## Hard break (backslash)
+
+Author  
+Affiliation
+
+## Paragraph break (blank line)
+
+Author
+
+Affiliation
+
+## Soft break between formatted runs
+
+**Bold A Bold B**
+
+## Hard break between formatted runs (different formatting)
+
+Author **John** University XYZ
+
+## Multiple hard breaks in one paragraph
+
+Line 1  
+Line 2  
+Line 3
+
+## Mixed hard and soft breaks in one paragraph
+
+Line 1  
+Line 2 Line 3
+
+## Soft break in a list item
+
+- First Second
+- Item 2
+
+## Hard break in a list item
+
+- First line  
+Second line
+- Item 2
+
+## Multiple hard breaks in a list item
+
+- Line A  
+Line B  
+Line C
+- Item 2

--- a/tests/data/md/sources/line_breaks.md
+++ b/tests/data/md/sources/line_breaks.md
@@ -1,0 +1,63 @@
+# Line breaks
+
+## Soft break (bare newline)
+
+Author
+Affiliation
+
+## Hard break (two trailing spaces)
+
+Author  
+Affiliation
+
+## Hard break (backslash)
+
+Author\
+Affiliation
+
+## Paragraph break (blank line)
+
+Author
+
+Affiliation
+
+## Soft break between formatted runs
+
+**Bold A**
+**Bold B**
+
+## Hard break between formatted runs (different formatting)
+
+Author **John**  
+University XYZ
+
+## Multiple hard breaks in one paragraph
+
+Line 1  
+Line 2  
+Line 3
+
+## Mixed hard and soft breaks in one paragraph
+
+Line 1  
+Line 2
+Line 3
+
+## Soft break in a list item
+
+- First
+  Second
+- Item 2
+
+## Hard break in a list item
+
+- First line  
+  Second line
+- Item 2
+
+## Multiple hard breaks in a list item
+
+- Line A  
+  Line B  
+  Line C
+- Item 2

--- a/tests/test_backend_markdown.py
+++ b/tests/test_backend_markdown.py
@@ -519,15 +519,6 @@ def test_convert_hard_line_break():
     assert doc.texts[0].text == "Author 1\nAffiliation 1"
 
 
-def test_convert_hard_line_break():
-    markdown = "Author 1  \nAffiliation 1"
-
-    doc = _convert_markdown(markdown, MarkdownBackendOptions())
-
-    assert len(doc.texts) == 1
-    assert doc.texts[0].text == "Author 1\nAffiliation 1"
-
-
 def test_convert_soft_line_break():
     markdown = "Author 1\nAffiliation 1"
 
@@ -555,3 +546,37 @@ def test_convert_hard_line_break_preserves_formatting():
 
     assert doc.texts[2].text == "University XYZ"
     assert doc.texts[2].formatting is None
+
+
+def test_list_item_hard_line_break():
+    """A hard line break inside a list item is preserved in list_item.text."""
+    markdown = "- Item 1  \n  continued"
+
+    doc = _convert_markdown(markdown, MarkdownBackendOptions())
+
+    list_items = [t for t in doc.texts if t.label == "list_item"]
+    assert len(list_items) == 1
+    assert list_items[0].text == "Item 1\ncontinued"
+
+
+def test_list_item_multiple_hard_line_breaks():
+    """Multiple consecutive hard breaks inside one list item are all preserved."""
+    markdown = "- first  \nsecond  \nthird"
+
+    doc = _convert_markdown(markdown, MarkdownBackendOptions())
+
+    list_items = [t for t in doc.texts if t.label == "list_item"]
+    assert len(list_items) == 1
+    assert list_items[0].text == "first\nsecond\nthird"
+
+
+def test_list_items_hard_break_does_not_bleed_into_sibling():
+    """A hard break in one list item must not affect the text of the next item."""
+    markdown = "- Item 1  \n  continued\n- Item 2"
+
+    doc = _convert_markdown(markdown, MarkdownBackendOptions())
+
+    list_items = [t for t in doc.texts if t.label == "list_item"]
+    assert len(list_items) == 2
+    assert list_items[0].text == "Item 1\ncontinued"
+    assert list_items[1].text == "Item 2"

--- a/tests/test_backend_markdown.py
+++ b/tests/test_backend_markdown.py
@@ -35,7 +35,7 @@ def test_convert_valid():
     assert len(relevant_paths) > 0
 
     yaml_filter = ["inline_and_formatting", "mixed_without_h1"]
-    json_filter = ["escaped_characters", "signature_stamp_01"]
+    json_filter = ["escaped_characters", "line_breaks", "signature_stamp_01"]
 
     for in_path in relevant_paths:
         md_gt_path = md_path / "groundtruth" / f"{in_path.name}.md"
@@ -510,94 +510,79 @@ def test_utf8_bom_does_not_hide_the_first_heading(tmp_path):
         assert doc.texts[1].text == "Some body text."
 
 
-def test_convert_hard_line_break():
-    markdown = "Author 1  \nAffiliation 1"
+def test_convert_line_breaks():
+    """GFM line-break semantics are correctly mapped to DoclingDocument text fields.
 
-    doc = _convert_markdown(markdown, MarkdownBackendOptions())
+    - Soft break (bare newline): two runs joined with a space.
+    - Hard break (two trailing spaces or backslash before newline): two runs joined with '\\n'.
+    - Paragraph break (blank line): two separate TextItems.
+    - Hard break across a formatting boundary: runs that differ in formatting are
+      kept as separate TextItems; the break does not merge them.
+    - Hard and soft breaks inside list items are handled the same as in paragraphs,
+      and do not bleed across sibling items.
+    - Multiple hard breaks and mixed hard+soft breaks in one paragraph are all preserved.
+    """
+    opt = MarkdownBackendOptions()
 
-    assert len(doc.texts) == 1
-    assert doc.texts[0].text == "Author 1\nAffiliation 1"
-
-
-def test_convert_soft_line_break():
-    """A soft line break (bare newline) joins the two runs with a space (GFM §6.7)."""
-    markdown = "Author 1\nAffiliation 1"
-
-    doc = _convert_markdown(markdown, MarkdownBackendOptions())
-
+    # Soft break: joined with a space (GFM §6.7)
+    doc = _convert_markdown("Author 1\nAffiliation 1", opt)
     assert len(doc.texts) == 1
     assert doc.texts[0].text == "Author 1 Affiliation 1"
 
+    # Hard break (trailing spaces): joined with '\n'
+    doc = _convert_markdown("Author 1  \nAffiliation 1", opt)
+    assert len(doc.texts) == 1
+    assert doc.texts[0].text == "Author 1\nAffiliation 1"
 
-def test_convert_hard_line_break_preserves_formatting():
-    markdown = "Author **John**  \nUniversity XYZ"
+    # Paragraph break: two separate items
+    doc = _convert_markdown("Author 1\n\nAffiliation 1", opt)
+    assert len(doc.texts) == 2
+    assert doc.texts[0].text == "Author 1"
+    assert doc.texts[1].text == "Affiliation 1"
 
-    doc = _convert_markdown(markdown, MarkdownBackendOptions())
-
+    # Hard break across a formatting boundary: separate items per formatted run
+    doc = _convert_markdown("Author **John**  \nUniversity XYZ", opt)
     assert len(doc.texts) == 3
-
     assert doc.texts[0].text == "Author"
     assert doc.texts[0].formatting is None
-
     assert doc.texts[1].text == "John"
     assert doc.texts[1].formatting is not None
     assert doc.texts[1].formatting.bold is True
-
     assert doc.texts[2].text == "University XYZ"
     assert doc.texts[2].formatting is None
 
+    # Multiple hard breaks in one paragraph
+    doc = _convert_markdown("Line1  \nLine2  \nLine3", opt)
+    assert len(doc.texts) == 1
+    assert doc.texts[0].text == "Line1\nLine2\nLine3"
 
-def test_list_item_hard_line_break():
-    """A hard line break inside a list item is preserved in list_item.text."""
-    markdown = "- Item 1  \n  continued"
+    # Mixed hard + soft in one paragraph
+    doc = _convert_markdown("Line1  \nLine2\nLine3", opt)
+    assert len(doc.texts) == 1
+    assert doc.texts[0].text == "Line1\nLine2 Line3"
 
-    doc = _convert_markdown(markdown, MarkdownBackendOptions())
-
+    # Hard break in a list item
+    doc = _convert_markdown("- Item 1  \n  continued", opt)
     list_items = [t for t in doc.texts if t.label == "list_item"]
     assert len(list_items) == 1
     assert list_items[0].text == "Item 1\ncontinued"
 
-
-def test_list_item_multiple_hard_line_breaks():
-    """Multiple consecutive hard breaks inside one list item are all preserved."""
-    markdown = "- first  \nsecond  \nthird"
-
-    doc = _convert_markdown(markdown, MarkdownBackendOptions())
-
+    # Multiple hard breaks in one list item
+    doc = _convert_markdown("- first  \nsecond  \nthird", opt)
     list_items = [t for t in doc.texts if t.label == "list_item"]
     assert len(list_items) == 1
     assert list_items[0].text == "first\nsecond\nthird"
 
-
-def test_list_items_hard_break_does_not_bleed_into_sibling():
-    """A hard break in one list item must not affect the text of the next item."""
-    markdown = "- Item 1  \n  continued\n- Item 2"
-
-    doc = _convert_markdown(markdown, MarkdownBackendOptions())
-
+    # Hard break does not bleed into the next sibling list item
+    doc = _convert_markdown("- Item 1  \n  continued\n- Item 2", opt)
     list_items = [t for t in doc.texts if t.label == "list_item"]
     assert len(list_items) == 2
     assert list_items[0].text == "Item 1\ncontinued"
     assert list_items[1].text == "Item 2"
 
-
-def test_convert_soft_line_break_list_item():
-    """A soft line break inside a list item joins the runs with a space."""
-    markdown = "- First\n  Second\n- Item 2"
-
-    doc = _convert_markdown(markdown, MarkdownBackendOptions())
-
+    # Soft break in a list item: joined with a space
+    doc = _convert_markdown("- First\n  Second\n- Item 2", opt)
     list_items = [t for t in doc.texts if t.label == "list_item"]
     assert len(list_items) == 2
     assert list_items[0].text == "First Second"
     assert list_items[1].text == "Item 2"
-
-
-def test_convert_mixed_line_breaks():
-    """A hard break produces '\\n' and a following soft break produces ' ' in the same paragraph."""
-    markdown = "Line1  \nLine2\nLine3"
-
-    doc = _convert_markdown(markdown, MarkdownBackendOptions())
-
-    assert len(doc.texts) == 1
-    assert doc.texts[0].text == "Line1\nLine2 Line3"

--- a/tests/test_backend_markdown.py
+++ b/tests/test_backend_markdown.py
@@ -540,7 +540,8 @@ def test_convert_line_breaks():
     assert doc.texts[0].text == "Author 1"
     assert doc.texts[1].text == "Affiliation 1"
 
-    # Hard break across a formatting boundary: separate items per formatted run
+    # Hard break across a formatting boundary: the break is preserved as a
+    # leading '\n' on the run that follows, since the runs cannot be merged.
     doc = _convert_markdown("Author **John**  \nUniversity XYZ", opt)
     assert len(doc.texts) == 3
     assert doc.texts[0].text == "Author"
@@ -548,7 +549,7 @@ def test_convert_line_breaks():
     assert doc.texts[1].text == "John"
     assert doc.texts[1].formatting is not None
     assert doc.texts[1].formatting.bold is True
-    assert doc.texts[2].text == "University XYZ"
+    assert doc.texts[2].text == "\nUniversity XYZ"
     assert doc.texts[2].formatting is None
 
     # Multiple hard breaks in one paragraph

--- a/tests/test_backend_markdown.py
+++ b/tests/test_backend_markdown.py
@@ -508,3 +508,48 @@ def test_utf8_bom_does_not_hide_the_first_heading(tmp_path):
         assert doc.texts[0].label == "title"
         assert doc.texts[0].text == "Title"
         assert doc.texts[1].text == "Some body text."
+def test_convert_hard_line_break():
+    markdown = "Author 1  \nAffiliation 1"
+
+    doc = _convert_markdown(markdown, MarkdownBackendOptions())
+
+    assert len(doc.texts) == 1
+    assert doc.texts[0].text == "Author 1\nAffiliation 1"
+
+
+def test_convert_hard_line_break():
+    markdown = "Author 1  \nAffiliation 1"
+
+    doc = _convert_markdown(markdown, MarkdownBackendOptions())
+
+    assert len(doc.texts) == 1
+    assert doc.texts[0].text == "Author 1\nAffiliation 1"
+
+
+def test_convert_soft_line_break():
+    markdown = "Author 1\nAffiliation 1"
+
+    doc = _convert_markdown(markdown, MarkdownBackendOptions())
+
+    assert [item.text for item in doc.texts] == [
+        "Author 1",
+        "Affiliation 1",
+    ]
+
+
+def test_convert_hard_line_break_preserves_formatting():
+    markdown = "Author **John**  \nUniversity XYZ"
+
+    doc = _convert_markdown(markdown, MarkdownBackendOptions())
+
+    assert len(doc.texts) == 3
+
+    assert doc.texts[0].text == "Author"
+    assert doc.texts[0].formatting is None
+
+    assert doc.texts[1].text == "John"
+    assert doc.texts[1].formatting is not None
+    assert doc.texts[1].formatting.bold is True
+
+    assert doc.texts[2].text == "University XYZ"
+    assert doc.texts[2].formatting is None

--- a/tests/test_backend_markdown.py
+++ b/tests/test_backend_markdown.py
@@ -508,6 +508,8 @@ def test_utf8_bom_does_not_hide_the_first_heading(tmp_path):
         assert doc.texts[0].label == "title"
         assert doc.texts[0].text == "Title"
         assert doc.texts[1].text == "Some body text."
+
+
 def test_convert_hard_line_break():
     markdown = "Author 1  \nAffiliation 1"
 

--- a/tests/test_backend_markdown.py
+++ b/tests/test_backend_markdown.py
@@ -520,14 +520,13 @@ def test_convert_hard_line_break():
 
 
 def test_convert_soft_line_break():
+    """A soft line break (bare newline) joins the two runs with a space (GFM §6.7)."""
     markdown = "Author 1\nAffiliation 1"
 
     doc = _convert_markdown(markdown, MarkdownBackendOptions())
 
-    assert [item.text for item in doc.texts] == [
-        "Author 1",
-        "Affiliation 1",
-    ]
+    assert len(doc.texts) == 1
+    assert doc.texts[0].text == "Author 1 Affiliation 1"
 
 
 def test_convert_hard_line_break_preserves_formatting():
@@ -580,3 +579,25 @@ def test_list_items_hard_break_does_not_bleed_into_sibling():
     assert len(list_items) == 2
     assert list_items[0].text == "Item 1\ncontinued"
     assert list_items[1].text == "Item 2"
+
+
+def test_convert_soft_line_break_list_item():
+    """A soft line break inside a list item joins the runs with a space."""
+    markdown = "- First\n  Second\n- Item 2"
+
+    doc = _convert_markdown(markdown, MarkdownBackendOptions())
+
+    list_items = [t for t in doc.texts if t.label == "list_item"]
+    assert len(list_items) == 2
+    assert list_items[0].text == "First Second"
+    assert list_items[1].text == "Item 2"
+
+
+def test_convert_mixed_line_breaks():
+    """A hard break produces '\\n' and a following soft break produces ' ' in the same paragraph."""
+    markdown = "Line1  \nLine2\nLine3"
+
+    doc = _convert_markdown(markdown, MarkdownBackendOptions())
+
+    assert len(doc.texts) == 1
+    assert doc.texts[0].text == "Line1\nLine2 Line3"


### PR DESCRIPTION
## Description

This PR fixes the Markdown parsing side of the hard line break round-trip
described in #4011.

A hard line break in GitHub Flavored Markdown (GFM) can be represented using
two trailing spaces before a newline:

```markdown
Author 1  
Affiliation 1
```

The expected Docling representation is a single `TextItem` containing an
embedded newline:

```python
TextItem.text == "Author 1\nAffiliation 1"
```

Previously, the Markdown backend could interpret the content after the hard
line break as a separate `TextItem`, resulting in a loss of the distinction
between an intra-block hard line break and a paragraph/document-item
boundary.

This PR preserves the hard line break as `\n` inside the appropriate
`TextItem`.

---

## Related Issue

Resolves #4011

---

## Problem

The Markdown round-trip consists of two directions:

```text
DoclingDocument
      │
      │ serialize
      ▼
   Markdown
      │
      │ parse
      ▼
DoclingDocument
```

For this round-trip to be lossless, an embedded newline in a `TextItem` must
have the same semantics in both directions.

For example, a `TextItem` containing:

```python
"Author 1\nAffiliation 1"
```

represents one text block with an intra-block line break.

It is different from two separate text items:

```python
doc.add_text(
    label=DocItemLabel.TEXT,
    text="Author 1",
)

doc.add_text(
    label=DocItemLabel.TEXT,
    text="Affiliation 1",
)
```

The Markdown representation of an embedded hard line break is:

```markdown
Author 1  
Affiliation 1
```

where the two spaces before the newline are significant.

---

## Investigation

I traced the problem through the Markdown parser and Docling document model
to understand where the hard line break was being lost.

### 1. Docling text-item representation

I first inspected `DoclingDocument.add_text()` and the `TextItem` structure.

Every call to `add_text()` creates a separate `TextItem`.

Therefore:

```python
doc.add_text(
    label=DocItemLabel.TEXT,
    text="Author 1",
)

doc.add_text(
    label=DocItemLabel.TEXT,
    text="Affiliation 1",
)
```

produces two separate document items.

Whereas:

```python
doc.add_text(
    label=DocItemLabel.TEXT,
    text="Author 1\nAffiliation 1",
)
```

keeps the newline inside one text item.

This confirmed that the parser must preserve a hard line break inside the same
`TextItem`.

### 2. Marko AST investigation

I then inspected how Marko parses Markdown line breaks.

For:

```markdown
Author 1  
Affiliation 1
```

Marko produces:

```python
marko.inline.LineBreak
```

with:

```python
soft=False
```

For a normal soft Markdown line break, Marko produces the same node type with:

```python
soft=True
```

This provides a semantic distinction between hard and soft line breaks without
having to manually inspect the original Markdown source.

The implementation therefore uses:

```python
if isinstance(element, marko.inline.LineBreak):
    if not element.soft:
        # hard line break
```

### 3. Inline formatting investigation

I also tested:

```markdown
Author **John**  
University XYZ
```

Marko represents formatted content as separate inline nodes.

Therefore, reconstructing the complete paragraph as plain text would risk losing
formatting information.

The implementation keeps the existing inline-node processing and introduces
only small state to represent a pending hard line break.

---

## Root Cause

The Markdown backend already processed:

```python
marko.inline.LineBreak
```

but did not preserve the semantic difference between:

```python
LineBreak(soft=True)
```

and:

```python
LineBreak(soft=False)
```

As a result, an explicit hard line break was not carried forward when the
following text was processed.

The parser could consequently create a new `TextItem` instead of keeping the
newline within the existing text item.

---

## Implementation

A pending hard-line-break state was added to the Markdown backend:

```python
self._pending_hard_line_break = False
```

When Marko reports an explicit hard line break:

```python
elif isinstance(element, marko.inline.LineBreak):
    if self.in_table:
        _log.debug("Line break in a table")
        self.md_table_buffer.append("")
    elif not element.soft:
        _log.debug("Hard line break")
        self._pending_hard_line_break = True
```

The newline is not immediately added as a separate document item.

Instead, the backend waits for the following text content.

When the next text node is processed, the pending state is consumed. If the
previous text item belongs to the same parent, the following text is appended
using `\n`:

```python
previous.text += "\n" + snippet_text
previous.orig += "\n" + snippet_text
```

Otherwise, normal `add_text()` behavior is retained.

The pending state is then reset:

```python
self._pending_hard_line_break = False
```

This preserves the hard line break without introducing an unnecessary
paragraph-level `TextItem`.

---

## Example

### Before

Input:

```markdown
Author 1  
Affiliation 1
```

The parser could produce:

```text
TextItem("Author 1")
TextItem("Affiliation 1")
```

which loses the distinction between a hard line break and separate document
items.

### After

The parser produces:

```text
TextItem("Author 1\nAffiliation 1")
```

This matches the expected Docling representation.

---

## Formatted Example

Input:

```markdown
Author **John**  
University XYZ
```

The parser continues to preserve the formatting of `John` while also
preserving the hard line break.

The implementation operates on Marko's inline AST rather than flattening the
paragraph into plain text.

---

## Tables

Table handling is kept separate.

The existing table-specific behavior remains unchanged:

```python
if self.in_table:
    ...
```

Hard-line-break handling is therefore not applied as normal paragraph text
while processing table content.

---

## Soft Line Breaks

Normal soft line breaks are intentionally not treated as hard line breaks.

Marko distinguishes them using:

```python
element.soft
```

Therefore:

```python
element.soft is True
```

continues through the existing behavior, while:

```python
element.soft is False
```

is treated as an explicit hard line break.

This avoids changing existing semantics for ordinary Markdown line wrapping.

---

## Code and Formula Content

The implementation is limited to normal inline text processing.

Existing handling for code blocks, code spans, formulas, and other specialized
document elements remains unchanged.

---

## Tests

Regression tests were added to ensure the behavior remains stable.

### Plain hard line break

```python
def test_convert_hard_line_break():
    markdown = "Author 1  \nAffiliation 1"

    doc = _convert_markdown(markdown, MarkdownBackendOptions())

    assert len(doc.texts) == 1
    assert doc.texts[0].text == "Author 1\nAffiliation 1"
```

This verifies that the two Markdown lines remain inside a single `TextItem`.

### Hard line break with formatting

```python
def test_convert_hard_line_break_preserves_formatting():
    markdown = "Author **John**  \nUniversity XYZ"

    doc = _convert_markdown(markdown, MarkdownBackendOptions())
```

This verifies that hard-line-break handling does not break existing inline
formatting behavior.

---

## Verification

### Targeted hard-line-break test

```bash
uv run pytest tests/test_backend_markdown.py::test_convert_hard_line_break -q
```

Result:

```text
1 passed
```

### Formatted hard-line-break test

```bash
uv run pytest tests/test_backend_markdown.py::test_convert_hard_line_break_preserves_formatting -q
```

Result:

```text
1 passed
```

### Full Markdown backend test suite

```bash
uv run pytest tests/test_backend_markdown.py -q
```

Result:

```text
17 passed, 1 skipped, 1 warning
```

The warning is from the existing
`test_convert_leading_dash_sequences` test and is unrelated to this change.

---

## Code Quality Checks

The repository checks were run with:

```bash
uv run prek run --all-files
```

The following checks passed:

```text
trim trailing whitespace
fix end of files
check for merge conflicts
check for added large files
Ruff linter
Ruff formatter
ty
Tach
```

Two repository hooks invoke `python3` directly:

```text
tach-module-coverage
max-lines
```

On the Windows development environment, `python3` is not available as a
command.

The underlying scripts were therefore verified directly using the project's
Python environment:

```bash
uv run python scripts/check_tach_module_coverage.py
```

and:

```bash
uv run python scripts/check_max_lines.py --max-lines=1500
```

Both completed successfully.

No repository hook configuration was changed for this platform-specific issue.

---

## Files Changed

### `docling/backend/md_backend.py`

Updated Markdown AST processing to recognize explicit hard line breaks and
preserve them as embedded newlines in the appropriate `TextItem`.

### `tests/test_backend_markdown.py`

Added regression coverage for:

- Plain hard line breaks.
- Hard line breaks combined with inline formatting.

---

## Scope

This PR focuses specifically on the Markdown parsing side of the round-trip
described in #4011.

Markdown serialization is handled separately by `docling-core`.

No changes were made to the Markdown serializer in this repository.

---

## Acceptance Criteria

- [x] Markdown hard line breaks represented by
      `LineBreak(soft=False)` are recognized.
- [x] Hard line breaks are preserved as `\n`.
- [x] The newline remains inside the appropriate `TextItem`.
- [x] Unnecessary separate `TextItem`s are avoided.
- [x] Inline formatting is preserved.
- [x] Existing table handling remains unchanged.
- [x] Existing Markdown tests continue to pass.
- [x] Regression test added for a plain hard line break.
- [x] Regression test added for a formatted hard line break.
- [x] Ruff linting and formatting pass.
- [x] `ty` passes.
- [x] Tach passes.
- [x] Underlying `tach-module-coverage` check passes.
- [x] Underlying `max-lines` check passes.

---

## Checklist

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
