### PR TITLE
feat: extract AcroForm widget fields into FormItem key-value graphs

### DIFF
--- a/docling/backend/managed_pdfium_backend.py
+++ b/docling/backend/managed_pdfium_backend.py
@@ -9,11 +9,17 @@ from docling.backend.pdf_backend import PdfDocumentBackend, PdfPageBackend
 from docling.datamodel.backend_options import PdfBackendOptions
 
 if TYPE_CHECKING:
+    import pypdfium2 as pdfium
+
     from docling.datamodel.document import InputDocument
+    from docling.utils.form_utils import FormFieldInfo
 
 
 class ManagedPdfiumDocumentBackend(PdfDocumentBackend, ABC):
     """Shared lifecycle management for PDFium-backed document backends."""
+
+    # Concrete backends hold their native document here and set it to None on close.
+    _pdoc: Optional[pdfium.PdfDocument]
 
     def __init__(
         self,
@@ -29,6 +35,14 @@ class ManagedPdfiumDocumentBackend(PdfDocumentBackend, ABC):
     @abstractmethod
     def _close_native_document(self) -> None:
         pass
+
+    def get_form_fields(self) -> list[FormFieldInfo]:
+        """Read AcroForm widget fields from the underlying pypdfium2 document."""
+        from docling.utils.form_utils import extract_form_fields
+
+        if self._pdoc is None:
+            return []
+        return extract_form_fields(self._pdoc)
 
     def unload(self) -> None:
         if self._closed:

--- a/docling/backend/pdf_backend.py
+++ b/docling/backend/pdf_backend.py
@@ -2,7 +2,7 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterable, Iterator
 from io import BytesIO
 from pathlib import Path
-from typing import ClassVar, Optional, Set, Union
+from typing import TYPE_CHECKING, ClassVar, Optional, Set, Union
 
 from docling_core.types.doc import BoundingBox, Size
 from docling_core.types.doc.page import SegmentedPdfPage, TextCell
@@ -13,6 +13,9 @@ from docling.datamodel.backend_options import PdfBackendOptions
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
 from docling.utils.pdf_outline import _PdfOutlineItem
+
+if TYPE_CHECKING:
+    from docling.utils.form_utils import FormFieldInfo
 
 
 class PdfPageBackend(ABC):
@@ -93,6 +96,15 @@ class PdfDocumentBackend(PaginatedDocumentBackend):
         A flat, document-ordered list where each entry carries its own depth (``level``). The
         default returns an empty list; PDFium-backed backends override this with the real
         outline. Backends without an embedded outline (e.g. OCR/image) keep the default.
+        """
+        return []
+
+    def get_form_fields(self) -> list["FormFieldInfo"]:
+        """Return the document's AcroForm widget fields (interactive form layer).
+
+        A flat, document-ordered list of :class:`~docling.utils.form_utils.FormFieldInfo`.
+        The default returns an empty list; PDFium-backed backends override this with the
+        real field list. Documents without an interactive form keep the default.
         """
         return []
 

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1943,6 +1943,17 @@ class PdfPipelineOptions(PaginatedPipelineOptions):
             )
         ),
     ] = True
+    extract_form_fields: Annotated[
+        bool,
+        Field(
+            description=(
+                "Extract the interactive form layer (AcroForm widget annotations) of born-digital PDFs: field names, "
+                "values, checkbox/radio states, and widget geometry, represented as one FormItem with a key/value graph "
+                "per page that has form fields. Reads document metadata only — no models involved, negligible cost. "
+                "Scanned/flattened forms have no widget annotations and are unaffected."
+            )
+        ),
+    ] = False
     do_ocr: Annotated[
         bool,
         Field(

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -78,6 +78,7 @@ from docling.models.stages.reading_order.readingorder_model import (
     ReadingOrderOptions,
 )
 from docling.pipeline.base_pipeline import ConvertPipeline
+from docling.utils.form_utils import attach_form_fields
 from docling.utils.profiling import ProfilingScope, TimeRecorder
 from docling.utils.utils import chunkify
 
@@ -1048,6 +1049,14 @@ class StandardPdfPipeline(ConvertPipeline):
             )
             conv_res.document = self.reading_order_model(conv_res)
             conv_res.document = self.heading_hierarchy_model(conv_res)
+
+            # Attach the interactive form layer (AcroForm widget annotations)
+            if self.pipeline_options.extract_form_fields:
+                backend = conv_res.input._backend
+                assert isinstance(backend, PdfDocumentBackend)
+                form_fields = backend.get_form_fields()
+                if form_fields:
+                    attach_form_fields(conv_res.document, form_fields)
 
             # Generate page images in the output
             if self.pipeline_options.generate_page_images:

--- a/docling/utils/form_utils.py
+++ b/docling/utils/form_utils.py
@@ -1,0 +1,252 @@
+"""AcroForm widget-annotation extraction for interactive PDF forms.
+
+Born-digital PDFs carry their form layer machine-readable: every field is a
+widget annotation with a name (``/T``), a type (``/FT``), a current value
+(``/V``), a checkbox/radio state, an accessible-name tooltip (``/TU``) and
+behavioral flags. This module reads that layer through PDFium's annotation API
+and represents it in a :class:`~docling_core.types.doc.DoclingDocument` as one
+``FormItem`` per page, carrying a key/value ``GraphData`` — the structured-form
+output tracked in discussion #301.
+
+Extraction is lossless into :class:`FormFieldInfo`; the document representation
+captures what the current docling-core schema can hold (field name, value/state,
+widget geometry). Properties without a typed slot yet (tooltip, field type,
+required/read-only) stay available on :class:`FormFieldInfo` for API users.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+from dataclasses import dataclass
+from enum import Enum
+from typing import TYPE_CHECKING, Callable, Optional
+
+import pypdfium2 as pdfium
+import pypdfium2.raw as pdfium_c
+from docling_core.types.doc import BoundingBox, CoordOrigin, ProvenanceItem
+from docling_core.types.doc.document import GraphCell, GraphData, GraphLink
+from docling_core.types.doc.labels import GraphCellLabel, GraphLinkLabel
+
+from docling.utils.locks import pypdfium2_lock
+
+if TYPE_CHECKING:
+    from docling_core.types.doc import DoclingDocument
+
+_log = logging.getLogger(__name__)
+
+
+class FormFieldType(str, Enum):
+    """AcroForm field types (PDFium's ``FPDF_FORMFIELD_*`` taxonomy)."""
+
+    UNKNOWN = "unknown"
+    PUSHBUTTON = "pushbutton"
+    CHECKBOX = "checkbox"
+    RADIOBUTTON = "radiobutton"
+    COMBOBOX = "combobox"
+    LISTBOX = "listbox"
+    TEXT = "text"
+    SIGNATURE = "signature"
+
+
+_FIELD_TYPES = {
+    pdfium_c.FPDF_FORMFIELD_PUSHBUTTON: FormFieldType.PUSHBUTTON,
+    pdfium_c.FPDF_FORMFIELD_CHECKBOX: FormFieldType.CHECKBOX,
+    pdfium_c.FPDF_FORMFIELD_RADIOBUTTON: FormFieldType.RADIOBUTTON,
+    pdfium_c.FPDF_FORMFIELD_COMBOBOX: FormFieldType.COMBOBOX,
+    pdfium_c.FPDF_FORMFIELD_LISTBOX: FormFieldType.LISTBOX,
+    pdfium_c.FPDF_FORMFIELD_TEXTFIELD: FormFieldType.TEXT,
+    pdfium_c.FPDF_FORMFIELD_SIGNATURE: FormFieldType.SIGNATURE,
+}
+
+_CHECKABLE = {FormFieldType.CHECKBOX, FormFieldType.RADIOBUTTON}
+
+
+@dataclass
+class FormFieldInfo:
+    """One widget-annotation form field, as read from the PDF."""
+
+    page_no: int  # 1-based, matching DoclingDocument page numbering
+    field_type: FormFieldType
+    name: str  # fully qualified field name (/T chain)
+    # Current value: /V for text-like fields; for checkable fields PDFium resolves
+    # the state name (e.g. "Yes"/"Off") from /V or the appearance state (/AS).
+    value: str
+    tooltip: str  # alternate field name (/TU) — the PDF/UA accessible name
+    checked: Optional[bool]  # checkbox/radio state; None for other types
+    required: bool  # /Ff bit 2
+    readonly: bool  # /Ff bit 1
+    # Widget rectangle in PDF points, bottom-left origin: (left, bottom, right, top).
+    rect: tuple[float, float, float, float]
+
+
+def _annot_string(func: Callable, formenv_handle: object, annot: object) -> str:
+    """Read a PDFium UTF-16LE string via the two-call buffer-length protocol."""
+    n_bytes = func(formenv_handle, annot, None, 0)
+    if n_bytes <= 2:  # empty string: just the NUL terminator
+        return ""
+    buffer = ctypes.create_string_buffer(n_bytes)
+    func(
+        formenv_handle,
+        annot,
+        ctypes.cast(buffer, ctypes.POINTER(pdfium_c.FPDF_WCHAR)),
+        n_bytes,
+    )
+    return buffer.raw[: n_bytes - 2].decode("utf-16-le", errors="replace")
+
+
+def extract_form_fields(pdoc: pdfium.PdfDocument) -> list[FormFieldInfo]:
+    """Read all AcroForm widget fields of an open pypdfium2 document.
+
+    Returns an empty list for documents without an interactive form. The
+    caller keeps ownership of ``pdoc``; pages and annotations opened here are
+    closed before returning.
+    """
+    fields: list[FormFieldInfo] = []
+    with pypdfium2_lock:
+        if pdoc.formenv is None:
+            try:
+                pdoc.init_forms()
+            except pdfium.PdfiumError as err:  # malformed AcroForm: no form layer
+                _log.warning("Could not initialize PDF form environment: %s", err)
+                return fields
+        if pdoc.formenv is None:  # document has no interactive form
+            return fields
+        formenv = pdoc.formenv.raw
+
+        for page_index in range(len(pdoc)):
+            page = pdoc.get_page(page_index)
+            try:
+                annot_count = pdfium_c.FPDFPage_GetAnnotCount(page.raw)
+                for annot_index in range(annot_count):
+                    annot = pdfium_c.FPDFPage_GetAnnot(page.raw, annot_index)
+                    if not annot:  # pragma: no cover - defensive against API failure
+                        continue
+                    try:
+                        subtype = pdfium_c.FPDFAnnot_GetSubtype(annot)
+                        if subtype != pdfium_c.FPDF_ANNOT_WIDGET:
+                            continue
+                        field = _read_widget(formenv, annot, page_no=page_index + 1)
+                        if field is not None:
+                            fields.append(field)
+                    finally:
+                        pdfium_c.FPDFPage_CloseAnnot(annot)
+            finally:
+                page.close()
+    return fields
+
+
+def _read_widget(
+    formenv: object, annot: object, page_no: int
+) -> Optional[FormFieldInfo]:
+    """Map one widget annotation to :class:`FormFieldInfo`."""
+    raw_type = pdfium_c.FPDFAnnot_GetFormFieldType(formenv, annot)
+    field_type = _FIELD_TYPES.get(raw_type, FormFieldType.UNKNOWN)
+
+    rect_struct = pdfium_c.FS_RECTF()
+    got_rect = pdfium_c.FPDFAnnot_GetRect(annot, rect_struct)
+    if not got_rect:  # pragma: no cover - defensive against API failure
+        return None
+    # FS_RECTF is in page space (bottom-left origin); normalize the corner order.
+    left = min(rect_struct.left, rect_struct.right)
+    right = max(rect_struct.left, rect_struct.right)
+    bottom = min(rect_struct.bottom, rect_struct.top)
+    top = max(rect_struct.bottom, rect_struct.top)
+
+    name = _annot_string(pdfium_c.FPDFAnnot_GetFormFieldName, formenv, annot)
+    value = _annot_string(pdfium_c.FPDFAnnot_GetFormFieldValue, formenv, annot)
+    tooltip = _annot_string(
+        pdfium_c.FPDFAnnot_GetFormFieldAlternateName, formenv, annot
+    )
+    flags = pdfium_c.FPDFAnnot_GetFormFieldFlags(formenv, annot)
+
+    checked: Optional[bool] = None
+    if field_type in _CHECKABLE:
+        checked = bool(pdfium_c.FPDFAnnot_IsChecked(formenv, annot))
+
+    return FormFieldInfo(
+        page_no=page_no,
+        field_type=field_type,
+        name=name,
+        value=value,
+        tooltip=tooltip,
+        checked=checked,
+        required=bool(flags & pdfium_c.FPDF_FORMFLAG_REQUIRED),
+        readonly=bool(flags & pdfium_c.FPDF_FORMFLAG_READONLY),
+        rect=(left, bottom, right, top),
+    )
+
+
+def attach_form_fields(doc: DoclingDocument, fields: list[FormFieldInfo]) -> None:
+    """Represent extracted fields in ``doc`` as one ``FormItem`` per page.
+
+    Each field becomes a ``key`` cell (the field name; no page provenance — the
+    name is dictionary metadata, not page text) linked ``to_value`` to a value
+    cell anchored at the widget rectangle. Checkable fields use the ``checkbox``
+    cell label with an explicit ``checked``/``unchecked`` text so state survives
+    every export path.
+    """
+    by_page: dict[int, list[FormFieldInfo]] = {}
+    for field in fields:
+        by_page.setdefault(field.page_no, []).append(field)
+
+    for page_no in sorted(by_page):
+        page_fields = by_page[page_no]
+        cells: list[GraphCell] = []
+        links: list[GraphLink] = []
+        for field in page_fields:
+            key_id = len(cells)
+            cells.append(
+                GraphCell(
+                    label=GraphCellLabel.KEY,
+                    cell_id=key_id,
+                    text=field.name,
+                    orig=field.name,
+                    prov=None,
+                )
+            )
+            if field.checked is not None:
+                value_label = GraphCellLabel.CHECKBOX
+                value_text = "checked" if field.checked else "unchecked"
+            else:
+                value_label = GraphCellLabel.VALUE
+                value_text = field.value
+            value_id = len(cells)
+            cells.append(
+                GraphCell(
+                    label=value_label,
+                    cell_id=value_id,
+                    text=value_text,
+                    orig=value_text,
+                    prov=ProvenanceItem(
+                        page_no=page_no,
+                        bbox=BoundingBox(
+                            l=field.rect[0],
+                            b=field.rect[1],
+                            r=field.rect[2],
+                            t=field.rect[3],
+                            coord_origin=CoordOrigin.BOTTOMLEFT,
+                        ),
+                        charspan=(0, len(value_text)),
+                    ),
+                )
+            )
+            links.append(
+                GraphLink(
+                    label=GraphLinkLabel.TO_VALUE,
+                    source_cell_id=key_id,
+                    target_cell_id=value_id,
+                )
+            )
+
+        form_bbox = BoundingBox(
+            l=min(f.rect[0] for f in page_fields),
+            b=min(f.rect[1] for f in page_fields),
+            r=max(f.rect[2] for f in page_fields),
+            t=max(f.rect[3] for f in page_fields),
+            coord_origin=CoordOrigin.BOTTOMLEFT,
+        )
+        doc.add_form(
+            graph=GraphData(cells=cells, links=links),
+            prov=ProvenanceItem(page_no=page_no, bbox=form_bbox, charspan=(0, 0)),
+        )

--- a/tests/data/pdf/sources/acroform_sample.pdf
+++ b/tests/data/pdf/sources/acroform_sample.pdf
@@ -1,0 +1,66 @@
+%PDF-1.6
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [6 0 R 7 0 R 8 0 R 10 0 R] /DR << /Font << /Helv 5 0 R >> >> /DA (/Helv 0 Tf 0 g) >> >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> /Annots [6 0 R 7 0 R 8 0 R 9 0 R 10 0 R] >>
+endobj
+4 0 obj
+<< /Length 258 >>
+stream
+BT /F1 12 Tf 72 695 Td (Full name:) Tj ET BT /F1 12 Tf 95 643 Td (I agree to the terms) Tj ET BT /F1 12 Tf 95 613 Td (Subscribe to newsletter) Tj ET BT /F1 12 Tf 95 583 Td (Monthly mail digest) Tj ET BT /F1 12 Tf 72 563 Td (See example.org for details) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+6 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Tx /T (applicant_name) /TU (Full legal name) /V (Ada Lovelace) /Ff 2 /F 4 /Rect [150 690 400 710] /P 3 0 R /DA (/Helv 12 Tf 0 g) >>
+endobj
+7 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Btn /T (agree_terms) /TU (I agree to the terms) /V /Yes /AS /Yes /F 4 /Rect [72 638 86 652] /P 3 0 R >>
+endobj
+8 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Btn /T (newsletter) /V /Off /AS /Off /F 4 /Rect [72 608 86 622] /P 3 0 R >>
+endobj
+9 0 obj
+<< /Type /Annot /Subtype /Link /Rect [72 558 230 573] /Border [0 0 0] /A << /S /URI /URI (https://example.org) >> >>
+endobj
+10 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Btn /T (mail_optin) /AS /On /F 4 /Rect [72 578 86 592] /P 3 0 R /AP << /N << /On 11 0 R /Off 12 0 R >> >> >>
+endobj
+11 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 14 14] /Length 0 >>
+stream
+
+endstream
+endobj
+12 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 14 14] /Length 0 >>
+stream
+
+endstream
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000000009 00000 n 
+0000000164 00000 n 
+0000000221 00000 n 
+0000000388 00000 n 
+0000000697 00000 n 
+0000000767 00000 n 
+0000000952 00000 n 
+0000001109 00000 n 
+0000001238 00000 n 
+0000001370 00000 n 
+0000001533 00000 n 
+0000001631 00000 n 
+trailer
+<< /Size 13 /Root 1 0 R >>
+startxref
+1729
+%%EOF

--- a/tests/test_form_extraction.py
+++ b/tests/test_form_extraction.py
@@ -1,0 +1,187 @@
+from pathlib import Path
+
+import pypdfium2 as pdfium
+import pytest
+from docling_core.types.doc.document import DoclingDocument, FormItem
+from docling_core.types.doc.labels import GraphCellLabel, GraphLinkLabel
+
+from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
+from docling.backend.image_backend import ImageDocumentBackend
+from docling.backend.pypdfium2_backend import PyPdfiumDocumentBackend
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.document import InputDocument
+from docling.datamodel.pipeline_options import PdfPipelineOptions
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.utils.form_utils import (
+    FormFieldType,
+    attach_form_fields,
+    extract_form_fields,
+)
+
+FORM_PDF = Path("./tests/data/pdf/sources/acroform_sample.pdf")
+PLAIN_PDF = Path("./tests/data/pdf/sources/2305.03393v1-pg9.pdf")
+PLAIN_IMAGE = Path("./tests/data/ocr/sources/old_newspaper.png")
+
+
+def _get_backend(backend_cls, pdf_path: Path):
+    in_doc = InputDocument(
+        path_or_stream=pdf_path,
+        format=InputFormat.PDF,
+        backend=backend_cls,
+    )
+    return in_doc._backend
+
+
+@pytest.mark.parametrize(
+    "backend_cls", [PyPdfiumDocumentBackend, DoclingParseDocumentBackend]
+)
+def test_backend_reads_acroform_widget_fields(backend_cls):
+    backend = _get_backend(backend_cls, FORM_PDF)
+    try:
+        fields = backend.get_form_fields()
+    finally:
+        backend.unload()
+
+    # The fixture also carries a Link annotation; only widgets may surface here.
+    assert [f.name for f in fields] == [
+        "applicant_name",
+        "agree_terms",
+        "newsletter",
+        "mail_optin",
+    ]
+
+    text_field, checked_box, unchecked_box, as_only_box = fields
+
+    assert text_field.field_type == FormFieldType.TEXT
+    assert text_field.value == "Ada Lovelace"
+    assert text_field.tooltip == "Full legal name"  # /TU: the accessible name
+    assert text_field.required is True
+    assert text_field.readonly is False
+    assert text_field.checked is None
+    assert text_field.page_no == 1
+    left, bottom, right, top = text_field.rect
+    assert (left, bottom, right, top) == (150.0, 690.0, 400.0, 710.0)
+
+    assert checked_box.field_type == FormFieldType.CHECKBOX
+    assert checked_box.checked is True
+    assert checked_box.tooltip == "I agree to the terms"
+
+    assert unchecked_box.field_type == FormFieldType.CHECKBOX
+    assert unchecked_box.checked is False
+    assert unchecked_box.required is False
+
+    # Checked only through /AS (no /V): PDFium resolves the state name from
+    # the appearance dictionary, a common pattern in viewer-filled forms.
+    assert as_only_box.field_type == FormFieldType.CHECKBOX
+    assert as_only_box.checked is True
+    assert as_only_box.value == "On"
+
+
+@pytest.mark.parametrize(
+    "backend_cls", [PyPdfiumDocumentBackend, DoclingParseDocumentBackend]
+)
+def test_backend_without_acroform_yields_no_fields(backend_cls):
+    backend = _get_backend(backend_cls, PLAIN_PDF)
+    try:
+        assert backend.get_form_fields() == []
+    finally:
+        backend.unload()
+
+
+def test_attach_form_fields_builds_one_form_item_per_page():
+    backend = _get_backend(PyPdfiumDocumentBackend, FORM_PDF)
+    try:
+        fields = extract_form_fields(backend._pdoc)
+    finally:
+        backend.unload()
+
+    doc = DoclingDocument(name="acroform_sample")
+    attach_form_fields(doc, fields)
+
+    assert len(doc.form_items) == 1
+    form = doc.form_items[0]
+    assert isinstance(form, FormItem)
+    assert form.prov[0].page_no == 1
+
+    cells = form.graph.cells
+    links = form.graph.links
+    assert len(cells) == 8  # key + value per field
+    assert len(links) == 4
+    assert all(link.label == GraphLinkLabel.TO_VALUE for link in links)
+
+    by_key = {}
+    for link in links:
+        key = next(c for c in cells if c.cell_id == link.source_cell_id)
+        value = next(c for c in cells if c.cell_id == link.target_cell_id)
+        by_key[key.text] = value
+
+    assert by_key["applicant_name"].label == GraphCellLabel.VALUE
+    assert by_key["applicant_name"].text == "Ada Lovelace"
+    # The value cell anchors at the widget rectangle; the key cell carries no
+    # page provenance (a field name is dictionary metadata, not page text).
+    assert by_key["applicant_name"].prov.page_no == 1
+    key_cells = [c for c in cells if c.label == GraphCellLabel.KEY]
+    assert all(c.prov is None for c in key_cells)
+
+    assert by_key["agree_terms"].label == GraphCellLabel.CHECKBOX
+    assert by_key["agree_terms"].text == "checked"
+    assert by_key["newsletter"].label == GraphCellLabel.CHECKBOX
+    assert by_key["newsletter"].text == "unchecked"
+    assert by_key["mail_optin"].text == "checked"
+
+
+def test_form_fields_empty_after_unload():
+    backend = _get_backend(PyPdfiumDocumentBackend, FORM_PDF)
+    backend.unload()
+    assert backend.get_form_fields() == []
+
+
+def test_malformed_form_environment_degrades_to_no_fields(monkeypatch, caplog):
+    """A document whose form layer cannot be initialized yields no fields, no crash."""
+    pdoc = pdfium.PdfDocument(FORM_PDF)
+    try:
+
+        def _raise(*args, **kwargs):
+            raise pdfium.PdfiumError("form init failed")
+
+        monkeypatch.setattr(pdoc, "init_forms", _raise)
+        with caplog.at_level("WARNING", logger="docling.utils.form_utils"):
+            assert extract_form_fields(pdoc) == []
+        assert "form environment" in caplog.text
+    finally:
+        pdoc.close()
+
+
+def test_non_pdfium_backend_reports_no_form_fields():
+    """Backends without a PDFium handle (e.g. images) keep the empty default."""
+    in_doc = InputDocument(
+        path_or_stream=PLAIN_IMAGE,
+        format=InputFormat.IMAGE,
+        backend=ImageDocumentBackend,
+    )
+    backend = in_doc._backend
+    try:
+        assert backend.get_form_fields() == []
+    finally:
+        backend.unload()
+
+
+def test_pipeline_option_gates_form_extraction():
+    def convert(extract_form_fields: bool):
+        options = PdfPipelineOptions(extract_form_fields=extract_form_fields)
+        converter = DocumentConverter(
+            format_options={InputFormat.PDF: PdfFormatOption(pipeline_options=options)}
+        )
+        return converter.convert(FORM_PDF).document
+
+    enabled = convert(extract_form_fields=True)
+    assert len(enabled.form_items) == 1
+    assert {c.text for c in enabled.form_items[0].graph.cells} >= {
+        "applicant_name",
+        "Ada Lovelace",
+        "checked",
+        "unchecked",
+    }
+
+    disabled = convert(extract_form_fields=False)
+    assert len(disabled.form_items) == 0


### PR DESCRIPTION
Follow-up to the offer in #301 (discussion): this makes the PDF pipeline read the interactive form layer of born-digital PDFs instead of dropping it.

**What it does**

- `docling/utils/form_utils.py` — lossless widget-annotation extraction via PDFium's annotation API. Each field yields a `FormFieldInfo`: fully qualified name (`/T`), type (text/checkbox/radio/combobox/listbox/pushbutton/signature), current value (`/V`), tooltip (`/TU` — the PDF/UA accessible name), checkbox/radio state, required/read-only flags, and the widget rectangle.
- `PdfDocumentBackend.get_form_fields()` — new backend surface with an empty default (mirroring `get_document_outline()`), implemented once in `ManagedPdfiumDocumentBackend` so both the docling-parse and pypdfium2 backends serve it from the pypdfium2 document handle they already hold.
- `PdfPipelineOptions.extract_form_fields` (default `False`) — when enabled, `StandardPdfPipeline` attaches one `FormItem` per page-with-fields, carrying a key/value `GraphData`: the field name as a `key` cell (no page provenance — it's dictionary metadata, not page text), linked `to_value` to a value cell anchored at the widget rectangle. Checkable fields become `checkbox` cells with explicit `checked`/`unchecked` text, so state survives every export path. Metadata-only: no models run, negligible cost; scanned/flattened forms have no widget annotations and are unaffected.

**What it deliberately does not do (yet)**

- Properties without a typed slot in today's docling-core schema — tooltip, field type, required/read-only, radio-group semantics, a source-widget reference — are preserved on `FormFieldInfo` for API users but not yet serialized into the document. We'll follow up with a docling-core schema proposal for those (flagged in #301); this PR keeps the extraction layer and the schema discussion decoupled.
- No visible-label ↔ field binding: linking the page text near a widget to the field is a semantics problem (and where scanned-form support would join); out of scope here.
- `VlmPipeline` is untouched; the option lives on `PdfPipelineOptions`.

**Tests**

`tests/test_form_extraction.py` with a hand-crafted AcroForm fixture (`tests/data/pdf/sources/acroform_sample.pdf`: a filled required text field with `/TU`, a checked and an unchecked checkbox, a checkbox checked only via `/AS` with no `/V` — the viewer-filled pattern, resolved through the appearance state — and a Link annotation that field extraction must skip, plus visible text labels): backend extraction across both PDF backends, document representation (cells/links/provenance), the pipeline option gate in both positions, the no-form fallback on an existing fixture, plus degradation paths — `get_form_fields()` after `unload()`, a form environment that fails to initialize, and the empty default on non-PDFium backends (image input).

cc @cau-git — this is the "populate the existing model from widget annotations" PR from the discussion. @Ptark, your pypdfium2 approach is exactly the route taken (shared utility on the backends' existing handle); review from you would be very welcome, and if you'd like to build any of your richer extraction (JS actions, etc.) on top, happy to co-develop.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)