### PR TITLE
docs: add haiku.rag integration

### DIFF
--- a/docs/integrations/haiku_rag.md
+++ b/docs/integrations/haiku_rag.md
@@ -1,0 +1,13 @@
+Docling is the default document converter and chunker in [haiku.rag](https://ggozad.github.io/haiku.rag/), an agentic RAG library. haiku.rag stores the full `DoclingDocument` and uses it for structure-aware context expansion and visual grounding, and mounts its structure as a virtual filesystem so agents can navigate a document's outline and items directly when analyzing it. Both `docling` and [Docling Serve](https://github.com/docling-project/docling-serve) backends are supported.
+
+- 💻 [haiku.rag GitHub][github]
+- 📖 [haiku.rag docs][docs]
+- 📦 [haiku.rag PyPI][pypi]
+- ⚙️ [Docling setup in haiku.rag][setup]
+- 🌐 [Docling Serve setup in haiku.rag][serve]
+
+[github]: https://github.com/ggozad/haiku.rag
+[docs]: https://ggozad.github.io/haiku.rag/
+[pypi]: https://pypi.org/project/haiku.rag/
+[setup]: https://ggozad.github.io/haiku.rag/configuration/processing/
+[serve]: https://ggozad.github.io/haiku.rag/remote-processing/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -162,6 +162,7 @@ nav:
     - 🤖 Agentic / AI dev frameworks:
       - "Bee Agent Framework": integrations/bee.md
       - "Crew AI": integrations/crewai.md
+      - "haiku.rag": integrations/haiku_rag.md
       - "Haystack": integrations/haystack.md
       - "Hector": integrations/hector.md
       - "LangChain": integrations/langchain.md


### PR DESCRIPTION
Adds an integration page for [haiku.rag](https://ggozad.github.io/haiku.rag/), an agentic RAG library that uses Docling as its default document converter and chunker, supporting both the `docling` and Docling Serve backends.

haiku.rag keeps the full `DoclingDocument` rather than discarding it after conversion, and uses it for structure-aware context expansion, visual grounding, and a virtual filesystem that lets agents navigate a document's outline and items during analysis.

Listed under *Agentic / AI dev frameworks*, alphabetically.

**Checklist:**

- [X] Documentation has been updated, if necessary.
- [X] Examples have been added, if necessary.
- [X] Tests have been added, if necessary.
