### PR TITLE
test: cover docling-tools CLI, profiling and debug visualization

### DIFF
--- a/docling/cli/models.py
+++ b/docling/cli/models.py
@@ -249,7 +249,8 @@ def download_hf_repo(
         )
 
     for item in models:
-        typer.secho(f"\nDownloading {item} model from HuggingFace...")
+        if not quiet:
+            typer.secho(f"\nDownloading {item} model from HuggingFace...")
         download_hf_model(
             repo_id=item,
             # would be better to reuse "repo_cache_folder" property: https://github.com/docling-project/docling/blob/main/docling/datamodel/pipeline_options_vlm_model.py#L76

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -52,13 +52,22 @@ def _enabled(recorded: dict[str, Any]) -> set[str]:
     return {key for key, value in recorded.items() if key.startswith("with_") and value}
 
 
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
+_BOX_DRAWING = re.compile(r"[\u2500-\u257f]")
+
+
 def _flat(output: str) -> str:
-    """Collapse Rich's box-drawing and line wrapping into a single line.
+    """Reduce a Rich error panel to a single line of plain text.
 
     Typer renders ``BadParameter`` messages inside a bordered panel and hard
-    wraps them, so error text cannot be matched against the raw output.
+    wraps them, so error text cannot be matched against the raw output. When
+    the output stream is a terminal -- as it is under CI -- Rich also emits
+    colour codes, including between the wrapped halves of a sentence, so the
+    escapes have to go before whitespace is collapsed or the message is still
+    split.
     """
-    stripped = re.sub(r"[\u2500-\u257f]", " ", output)
+    stripped = _ANSI_ESCAPE.sub("", output)
+    stripped = _BOX_DRAWING.sub(" ", stripped)
     return re.sub(r"\s+", " ", stripped)
 
 
@@ -158,8 +167,10 @@ def test_verbose_download_prints_offline_usage_hint(tmp_path, recorded_download)
     result = runner.invoke(app, ["models", "download", "-o", str(tmp_path), "layout"])
 
     assert result.exit_code == 0
-    assert "Models downloaded into" in result.output
-    assert "--artifacts-path" in result.output
+    # Rich wraps and colours this hint, so normalise before matching.
+    output = _flat(result.output)
+    assert "Models downloaded into" in output
+    assert "--artifacts-path" in output
 
 
 def test_easyocr_lang_is_forwarded_when_easyocr_is_selected(

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -1,0 +1,316 @@
+"""Tests for the ``docling-tools`` CLI.
+
+These exercise the option surface of ``docling-tools models`` without
+downloading anything: the downloader entry points are replaced with recorders
+so the tests can assert which model selection the CLI derives from a given set
+of flags. That mapping is the actual contract of these commands -- everything
+else they do is delegated.
+"""
+
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+from typer.testing import CliRunner
+
+import docling.cli.models as models_cli
+from docling.cli.models import _AvailableModels, _default_models
+from docling.cli.tools import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def recorded_download(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    """Replace ``download_models`` with a recorder returning its output dir."""
+    recorded: dict[str, Any] = {}
+
+    def _fake_download_models(**kwargs: Any) -> Path:
+        recorded.update(kwargs)
+        return kwargs["output_dir"]
+
+    monkeypatch.setattr(models_cli, "download_models", _fake_download_models)
+    return recorded
+
+
+@pytest.fixture
+def recorded_hf_download(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Replace ``download_hf_model`` with a recorder of per-repo calls."""
+    calls: list[dict[str, Any]] = []
+
+    def _fake_download_hf_model(**kwargs: Any) -> Path:
+        calls.append(kwargs)
+        return kwargs["local_dir"]
+
+    monkeypatch.setattr(models_cli, "download_hf_model", _fake_download_hf_model)
+    return calls
+
+
+def _enabled(recorded: dict[str, Any]) -> set[str]:
+    """The ``with_*`` selection flags the CLI turned on."""
+    return {key for key, value in recorded.items() if key.startswith("with_") and value}
+
+
+def _flat(output: str) -> str:
+    """Collapse Rich's box-drawing and line wrapping into a single line.
+
+    Typer renders ``BadParameter`` messages inside a bordered panel and hard
+    wraps them, so error text cannot be matched against the raw output.
+    """
+    stripped = re.sub(r"[\u2500-\u257f]", " ", output)
+    return re.sub(r"\s+", " ", stripped)
+
+
+def test_tools_help_lists_models_subcommand():
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "models" in result.output
+
+
+def test_tools_without_arguments_shows_help():
+    result = runner.invoke(app, [])
+    # no_args_is_help=True makes Typer exit with the usage screen.
+    assert result.exit_code != 0
+    assert "Usage" in result.output
+
+
+def test_models_without_arguments_shows_help():
+    result = runner.invoke(app, ["models"])
+    assert result.exit_code != 0
+    assert "download" in result.output
+
+
+def test_download_defaults_to_the_predefined_model_set(tmp_path, recorded_download):
+    result = runner.invoke(app, ["models", "download", "-o", str(tmp_path)])
+
+    assert result.exit_code == 0
+    assert recorded_download["output_dir"] == tmp_path
+    assert recorded_download["force"] is False
+    assert recorded_download["progress"] is True
+    assert _enabled(recorded_download) == {
+        "with_layout",
+        "with_tableformer",
+        "with_code_formula",
+        "with_picture_classifier",
+        "with_rapidocr",
+    }
+    assert len(_default_models) == 5
+
+
+def test_download_all_selects_every_available_model(tmp_path, recorded_download):
+    result = runner.invoke(app, ["models", "download", "-o", str(tmp_path), "--all"])
+
+    assert result.exit_code == 0
+    selection = {k: v for k, v in recorded_download.items() if k.startswith("with_")}
+    assert len(selection) == len(_AvailableModels)
+    assert all(selection.values()), (
+        f"not selected by --all: {_enabled(recorded_download) ^ set(selection)}"
+    )
+
+
+def test_download_explicit_models_override_the_defaults(tmp_path, recorded_download):
+    result = runner.invoke(
+        app, ["models", "download", "-o", str(tmp_path), "layout", "smolvlm"]
+    )
+
+    assert result.exit_code == 0
+    assert _enabled(recorded_download) == {"with_layout", "with_smolvlm"}
+
+
+def test_download_rejects_all_together_with_explicit_models(tmp_path):
+    result = runner.invoke(
+        app, ["models", "download", "-o", str(tmp_path), "--all", "layout"]
+    )
+
+    assert result.exit_code != 0
+    assert "Cannot simultaneously set" in _flat(result.output)
+
+
+def test_download_rejects_unknown_model_name(tmp_path):
+    result = runner.invoke(
+        app, ["models", "download", "-o", str(tmp_path), "not-a-model"]
+    )
+
+    assert result.exit_code != 0
+
+
+def test_download_forwards_force_flag(tmp_path, recorded_download):
+    result = runner.invoke(
+        app, ["models", "download", "-o", str(tmp_path), "--force", "layout"]
+    )
+
+    assert result.exit_code == 0
+    assert recorded_download["force"] is True
+
+
+def test_quiet_download_prints_only_the_output_directory(tmp_path, recorded_download):
+    result = runner.invoke(
+        app, ["models", "download", "-o", str(tmp_path), "-q", "layout"]
+    )
+
+    assert result.exit_code == 0
+    assert recorded_download["progress"] is False
+    assert result.output.strip() == str(tmp_path)
+
+
+def test_verbose_download_prints_offline_usage_hint(tmp_path, recorded_download):
+    result = runner.invoke(app, ["models", "download", "-o", str(tmp_path), "layout"])
+
+    assert result.exit_code == 0
+    assert "Models downloaded into" in result.output
+    assert "--artifacts-path" in result.output
+
+
+def test_easyocr_lang_is_forwarded_when_easyocr_is_selected(
+    tmp_path, recorded_download
+):
+    result = runner.invoke(
+        app,
+        [
+            "models",
+            "download",
+            "-o",
+            str(tmp_path),
+            "--easyocr-lang",
+            "en",
+            "--easyocr-lang",
+            "de",
+            "easyocr",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert recorded_download["easyocr_languages"] == ["en", "de"]
+
+
+def test_easyocr_lang_requires_the_easyocr_model(tmp_path):
+    result = runner.invoke(
+        app,
+        ["models", "download", "-o", str(tmp_path), "--easyocr-lang", "en", "layout"],
+    )
+
+    assert result.exit_code != 0
+    assert "requires the 'easyocr' model" in _flat(result.output)
+
+
+def test_easyocr_lang_rejects_an_unresolvable_language(tmp_path):
+    result = runner.invoke(
+        app,
+        [
+            "models",
+            "download",
+            "-o",
+            str(tmp_path),
+            "--easyocr-lang",
+            "not-a-language",
+            "easyocr",
+        ],
+    )
+
+    assert result.exit_code != 0
+
+
+def test_rapidocr_backend_lang_is_forwarded_when_rapidocr_is_selected(
+    tmp_path, recorded_download
+):
+    result = runner.invoke(
+        app,
+        [
+            "models",
+            "download",
+            "-o",
+            str(tmp_path),
+            "--rapidocr-backend-lang",
+            "onnxruntime:el",
+            "rapidocr",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert recorded_download["rapidocr_models"] == ["onnxruntime:el"]
+
+
+def test_rapidocr_backend_lang_requires_the_rapidocr_model(tmp_path):
+    result = runner.invoke(
+        app,
+        [
+            "models",
+            "download",
+            "-o",
+            str(tmp_path),
+            "--rapidocr-backend-lang",
+            "onnxruntime:el",
+            "layout",
+        ],
+    )
+
+    assert result.exit_code != 0
+    assert "requires the 'rapidocr' model" in _flat(result.output)
+
+
+def test_rapidocr_backend_lang_rejects_a_malformed_spec(tmp_path):
+    result = runner.invoke(
+        app,
+        [
+            "models",
+            "download",
+            "-o",
+            str(tmp_path),
+            "--rapidocr-backend-lang",
+            "no-separator-here",
+            "rapidocr",
+        ],
+    )
+
+    assert result.exit_code != 0
+
+
+def test_download_hf_repo_maps_repo_ids_to_local_directories(
+    tmp_path, recorded_hf_download
+):
+    result = runner.invoke(
+        app,
+        [
+            "models",
+            "download-hf-repo",
+            "-o",
+            str(tmp_path),
+            "docling-project/docling-models",
+            "org/other",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert [call["repo_id"] for call in recorded_hf_download] == [
+        "docling-project/docling-models",
+        "org/other",
+    ]
+    # The repo id is flattened into a single directory name.
+    assert [call["local_dir"] for call in recorded_hf_download] == [
+        tmp_path / "docling-project--docling-models",
+        tmp_path / "org--other",
+    ]
+    assert all(call["force"] is False for call in recorded_hf_download)
+    assert all(call["progress"] is True for call in recorded_hf_download)
+
+
+def test_quiet_download_hf_repo_prints_only_the_output_directory(
+    tmp_path, recorded_hf_download
+):
+    result = runner.invoke(
+        app,
+        ["models", "download-hf-repo", "-o", str(tmp_path), "-q", "org/repo"],
+    )
+
+    assert result.exit_code == 0
+    assert recorded_hf_download[0]["progress"] is False
+    # --quiet documents that only the directory is printed; the per-repo
+    # progress line must stay suppressed here as it is for `download`.
+    assert result.output.strip() == str(tmp_path)
+
+
+def test_download_hf_repo_requires_at_least_one_repo(tmp_path):
+    result = runner.invoke(app, ["models", "download-hf-repo", "-o", str(tmp_path)])
+
+    assert result.exit_code != 0

--- a/tests/test_profiling.py
+++ b/tests/test_profiling.py
@@ -1,0 +1,181 @@
+"""Tests for pipeline timing instrumentation.
+
+Timing is gated behind ``settings.debug.profile_pipeline_timings``, which is
+off everywhere by default. These tests drive both states: the recorders must
+be inert when profiling is off, and must enforce their interval state machine
+when it is on.
+"""
+
+import pytest
+
+from docling.datamodel.settings import settings
+from docling.utils.profiling import (
+    ProfilingItem,
+    ProfilingScope,
+    TimeIntervalRecorder,
+    TimeRecorder,
+)
+
+
+class _StubConversionResult:
+    """Minimal stand-in exposing the only attribute the recorders touch."""
+
+    def __init__(self) -> None:
+        self.timings: dict[str, ProfilingItem] = {}
+
+
+@pytest.fixture
+def profiling_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings.debug, "profile_pipeline_timings", True)
+
+
+@pytest.fixture
+def profiling_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(settings.debug, "profile_pipeline_timings", False)
+
+
+def test_profiling_item_statistics():
+    item = ProfilingItem(scope=ProfilingScope.PAGE, times=[1.0, 2.0, 3.0, 4.0])
+
+    assert item.total() == pytest.approx(10.0)
+    assert item.avg() == pytest.approx(2.5)
+    assert item.mean() == pytest.approx(2.5)
+    assert item.std() == pytest.approx(1.1180339887)
+    assert item.percentile(50) == pytest.approx(2.5)
+    assert item.percentile(0) == pytest.approx(1.0)
+    assert item.percentile(100) == pytest.approx(4.0)
+
+
+def test_time_recorder_records_one_sample_per_scope(profiling_enabled):
+    conv_res = _StubConversionResult()
+
+    with TimeRecorder(conv_res, "layout", scope=ProfilingScope.PAGE):
+        pass
+
+    item = conv_res.timings["layout"]
+    assert item.scope == ProfilingScope.PAGE
+    assert item.count == 1
+    assert len(item.times) == 1
+    assert len(item.start_timestamps) == 1
+    assert item.times[0] >= 0.0
+
+
+def test_time_recorder_accumulates_across_reuse_of_one_key(profiling_enabled):
+    conv_res = _StubConversionResult()
+
+    for _ in range(3):
+        with TimeRecorder(conv_res, "ocr"):
+            pass
+
+    item = conv_res.timings["ocr"]
+    assert item.count == 3
+    assert len(item.times) == 3
+    # The item is created once and reused, not replaced per invocation.
+    assert len(item.start_timestamps) == 3
+
+
+def test_time_recorder_defaults_to_page_scope(profiling_enabled):
+    conv_res = _StubConversionResult()
+
+    with TimeRecorder(conv_res, "assemble"):
+        pass
+
+    assert conv_res.timings["assemble"].scope == ProfilingScope.PAGE
+
+
+def test_time_recorder_is_inert_when_profiling_is_disabled(profiling_disabled):
+    conv_res = _StubConversionResult()
+
+    with TimeRecorder(conv_res, "layout"):
+        pass
+
+    assert conv_res.timings == {}
+
+
+def test_interval_recorder_banks_disjoint_intervals_into_one_sample(profiling_enabled):
+    conv_res = _StubConversionResult()
+
+    recorder = TimeIntervalRecorder(conv_res, "vlm", scope=ProfilingScope.DOCUMENT)
+    recorder.resume()
+    recorder.pause()
+    recorder.resume()
+    recorder.pause()
+    recorder.close()
+
+    item = conv_res.timings["vlm"]
+    assert item.scope == ProfilingScope.DOCUMENT
+    # Two intervals collapse into a single sample, unlike TimeRecorder.
+    assert item.count == 1
+    assert len(item.times) == 1
+    assert len(item.start_timestamps) == 1
+
+
+def test_interval_recorder_add_contributes_to_the_total(profiling_enabled):
+    conv_res = _StubConversionResult()
+
+    recorder = TimeIntervalRecorder(conv_res, "remote")
+    recorder.add(1.5)
+    recorder.add(2.5)
+    recorder.close()
+
+    assert conv_res.timings["remote"].times[0] == pytest.approx(4.0)
+
+
+def test_interval_recorder_close_without_any_interval_records_zero(profiling_enabled):
+    conv_res = _StubConversionResult()
+
+    recorder = TimeIntervalRecorder(conv_res, "idle")
+    recorder.close()
+
+    assert conv_res.timings["idle"].times == [0.0]
+    assert conv_res.timings["idle"].count == 1
+
+
+def test_interval_recorder_rejects_double_resume(profiling_enabled):
+    recorder = TimeIntervalRecorder(_StubConversionResult(), "vlm")
+    recorder.resume()
+
+    with pytest.raises(RuntimeError, match="already running"):
+        recorder.resume()
+
+
+def test_interval_recorder_rejects_pause_without_resume(profiling_enabled):
+    recorder = TimeIntervalRecorder(_StubConversionResult(), "vlm")
+
+    with pytest.raises(RuntimeError, match="without a matching resume"):
+        recorder.pause()
+
+
+def test_interval_recorder_rejects_close_while_running(profiling_enabled):
+    recorder = TimeIntervalRecorder(_StubConversionResult(), "vlm")
+    recorder.resume()
+
+    with pytest.raises(RuntimeError, match="still running"):
+        recorder.close()
+
+
+@pytest.mark.parametrize("operation", ["resume", "pause", "add", "close"])
+def test_interval_recorder_rejects_use_after_close(profiling_enabled, operation):
+    recorder = TimeIntervalRecorder(_StubConversionResult(), "vlm")
+    recorder.close()
+
+    with pytest.raises(RuntimeError, match="closed"):
+        if operation == "add":
+            recorder.add(1.0)
+        else:
+            getattr(recorder, operation)()
+
+
+def test_interval_recorder_is_inert_when_profiling_is_disabled(profiling_disabled):
+    conv_res = _StubConversionResult()
+
+    recorder = TimeIntervalRecorder(conv_res, "vlm")
+    # Every call is a no-op, including sequences that would otherwise raise.
+    recorder.pause()
+    recorder.resume()
+    recorder.resume()
+    recorder.add(5.0)
+    recorder.close()
+    recorder.close()
+
+    assert conv_res.timings == {}

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1,0 +1,219 @@
+"""Tests for the layout debug visualisation helpers.
+
+These only run when a ``settings.debug.visualize_*`` flag is set, which no
+other test does, so the drawing code is otherwise never executed. The
+assertions target what the helpers are for: producing a side-by-side image
+that splits region clusters from the rest, written where the debug settings
+point.
+"""
+
+from pathlib import Path
+
+import pytest
+from docling_core.types.doc import BoundingBox, CoordOrigin, DocItemLabel, Size
+from docling_core.types.doc.page import BoundingRectangle, TextCell
+from PIL import Image
+
+from docling.datamodel.base_models import Cluster, Page
+from docling.datamodel.settings import settings
+from docling.utils.visualization import (
+    draw_clusters,
+    draw_clusters_and_cells_side_by_side,
+)
+
+PAGE_WIDTH = 120
+PAGE_HEIGHT = 80
+
+
+def _cell(x0: float, y0: float, x1: float, y1: float, text: str = "cell") -> TextCell:
+    return TextCell(
+        index=0,
+        text=text,
+        orig=text,
+        from_ocr=False,
+        rect=BoundingRectangle.from_bounding_box(
+            BoundingBox(l=x0, t=y0, r=x1, b=y1, coord_origin=CoordOrigin.TOPLEFT)
+        ),
+    )
+
+
+def _cluster(
+    cluster_id: int,
+    label: DocItemLabel,
+    bbox: tuple[float, float, float, float] = (10, 10, 60, 40),
+    confidence: float = 0.9,
+    cells: list[TextCell] | None = None,
+    children: list[Cluster] | None = None,
+) -> Cluster:
+    x0, y0, x1, y1 = bbox
+    return Cluster(
+        id=cluster_id,
+        label=label,
+        bbox=BoundingBox(l=x0, t=y0, r=x1, b=y1, coord_origin=CoordOrigin.TOPLEFT),
+        confidence=confidence,
+        cells=cells or [],
+        children=children or [],
+    )
+
+
+def _page_with_image() -> Page:
+    page = Page(page_no=0, size=Size(width=PAGE_WIDTH, height=PAGE_HEIGHT))
+    image = Image.new("RGB", (PAGE_WIDTH, PAGE_HEIGHT), color=(255, 255, 255))
+    page._image_cache = {1.0: image}
+    return page
+
+
+def test_draw_clusters_marks_the_cluster_area():
+    image = Image.new("RGB", (PAGE_WIDTH, PAGE_HEIGHT), color=(255, 255, 255))
+    before = image.copy()
+
+    draw_clusters(image, [_cluster(1, DocItemLabel.TEXT)], scale_x=1.0, scale_y=1.0)
+
+    assert image.tobytes() != before.tobytes()
+    # A pixel well inside the cluster is tinted; one outside is untouched.
+    assert image.getpixel((40, 30)) != (255, 255, 255)
+    assert image.getpixel((110, 75)) == (255, 255, 255)
+
+
+def test_draw_clusters_on_an_empty_list_leaves_the_image_untouched():
+    image = Image.new("RGB", (PAGE_WIDTH, PAGE_HEIGHT), color=(255, 255, 255))
+    before = image.copy()
+
+    draw_clusters(image, [], scale_x=1.0, scale_y=1.0)
+
+    assert image.tobytes() == before.tobytes()
+
+
+def test_draw_clusters_renders_children_and_cells():
+    child = _cluster(2, DocItemLabel.LIST_ITEM, bbox=(70, 50, 110, 70))
+    parent = _cluster(
+        1,
+        DocItemLabel.TEXT,
+        cells=[_cell(12, 12, 55, 20)],
+        children=[child],
+    )
+    image = Image.new("RGB", (PAGE_WIDTH, PAGE_HEIGHT), color=(255, 255, 255))
+
+    draw_clusters(image, [parent], scale_x=1.0, scale_y=1.0)
+
+    # The child cluster sits outside the parent box and must also be drawn.
+    assert image.getpixel((90, 60)) != (255, 255, 255)
+
+
+def test_draw_clusters_normalises_inverted_boxes():
+    """A box given bottom-right first must still be drawn, not skipped."""
+    inverted = _cluster(1, DocItemLabel.TEXT, bbox=(60, 40, 10, 10))
+    image = Image.new("RGB", (PAGE_WIDTH, PAGE_HEIGHT), color=(255, 255, 255))
+
+    draw_clusters(image, [inverted], scale_x=1.0, scale_y=1.0)
+
+    assert image.getpixel((40, 30)) != (255, 255, 255)
+
+
+def test_draw_clusters_applies_the_scale_factors():
+    image = Image.new("RGB", (PAGE_WIDTH, PAGE_HEIGHT), color=(255, 255, 255))
+    # At half scale the same cluster covers a quarter of the area, so a point
+    # inside the unscaled box falls outside the scaled one.
+    draw_clusters(image, [_cluster(1, DocItemLabel.TEXT)], scale_x=0.5, scale_y=0.5)
+
+    assert image.getpixel((15, 15)) != (255, 255, 255)
+    assert image.getpixel((50, 35)) == (255, 255, 255)
+
+
+@pytest.fixture
+def debug_output_dir(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(settings.debug, "debug_output_path", str(tmp_path))
+    return tmp_path
+
+
+def test_side_by_side_writes_a_double_width_image(debug_output_dir):
+    page = _page_with_image()
+
+    draw_clusters_and_cells_side_by_side(
+        input_file=Path("report.pdf"),
+        page=page,
+        clusters=[_cluster(1, DocItemLabel.TEXT)],
+        mode_prefix="postprocessed",
+    )
+
+    out_file = debug_output_dir / "debug_report" / "postprocessed_layout_page_00000.png"
+    assert out_file.exists()
+    with Image.open(out_file) as written:
+        assert written.size == (PAGE_WIDTH * 2, PAGE_HEIGHT)
+
+
+def test_side_by_side_splits_region_labels_onto_the_right_half(debug_output_dir):
+    """FORM, KEY_VALUE_REGION and PICTURE go right; everything else goes left."""
+    page = _page_with_image()
+
+    draw_clusters_and_cells_side_by_side(
+        input_file=Path("report.pdf"),
+        page=page,
+        clusters=[
+            _cluster(1, DocItemLabel.TEXT, bbox=(10, 10, 50, 30)),
+            _cluster(2, DocItemLabel.PICTURE, bbox=(10, 10, 50, 30)),
+        ],
+        mode_prefix="raw",
+    )
+
+    out_file = debug_output_dir / "debug_report" / "raw_layout_page_00000.png"
+    with Image.open(out_file) as written:
+        left = written.crop((0, 0, PAGE_WIDTH, PAGE_HEIGHT))
+        right = written.crop((PAGE_WIDTH, 0, PAGE_WIDTH * 2, PAGE_HEIGHT))
+        # Both halves are drawn on, but with different label colours.
+        assert left.getpixel((30, 20)) != (255, 255, 255)
+        assert right.getpixel((30, 20)) != (255, 255, 255)
+        assert left.getpixel((30, 20)) != right.getpixel((30, 20))
+
+
+def test_side_by_side_names_the_file_after_the_page_number(debug_output_dir):
+    page = _page_with_image()
+    page.page_no = 12
+
+    draw_clusters_and_cells_side_by_side(
+        input_file=Path("nested/dir/report.pdf"),
+        page=page,
+        clusters=[],
+        mode_prefix="raw",
+    )
+
+    # The directory is derived from the file stem, dropping any parent path.
+    assert (debug_output_dir / "debug_report" / "raw_layout_page_00012.png").exists()
+
+
+def test_side_by_side_reuses_an_existing_debug_directory(debug_output_dir):
+    page = _page_with_image()
+    out_dir = debug_output_dir / "debug_report"
+    out_dir.mkdir(parents=True)
+    (out_dir / "sentinel.txt").write_text("kept")
+
+    draw_clusters_and_cells_side_by_side(
+        input_file=Path("report.pdf"),
+        page=page,
+        clusters=[],
+        mode_prefix="raw",
+    )
+
+    assert (out_dir / "sentinel.txt").read_text() == "kept"
+    assert (out_dir / "raw_layout_page_00000.png").exists()
+
+
+def test_side_by_side_show_mode_does_not_write_a_file(
+    debug_output_dir, monkeypatch: pytest.MonkeyPatch
+):
+    page = _page_with_image()
+    shown: list[Image.Image] = []
+    monkeypatch.setattr(
+        Image.Image, "show", lambda self, *args, **kwargs: shown.append(self)
+    )
+
+    draw_clusters_and_cells_side_by_side(
+        input_file=Path("report.pdf"),
+        page=page,
+        clusters=[],
+        mode_prefix="raw",
+        show=True,
+    )
+
+    assert len(shown) == 1
+    assert not (debug_output_dir / "debug_report").exists()


### PR DESCRIPTION
Second iteration of the coverage work started in #4044. Targets three modules that had no test reaching them at all, and fixes one bug the new tests surfaced.

## Coverage

Measured in the core lane with `--cov-branch`:

| module | line | branch |
|---|---|---|
| `utils/visualization.py` | 12.7% → **100%** | → **100%** |
| `utils/profiling.py` | 37.4% → **99.2%** | → **97.2%** |
| `cli/models.py` | never imported → **88.0%** | → **96.2%** |
| `cli/tools.py` | 0% → 39.1% | → 50% |

`cli/tools.py` cannot go much higher: 14 of its 21 statements are an `ImportError` fallback that only runs when `typer` is absent, which never happens in CI.

## Why these were dark

- `utils/profiling.py` and `utils/visualization.py` sit behind `settings.debug.*` flags that default to `False`, and no test enables them.
- `docling-tools` (`cli/tools.py` → `cli/models.py`) was never imported by any test in the core lane.

## The fix

`docling-tools models download-hf-repo --quiet` printed a per-repo progress line even though `--quiet` documents "no extra output is generated, the CLI prints only the directory with the cached models". The sibling `download` command already behaved correctly, so quiet output could not be consumed as a plain path.

## Approach

The CLI tests replace the downloader entry points with recorders and assert **which model selection the CLI derives from a given set of flags** — the option-plumbing contract — rather than asserting on the calls themselves. No model is downloaded.

The visualization tests render synthetic clusters onto a real page image and assert on resulting pixels, the region-label split between the two halves, scale factors, inverted-box normalisation, and the debug output paths. The profiling tests drive the `TimeIntervalRecorder` state machine and its error paths in both the enabled and disabled states.

## Notes

- Two commits: the `fix:` ships via semantic-release, the `test:` commit does not.
- No `pyproject.toml` or `uv.lock` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)