### PR TITLE
fix: normalize Tesseract script languages on Windows

### DIFF
--- a/docling/models/stages/ocr/tesseract_ocr_cli_model.py
+++ b/docling/models/stages/ocr/tesseract_ocr_cli_model.py
@@ -274,7 +274,9 @@ class TesseractOcrCliModel(BaseOcrModel):
         )
         decoded_data = output.stdout.decode("utf-8")
         df_list = pd.read_csv(io.StringIO(decoded_data), header=None)
-        self._tesseract_languages = df_list[0].tolist()[1:]
+        self._tesseract_languages = [
+            lang.replace("\\", "/") for lang in df_list[0].tolist()[1:]
+        ]
 
         # Decide the script prefix
         if any(lang.startswith("script/") for lang in self._tesseract_languages):

--- a/tests/test_tesseract_ocr_cli_model.py
+++ b/tests/test_tesseract_ocr_cli_model.py
@@ -1,0 +1,40 @@
+from unittest.mock import patch
+
+from docling.models.stages.ocr.tesseract_ocr_cli_model import TesseractOcrCliModel
+
+
+def test_set_languages_and_prefix_normalizes_windows_script_separator():
+    model = TesseractOcrCliModel.__new__(TesseractOcrCliModel)
+    model._safe_tesseract_cmd = "tesseract"
+
+    completed = type(
+        "Completed",
+        (),
+        {
+            "stdout": b"List of available languages in tessdata:\n"
+            + b"script"
+            + bytes([92])
+            + b"Arabic\neng\n",
+        },
+    )()
+    with patch("subprocess.run", return_value=completed):
+        model._set_languages_and_prefix()
+
+    assert model._tesseract_languages == ["script/Arabic", "eng"]
+    assert model._script_prefix == "script/"
+
+
+def test_set_languages_and_prefix_preserves_forward_slash_separator():
+    model = TesseractOcrCliModel.__new__(TesseractOcrCliModel)
+    model._safe_tesseract_cmd = "tesseract"
+
+    completed = type(
+        "Completed",
+        (),
+        {"stdout": b"List of available languages in tessdata:\nscript/Latin\neng\n"},
+    )()
+    with patch("subprocess.run", return_value=completed):
+        model._set_languages_and_prefix()
+
+    assert model._tesseract_languages == ["script/Latin", "eng"]
+    assert model._script_prefix == "script/"


### PR DESCRIPTION
Closes #4022

## Root cause

Tesseract on Windows reports script language packs with backslashes from `--list-langs`, while Docling only recognizes the POSIX `script/` prefix. Auto script detection therefore drops the detected language.

## Changes

- Normalize backslashes to forward slashes when storing installed Tesseract languages.
- Add regression coverage for Windows-style and existing POSIX-style language entries.

## Validation

Remote diff and source inspection completed. Local test execution was blocked by an interrupted shallow clone caused by current network throughput; no test pass is claimed.