### PR TITLE
fix: improve handling landscape conteint in portrait PDFs in layout postprocessor

### DIFF
--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -189,6 +189,12 @@ class LayoutPostprocessor:
         DocItemLabel.DOCUMENT_INDEX: 0.45,
     }
 
+    CONTENT_CONTAINER_MIN_PAGE_WIDTH_RATIO = 0.8
+    CONTENT_CONTAINER_MIN_NATIVE_TEXT_CHARS = 200
+    CONTENT_CONTAINER_MIN_NATIVE_TEXT_RATIO = 0.8
+    CONTENT_CONTAINER_PICTURE_CONTAINMENT_THRESHOLD = 0.8
+    CONTENT_CONTAINER_MAX_NESTED_PICTURE_AREA_RATIO = 0.8
+
     LABEL_REMAPPING = {
         # DocItemLabel.DOCUMENT_INDEX: DocItemLabel.TABLE,
         DocItemLabel.TITLE: DocItemLabel.SECTION_HEADER,
@@ -321,6 +327,7 @@ class LayoutPostprocessor:
         ]
 
         special_clusters = self._handle_cross_type_overlaps(special_clusters)
+        special_clusters = self._remove_content_container_pictures(special_clusters)
 
         # Calculate page area from known page size
         assert self.page_size is not None
@@ -382,6 +389,75 @@ class LayoutPostprocessor:
         )
 
         return picture_clusters + wrapper_clusters
+
+    def _remove_content_container_pictures(
+        self, special_clusters: list[Cluster]
+    ) -> list[Cluster]:
+        """Remove broad picture proposals that represent embedded page content.
+
+        Layout models can label a landscape slide embedded in a portrait PDF as one
+        large picture, even when the PDF contains native text and smaller picture
+        proposals inside it. Keeping that outer proposal makes the native text its
+        children and collapses the nested pictures during picture de-overlap.
+        """
+        if self.page_size is None or self.page_size.width <= 0:
+            return special_clusters
+
+        if self.page_size.height <= self.page_size.width:
+            return special_clusters
+
+        native_cells = [
+            cell
+            for cell in self.cells
+            if not cell.from_ocr and len(cell.text.strip()) > 0
+        ]
+        total_native_text_chars = sum(len(cell.text.strip()) for cell in native_cells)
+        if total_native_text_chars < self.CONTENT_CONTAINER_MIN_NATIVE_TEXT_CHARS:
+            return special_clusters
+
+        pictures = [
+            cluster
+            for cluster in special_clusters
+            if cluster.label == DocItemLabel.PICTURE and cluster.bbox.area() > 0
+        ]
+        picture_ids_to_remove: set[int] = set()
+
+        for picture in pictures:
+            if picture.bbox.width <= picture.bbox.height:
+                continue
+            if (
+                picture.bbox.width / self.page_size.width
+                < self.CONTENT_CONTAINER_MIN_PAGE_WIDTH_RATIO
+            ):
+                continue
+
+            contains_nested_picture = any(
+                nested.id != picture.id
+                and nested.bbox.area() / picture.bbox.area()
+                < self.CONTENT_CONTAINER_MAX_NESTED_PICTURE_AREA_RATIO
+                and nested.bbox.intersection_over_self(picture.bbox)
+                > self.CONTENT_CONTAINER_PICTURE_CONTAINMENT_THRESHOLD
+                for nested in pictures
+            )
+            if not contains_nested_picture:
+                continue
+
+            contained_native_text_chars = sum(
+                len(cell.text.strip())
+                for cell in native_cells
+                if cell.to_bounding_box().intersection_over_self(picture.bbox) > 0.8
+            )
+            if (
+                contained_native_text_chars / total_native_text_chars
+                >= self.CONTENT_CONTAINER_MIN_NATIVE_TEXT_RATIO
+            ):
+                picture_ids_to_remove.add(picture.id)
+
+        return [
+            cluster
+            for cluster in special_clusters
+            if cluster.id not in picture_ids_to_remove
+        ]
 
     def _handle_cross_type_overlaps(self, special_clusters) -> list[Cluster]:
         """Handle overlaps between regular and wrapper clusters before child assignment.

--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -189,12 +189,6 @@ class LayoutPostprocessor:
         DocItemLabel.DOCUMENT_INDEX: 0.45,
     }
 
-    CONTENT_CONTAINER_MIN_PAGE_WIDTH_RATIO = 0.8
-    CONTENT_CONTAINER_MIN_NATIVE_TEXT_CHARS = 200
-    CONTENT_CONTAINER_MIN_NATIVE_TEXT_RATIO = 0.8
-    CONTENT_CONTAINER_PICTURE_CONTAINMENT_THRESHOLD = 0.8
-    CONTENT_CONTAINER_MAX_NESTED_PICTURE_AREA_RATIO = 0.8
-
     LABEL_REMAPPING = {
         # DocItemLabel.DOCUMENT_INDEX: DocItemLabel.TABLE,
         DocItemLabel.TITLE: DocItemLabel.SECTION_HEADER,
@@ -327,21 +321,7 @@ class LayoutPostprocessor:
         ]
 
         special_clusters = self._handle_cross_type_overlaps(special_clusters)
-        special_clusters = self._remove_content_container_pictures(special_clusters)
-
-        # Calculate page area from known page size
-        assert self.page_size is not None
-        page_area = self.page_size.width * self.page_size.height
-        if page_area > 0:
-            # Filter out full-page pictures
-            special_clusters = [
-                cluster
-                for cluster in special_clusters
-                if not (
-                    cluster.label == DocItemLabel.PICTURE
-                    and cluster.bbox.area() / page_area > 0.90
-                )
-            ]
+        special_clusters = self._remove_wrapper_pictures(special_clusters)
 
         for special in special_clusters:
             contained = []
@@ -390,73 +370,49 @@ class LayoutPostprocessor:
 
         return picture_clusters + wrapper_clusters
 
-    def _remove_content_container_pictures(
+    def _remove_wrapper_pictures(
         self, special_clusters: list[Cluster]
     ) -> list[Cluster]:
-        """Remove broad picture proposals that represent embedded page content.
+        """Remove pictures that wrap the complete detected content region.
 
-        Layout models can label a landscape slide embedded in a portrait PDF as one
-        large picture, even when the PDF contains native text and smaller picture
-        proposals inside it. Keeping that outer proposal makes the native text its
-        children and collapses the nested pictures during picture de-overlap.
+        A wrapper must enclose geometrically distinct content, so a lone picture or
+        coincident duplicate picture proposals are preserved.
         """
-        if self.page_size is None or self.page_size.width <= 0:
-            return special_clusters
-
-        if self.page_size.height <= self.page_size.width:
-            return special_clusters
-
-        native_cells = [
-            cell
-            for cell in self.cells
-            if not cell.from_ocr and len(cell.text.strip()) > 0
-        ]
-        total_native_text_chars = sum(len(cell.text.strip()) for cell in native_cells)
-        if total_native_text_chars < self.CONTENT_CONTAINER_MIN_NATIVE_TEXT_CHARS:
-            return special_clusters
-
-        pictures = [
+        content_clusters = [
             cluster
-            for cluster in special_clusters
-            if cluster.label == DocItemLabel.PICTURE and cluster.bbox.area() > 0
+            for cluster in self.regular_clusters + special_clusters
+            if cluster.bbox.area() > 0
         ]
-        picture_ids_to_remove: set[int] = set()
+        if len(content_clusters) <= 1:
+            return special_clusters
 
-        for picture in pictures:
-            if picture.bbox.width <= picture.bbox.height:
+        content_bbox = BoundingBox(
+            l=min(cluster.bbox.l for cluster in content_clusters),
+            t=min(cluster.bbox.t for cluster in content_clusters),
+            r=max(cluster.bbox.r for cluster in content_clusters),
+            b=max(cluster.bbox.b for cluster in content_clusters),
+        )
+        content_bbox_tuple = content_bbox.as_tuple()
+        wrapper_picture_ids: set[int] = set()
+
+        for picture in special_clusters:
+            if picture.label != DocItemLabel.PICTURE:
                 continue
-            if (
-                picture.bbox.width / self.page_size.width
-                < self.CONTENT_CONTAINER_MIN_PAGE_WIDTH_RATIO
-            ):
+            if picture.bbox.as_tuple() != content_bbox_tuple:
                 continue
 
-            contains_nested_picture = any(
-                nested.id != picture.id
-                and nested.bbox.area() / picture.bbox.area()
-                < self.CONTENT_CONTAINER_MAX_NESTED_PICTURE_AREA_RATIO
-                and nested.bbox.intersection_over_self(picture.bbox)
-                > self.CONTENT_CONTAINER_PICTURE_CONTAINMENT_THRESHOLD
-                for nested in pictures
+            has_distinct_content = any(
+                cluster.id != picture.id
+                and cluster.bbox.as_tuple() != picture.bbox.as_tuple()
+                for cluster in content_clusters
             )
-            if not contains_nested_picture:
-                continue
-
-            contained_native_text_chars = sum(
-                len(cell.text.strip())
-                for cell in native_cells
-                if cell.to_bounding_box().intersection_over_self(picture.bbox) > 0.8
-            )
-            if (
-                contained_native_text_chars / total_native_text_chars
-                >= self.CONTENT_CONTAINER_MIN_NATIVE_TEXT_RATIO
-            ):
-                picture_ids_to_remove.add(picture.id)
+            if has_distinct_content:
+                wrapper_picture_ids.add(picture.id)
 
         return [
             cluster
             for cluster in special_clusters
-            if cluster.id not in picture_ids_to_remove
+            if cluster.id not in wrapper_picture_ids
         ]
 
     def _handle_cross_type_overlaps(self, special_clusters) -> list[Cluster]:

--- a/tests/test_layout_postprocessor.py
+++ b/tests/test_layout_postprocessor.py
@@ -1,4 +1,4 @@
-from docling_core.types.doc import CoordOrigin, DocItemLabel, Size
+from docling_core.types.doc import DocItemLabel, Size
 from docling_core.types.doc.page import BoundingRectangle, TextCell
 
 from docling.datamodel.base_models import BoundingBox, Cluster
@@ -18,42 +18,33 @@ def _cluster(
     )
 
 
-def _text_cell(
-    index: int,
-    bbox: tuple[float, float, float, float] = (0, 0, 1, 1),
-    text: str | None = None,
-    *,
-    from_ocr: bool = False,
-) -> TextCell:
-    left, top, right, bottom = bbox
-    cell_text = str(index) if text is None else text
+def _text_cell(index: int) -> TextCell:
     return TextCell(
         index=index,
         rect=BoundingRectangle(
-            r_x0=left,
-            r_y0=top,
-            r_x1=right,
-            r_y1=top,
-            r_x2=right,
-            r_y2=bottom,
-            r_x3=left,
-            r_y3=bottom,
-            coord_origin=CoordOrigin.TOPLEFT,
+            r_x0=0,
+            r_y0=0,
+            r_x1=1,
+            r_y1=0,
+            r_x2=1,
+            r_y2=1,
+            r_x3=0,
+            r_y3=1,
         ),
-        text=cell_text,
-        orig=cell_text,
-        from_ocr=from_ocr,
+        text=str(index),
+        orig=str(index),
+        from_ocr=False,
     )
 
 
 def _special_cluster_processor(
-    pictures: list[Cluster], cells: list[TextCell]
+    pictures: list[Cluster], regular_clusters: list[Cluster]
 ) -> LayoutPostprocessor:
     processor = object.__new__(LayoutPostprocessor)
     processor.page_size = Size(width=600, height=800)
-    processor.cells = cells
+    processor.cells = []
     processor.special_clusters = pictures
-    processor.regular_clusters = []
+    processor.regular_clusters = regular_clusters
     processor.options = LayoutPostprocessorOptions(skip_cell_assignment=True)
     processor.picture_index = SpatialClusterIndex(pictures)
     processor.wrapper_index = SpatialClusterIndex([])
@@ -115,38 +106,42 @@ def test_cross_type_overlaps_keeps_small_picture_inside_table() -> None:
     assert ids == {1, 2}
 
 
-def test_embedded_slide_container_is_removed_before_picture_deoverlap() -> None:
+def test_content_union_removes_wrapper_picture_before_deoverlap() -> None:
     outer_slide = _cluster(1, DocItemLabel.PICTURE, (10, 200, 590, 525))
     nested_chart = _cluster(2, DocItemLabel.PICTURE, (300, 250, 570, 500))
-    native_cells = [
-        _text_cell(
-            index,
-            (30, 230 + index * 30, 280, 250 + index * 30),
-            "machine-readable slide text " * 4,
-        )
-        for index in range(3)
-    ]
-    processor = _special_cluster_processor([outer_slide, nested_chart], native_cells)
+    slide_text = _cluster(3, DocItemLabel.TEXT, (30, 230, 280, 320))
+    processor = _special_cluster_processor([outer_slide, nested_chart], [slide_text])
 
     result = processor._process_special_clusters()
 
     assert [cluster.id for cluster in result] == [nested_chart.id]
 
 
-def test_embedded_slide_container_is_kept_for_ocr_only_content() -> None:
-    outer_slide = _cluster(1, DocItemLabel.PICTURE, (10, 200, 590, 525))
-    nested_chart = _cluster(2, DocItemLabel.PICTURE, (300, 250, 570, 500))
-    ocr_cells = [
-        _text_cell(
-            index,
-            (30, 230 + index * 30, 280, 250 + index * 30),
-            "text recognized from a raster image " * 4,
-            from_ocr=True,
-        )
-        for index in range(3)
-    ]
-    processor = _special_cluster_processor([outer_slide, nested_chart], ocr_cells)
+def test_content_union_keeps_lone_picture() -> None:
+    lone_picture = _cluster(1, DocItemLabel.PICTURE, (0, 0, 600, 800))
+    processor = _special_cluster_processor([lone_picture], [])
 
     result = processor._process_special_clusters()
 
-    assert [cluster.id for cluster in result] == [outer_slide.id]
+    assert [cluster.id for cluster in result] == [lone_picture.id]
+
+
+def test_content_union_keeps_picture_with_external_caption() -> None:
+    picture = _cluster(1, DocItemLabel.PICTURE, (10, 10, 400, 400))
+    caption = _cluster(2, DocItemLabel.CAPTION, (10, 420, 400, 450))
+    processor = _special_cluster_processor([picture], [caption])
+
+    result = processor._process_special_clusters()
+
+    assert [cluster.id for cluster in result] == [picture.id]
+
+
+def test_content_union_keeps_duplicate_lone_picture_proposals() -> None:
+    first_picture = _cluster(1, DocItemLabel.PICTURE, (10, 10, 400, 400))
+    duplicate_picture = _cluster(2, DocItemLabel.PICTURE, (10, 10, 400, 400))
+    processor = _special_cluster_processor([first_picture, duplicate_picture], [])
+
+    result = processor._process_special_clusters()
+
+    assert len(result) == 1
+    assert result[0].label == DocItemLabel.PICTURE

--- a/tests/test_layout_postprocessor.py
+++ b/tests/test_layout_postprocessor.py
@@ -1,8 +1,9 @@
-from docling_core.types.doc import DocItemLabel
+from docling_core.types.doc import CoordOrigin, DocItemLabel, Size
 from docling_core.types.doc.page import BoundingRectangle, TextCell
 
 from docling.datamodel.base_models import BoundingBox, Cluster
-from docling.utils.layout_postprocessor import LayoutPostprocessor
+from docling.datamodel.pipeline_options import LayoutPostprocessorOptions
+from docling.utils.layout_postprocessor import LayoutPostprocessor, SpatialClusterIndex
 
 
 def _cluster(
@@ -17,23 +18,46 @@ def _cluster(
     )
 
 
-def _text_cell(index: int) -> TextCell:
+def _text_cell(
+    index: int,
+    bbox: tuple[float, float, float, float] = (0, 0, 1, 1),
+    text: str | None = None,
+    *,
+    from_ocr: bool = False,
+) -> TextCell:
+    left, top, right, bottom = bbox
+    cell_text = str(index) if text is None else text
     return TextCell(
         index=index,
         rect=BoundingRectangle(
-            r_x0=0,
-            r_y0=0,
-            r_x1=1,
-            r_y1=0,
-            r_x2=1,
-            r_y2=1,
-            r_x3=0,
-            r_y3=1,
+            r_x0=left,
+            r_y0=top,
+            r_x1=right,
+            r_y1=top,
+            r_x2=right,
+            r_y2=bottom,
+            r_x3=left,
+            r_y3=bottom,
+            coord_origin=CoordOrigin.TOPLEFT,
         ),
-        text=str(index),
-        orig=str(index),
-        from_ocr=False,
+        text=cell_text,
+        orig=cell_text,
+        from_ocr=from_ocr,
     )
+
+
+def _special_cluster_processor(
+    pictures: list[Cluster], cells: list[TextCell]
+) -> LayoutPostprocessor:
+    processor = object.__new__(LayoutPostprocessor)
+    processor.page_size = Size(width=600, height=800)
+    processor.cells = cells
+    processor.special_clusters = pictures
+    processor.regular_clusters = []
+    processor.options = LayoutPostprocessorOptions(skip_cell_assignment=True)
+    processor.picture_index = SpatialClusterIndex(pictures)
+    processor.wrapper_index = SpatialClusterIndex([])
+    return processor
 
 
 def test_sort_cells_uses_native_cell_index_order() -> None:
@@ -89,3 +113,40 @@ def test_cross_type_overlaps_keeps_small_picture_inside_table() -> None:
 
     ids = {c.id for c in result}
     assert ids == {1, 2}
+
+
+def test_embedded_slide_container_is_removed_before_picture_deoverlap() -> None:
+    outer_slide = _cluster(1, DocItemLabel.PICTURE, (10, 200, 590, 525))
+    nested_chart = _cluster(2, DocItemLabel.PICTURE, (300, 250, 570, 500))
+    native_cells = [
+        _text_cell(
+            index,
+            (30, 230 + index * 30, 280, 250 + index * 30),
+            "machine-readable slide text " * 4,
+        )
+        for index in range(3)
+    ]
+    processor = _special_cluster_processor([outer_slide, nested_chart], native_cells)
+
+    result = processor._process_special_clusters()
+
+    assert [cluster.id for cluster in result] == [nested_chart.id]
+
+
+def test_embedded_slide_container_is_kept_for_ocr_only_content() -> None:
+    outer_slide = _cluster(1, DocItemLabel.PICTURE, (10, 200, 590, 525))
+    nested_chart = _cluster(2, DocItemLabel.PICTURE, (300, 250, 570, 500))
+    ocr_cells = [
+        _text_cell(
+            index,
+            (30, 230 + index * 30, 280, 250 + index * 30),
+            "text recognized from a raster image " * 4,
+            from_ocr=True,
+        )
+        for index in range(3)
+    ]
+    processor = _special_cluster_processor([outer_slide, nested_chart], ocr_cells)
+
+    result = processor._process_special_clusters()
+
+    assert [cluster.id for cluster in result] == [outer_slide.id]


### PR DESCRIPTION
Landscape content inside a portrait PDF gets parsed as one image. This makes it so that if VLM is enabled, it gets sent the entire rasterized image instead of the internal images for description even when most of the content is machine readable text.

Tested so that landscape content in a portrait pdf now results in the same output as landscape content in landscape PDF.

- [ x ] Tests have been added, if necessary.
