### PR TITLE
docs: fix broken ConfidenceReport reference link in confidence scores page

### DIFF
--- a/docs/concepts/confidence_scores.md
+++ b/docs/concepts/confidence_scores.md
@@ -53,7 +53,7 @@ Two aggregate grades provide overall document quality assessment:
 Confidence grades are calculated at two levels:
 
 - **Page-level**: Individual scores and grades for each page, stored in the `pages` field
-- **Document-level**: Overall scores and grades for the entire document, calculated as averages of the page-level grades and stored in fields equally named in the root [`ConfidenceReport`](h../../reference/document_converter/#docling.document_converter.ConversionResult.confidence)
+- **Document-level**: Overall scores and grades for the entire document, calculated as averages of the page-level grades and stored in fields equally named in the root [`ConfidenceReport`](../../reference/document_converter/#docling.document_converter.ConversionResult.confidence)
 
 ### Example
 


### PR DESCRIPTION
### What

Removes a stray `h` character from the `ConfidenceReport` link target in `docs/concepts/confidence_scores.md`.

```diff
-[`ConfidenceReport`](h../../reference/document_converter/#...ConversionResult.confidence)
+[`ConfidenceReport`](../../reference/document_converter/#...ConversionResult.confidence)
```

### Why

The typo makes the link resolve to `/docling/concepts/h../../reference/document_converter/`, which **404s** on the published docs site.

Line 3 of the same file already uses the identical, working URL for the `confidence` field, so the intended target is unambiguous.

### Testing

Verified against the live documentation site:

| Check | Result |
|---|---|
| Rendered href on the live page | `../h../../reference/...` (malformed) |
| Broken URL | **404** |
| Corrected URL `/docling/reference/document_converter/` | **200** |
| Anchor `docling.document_converter.ConversionResult.confidence` on target page | present |

Also re-scanned all of `docs/` for similarly malformed relative links — this was the only occurrence.

Note: `ConfidenceReport` has no anchor of its own on the reference page, so `ConversionResult.confidence` (already used on line 3) is the correct target. Kept the change minimal for that reason.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.