### PR TITLE
fix(vlm): use official Unlimited-OCR prompt

### DIFF
--- a/docling/datamodel/vlm_prompts.py
+++ b/docling/datamodel/vlm_prompts.py
@@ -63,7 +63,5 @@ DOTS_LAYOUT_PROMPT = (
     "5. Final Output: The entire output must be a single JSON object."
 )
 
-# Unlimited-OCR only responds to this exact wording. Other phrasings — including generic
-# "convert to markdown" instructions — make the model return an empty completion with
-# finish_reason "stop" and no error, so the prompt is kept verbatim as a constant.
-UNLIMITED_OCR_GROUNDING_PROMPT = "<image>\n<|grounding|>OCR this image."
+# Keep the official Unlimited-OCR model-card prompt verbatim.
+UNLIMITED_OCR_GROUNDING_PROMPT = "<image>document parsing."

--- a/tests/test_vlm_presets_and_runtime_options.py
+++ b/tests/test_vlm_presets_and_runtime_options.py
@@ -494,12 +494,6 @@ class TestPresetBasedOptionsCreation:
         assert options.engine_options.engine_type == VlmEngineType.AUTO_INLINE
         assert options.scale == 2.0
 
-    def test_unlimited_ocr_uses_official_prompt(self):
-        """Test that the Unlimited-OCR preset uses its documented prompt."""
-        options = VlmConvertOptions.from_preset("unlimited_ocr")
-
-        assert options.model_spec.prompt == "<image>document parsing."
-
     def test_create_vlm_convert_from_preset_with_engine_override(self):
         """Test creating VlmConvertOptions with engine override."""
         # Override with Transformers engine

--- a/tests/test_vlm_presets_and_runtime_options.py
+++ b/tests/test_vlm_presets_and_runtime_options.py
@@ -494,6 +494,12 @@ class TestPresetBasedOptionsCreation:
         assert options.engine_options.engine_type == VlmEngineType.AUTO_INLINE
         assert options.scale == 2.0
 
+    def test_unlimited_ocr_uses_official_prompt(self):
+        """Test that the Unlimited-OCR preset uses its documented prompt."""
+        options = VlmConvertOptions.from_preset("unlimited_ocr")
+
+        assert options.model_spec.prompt == "<image>document parsing."
+
     def test_create_vlm_convert_from_preset_with_engine_override(self):
         """Test creating VlmConvertOptions with engine override."""
         # Override with Transformers engine


### PR DESCRIPTION
## Summary

- replace the Unlimited-OCR preset's DeepSeek-style grounding prompt with the
  model's documented `<image>document parsing.` prompt
- keep the existing preset settings and response parser unchanged
- add a regression test through the public `VlmConvertOptions.from_preset` API

**Issue resolved by this Pull Request:**

Resolves #4030

## Testing

- `make validate`
- `make typecheck` (exits successfully with the existing repository warnings)
- `uv run pytest -q tests/test_vlm_presets_and_runtime_options.py tests/test_unlimited_ocr_markdown.py`
  (`43 passed, 1 skipped`)
- CI-equivalent core suite (`1,224 passed, 22 skipped, 2 xfailed`; six
  `example.com` cases deselected because the local proxy DNS maps that hostname
  to a reserved address and triggers the SSRF guard)
- `uv build`

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
