### PR TITLE
fix(tesseract): normalize the script pack separator from --list-langs (#4022)

### DIFF
--- a/docling/models/stages/ocr/tesseract_ocr_cli_model.py
+++ b/docling/models/stages/ocr/tesseract_ocr_cli_model.py
@@ -274,7 +274,13 @@ class TesseractOcrCliModel(BaseOcrModel):
         )
         decoded_data = output.stdout.decode("utf-8")
         df_list = pd.read_csv(io.StringIO(decoded_data), header=None)
-        self._tesseract_languages = df_list[0].tolist()[1:]
+        # Tesseract prints script packs with the OS path separator, so on Windows
+        # `--list-langs` reports `script\Latin` rather than `script/Latin`. The
+        # forward-slash form is the one `_sanitize_lang` accepts and the one
+        # `tesseract -l` expects on every platform, so normalize on the way in.
+        self._tesseract_languages = [
+            str(lang).replace("\\", "/") for lang in df_list[0].tolist()[1:]
+        ]
 
         # Decide the script prefix
         if any(lang.startswith("script/") for lang in self._tesseract_languages):

--- a/tests/test_tesseract_ocr_cli_lang.py
+++ b/tests/test_tesseract_ocr_cli_lang.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pandas as pd
+import pytest
 
 from docling.models.stages.ocr.tesseract_ocr_cli_model import TesseractOcrCliModel
 
@@ -24,18 +25,11 @@ def _model_for_listing(listing: str) -> TesseractOcrCliModel:
     return model
 
 
-def test_script_packs_listed_with_a_posix_separator():
-    model = _model_for_listing(
-        "List of available languages (3):\neng\nscript/Arabic\nscript/Latin\n"
-    )
-    assert model._script_prefix == "script/"
-    assert "script/Arabic" in model._tesseract_languages
-
-
-def test_script_packs_listed_with_a_windows_separator():
+@pytest.mark.parametrize("sep", ["/", "\\"], ids=["posix", "windows"])
+def test_script_packs_are_listed_with_either_separator(sep: str):
     """Windows tesseract prints `script\\Arabic`; the prefix must still be detected."""
     model = _model_for_listing(
-        "List of available languages (3):\neng\nscript\\Arabic\nscript\\Latin\n"
+        f"List of available languages (3):\neng\nscript{sep}Arabic\nscript{sep}Latin\n"
     )
     assert model._script_prefix == "script/"
     assert "script/Arabic" in model._tesseract_languages

--- a/tests/test_tesseract_ocr_cli_lang.py
+++ b/tests/test_tesseract_ocr_cli_lang.py
@@ -1,0 +1,56 @@
+from unittest.mock import patch
+
+import pandas as pd
+
+from docling.models.stages.ocr.tesseract_ocr_cli_model import TesseractOcrCliModel
+
+_MODULE = "docling.models.stages.ocr.tesseract_ocr_cli_model"
+
+
+class _FakeCompletedProcess:
+    def __init__(self, stdout: bytes) -> None:
+        self.stdout = stdout
+
+
+def _model_for_listing(listing: str) -> TesseractOcrCliModel:
+    """Build a model whose language list comes from the given `--list-langs` output."""
+    model = TesseractOcrCliModel.__new__(TesseractOcrCliModel)
+    model._safe_tesseract_cmd = "tesseract"
+    with patch(
+        f"{_MODULE}.subprocess.run",
+        return_value=_FakeCompletedProcess(listing.encode("utf-8")),
+    ):
+        model._set_languages_and_prefix()
+    return model
+
+
+def test_script_packs_listed_with_a_posix_separator():
+    model = _model_for_listing(
+        "List of available languages (3):\neng\nscript/Arabic\nscript/Latin\n"
+    )
+    assert model._script_prefix == "script/"
+    assert "script/Arabic" in model._tesseract_languages
+
+
+def test_script_packs_listed_with_a_windows_separator():
+    """Windows tesseract prints `script\\Arabic`; the prefix must still be detected."""
+    model = _model_for_listing(
+        "List of available languages (3):\neng\nscript\\Arabic\nscript\\Latin\n"
+    )
+    assert model._script_prefix == "script/"
+    assert "script/Arabic" in model._tesseract_languages
+
+
+def test_detected_script_resolves_against_a_windows_listing():
+    """lang=["auto"] must resolve the detected script to an installed pack."""
+    model = _model_for_listing(
+        "List of available languages (2):\neng\nscript\\Arabic\n"
+    )
+    osd = pd.DataFrame({"key": ["Script"], "value": ["Arabic"]})
+
+    lang = model._parse_language(osd)
+
+    assert lang == "script/Arabic"
+    # the resolved identifier is passed to tesseract via _sanitize_lang, which
+    # rejects backslashes outright
+    assert TesseractOcrCliModel._sanitize_lang(lang) == "script/Arabic"


### PR DESCRIPTION
Fixes #4022.

### The bug

`TesseractOcrCliModel._set_languages_and_prefix()` decides whether the installed
tesseract has script packs by probing the `--list-langs` output for a `script/`
prefix:

```python
self._tesseract_languages = df_list[0].tolist()[1:]
if any(lang.startswith("script/") for lang in self._tesseract_languages):
    script_prefix = "script/"
else:
    script_prefix = ""
```

tesseract prints those entries with the **OS** path separator, so on Windows the
listing reads `script\Arabic`, `script\Latin`, … and the probe never matches.
`_script_prefix` stays `""`, and `_parse_language()` then builds `lang = "Arabic"`
instead of `"script/Arabic"`, fails the membership check against
`self._tesseract_languages`, and logs:

> Tesseract detected the script 'Arabic' and language 'Arabic'. However this
> language is not installed in your system and will be ignored.

`_run_tesseract()` therefore appends no `-l` flag at all, and
`TesseractCliOcrOptions(lang=["auto"])` silently OCRs with tesseract's built-in
default instead of the detected script model.

### The fix

Normalize backslashes to forward slashes when reading the listing.

Two reasons this is the right normalization direction rather than switching the
probe to `os.sep`:

* `tesseract -l script/Arabic` works on Windows — the reporter confirmed it, and
  the backslash form only ever appears in `--list-langs` output.
* The resolved identifier is passed through `_sanitize_lang()`, whose
  `_VALID_LANG_RE = ^[a-zA-Z0-9_/][a-zA-Z0-9_/+-]*$` **rejects backslashes**.
  Carrying the native separator through would convert today's silent fallback
  into a `ValueError`.

POSIX listings pass through unchanged, so nothing changes on Linux/macOS.

### Tests

`tests/test_tesseract_ocr_cli_lang.py` drives `_set_languages_and_prefix()` with
a stubbed `--list-langs` payload (the real script packs cannot be installed in
CI) and covers three cases: the POSIX listing, the Windows listing, and the
end-to-end `lang=["auto"]` resolution through `_parse_language()` plus
`_sanitize_lang()`.

Verified locally on Windows: the two Windows cases fail on `main` with exactly
the warning quoted above and pass with this change; the POSIX case is green both
ways. `ruff` and `ruff-format` v0.15.12 (the `.pre-commit-config.yaml` pin) are
clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
