### PR TITLE
feat(service-client): advertise accepted DoclingDocument version via Accept-Docling-Document-Version header

### DIFF
--- a/docling/service_client/_async_client.py
+++ b/docling/service_client/_async_client.py
@@ -19,6 +19,7 @@ from urllib.parse import urlencode, urlparse
 
 import httpx
 from docling_core.types.doc import DoclingDocument
+from docling_core.types.doc.common.constants import CURRENT_VERSION
 from docling_core.types.io import DocumentStream
 from pydantic import ValidationError
 
@@ -145,7 +146,11 @@ class AsyncDoclingServiceClient(_BaseDoclingServiceClient):
             write=self._http_read_timeout,
             pool=self._http_read_timeout,
         )
-        headers: dict[str, str] = {}
+        headers: dict[str, str] = {
+            # Tell the server the newest DoclingDocument version this client's
+            # installed docling-core can read; the server down-projects if needed.
+            "Accept-Docling-Document-Version": CURRENT_VERSION,
+        }
         if self._api_key:
             headers["X-Api-Key"] = self._api_key
         self._async_client = httpx.AsyncClient(timeout=timeout, headers=headers)

--- a/docling/service_client/client.py
+++ b/docling/service_client/client.py
@@ -26,6 +26,7 @@ from urllib.parse import urlencode, urlparse
 
 import httpx
 from docling_core.types.doc import DoclingDocument, ImageRef, PictureItem
+from docling_core.types.doc.common.constants import CURRENT_VERSION
 from docling_core.types.io import DocumentStream
 from PIL import Image as PILImage
 from pydantic import AnyHttpUrl, SecretBytes, SecretStr, TypeAdapter, ValidationError
@@ -841,7 +842,11 @@ class DoclingServiceClient(_BaseDoclingServiceClient):
             write=http_read_timeout,
             pool=http_read_timeout,
         )
-        headers: dict[str, str] = {}
+        headers: dict[str, str] = {
+            # Tell the server the newest DoclingDocument version this client's
+            # installed docling-core can read; the server down-projects if needed.
+            "Accept-Docling-Document-Version": CURRENT_VERSION,
+        }
         if api_key:
             headers["X-Api-Key"] = api_key
         self._http_client = httpx.Client(timeout=timeout, headers=headers)

--- a/tests/test_service_client_sdk_unit.py
+++ b/tests/test_service_client_sdk_unit.py
@@ -4332,3 +4332,25 @@ async def test_async_submit_batch_rejects_both_target_and_targets() -> None:
                 target=PresignedUrlTarget(),
                 targets=[PresignedUrlTarget()],
             )
+
+
+_ACCEPT_DOC_VERSION_HEADER = "Accept-Docling-Document-Version"
+
+
+def test_sync_client_stamps_accept_doc_version_header() -> None:
+    from docling_core.types.doc.common.constants import CURRENT_VERSION
+
+    with DoclingServiceClient(url=TEST_BASE_URL) as client:
+        assert (
+            client._http_client.headers[_ACCEPT_DOC_VERSION_HEADER] == CURRENT_VERSION
+        )
+
+
+@pytest.mark.anyio
+async def test_async_client_stamps_accept_doc_version_header() -> None:
+    from docling_core.types.doc.common.constants import CURRENT_VERSION
+
+    async with AsyncDoclingServiceClient(url=TEST_BASE_URL) as client:
+        assert (
+            client._async_client.headers[_ACCEPT_DOC_VERSION_HEADER] == CURRENT_VERSION
+        )


### PR DESCRIPTION
## What

Automatically advertise the newest `DoclingDocument` schema version this client's installed `docling-core` can read, so a newer server can down-project the produced document before returning it.

Both service clients now stamp every outgoing request with:

```
Accept-Docling-Document-Version: <docling_core CURRENT_VERSION>
```

## Why

A conversion server may run a newer `docling-core` than the client and emit a `DoclingDocument` at a schema version the client cannot parse. By telling the server "the newest version I can read," the server can down-project (via `docling_core.compat.project_to`) to a version `<=` that before responding. The client's own `docling-core` validators still upgrade the doc on load, so anything at-or-below the advertised version deserializes cleanly.

No public API change: the header is derived from the installed `docling-core` `CURRENT_VERSION` and sent transparently — no new `ConvertDocumentsOptions` field, no user-facing argument.

## Changes

- `docling/service_client/client.py` — stamp header on the sync `httpx.Client`.
- `docling/service_client/_async_client.py` — stamp header on the async `httpx.AsyncClient`.
- Unit tests asserting both clients carry the header set to `CURRENT_VERSION`.

## Related

Client half of the cross-repo feature. Server-side handling lands in `docling-serve` and `docling-jobkit`. Relies on the `docling_core.compat` projection system.
