### PR TITLE
fix(xlsx): do not absorb disconnected content into a neighboring table's flood-filled bounds

### DIFF
--- a/docling/backend/msexcel_backend.py
+++ b/docling/backend/msexcel_backend.py
@@ -1060,21 +1060,20 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         # --- Phase 2: Extract Data (Semantic Grid) ---
         data = []
 
-        # We iterate the bounding box of the found region
-        # Gaps inside the bounding box become empty cells (preserving layout)
+        # We iterate the bounding box of the found region. A cell the flood
+        # fill never reached stays out of table_cells and is emitted empty, so
+        # the outer loop in _find_data_tables gives it its own table later.
         for ri in range(min_r, max_r + 1):
             for rj in range(min_c, max_c + 1):
-                # If this cell was part of the flood-fill OR is inside the bounds
-                # (We include gaps inside the bounds to keep the table rectangular)
-
-                # Logic: If we found a "U" shape, do we fill the middle?
-                # Yes, Excel tables are typically treated as rectangular bounding boxes.
-
                 cell = sheet.cell(row=ri + 1, column=rj + 1)
                 if merged_cell_index.is_shadow(cell):
                     continue
 
-                cell_text = str(cell.value) if cell.value is not None else ""
+                cell_text = (
+                    str(cell.value)
+                    if (ri, rj) in table_cells and cell.value is not None
+                    else ""
+                )
 
                 # Compute Spans
                 row_span, col_span = merged_cell_index.span_at(ri, rj)

--- a/tests/test_backend_msexcel.py
+++ b/tests/test_backend_msexcel.py
@@ -676,6 +676,63 @@ def test_merged_cells_are_indexed_once_and_preserve_semantics(tmp_path: Path) ->
     assert comment_map[(3, 3)] == ("Codex", "Synthetic note", None)
 
 
+def test_disconnected_pocket_inside_bounding_box_is_not_duplicated(
+    tmp_path: Path,
+) -> None:
+    """A cell inside the flood-filled bounding box but never reached by the BFS
+    (separated from the ring by more than gap_tolerance empty cells) must not be
+    absorbed into the ring's own table data, since it is not actually connected
+    to it. It must instead surface once, as its own separate table.
+    """
+    workbook = Workbook()
+    sheet = workbook.active
+    # A 5x5 ring border, all filled, plus one disconnected marker cell in the
+    # interior (2,2 / 0-based) separated from the border by an empty gap of 1
+    # cell on every side, i.e. unreachable at gap_tolerance=0.
+    for row in range(1, 6):
+        for col in range(1, 6):
+            is_border = row in (1, 5) or col in (1, 5)
+            if is_border:
+                sheet.cell(row=row, column=col, value=f"border-{row}-{col}")
+    sheet.cell(row=3, column=3, value="island-marker")
+    file_path = tmp_path / "disconnected-pocket.xlsx"
+    workbook.save(file_path)
+
+    in_doc = InputDocument(
+        path_or_stream=file_path,
+        format=InputFormat.XLSX,
+        filename=file_path.stem,
+        backend=MsExcelDocumentBackend,
+    )
+    backend = MsExcelDocumentBackend(in_doc=in_doc, path_or_stream=file_path)
+    loaded_sheet = backend.workbook.active
+
+    tables, _ = backend._find_data_tables(loaded_sheet)
+
+    marker_occurrences = [
+        (t_idx, cell)
+        for t_idx, table in enumerate(tables)
+        for cell in table.data
+        if cell.text == "island-marker"
+    ]
+    assert len(marker_occurrences) == 1, (
+        f"'island-marker' must surface exactly once, found {len(marker_occurrences)} "
+        f"times across {len(tables)} table(s)"
+    )
+
+    marker_table_idx, marker_cell = marker_occurrences[0]
+    marker_table = tables[marker_table_idx]
+    assert (marker_table.num_rows, marker_table.num_cols) == (1, 1), (
+        "the disconnected marker must form its own single-cell table, not be "
+        "folded into the ring table"
+    )
+
+    ring_table = next(t for t in tables if t is not marker_table)
+    assert all(cell.text != "island-marker" for cell in ring_table.data), (
+        "the ring table's own grid must not carry the disconnected marker's text"
+    )
+
+
 def test_split_leading_section_label_helper() -> None:
     backend = object.__new__(MsExcelDocumentBackend)
 


### PR DESCRIPTION
Fixes #3685

## Root cause

`MsExcelDocumentBackend._find_table_bounds` finds a table by flood-filling
outward from a seed cell over 4-directionally-adjacent non-empty/merged
cells. Phase 2 of that method then re-scans the *entire rectangular
bounding box* of the flood-filled shape and emits a cell for every
non-empty value it finds there, regardless of whether the BFS ever reached
that cell.

For a rectangular table this is harmless: everything inside the bounding
box belongs to the table. For a non-rectangular shape (an L, a ring, any
concave outline, which the backend's own docstring commits to supporting),
the bounding box can contain a pocket holding a genuinely separate,
disconnected cluster of content. That content gets absorbed into the
first table's grid at a position nothing structurally connects it to, and
because Phase 2 never marks it visited, the caller's outer loop in
`_find_data_tables` later starts a fresh flood fill from the same cell and
emits it again as its own table. The same text ends up duplicated across
two output tables, matching the "section headers appear both inside the
main table and again as separate tables" fragmentation this issue
describes.

## Fix

Restrict Phase 2 to emit real content only for cells the flood fill
actually reached (`table_cells`); a bounding-box cell it never reached is
emitted empty, exactly as a legitimate interior gap already was, and it
stays out of `table_cells` so the outer loop still visits it and gives it
its own table.

## Verification

- New regression test (`test_disconnected_pocket_inside_bounding_box_is_not_duplicated`):
  a 5x5 ring of connected cells around one disconnected interior cell. It
  fails on main (the marker text surfaces twice, across two tables) and
  passes on this branch (it surfaces once, as its own single-cell table).
- Full `tests/test_backend_msexcel.py` suite: 22 passed, 2 skipped
  (unrelated, LibreOffice-dependent), including `test_gap_tolerance_comparison`,
  which already covers the legitimate L-shape/staggered-column case this
  change must not regress.
- `ruff format --check` and `ruff check` clean on both changed files.
- Not verified: the same flood-fill-then-full-bbox-extraction pattern also
  exists in the ODS backend (`opendocument_backend.py`, introduced by
  #3480) and is very likely reachable there too, but I did not reproduce
  or fix it in this PR; it deserves its own issue/PR.
