### PR TITLE
feat: add compact_tables to ConvertDocumentsOptions

### DIFF
--- a/docling/datamodel/service/options.py
+++ b/docling/datamodel/service/options.py
@@ -566,9 +566,7 @@ class ConvertDocumentsOptions(BaseModel):
                 "Whether to use compact table format without column padding in the "
                 "markdown output. When False (default), tables use padded columns "
                 "for better visual formatting. When True, tables use minimal "
-                "whitespace, which avoids exponential whitespace growth on tables "
-                "with a wide outlier cell (e.g. a merged banner/disclaimer row) and "
-                "is better for large tables and downstream processing."
+                "whitespace, which is better for large tables and downstream processing."
             ),
             examples=[False],
         ),

--- a/docling/datamodel/service/options.py
+++ b/docling/datamodel/service/options.py
@@ -559,6 +559,21 @@ class ConvertDocumentsOptions(BaseModel):
         ),
     ] = ""
 
+    compact_tables: Annotated[
+        bool,
+        Field(
+            description=(
+                "Whether to use compact table format without column padding in the "
+                "markdown output. When False (default), tables use padded columns "
+                "for better visual formatting. When True, tables use minimal "
+                "whitespace, which avoids exponential whitespace growth on tables "
+                "with a wide outlier cell (e.g. a merged banner/disclaimer row) and "
+                "is better for large tables and downstream processing."
+            ),
+            examples=[False],
+        ),
+    ] = False
+
     chunking_options: Annotated[
         Optional[ChunkingOptionType],
         Field(

--- a/docling/datamodel/service/options.py
+++ b/docling/datamodel/service/options.py
@@ -559,7 +559,7 @@ class ConvertDocumentsOptions(BaseModel):
         ),
     ] = ""
 
-    compact_tables: Annotated[
+    md_compact_tables: Annotated[
         bool,
         Field(
             description=(


### PR DESCRIPTION
Adds `compact_tables: bool = False` to `ConvertDocumentsOptions`, exposing the `compact_tables` parameter that `DoclingDocument.export_to_markdown()` and `save_as_markdown()` already support - added to fix unbounded whitespace growth in markdown table export (#2907). A single wide cell in a column (e.g. a merged banner/disclaimer row) currently forces every other cell in that column to pad out to match, which can turn a small, sparse table into megabytes of near-entirely-whitespace output.

This was originally submitted directly to `docling-jobkit` in [docling-jobkit#108](https://github.com/docling-project/docling-jobkit/pull/108), which added the field to `ConvertDocumentsOptions` there. That PR was redirected here because `ConvertDocumentsOptions` has since moved to live in this repo (`docling-jobkit`'s copy is now just a compatibility re-export). This PR is that redirected change.

I've also looked at where this options could be used in docling-jobkit and there seem to be quite a few places. I prepared a potential PR for that, but not very confident if it covers everything. Can open if you like.