### PR TITLE
test: service client payload fidelity and an in-process docling-serve fake

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,6 +321,10 @@ pr-fast-checks = [
 dev = [
   { include-group = "typecheck" },
   "dprint-py==0.53.1.0",
+  # Test fakes serve a real socket so both httpx and requests code paths are
+  # covered by one harness; see tests/fakes/.
+  "fastapi>=0.115",
+  "uvicorn>=0.30",
   "prek>=0.3.10",
   "tach>=0.34.0,<1",
   "coverage~=7.6",

--- a/tests/fakes/__init__.py
+++ b/tests/fakes/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable in-process fakes for services Docling talks to over the network."""

--- a/tests/fakes/docling_serve.py
+++ b/tests/fakes/docling_serve.py
@@ -9,17 +9,38 @@ per route.
 
 from __future__ import annotations
 
+import json
 import re
 from dataclasses import dataclass, field
 from itertools import count
 from typing import Any
 
 from docling_core.types.doc import DoclingDocument
+from pydantic import BaseModel
 
 from docling.datamodel.base_models import ConversionStatus
+from docling.datamodel.service.responses import (
+    ArtifactRef,
+    ConvertDocumentResponse,
+    DocumentArtifactItem,
+    ExportDocumentResponse,
+    PresignedUrlConvertResponse,
+    TaskStatusResponse,
+)
+from docling.datamodel.service.tasks import TaskType
 from tests.fakes.http_service import FakeHttpService, RecordedRequest, Response
 
 DEFAULT_MARKDOWN = "# Fake service result\n\nConverted by the in-process fake.\n"
+
+
+def _as_wire(model: BaseModel) -> dict[str, Any]:
+    """Serialise a response model exactly as the service would put it on the wire.
+
+    Building every response from this repo's own response models is what keeps
+    the fake from becoming a second, drifting copy of the docling-serve API: a
+    change to the models either flows through here or fails loudly.
+    """
+    return json.loads(model.model_dump_json())
 
 
 def _fake_document(name: str) -> DoclingDocument:
@@ -98,57 +119,62 @@ class FakeDoclingServe:
         return match.group(1).decode() if match else "inbody"
 
     def _status_payload(self, task: FakeTask) -> dict[str, Any]:
-        payload: dict[str, Any] = {
-            "task_id": task.task_id,
-            "task_type": task.task_type,
-            "task_status": task.status().value,
-            "task_position": 0,
-        }
-        if task.status() is ConversionStatus.FAILURE:
-            payload["error_message"] = "conversion failed in the fake service"
-        return payload
+        status = TaskStatusResponse(
+            task_id=task.task_id,
+            task_type=TaskType(task.task_type),
+            task_status=task.status(),
+            task_position=0,
+            error_message=(
+                "conversion failed in the fake service"
+                if task.status() is ConversionStatus.FAILURE
+                else None
+            ),
+        )
+        return _as_wire(status)
 
     def _result_payload(self, task: FakeTask) -> dict[str, Any]:
         """The result envelope the client expects for the requested target."""
         if task.target_kind == "presigned_url":
             failed = task.terminal_status is ConversionStatus.FAILURE
-            return {
-                "num_converted": 1,
-                "num_succeeded": 0 if failed else 1,
-                "num_failed": 1 if failed else 0,
-                "processing_time": 0.25,
-                "documents": [
-                    {
-                        "source_index": 0,
-                        "source_uri": task.source_uri,
-                        "filename": task.filename,
-                        "status": task.terminal_status.value,
-                        "errors": task.errors,
-                        "artifacts": [
-                            {
-                                "artifact_type": "json",
-                                "mime_type": "application/json",
-                                "uri": f"{self.base_url}/artifacts/{task.task_id}/json",
-                            },
-                            {
-                                "artifact_type": "markdown",
-                                "mime_type": "text/markdown",
-                                "uri": f"{self.base_url}/artifacts/{task.task_id}/md",
-                            },
+            response = PresignedUrlConvertResponse(
+                num_converted=1,
+                num_succeeded=0 if failed else 1,
+                num_failed=1 if failed else 0,
+                processing_time=0.25,
+                documents=[
+                    DocumentArtifactItem(
+                        source_index=0,
+                        source_uri=task.source_uri,
+                        filename=task.filename,
+                        status=task.terminal_status,
+                        artifacts=[
+                            ArtifactRef(
+                                artifact_type="json",
+                                mime_type="application/json",
+                                uri=f"{self.base_url}/artifacts/{task.task_id}/json",
+                            ),
+                            ArtifactRef(
+                                artifact_type="markdown",
+                                mime_type="text/markdown",
+                                uri=f"{self.base_url}/artifacts/{task.task_id}/md",
+                            ),
                         ],
-                    }
+                    )
                 ],
-            }
-        return {
-            "document": {
-                "filename": task.filename,
-                "md_content": task.markdown,
-                "json_content": _fake_document(task.filename).export_to_dict(),
-            },
-            "status": task.terminal_status.value,
-            "errors": task.errors,
-            "processing_time": 0.25,
-        }
+            )
+            return _as_wire(response)
+
+        return _as_wire(
+            ConvertDocumentResponse(
+                document=ExportDocumentResponse(
+                    filename=task.filename,
+                    md_content=task.markdown,
+                    json_content=_fake_document(task.filename),
+                ),
+                status=task.terminal_status,
+                processing_time=0.25,
+            )
+        )
 
     # -- routes ----------------------------------------------------------
 

--- a/tests/fakes/docling_serve.py
+++ b/tests/fakes/docling_serve.py
@@ -1,24 +1,24 @@
-"""A docling-serve route pack for :class:`FakeHttpService`.
+"""A docling-serve route pack.
 
-Routes mirror docling-serve's own ``app.py``. Verified against it:
-``/health``, ``/version``, ``/v1/convert/source/async``,
-``/v1/convert/file/async``, ``/v1/convert/source/batch``,
-``/v1/chunk/{path_name}/source/async``, ``/v1/chunk/{path_name}/file/async``,
-``/v1/status/poll/{task_id}`` and ``/v1/result/{task_id}`` -- which is every
-path the service client can construct, except the WebSocket status stream
-(``/v1/status/ws/{task_id}``) that this server does not implement. Clients
-must therefore use ``StatusWatcherKind.POLLING``; the WebSocket watcher is
-not exercised here.
+Paths and response models mirror docling-serve's own ``app.py`` so the two can
+be diffed. Verified against it: ``/health``, ``/version``,
+``/v1/convert/source/async``, ``/v1/convert/file/async``,
+``/v1/convert/source/batch``, ``/v1/chunk/{path_name}/source/async``,
+``/v1/chunk/{path_name}/file/async``, ``/v1/status/poll/{task_id}`` and
+``/v1/result/{task_id}`` -- every path the service client can construct except
+the WebSocket status stream (``/v1/status/ws/{task_id}``), which is not
+implemented here. Clients must therefore use ``StatusWatcherKind.POLLING``;
+the WebSocket watcher is not exercised.
 
-``/artifacts/...`` is not a docling-serve route. It stands in for the
-external storage a presigned URL points at, so the client's artifact
-download runs against a real endpoint.
+``/artifacts/...`` is not a docling-serve route. It stands in for the external
+storage a presigned URL points at, so the client's artifact download and its
+SSRF check run against a real endpoint.
 
-Submitting a task returns ``pending``; each poll advances the task one step
-along ``pending -> started -> success``, so the client's polling loop and the
-watcher actually iterate instead of short-circuiting on a canned terminal
-status. Tests can override the step count, force a failure, or inject faults
-per route.
+Submitting returns ``pending``; each poll advances the task one step along
+``pending -> started -> success``, so the polling loop and the watcher
+genuinely iterate rather than short-circuiting on a canned terminal status.
+Every response is built from this repo's own response models, so the fake
+cannot drift into being a second copy of the API.
 """
 
 from __future__ import annotations
@@ -30,6 +30,8 @@ from itertools import count
 from typing import Any
 
 from docling_core.types.doc import DoclingDocument
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse, PlainTextResponse
 from pydantic import BaseModel
 
 from docling.datamodel.base_models import ConversionStatus
@@ -43,18 +45,12 @@ from docling.datamodel.service.responses import (
     TaskStatusResponse,
 )
 from docling.datamodel.service.tasks import TaskType
-from tests.fakes.http_service import FakeHttpService, RecordedRequest, Response
 
 DEFAULT_MARKDOWN = "# Fake service result\n\nConverted by the in-process fake.\n"
 
 
-def _as_wire(model: BaseModel) -> dict[str, Any]:
-    """Serialise a response model exactly as the service would put it on the wire.
-
-    Building every response from this repo's own response models is what keeps
-    the fake from becoming a second, drifting copy of the docling-serve API: a
-    change to the models either flows through here or fails loudly.
-    """
+def _as_wire(model: BaseModel) -> Any:
+    """Serialise a response model exactly as the service would send it."""
     return json.loads(model.model_dump_json())
 
 
@@ -86,27 +82,21 @@ class FakeTask:
             return ConversionStatus.STARTED
         return self.terminal_status
 
-    def is_terminal(self) -> bool:
-        return self.status() in (
-            ConversionStatus.SUCCESS,
-            ConversionStatus.PARTIAL_SUCCESS,
-            ConversionStatus.FAILURE,
-        )
-
 
 class FakeDoclingServe:
-    """Registers docling-serve routes onto a :class:`FakeHttpService`."""
+    """State plus an ``APIRouter`` mirroring docling-serve."""
 
-    def __init__(self, service: FakeHttpService, base_url: str = "") -> None:
-        self.service = service
+    def __init__(self, base_url: str = "") -> None:
         self.base_url = base_url.rstrip("/")
         self.tasks: dict[str, FakeTask] = {}
         self._ids = count(1)
-        # Defaults applied to tasks created by the submit routes; a test can
-        # change these before submitting to script a slow or failing task.
+        # Applied to tasks created by the submit routes; a test changes these
+        # before submitting to script a slow or failing task.
         self.polls_before_success = 1
         self.terminal_status = ConversionStatus.SUCCESS
-        self._register()
+        # Set by the fixture once the server is bound, so tests can reach it.
+        self.service: Any = None
+        self.router = self._build_router()
 
     # -- task helpers ----------------------------------------------------
 
@@ -124,17 +114,18 @@ class FakeDoclingServe:
         return task
 
     @staticmethod
-    def _requested_target(request: RecordedRequest) -> str:
-        """The target kind the client asked for, from JSON body or form data."""
+    async def _requested_target(request: Request) -> str:
+        """The target kind the caller asked for, from JSON body or form data."""
+        body = await request.body()
         if request.headers.get("content-type", "").startswith("application/json"):
-            target = request.json().get("target") or {}
+            target = json.loads(body).get("target") or {}
             return target.get("kind", "inbody")
         # File uploads send options as multipart form fields.
-        match = re.search(rb'name="target_type"\r\n\r\n([^\r]+)', request.body)
+        match = re.search(rb'name="target_type"\r\n\r\n([^\r]+)', body)
         return match.group(1).decode() if match else "inbody"
 
-    def _status_payload(self, task: FakeTask) -> dict[str, Any]:
-        status = TaskStatusResponse(
+    def _status(self, task: FakeTask) -> TaskStatusResponse:
+        return TaskStatusResponse(
             task_id=task.task_id,
             task_type=TaskType(task.task_type),
             task_status=task.status(),
@@ -145,13 +136,12 @@ class FakeDoclingServe:
                 else None
             ),
         )
-        return _as_wire(status)
 
-    def _result_payload(self, task: FakeTask) -> dict[str, Any]:
+    def _result(self, task: FakeTask) -> BaseModel:
         """The result envelope the client expects for the requested target."""
         if task.target_kind == "presigned_url":
             failed = task.terminal_status is ConversionStatus.FAILURE
-            response = PresignedUrlConvertResponse(
+            return PresignedUrlConvertResponse(
                 num_converted=1,
                 num_succeeded=0 if failed else 1,
                 num_failed=1 if failed else 0,
@@ -177,85 +167,81 @@ class FakeDoclingServe:
                     )
                 ],
             )
-            return _as_wire(response)
-
-        return _as_wire(
-            ConvertDocumentResponse(
-                document=ExportDocumentResponse(
-                    filename=task.filename,
-                    md_content=task.markdown,
-                    json_content=_fake_document(task.filename),
-                ),
-                status=task.terminal_status,
-                processing_time=0.25,
-            )
+        return ConvertDocumentResponse(
+            document=ExportDocumentResponse(
+                filename=task.filename,
+                md_content=task.markdown,
+                json_content=_fake_document(task.filename),
+            ),
+            status=task.terminal_status,
+            processing_time=0.25,
         )
 
     # -- routes ----------------------------------------------------------
 
-    def _register(self) -> None:
-        service = self.service
+    def _build_router(self) -> APIRouter:
+        router = APIRouter()
 
-        @service.route("GET", r"/health")
-        def _health(request: RecordedRequest, match: re.Match[str]) -> Response:
-            return Response(body=_as_wire(HealthCheckResponse()))
+        @router.get("/health", response_model=HealthCheckResponse)
+        async def health() -> HealthCheckResponse:
+            return HealthCheckResponse()
 
-        @service.route("GET", r"/version")
-        def _version(request: RecordedRequest, match: re.Match[str]) -> Response:
-            return Response(body={"version": "0.0.0-fake"})
+        @router.get("/version")
+        async def version() -> dict[str, str]:
+            return {"version": "0.0.0-fake"}
 
-        @service.route("POST", r"/v1/convert/source/async")
-        def _submit_source(request: RecordedRequest, match: re.Match[str]) -> Response:
-            task = self.new_task(target_kind=self._requested_target(request))
-            return Response(body=self._status_payload(task))
+        @router.post("/v1/convert/source/async", response_model=TaskStatusResponse)
+        async def convert_source_async(request: Request) -> TaskStatusResponse:
+            kind = await self._requested_target(request)
+            return self._status(self.new_task(target_kind=kind))
 
-        @service.route("POST", r"/v1/convert/file/async")
-        def _submit_file(request: RecordedRequest, match: re.Match[str]) -> Response:
-            task = self.new_task(target_kind=self._requested_target(request))
-            return Response(body=self._status_payload(task))
+        @router.post("/v1/convert/file/async", response_model=TaskStatusResponse)
+        async def convert_file_async(request: Request) -> TaskStatusResponse:
+            kind = await self._requested_target(request)
+            return self._status(self.new_task(target_kind=kind))
 
-        @service.route("POST", r"/v1/convert/source/batch")
-        def _submit_batch(request: RecordedRequest, match: re.Match[str]) -> Response:
-            task = self.new_task(target_kind=self._requested_target(request))
-            return Response(body=self._status_payload(task))
+        @router.post("/v1/convert/source/batch", response_model=TaskStatusResponse)
+        async def convert_source_batch(request: Request) -> TaskStatusResponse:
+            kind = await self._requested_target(request)
+            return self._status(self.new_task(target_kind=kind))
 
-        @service.route("POST", r"/v1/chunk/[^/]+/source/async")
-        def _submit_chunk_source(
-            request: RecordedRequest, match: re.Match[str]
-        ) -> Response:
-            return Response(body=self._status_payload(self.new_task("chunk")))
+        @router.post(
+            "/v1/chunk/{path_name}/source/async", response_model=TaskStatusResponse
+        )
+        async def chunk_source_async(path_name: str) -> TaskStatusResponse:
+            return self._status(self.new_task("chunk"))
 
-        @service.route("POST", r"/v1/chunk/[^/]+/file/async")
-        def _submit_chunk_file(
-            request: RecordedRequest, match: re.Match[str]
-        ) -> Response:
-            return Response(body=self._status_payload(self.new_task("chunk")))
+        @router.post(
+            "/v1/chunk/{path_name}/file/async", response_model=TaskStatusResponse
+        )
+        async def chunk_file_async(path_name: str) -> TaskStatusResponse:
+            return self._status(self.new_task("chunk"))
 
-        @service.route("GET", r"/v1/status/poll/(?P<task_id>[^/]+)")
-        def _poll(request: RecordedRequest, match: re.Match[str]) -> Response:
-            task = self.tasks.get(match.group("task_id"))
+        @router.get("/v1/status/poll/{task_id}", response_model=TaskStatusResponse)
+        async def poll(task_id: str) -> Any:
+            task = self.tasks.get(task_id)
             if task is None:
-                return Response(status=404, body={"detail": "task not found"})
+                return JSONResponse({"detail": "task not found"}, status_code=404)
             task.polls += 1
-            return Response(body=self._status_payload(task))
+            return self._status(task)
 
-        @service.route("GET", r"/v1/result/(?P<task_id>[^/]+)")
-        def _result(request: RecordedRequest, match: re.Match[str]) -> Response:
-            task = self.tasks.get(match.group("task_id"))
+        # The real route returns a union of result envelopes; serialising the
+        # chosen model directly avoids FastAPI filtering fields against a
+        # response_model that cannot describe every branch.
+        @router.get("/v1/result/{task_id}")
+        async def result(task_id: str) -> JSONResponse:
+            task = self.tasks.get(task_id)
             if task is None:
-                return Response(status=404, body={"detail": "task not found"})
-            return Response(body=self._result_payload(task))
+                return JSONResponse({"detail": "task not found"}, status_code=404)
+            return JSONResponse(_as_wire(self._result(task)))
 
-        # Presigned artifacts are served from this same host, so the client's
-        # artifact download and URL validation run for real.
-        @service.route("GET", r"/artifacts/(?P<task_id>[^/]+)/(?P<kind>json|md)")
-        def _artifact(request: RecordedRequest, match: re.Match[str]) -> Response:
-            task = self.tasks.get(match.group("task_id"))
+        @router.get("/artifacts/{task_id}/{kind}")
+        async def artifact(task_id: str, kind: str) -> Any:
+            task = self.tasks.get(task_id)
             if task is None:
-                return Response(status=404, body={"detail": "task not found"})
-            if match.group("kind") == "md":
-                return Response(
-                    body=task.markdown, headers={"Content-Type": "text/markdown"}
-                )
-            document = _fake_document(task.filename)
-            return Response(body=document.export_to_dict())
+                return JSONResponse({"detail": "task not found"}, status_code=404)
+            if kind == "md":
+                return PlainTextResponse(task.markdown, media_type="text/markdown")
+            return JSONResponse(_fake_document(task.filename).export_to_dict())
+
+        return router

--- a/tests/fakes/docling_serve.py
+++ b/tests/fakes/docling_serve.py
@@ -1,5 +1,19 @@
 """A docling-serve route pack for :class:`FakeHttpService`.
 
+Routes mirror docling-serve's own ``app.py``. Verified against it:
+``/health``, ``/version``, ``/v1/convert/source/async``,
+``/v1/convert/file/async``, ``/v1/convert/source/batch``,
+``/v1/chunk/{path_name}/source/async``, ``/v1/chunk/{path_name}/file/async``,
+``/v1/status/poll/{task_id}`` and ``/v1/result/{task_id}`` -- which is every
+path the service client can construct, except the WebSocket status stream
+(``/v1/status/ws/{task_id}``) that this server does not implement. Clients
+must therefore use ``StatusWatcherKind.POLLING``; the WebSocket watcher is
+not exercised here.
+
+``/artifacts/...`` is not a docling-serve route. It stands in for the
+external storage a presigned URL points at, so the client's artifact
+download runs against a real endpoint.
+
 Submitting a task returns ``pending``; each poll advances the task one step
 along ``pending -> started -> success``, so the client's polling loop and the
 watcher actually iterate instead of short-circuiting on a canned terminal
@@ -24,6 +38,7 @@ from docling.datamodel.service.responses import (
     ConvertDocumentResponse,
     DocumentArtifactItem,
     ExportDocumentResponse,
+    HealthCheckResponse,
     PresignedUrlConvertResponse,
     TaskStatusResponse,
 )
@@ -183,7 +198,7 @@ class FakeDoclingServe:
 
         @service.route("GET", r"/health")
         def _health(request: RecordedRequest, match: re.Match[str]) -> Response:
-            return Response(body={"status": "ok"})
+            return Response(body=_as_wire(HealthCheckResponse()))
 
         @service.route("GET", r"/version")
         def _version(request: RecordedRequest, match: re.Match[str]) -> Response:
@@ -196,6 +211,11 @@ class FakeDoclingServe:
 
         @service.route("POST", r"/v1/convert/file/async")
         def _submit_file(request: RecordedRequest, match: re.Match[str]) -> Response:
+            task = self.new_task(target_kind=self._requested_target(request))
+            return Response(body=self._status_payload(task))
+
+        @service.route("POST", r"/v1/convert/source/batch")
+        def _submit_batch(request: RecordedRequest, match: re.Match[str]) -> Response:
             task = self.new_task(target_kind=self._requested_target(request))
             return Response(body=self._status_payload(task))
 

--- a/tests/fakes/docling_serve.py
+++ b/tests/fakes/docling_serve.py
@@ -1,0 +1,215 @@
+"""A docling-serve route pack for :class:`FakeHttpService`.
+
+Submitting a task returns ``pending``; each poll advances the task one step
+along ``pending -> started -> success``, so the client's polling loop and the
+watcher actually iterate instead of short-circuiting on a canned terminal
+status. Tests can override the step count, force a failure, or inject faults
+per route.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from itertools import count
+from typing import Any
+
+from docling_core.types.doc import DoclingDocument
+
+from docling.datamodel.base_models import ConversionStatus
+from tests.fakes.http_service import FakeHttpService, RecordedRequest, Response
+
+DEFAULT_MARKDOWN = "# Fake service result\n\nConverted by the in-process fake.\n"
+
+
+def _fake_document(name: str) -> DoclingDocument:
+    """A small but genuine DoclingDocument, as the real service would return."""
+    doc = DoclingDocument(name=name)
+    doc.add_title(text="Fake service result")
+    doc.add_text(label="text", text="Converted by the in-process fake.")
+    return doc
+
+
+@dataclass
+class FakeTask:
+    task_id: str
+    task_type: str = "convert"
+    polls_before_success: int = 1
+    terminal_status: ConversionStatus = ConversionStatus.SUCCESS
+    filename: str = "sample.pdf"
+    markdown: str = DEFAULT_MARKDOWN
+    errors: list[dict[str, Any]] = field(default_factory=list)
+    polls: int = 0
+    target_kind: str = "inbody"
+    source_uri: str = "https://example.com/sample.pdf"
+
+    def status(self) -> ConversionStatus:
+        if self.polls == 0:
+            return ConversionStatus.PENDING
+        if self.polls <= self.polls_before_success:
+            return ConversionStatus.STARTED
+        return self.terminal_status
+
+    def is_terminal(self) -> bool:
+        return self.status() in (
+            ConversionStatus.SUCCESS,
+            ConversionStatus.PARTIAL_SUCCESS,
+            ConversionStatus.FAILURE,
+        )
+
+
+class FakeDoclingServe:
+    """Registers docling-serve routes onto a :class:`FakeHttpService`."""
+
+    def __init__(self, service: FakeHttpService, base_url: str = "") -> None:
+        self.service = service
+        self.base_url = base_url.rstrip("/")
+        self.tasks: dict[str, FakeTask] = {}
+        self._ids = count(1)
+        # Defaults applied to tasks created by the submit routes; a test can
+        # change these before submitting to script a slow or failing task.
+        self.polls_before_success = 1
+        self.terminal_status = ConversionStatus.SUCCESS
+        self._register()
+
+    # -- task helpers ----------------------------------------------------
+
+    def new_task(
+        self, task_type: str = "convert", target_kind: str = "inbody"
+    ) -> FakeTask:
+        task = FakeTask(
+            task_id=f"task-{next(self._ids)}",
+            task_type=task_type,
+            polls_before_success=self.polls_before_success,
+            terminal_status=self.terminal_status,
+            target_kind=target_kind,
+        )
+        self.tasks[task.task_id] = task
+        return task
+
+    @staticmethod
+    def _requested_target(request: RecordedRequest) -> str:
+        """The target kind the client asked for, from JSON body or form data."""
+        if request.headers.get("content-type", "").startswith("application/json"):
+            target = request.json().get("target") or {}
+            return target.get("kind", "inbody")
+        # File uploads send options as multipart form fields.
+        match = re.search(rb'name="target_type"\r\n\r\n([^\r]+)', request.body)
+        return match.group(1).decode() if match else "inbody"
+
+    def _status_payload(self, task: FakeTask) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "task_id": task.task_id,
+            "task_type": task.task_type,
+            "task_status": task.status().value,
+            "task_position": 0,
+        }
+        if task.status() is ConversionStatus.FAILURE:
+            payload["error_message"] = "conversion failed in the fake service"
+        return payload
+
+    def _result_payload(self, task: FakeTask) -> dict[str, Any]:
+        """The result envelope the client expects for the requested target."""
+        if task.target_kind == "presigned_url":
+            failed = task.terminal_status is ConversionStatus.FAILURE
+            return {
+                "num_converted": 1,
+                "num_succeeded": 0 if failed else 1,
+                "num_failed": 1 if failed else 0,
+                "processing_time": 0.25,
+                "documents": [
+                    {
+                        "source_index": 0,
+                        "source_uri": task.source_uri,
+                        "filename": task.filename,
+                        "status": task.terminal_status.value,
+                        "errors": task.errors,
+                        "artifacts": [
+                            {
+                                "artifact_type": "json",
+                                "mime_type": "application/json",
+                                "uri": f"{self.base_url}/artifacts/{task.task_id}/json",
+                            },
+                            {
+                                "artifact_type": "markdown",
+                                "mime_type": "text/markdown",
+                                "uri": f"{self.base_url}/artifacts/{task.task_id}/md",
+                            },
+                        ],
+                    }
+                ],
+            }
+        return {
+            "document": {
+                "filename": task.filename,
+                "md_content": task.markdown,
+                "json_content": _fake_document(task.filename).export_to_dict(),
+            },
+            "status": task.terminal_status.value,
+            "errors": task.errors,
+            "processing_time": 0.25,
+        }
+
+    # -- routes ----------------------------------------------------------
+
+    def _register(self) -> None:
+        service = self.service
+
+        @service.route("GET", r"/health")
+        def _health(request: RecordedRequest, match: re.Match[str]) -> Response:
+            return Response(body={"status": "ok"})
+
+        @service.route("GET", r"/version")
+        def _version(request: RecordedRequest, match: re.Match[str]) -> Response:
+            return Response(body={"version": "0.0.0-fake"})
+
+        @service.route("POST", r"/v1/convert/source/async")
+        def _submit_source(request: RecordedRequest, match: re.Match[str]) -> Response:
+            task = self.new_task(target_kind=self._requested_target(request))
+            return Response(body=self._status_payload(task))
+
+        @service.route("POST", r"/v1/convert/file/async")
+        def _submit_file(request: RecordedRequest, match: re.Match[str]) -> Response:
+            task = self.new_task(target_kind=self._requested_target(request))
+            return Response(body=self._status_payload(task))
+
+        @service.route("POST", r"/v1/chunk/[^/]+/source/async")
+        def _submit_chunk_source(
+            request: RecordedRequest, match: re.Match[str]
+        ) -> Response:
+            return Response(body=self._status_payload(self.new_task("chunk")))
+
+        @service.route("POST", r"/v1/chunk/[^/]+/file/async")
+        def _submit_chunk_file(
+            request: RecordedRequest, match: re.Match[str]
+        ) -> Response:
+            return Response(body=self._status_payload(self.new_task("chunk")))
+
+        @service.route("GET", r"/v1/status/poll/(?P<task_id>[^/]+)")
+        def _poll(request: RecordedRequest, match: re.Match[str]) -> Response:
+            task = self.tasks.get(match.group("task_id"))
+            if task is None:
+                return Response(status=404, body={"detail": "task not found"})
+            task.polls += 1
+            return Response(body=self._status_payload(task))
+
+        @service.route("GET", r"/v1/result/(?P<task_id>[^/]+)")
+        def _result(request: RecordedRequest, match: re.Match[str]) -> Response:
+            task = self.tasks.get(match.group("task_id"))
+            if task is None:
+                return Response(status=404, body={"detail": "task not found"})
+            return Response(body=self._result_payload(task))
+
+        # Presigned artifacts are served from this same host, so the client's
+        # artifact download and URL validation run for real.
+        @service.route("GET", r"/artifacts/(?P<task_id>[^/]+)/(?P<kind>json|md)")
+        def _artifact(request: RecordedRequest, match: re.Match[str]) -> Response:
+            task = self.tasks.get(match.group("task_id"))
+            if task is None:
+                return Response(status=404, body={"detail": "task not found"})
+            if match.group("kind") == "md":
+                return Response(
+                    body=task.markdown, headers={"Content-Type": "text/markdown"}
+                )
+            document = _fake_document(task.filename)
+            return Response(body=document.export_to_dict())

--- a/tests/fakes/http_service.py
+++ b/tests/fakes/http_service.py
@@ -1,0 +1,202 @@
+"""A real HTTP server for tests, bound to an ephemeral localhost port.
+
+Docling reaches remote services through two different client libraries --
+``httpx`` in the service client and ``requests`` in the KServe and image
+helpers -- and through both sync and async code paths. Serving a real socket
+covers all of them with one fake, and keeps transport behaviour (timeouts,
+connection resets, retries, redirects) reachable from tests, which a
+library-specific mock transport cannot do.
+
+Route packs build on this: see :mod:`tests.fakes.docling_serve`.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+import time
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any, Callable
+from urllib.parse import parse_qs, urlsplit
+
+
+@dataclass
+class RecordedRequest:
+    """A request as the server received it."""
+
+    method: str
+    path: str
+    query: dict[str, list[str]]
+    headers: dict[str, str]
+    body: bytes
+
+    def json(self) -> Any:
+        return json.loads(self.body)
+
+    def param(self, name: str) -> str | None:
+        values = self.query.get(name)
+        return values[0] if values else None
+
+
+@dataclass
+class Response:
+    """What a route handler returns.
+
+    ``body`` may be ``bytes``, ``str``, or any JSON-serialisable object; the
+    last is encoded as JSON and given a JSON content type unless one is set.
+    ``delay`` holds the response open, which is how read-timeout handling is
+    exercised.
+    """
+
+    status: int = 200
+    body: Any = b""
+    headers: dict[str, str] = field(default_factory=dict)
+    delay: float = 0.0
+
+    def encoded(self) -> tuple[bytes, dict[str, str]]:
+        headers = dict(self.headers)
+        if isinstance(self.body, bytes):
+            return self.body, headers
+        if isinstance(self.body, str):
+            headers.setdefault("Content-Type", "text/plain; charset=utf-8")
+            return self.body.encode(), headers
+        headers.setdefault("Content-Type", "application/json")
+        return json.dumps(self.body, default=str).encode(), headers
+
+
+Handler = Callable[[RecordedRequest, re.Match[str]], Response]
+
+
+class FakeHttpService:
+    """Routes requests to registered handlers and records what it served.
+
+    Handlers are matched in registration order, so a test can shadow a route
+    pack's handler by registering a more specific one first.
+    """
+
+    def __init__(self) -> None:
+        self._routes: list[tuple[str, re.Pattern[str], Handler]] = []
+        self.requests: list[RecordedRequest] = []
+        self.base_url = ""
+        self._server: ThreadingHTTPServer | None = None
+        self._thread: threading.Thread | None = None
+        self._lock = threading.Lock()
+
+    # -- registration ----------------------------------------------------
+
+    def route(self, method: str, pattern: str) -> Callable[[Handler], Handler]:
+        """Register a handler for ``method`` and a full-match path regex."""
+
+        def decorator(handler: Handler) -> Handler:
+            self.add_route(method, pattern, handler)
+            return handler
+
+        return decorator
+
+    def add_route(self, method: str, pattern: str, handler: Handler) -> None:
+        self._routes.insert(0, (method.upper(), re.compile(pattern), handler))
+
+    def respond_once(self, method: str, pattern: str, response: Response) -> None:
+        """Serve ``response`` for the next matching request only.
+
+        Used to inject a single fault -- a 429, a 503, a truncated body --
+        ahead of an otherwise healthy route, so retry paths can be driven
+        without stubbing the client.
+        """
+        used = threading.Event()
+
+        def handler(request: RecordedRequest, match: re.Match[str]) -> Response:
+            if used.is_set():
+                return self._dispatch(request, skip_first=True)
+            used.set()
+            return response
+
+        self.add_route(method, pattern, handler)
+
+    # -- lifecycle -------------------------------------------------------
+
+    def start(self) -> str:
+        service = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def log_message(self, *args: Any) -> None:
+                pass  # keep pytest output clean
+
+            def _handle(self) -> None:
+                parsed = urlsplit(self.path)
+                length = int(self.headers.get("Content-Length") or 0)
+                request = RecordedRequest(
+                    method=self.command,
+                    path=parsed.path,
+                    query=parse_qs(parsed.query),
+                    headers={k.lower(): v for k, v in self.headers.items()},
+                    body=self.rfile.read(length) if length else b"",
+                )
+                with service._lock:
+                    service.requests.append(request)
+
+                response = service._dispatch(request)
+                if response.delay:
+                    time.sleep(response.delay)
+                payload, headers = response.encoded()
+                self.send_response(response.status)
+                for key, value in headers.items():
+                    self.send_header(key, value)
+                self.send_header("Content-Length", str(len(payload)))
+                self.end_headers()
+                self.wfile.write(payload)
+
+            do_GET = _handle
+            do_POST = _handle
+            do_PUT = _handle
+            do_DELETE = _handle
+            do_HEAD = _handle
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._server.daemon_threads = True
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+        host, port = self._server.server_address[:2]
+        self.base_url = f"http://{host}:{port}"
+        return self.base_url
+
+    def stop(self) -> None:
+        if self._server is not None:
+            self._server.shutdown()
+            self._server.server_close()
+            self._server = None
+        if self._thread is not None:
+            self._thread.join(timeout=5)
+            self._thread = None
+
+    # -- dispatch --------------------------------------------------------
+
+    def _dispatch(
+        self, request: RecordedRequest, *, skip_first: bool = False
+    ) -> Response:
+        matched = 0
+        for method, pattern, handler in self._routes:
+            if method != request.method:
+                continue
+            match = pattern.fullmatch(request.path)
+            if match is None:
+                continue
+            matched += 1
+            if skip_first and matched == 1:
+                continue
+            return handler(request, match)
+        return Response(status=404, body={"detail": f"no route for {request.path}"})
+
+    # -- assertions ------------------------------------------------------
+
+    def requests_for(self, method: str, pattern: str) -> list[RecordedRequest]:
+        compiled = re.compile(pattern)
+        return [
+            r
+            for r in self.requests
+            if r.method == method.upper() and compiled.fullmatch(r.path)
+        ]

--- a/tests/fakes/http_service.py
+++ b/tests/fakes/http_service.py
@@ -1,13 +1,18 @@
-"""A real HTTP server for tests, bound to an ephemeral localhost port.
+"""A FastAPI app served by uvicorn on an ephemeral localhost port.
 
-Docling reaches remote services through two different client libraries --
-``httpx`` in the service client and ``requests`` in the KServe and image
-helpers -- and through both sync and async code paths. Serving a real socket
-covers all of them with one fake, and keeps transport behaviour (timeouts,
-connection resets, retries, redirects) reachable from tests, which a
-library-specific mock transport cannot do.
+Docling reaches remote services through two client libraries -- ``httpx`` in
+the service client, ``requests`` in the OCR/VLM API helpers -- and through
+both sync and async code paths. Only a real socket serves all of them from
+one harness, which rules out ASGI-transport and library-specific mocks
+(``respx`` sees no ``requests`` traffic, ``responses`` sees no ``httpx``).
 
-Route packs build on this: see :mod:`tests.fakes.docling_serve`.
+FastAPI is used because the services being faked are themselves FastAPI apps:
+routes can be written with the same decorators and ``response_model`` as the
+originals, so a reviewer can diff them, and ``StreamingResponse`` covers SSE
+without hand-rolling chunked encoding.
+
+Route packs build on this: see :mod:`tests.fakes.docling_serve` and
+:mod:`tests.fakes.openai_compatible`.
 """
 
 from __future__ import annotations
@@ -15,11 +20,13 @@ from __future__ import annotations
 import json
 import re
 import threading
-import time
 from dataclasses import dataclass, field
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Callable
-from urllib.parse import parse_qs, urlsplit
+
+import uvicorn
+from fastapi import APIRouter, FastAPI, Request
+from fastapi.responses import JSONResponse, PlainTextResponse
+from starlette.middleware.base import BaseHTTPMiddleware
 
 
 @dataclass
@@ -42,154 +49,156 @@ class RecordedRequest:
 
 @dataclass
 class Response:
-    """What a route handler returns.
+    """A canned response used for test overrides and fault injection.
 
     ``body`` may be ``bytes``, ``str``, or any JSON-serialisable object; the
-    last is encoded as JSON and given a JSON content type unless one is set.
-    ``delay`` holds the response open, which is how read-timeout handling is
-    exercised.
+    last is encoded as JSON. Real behaviour belongs in the route packs -- this
+    exists so a test can force a 429, a 503 or a malformed body onto an
+    otherwise healthy route.
     """
 
     status: int = 200
     body: Any = b""
     headers: dict[str, str] = field(default_factory=dict)
-    delay: float = 0.0
 
-    def encoded(self) -> tuple[bytes, dict[str, str]]:
-        headers = dict(self.headers)
-        if isinstance(self.body, bytes):
-            return self.body, headers
-        if isinstance(self.body, str):
-            headers.setdefault("Content-Type", "text/plain; charset=utf-8")
-            return self.body.encode(), headers
-        headers.setdefault("Content-Type", "application/json")
-        return json.dumps(self.body, default=str).encode(), headers
-
-
-Handler = Callable[[RecordedRequest, re.Match[str]], Response]
+    def to_starlette(self) -> JSONResponse | PlainTextResponse:
+        if isinstance(self.body, (bytes, str)):
+            content = self.body.decode() if isinstance(self.body, bytes) else self.body
+            return PlainTextResponse(
+                content, status_code=self.status, headers=self.headers
+            )
+        return JSONResponse(
+            json.loads(json.dumps(self.body, default=str)),
+            status_code=self.status,
+            headers=self.headers,
+        )
 
 
-class FakeHttpService:
-    """Routes requests to registered handlers and records what it served.
+Override = Callable[[RecordedRequest], "Response | None"]
 
-    Handlers are matched in registration order, so a test can shadow a route
-    pack's handler by registering a more specific one first.
+
+class FakeService:
+    """Hosts one or more route packs and records what it served.
+
+    Overrides registered by tests take precedence over the mounted routes,
+    which is how faults are injected without stubbing the client.
     """
 
     def __init__(self) -> None:
-        self._routes: list[tuple[str, re.Pattern[str], Handler]] = []
+        self.app = FastAPI(docs_url=None, redoc_url=None, openapi_url=None)
         self.requests: list[RecordedRequest] = []
         self.base_url = ""
-        self._server: ThreadingHTTPServer | None = None
-        self._thread: threading.Thread | None = None
+        self._overrides: list[tuple[str, re.Pattern[str], Override]] = []
         self._lock = threading.Lock()
+        self._server: uvicorn.Server | None = None
+        self._thread: threading.Thread | None = None
+        self._install_middleware()
 
-    # -- registration ----------------------------------------------------
+    # -- composition -----------------------------------------------------
 
-    def route(self, method: str, pattern: str) -> Callable[[Handler], Handler]:
-        """Register a handler for ``method`` and a full-match path regex."""
+    def include(self, router: APIRouter) -> None:
+        """Mount a route pack."""
+        self.app.include_router(router)
 
-        def decorator(handler: Handler) -> Handler:
-            self.add_route(method, pattern, handler)
-            return handler
+    # -- test overrides --------------------------------------------------
 
-        return decorator
+    def add_route(
+        self, method: str, pattern: str, handler: Callable[..., Response]
+    ) -> None:
+        """Always serve ``handler`` for requests matching ``method``/``pattern``.
 
-    def add_route(self, method: str, pattern: str, handler: Handler) -> None:
-        self._routes.insert(0, (method.upper(), re.compile(pattern), handler))
+        Takes precedence over any mounted route, so a test can replace a
+        healthy endpoint with a failing one for its duration.
+        """
+        compiled = re.compile(pattern)
+
+        def override(request: RecordedRequest) -> Response:
+            return handler(request, compiled.fullmatch(request.path))
+
+        self._overrides.insert(0, (method.upper(), compiled, override))
 
     def respond_once(self, method: str, pattern: str, response: Response) -> None:
-        """Serve ``response`` for the next matching request only.
-
-        Used to inject a single fault -- a 429, a 503, a truncated body --
-        ahead of an otherwise healthy route, so retry paths can be driven
-        without stubbing the client.
-        """
+        """Serve ``response`` for the next matching request only."""
         used = threading.Event()
 
-        def handler(request: RecordedRequest, match: re.Match[str]) -> Response:
+        def override(request: RecordedRequest) -> Response | None:
             if used.is_set():
-                return self._dispatch(request, skip_first=True)
+                return None  # fall through to the real route
             used.set()
             return response
 
-        self.add_route(method, pattern, handler)
+        self._overrides.insert(0, (method.upper(), re.compile(pattern), override))
+
+    def _find_override(self, request: RecordedRequest) -> Response | None:
+        for method, pattern, override in self._overrides:
+            if method != request.method or not pattern.fullmatch(request.path):
+                continue
+            response = override(request)
+            if response is not None:
+                return response
+        return None
+
+    # -- recording -------------------------------------------------------
+
+    def _install_middleware(self) -> None:
+        service = self
+
+        class _Recorder(BaseHTTPMiddleware):
+            async def dispatch(self, request: Request, call_next):
+                body = await request.body()
+                recorded = RecordedRequest(
+                    method=request.method,
+                    path=request.url.path,
+                    query={
+                        key: request.query_params.getlist(key)
+                        for key in request.query_params
+                    },
+                    headers={k.lower(): v for k, v in request.headers.items()},
+                    body=body,
+                )
+                with service._lock:
+                    service.requests.append(recorded)
+                forced = service._find_override(recorded)
+                if forced is not None:
+                    return forced.to_starlette()
+                return await call_next(request)
+
+        self.app.add_middleware(_Recorder)
 
     # -- lifecycle -------------------------------------------------------
 
     def start(self) -> str:
-        service = self
-
-        class _Handler(BaseHTTPRequestHandler):
-            protocol_version = "HTTP/1.1"
-
-            def log_message(self, *args: Any) -> None:
-                pass  # keep pytest output clean
-
-            def _handle(self) -> None:
-                parsed = urlsplit(self.path)
-                length = int(self.headers.get("Content-Length") or 0)
-                request = RecordedRequest(
-                    method=self.command,
-                    path=parsed.path,
-                    query=parse_qs(parsed.query),
-                    headers={k.lower(): v for k, v in self.headers.items()},
-                    body=self.rfile.read(length) if length else b"",
-                )
-                with service._lock:
-                    service.requests.append(request)
-
-                response = service._dispatch(request)
-                if response.delay:
-                    time.sleep(response.delay)
-                payload, headers = response.encoded()
-                self.send_response(response.status)
-                for key, value in headers.items():
-                    self.send_header(key, value)
-                self.send_header("Content-Length", str(len(payload)))
-                self.end_headers()
-                self.wfile.write(payload)
-
-            do_GET = _handle
-            do_POST = _handle
-            do_PUT = _handle
-            do_DELETE = _handle
-            do_HEAD = _handle
-
-        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
-        self._server.daemon_threads = True
-        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        config = uvicorn.Config(
+            self.app, host="127.0.0.1", port=0, log_level="warning", access_log=False
+        )
+        self._server = uvicorn.Server(config)
+        self._thread = threading.Thread(target=self._server.run, daemon=True)
         self._thread.start()
-        host, port = self._server.server_address[:2]
+
+        # port=0 means the real port is known only once the socket is bound.
+        tick = threading.Event()
+        while not self._server.started:
+            if not self._thread.is_alive():
+                raise RuntimeError("the fake service failed to start")
+            tick.wait(0.01)
+        host, port = self._server.servers[0].sockets[0].getsockname()[:2]
         self.base_url = f"http://{host}:{port}"
         return self.base_url
 
     def stop(self) -> None:
         if self._server is not None:
-            self._server.shutdown()
-            self._server.server_close()
+            self._server.should_exit = True
             self._server = None
         if self._thread is not None:
-            self._thread.join(timeout=5)
+            self._thread.join(timeout=10)
             self._thread = None
 
-    # -- dispatch --------------------------------------------------------
+    def __enter__(self) -> FakeService:
+        self.start()
+        return self
 
-    def _dispatch(
-        self, request: RecordedRequest, *, skip_first: bool = False
-    ) -> Response:
-        matched = 0
-        for method, pattern, handler in self._routes:
-            if method != request.method:
-                continue
-            match = pattern.fullmatch(request.path)
-            if match is None:
-                continue
-            matched += 1
-            if skip_first and matched == 1:
-                continue
-            return handler(request, match)
-        return Response(status=404, body={"detail": f"no route for {request.path}"})
+    def __exit__(self, *exc: object) -> None:
+        self.stop()
 
     # -- assertions ------------------------------------------------------
 

--- a/tests/fakes/openai_compatible.py
+++ b/tests/fakes/openai_compatible.py
@@ -1,0 +1,137 @@
+"""An OpenAI-compatible chat-completions route pack.
+
+Every remote VLM and picture-description path in Docling funnels through
+``docling.utils.api_image_request``, which uses ``requests`` -- so this has to
+be served over a real socket rather than an httpx-only mock.
+
+Non-streaming responses are built from this repo's own ``OpenAiApiResponse``
+models. Streaming uses FastAPI's ``StreamingResponse`` to emit genuine SSE
+chunks, so the client's ``iter_lines`` parsing, its accumulation of ``delta``
+content and its generation stoppers all run against real chunked transfer
+rather than one pre-assembled body.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse, StreamingResponse
+
+from docling.datamodel.base_models import (
+    OpenAiApiResponse,
+    OpenAiChatMessage,
+    OpenAiResponseChoice,
+    OpenAiResponseUsage,
+)
+
+DEFAULT_COMPLETION = "Fake VLM output."
+
+
+@dataclass
+class FakeOpenAiApi:
+    """State plus an ``APIRouter`` serving ``/v1/chat/completions``."""
+
+    completion: str = DEFAULT_COMPLETION
+    #: Emitted one SSE chunk at a time when the caller asks for a stream.
+    stream_chunks: list[str] = field(default_factory=list)
+    prompt_tokens: int = 11
+    completion_tokens: int = 7
+    #: Set to omit the usage block, as some gateways do.
+    report_usage: bool = True
+    #: Held open before responding, to drive client read timeouts.
+    delay_seconds: float = 0.0
+    #: Non-2xx status to answer with instead of a completion.
+    fail_status: int | None = None
+    #: Emitted verbatim before the data chunks; proxies inject comments here.
+    stream_preamble: list[str] = field(default_factory=list)
+    router: APIRouter = field(init=False)
+    #: Set by the fixture once the server is bound, so tests can reach it.
+    service: Any = field(init=False, default=None)
+
+    def __post_init__(self) -> None:
+        self.router = self._build_router()
+
+    # -- payloads --------------------------------------------------------
+
+    def _usage(self) -> OpenAiResponseUsage | None:
+        if not self.report_usage:
+            return None
+        return OpenAiResponseUsage(
+            prompt_tokens=self.prompt_tokens,
+            completion_tokens=self.completion_tokens,
+            total_tokens=self.prompt_tokens + self.completion_tokens,
+        )
+
+    def _completion_response(self, model: str | None) -> dict[str, Any]:
+        response = OpenAiApiResponse(
+            id="chatcmpl-fake-1",
+            model=model,
+            created=1_700_000_000,
+            choices=[
+                OpenAiResponseChoice(
+                    index=0,
+                    message=OpenAiChatMessage(
+                        role="assistant", content=self.completion
+                    ),
+                    finish_reason="stop",
+                )
+            ],
+            usage=self._usage(),
+        )
+        return json.loads(response.model_dump_json())
+
+    def _chunks(self) -> list[str]:
+        return self.stream_chunks or [self.completion]
+
+    async def _sse(self, model: str | None) -> AsyncIterator[bytes]:
+        """Emit the OpenAI streaming delta format, terminated by [DONE]."""
+        for line in self.stream_preamble:
+            yield f"{line}\n\n".encode()
+        for piece in self._chunks():
+            event = {
+                "id": "chatcmpl-fake-1",
+                "model": model,
+                "created": 1_700_000_000,
+                "choices": [{"index": 0, "delta": {"content": piece}}],
+            }
+            yield f"data: {json.dumps(event)}\n\n".encode()
+        usage = self._usage()
+        if usage is not None:
+            final = {
+                "id": "chatcmpl-fake-1",
+                "model": model,
+                "created": 1_700_000_000,
+                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                "usage": json.loads(usage.model_dump_json()),
+            }
+            yield f"data: {json.dumps(final)}\n\n".encode()
+        yield b"data: [DONE]\n\n"
+
+    # -- routes ----------------------------------------------------------
+
+    def _build_router(self) -> APIRouter:
+        router = APIRouter()
+
+        @router.post("/v1/chat/completions")
+        async def chat_completions(request: Request) -> Any:
+            payload = json.loads(await request.body())
+            model = payload.get("model")
+            if self.delay_seconds:
+                await asyncio.sleep(self.delay_seconds)
+            if self.fail_status is not None:
+                return JSONResponse(
+                    {"error": {"message": "fake failure"}},
+                    status_code=self.fail_status,
+                )
+            if payload.get("stream"):
+                return StreamingResponse(
+                    self._sse(model), media_type="text/event-stream"
+                )
+            return JSONResponse(self._completion_response(model))
+
+        return router

--- a/tests/test_api_openai_compatible_fake.py
+++ b/tests/test_api_openai_compatible_fake.py
@@ -1,0 +1,253 @@
+"""Remote VLM calls driven against a real OpenAI-compatible server.
+
+Every remote VLM and picture-description path funnels through
+``docling.utils.api_image_request``, which uses ``requests``. An httpx-only
+mock cannot see that traffic at all, so these run against a real socket.
+
+The emphasis is on whether the *options* a caller configures actually govern
+the outgoing call -- the same question as the ``serialize_as_any`` regression,
+one layer further out -- plus the streaming paths, which only a genuinely
+chunked response exercises.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+
+import pytest
+from PIL import Image
+from pydantic import AnyUrl
+
+from docling.datamodel.base_models import VlmStopReason
+from docling.datamodel.vlm_engine_options import ApiVlmEngineOptions, VlmEngineType
+from docling.models.inference_engines.vlm.api_openai_compatible_engine import (
+    ApiVlmEngine,
+)
+from docling.models.inference_engines.vlm.base import VlmEngineInput
+from docling.utils.api_image_request import (
+    api_image_request,
+    api_image_request_streaming,
+)
+from tests.fakes.http_service import FakeService
+from tests.fakes.openai_compatible import FakeOpenAiApi
+
+
+@pytest.fixture
+def api() -> Iterator[FakeOpenAiApi]:
+    service = FakeService()
+    fake = FakeOpenAiApi()
+    service.include(fake.router)
+    service.start()
+    fake.service = service
+    try:
+        yield fake
+    finally:
+        service.stop()
+
+
+@pytest.fixture
+def endpoint(api: FakeOpenAiApi) -> AnyUrl:
+    return AnyUrl(f"{api.service.base_url}/v1/chat/completions")
+
+
+@pytest.fixture
+def image() -> Image.Image:
+    return Image.new("RGB", (8, 8), color="white")
+
+
+def _sent_body(api: FakeOpenAiApi) -> dict:
+    requests = api.service.requests_for("POST", r"/v1/chat/completions")
+    assert requests, "no call reached the API"
+    return requests[-1].json()
+
+
+# -- what the caller configures must govern the call ---------------------
+
+
+def test_generation_params_are_merged_into_the_request_body(api, endpoint, image):
+    api_image_request(
+        image,
+        "describe",
+        endpoint,
+        model="custom-vlm",
+        temperature=0.1,
+        max_tokens=256,
+    )
+
+    body = _sent_body(api)
+    assert body["model"] == "custom-vlm"
+    assert body["temperature"] == 0.1
+    assert body["max_tokens"] == 256
+
+
+def test_custom_headers_are_sent(api, endpoint, image):
+    api_image_request(
+        image,
+        "describe",
+        endpoint,
+        headers={"Authorization": "Bearer sk-not-real", "X-Tenant": "acme"},
+        model="custom-vlm",
+    )
+
+    sent = api.service.requests_for("POST", r"/v1/chat/completions")[-1].headers
+    assert sent["authorization"] == "Bearer sk-not-real"
+    assert sent["x-tenant"] == "acme"
+
+
+def test_the_prompt_and_image_are_both_sent_in_the_message(api, endpoint, image):
+    api_image_request(image, "what is in this picture?", endpoint, model="m")
+
+    content = _sent_body(api)["messages"][0]["content"]
+    kinds = {part["type"] for part in content}
+    assert kinds == {"image_url", "text"}
+    text_part = next(p for p in content if p["type"] == "text")
+    assert text_part["text"] == "what is in this picture?"
+    image_part = next(p for p in content if p["type"] == "image_url")
+    assert image_part["image_url"]["url"].startswith("data:image/png;base64,")
+
+
+def test_timeout_is_applied_and_reported_as_an_empty_result(api, endpoint, image):
+    """A read timeout is swallowed rather than raised.
+
+    The caller gets an empty result with an unspecified stop reason, which is
+    indistinguishable from a model that genuinely produced nothing. Asserted
+    here as the current contract, not as an endorsement of it.
+    """
+    api.delay_seconds = 1.0
+
+    started = time.monotonic()
+    result = api_image_request(image, "describe", endpoint, timeout=0.15, model="m")
+    elapsed = time.monotonic() - started
+
+    assert result.text == ""
+    assert result.stop_reason == VlmStopReason.UNSPECIFIED
+    # It gave up on the configured timeout instead of waiting for the response.
+    assert elapsed < 0.9
+
+
+# -- responses -----------------------------------------------------------
+
+
+def test_completion_text_and_token_count_are_returned(api, endpoint, image):
+    api.completion = "A white square."
+    api.prompt_tokens, api.completion_tokens = 11, 7
+
+    result = api_image_request(image, "describe", endpoint, model="m")
+
+    assert result.text == "A white square."
+    assert result.num_tokens == 18
+    assert result.stop_reason == VlmStopReason.END_OF_SEQUENCE
+
+
+def test_a_missing_usage_block_leaves_the_token_count_unset(api, endpoint, image):
+    api.report_usage = False
+
+    result = api_image_request(image, "describe", endpoint, model="m")
+
+    assert result.text
+    assert result.num_tokens is None
+
+
+@pytest.mark.parametrize("status", [400, 401, 429, 500])
+def test_api_errors_do_not_raise_but_yield_no_text(api, endpoint, image, status):
+    """A failed call is reported as empty output, not an exception."""
+    api.fail_status = status
+
+    result = api_image_request(image, "describe", endpoint, model="m")
+
+    assert result.text == ""
+
+
+# -- streaming -----------------------------------------------------------
+
+
+def test_streamed_deltas_are_reassembled_in_order(api, endpoint, image):
+    api.stream_chunks = ["Hel", "lo ", "world"]
+
+    result = api_image_request_streaming(image, "describe", endpoint, model="m")
+
+    assert result.text == "Hello world"
+    assert _sent_body(api)["stream"] is True
+
+
+def test_streaming_reports_usage_from_the_final_chunk(api, endpoint, image):
+    api.stream_chunks = ["a", "b"]
+    api.prompt_tokens, api.completion_tokens = 3, 4
+
+    result = api_image_request_streaming(image, "describe", endpoint, model="m")
+
+    assert result.num_tokens == 7
+
+
+def test_non_data_lines_in_the_stream_are_ignored(api, endpoint, image):
+    """Proxies inject comments and keep-alives; they must not corrupt output."""
+    api.stream_chunks = ["ok"]
+    api.stream_preamble = [": keep-alive comment", "event: ping"]
+
+    result = api_image_request_streaming(image, "describe", endpoint, model="m")
+
+    assert result.text == "ok"
+
+
+def test_malformed_json_chunks_are_skipped(api, endpoint, image):
+    api.stream_chunks = ["good"]
+    api.stream_preamble = ["data: {not valid json"]
+
+    result = api_image_request_streaming(image, "describe", endpoint, model="m")
+
+    assert result.text == "good"
+
+
+# -- the engine layer ----------------------------------------------------
+
+
+def _engine(api: FakeOpenAiApi, **overrides) -> ApiVlmEngine:
+    options = ApiVlmEngineOptions(
+        engine_type=VlmEngineType.API_OPENAI,
+        url=AnyUrl(f"{api.service.base_url}/v1/chat/completions"),
+        **overrides,
+    )
+    return ApiVlmEngine(enable_remote_services=True, options=options)
+
+
+def test_engine_options_drive_the_outgoing_request(api, image):
+    """params and headers set on the engine options must reach the server."""
+    engine = _engine(
+        api,
+        params={"model": "custom-vlm", "temperature": 0.25},
+        headers={"X-Tenant": "acme"},
+    )
+
+    outputs = engine.predict_batch([VlmEngineInput(image=image, prompt="describe")])
+
+    assert outputs[0].text
+    body = _sent_body(api)
+    assert body["model"] == "custom-vlm"
+    assert body["temperature"] == 0.25
+    sent = api.service.requests_for("POST", r"/v1/chat/completions")[-1].headers
+    assert sent["x-tenant"] == "acme"
+
+
+def test_engine_requires_remote_services_to_be_enabled(api):
+    options = ApiVlmEngineOptions(
+        engine_type=VlmEngineType.API_OPENAI,
+        url=AnyUrl(f"{api.service.base_url}/v1/chat/completions"),
+    )
+
+    with pytest.raises(Exception, match="remote"):
+        ApiVlmEngine(enable_remote_services=False, options=options)
+
+
+def test_engine_batches_every_input(api, image):
+    engine = _engine(api, params={"model": "m"})
+
+    outputs = engine.predict_batch(
+        [
+            VlmEngineInput(image=image, prompt="first"),
+            VlmEngineInput(image=image, prompt="second"),
+        ]
+    )
+
+    assert len(outputs) == 2
+    assert len(api.service.requests_for("POST", r"/v1/chat/completions")) == 2

--- a/tests/test_service_client_fake_service.py
+++ b/tests/test_service_client_fake_service.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 
 import pytest
+from pydantic import ValidationError
 
 import docling.service_client.client as client_module
 from docling.datamodel.base_models import ConversionStatus
@@ -401,3 +402,37 @@ async def test_async_client_surfaces_submit_errors(async_client_kwargs, service)
     async with AsyncDoclingServiceClient(**async_client_kwargs) as remote:
         with pytest.raises(ServiceError):
             await remote.submit(SOURCE, target=InBodyTarget())
+
+
+BATCH_SOURCES = [
+    {"kind": "http", "url": "https://example.com/a.pdf"},
+    {"kind": "http", "url": "https://example.com/b.pdf"},
+]
+
+
+def test_submit_batch_reaches_the_batch_endpoint(client, service):
+    """Batch submission uses its own route, distinct from per-source submits."""
+    job = client.submit_batch(sources=BATCH_SOURCES, target=PresignedUrlTarget())
+
+    assert job.task_id
+    assert len(service.requests_for("POST", r"/v1/convert/source/batch")) == 1
+    # The per-source route must not have been used for a batch submission.
+    assert not service.requests_for("POST", r"/v1/convert/source/async")
+
+
+def test_submit_batch_rejects_a_non_storage_target(client):
+    """Batch results go to storage, so InBody is not a valid batch target."""
+    with pytest.raises(ValidationError):
+        client.submit_batch(sources=BATCH_SOURCES, target=InBodyTarget())
+
+
+def test_submit_batch_requires_exactly_one_of_target_or_targets(client):
+    with pytest.raises(ValueError, match="requires either"):
+        client.submit_batch(sources=BATCH_SOURCES)
+
+    with pytest.raises(ValueError, match="only one"):
+        client.submit_batch(
+            sources=BATCH_SOURCES,
+            target=PresignedUrlTarget(),
+            targets=[PresignedUrlTarget()],
+        )

--- a/tests/test_service_client_fake_service.py
+++ b/tests/test_service_client_fake_service.py
@@ -1,0 +1,403 @@
+"""Service client tests driven against a real in-process docling-serve fake.
+
+The existing unit tests reach into ``client._http_client`` to install an
+``httpx.MockTransport``, which cannot exercise anything below the request
+layer. Here the client talks to a real socket, so submission, the polling
+loop, target negotiation, retries, artifact download and the error taxonomy
+all run as they would against a live service.
+
+Assertions target outcomes that survive a wire-format change -- the resulting
+document, the status, the exception type -- not the exact bytes exchanged.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import pytest
+
+import docling.service_client.client as client_module
+from docling.datamodel.base_models import ConversionStatus
+from docling.datamodel.service.targets import InBodyTarget, PresignedUrlTarget
+from docling.service_client import (
+    AsyncDoclingServiceClient,
+    ConversionError,
+    DoclingServiceClient,
+    ServiceUnavailableError,
+)
+from docling.service_client.client import ConversionItem, StatusWatcherKind
+from docling.service_client.exceptions import ServiceError, TaskNotFoundError
+from tests.fakes.docling_serve import FakeDoclingServe
+from tests.fakes.http_service import FakeHttpService, Response
+
+SOURCE = "https://example.com/report.pdf"
+
+
+@pytest.fixture
+def serve() -> Iterator[FakeDoclingServe]:
+    """A running fake docling-serve; also exposes the underlying HTTP service."""
+    fake_service = FakeHttpService()
+    base_url = fake_service.start()
+    try:
+        yield FakeDoclingServe(fake_service, base_url)
+    finally:
+        fake_service.stop()
+
+
+@pytest.fixture
+def service(serve: FakeDoclingServe) -> FakeHttpService:
+    return serve.service
+
+
+@pytest.fixture
+def client(service: FakeHttpService) -> Iterator[DoclingServiceClient]:
+    with DoclingServiceClient(
+        url=service.base_url,
+        # The fake answers polls immediately rather than long-polling, so drop
+        # the client-side cadence that would otherwise pace each poll by 5s.
+        status_watcher=StatusWatcherKind.POLLING,
+        poll_server_wait=0.01,
+        poll_client_interval=0.01,
+    ) as remote:
+        yield remote
+
+
+@pytest.fixture
+def allow_loopback_artifacts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Let artifact downloads reach the loopback fake.
+
+    ``_is_safe_artifact_url`` is an SSRF guard that rejects non-routable hosts
+    by design, which includes the test server. The guard itself is covered by
+    ``test_presigned_artifact_on_a_loopback_host_is_refused``.
+    """
+    monkeypatch.setattr(client_module, "_is_safe_artifact_url", lambda url: True)
+
+
+# -- basic endpoints -----------------------------------------------------
+
+
+def test_health_and_version_reach_the_service(client, service):
+    assert client.health().status == "ok"
+    assert client.version()["version"] == "0.0.0-fake"
+    assert [r.path for r in service.requests] == ["/health", "/version"]
+
+
+def test_base_url_including_v1_is_rejected(service):
+    """The client owns the /v1 prefix; callers pass the service root."""
+    with pytest.raises(ValueError, match="not include /v1"):
+        DoclingServiceClient(url=f"{service.base_url}/v1")
+
+
+@pytest.mark.parametrize("bad_url", ["ftp://example.com", "not-a-url", ""])
+def test_non_http_base_urls_are_rejected(bad_url):
+    with pytest.raises(ValueError, match="absolute http"):
+        DoclingServiceClient(url=bad_url)
+
+
+def test_base_url_with_query_or_fragment_is_rejected(service):
+    with pytest.raises(ValueError, match="query or fragment"):
+        DoclingServiceClient(url=f"{service.base_url}/?token=abc")
+
+
+# -- the convert flow ----------------------------------------------------
+
+
+def test_convert_with_an_inbody_target_returns_the_document(client, service):
+    job = client.submit(SOURCE, target=InBodyTarget())
+    result = job.result()
+
+    assert result.status == ConversionStatus.SUCCESS
+    assert "Fake service result" in result.document.export_to_markdown()
+
+
+def test_convert_polls_until_the_task_reaches_a_terminal_status(
+    client, service, serve, allow_loopback_artifacts
+):
+    serve.polls_before_success = 3
+
+    result = client.convert(SOURCE)
+
+    assert result.status == ConversionStatus.SUCCESS
+    polls = service.requests_for("GET", r"/v1/status/poll/.*")
+    # pending -> started x3 -> success: the loop genuinely iterated.
+    assert len(polls) == 4
+
+
+def test_convert_downloads_presigned_artifacts(
+    client, service, allow_loopback_artifacts
+):
+    result = client.convert(SOURCE)
+
+    assert result.status == ConversionStatus.SUCCESS
+    assert "Fake service result" in result.document.export_to_markdown()
+    assert service.requests_for("GET", r"/artifacts/.*/json")
+
+
+def test_presigned_artifact_on_a_loopback_host_is_refused(client):
+    """The SSRF guard must reject artifact URLs that are not globally routable."""
+    result = client.convert(SOURCE, raises_on_error=False)
+
+    assert result.status == ConversionStatus.FAILURE
+    assert any("non-public URL" in item.error_message for item in result.errors), (
+        result.errors
+    )
+
+
+def test_convert_falls_back_to_inbody_when_presigned_is_unsupported(client, service):
+    """A service without artifact storage rejects presigned; the client retargets."""
+    # Only the first submission is rejected, so the InBody retry succeeds.
+    service.respond_once(
+        "POST",
+        r"/v1/convert/source/async",
+        Response(
+            status=422,
+            body={
+                "detail": "This deployment requires artifact storage to be configured"
+            },
+        ),
+    )
+
+    result = client.convert(SOURCE)
+
+    assert result.status == ConversionStatus.SUCCESS
+    assert len(service.requests_for("POST", r"/v1/convert/source/async")) == 2
+
+
+# -- failure handling ----------------------------------------------------
+
+
+def test_task_failure_raises_conversion_error(client, serve):
+    serve.terminal_status = ConversionStatus.FAILURE
+
+    with pytest.raises(ConversionError):
+        client.convert(SOURCE)
+
+
+def test_task_failure_is_returned_when_raises_on_error_is_false(client, serve):
+    serve.terminal_status = ConversionStatus.FAILURE
+
+    result = client.convert(SOURCE, raises_on_error=False)
+
+    assert result.status == ConversionStatus.FAILURE
+
+
+def test_unknown_task_poll_raises_task_not_found(client, service):
+    service.add_route(
+        "GET",
+        r"/v1/status/poll/.*",
+        lambda request, match: Response(status=404, body={"detail": "gone"}),
+    )
+
+    with pytest.raises(TaskNotFoundError):
+        client.convert(SOURCE)
+
+
+def test_server_error_on_submit_raises_a_service_error(client, service):
+    service.add_route(
+        "POST",
+        r"/v1/convert/source/async",
+        lambda request, match: Response(status=500, body={"detail": "boom"}),
+    )
+
+    with pytest.raises(ServiceError):
+        client.convert(SOURCE)
+
+
+def test_unreachable_service_raises_service_unavailable(service):
+    base_url = service.base_url
+    service.stop()
+
+    with DoclingServiceClient(
+        url=base_url, status_watcher=StatusWatcherKind.POLLING
+    ) as remote:
+        with pytest.raises(ServiceUnavailableError):
+            remote.health()
+
+
+# -- retries -------------------------------------------------------------
+
+
+@pytest.mark.parametrize("status", [500, 502])
+def test_server_errors_on_poll_are_retried(
+    client, service, allow_loopback_artifacts, status
+):
+    """500 and 502 retry on an exponential backoff, with no header needed."""
+    service.respond_once(
+        "GET", r"/v1/status/poll/.*", Response(status=status, body={"detail": "boom"})
+    )
+
+    result = client.convert(SOURCE)
+
+    assert result.status == ConversionStatus.SUCCESS
+    assert len(service.requests_for("GET", r"/v1/status/poll/.*")) >= 3
+
+
+@pytest.mark.parametrize("status", [429, 503])
+def test_throttling_responses_are_retried_when_retry_after_is_present(
+    client, service, allow_loopback_artifacts, status
+):
+    service.respond_once(
+        "GET",
+        r"/v1/status/poll/.*",
+        Response(
+            status=status, body={"detail": "slow down"}, headers={"Retry-After": "0"}
+        ),
+    )
+
+    result = client.convert(SOURCE)
+
+    assert result.status == ConversionStatus.SUCCESS
+    assert len(service.requests_for("GET", r"/v1/status/poll/.*")) >= 3
+
+
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        # 4xx and 5xx map to different exception types in the taxonomy.
+        (429, ServiceError),
+        (503, ServiceUnavailableError),
+    ],
+)
+def test_throttling_without_retry_after_is_surfaced_immediately(
+    client, service, status, expected
+):
+    """Without the header the client cannot know how long to wait, so it gives up."""
+    service.add_route(
+        "GET",
+        r"/v1/status/poll/.*",
+        lambda request, match: Response(status=status, body={"detail": "no header"}),
+    )
+
+    with pytest.raises(expected):
+        client.convert(SOURCE)
+
+    assert len(service.requests_for("GET", r"/v1/status/poll/.*")) == 1
+
+
+def test_client_error_on_poll_is_not_retried(client, service):
+    service.add_route(
+        "GET",
+        r"/v1/status/poll/.*",
+        lambda request, match: Response(status=400, body={"detail": "bad request"}),
+    )
+
+    with pytest.raises(ServiceError):
+        client.convert(SOURCE)
+
+    assert len(service.requests_for("GET", r"/v1/status/poll/.*")) == 1
+
+
+# -- multiple documents --------------------------------------------------
+
+
+def test_convert_all_yields_one_result_per_source(
+    client, service, allow_loopback_artifacts
+):
+    sources = [
+        "https://example.com/a.pdf",
+        "https://example.com/b.pdf",
+        "https://example.com/c.pdf",
+    ]
+
+    results = list(client.convert_all(sources))
+
+    assert len(results) == 3
+    assert all(r.status == ConversionStatus.SUCCESS for r in results)
+    assert len(service.requests_for("POST", r"/v1/convert/source/async")) == 3
+
+
+def test_submit_returns_a_job_whose_status_can_be_polled(client, serve):
+    serve.polls_before_success = 2
+
+    job = client.submit(SOURCE, target=InBodyTarget())
+    statuses = [update.task_status for update in job.watch(timeout=30)]
+
+    assert statuses[-1] == ConversionStatus.SUCCESS
+
+
+# -- the async client ----------------------------------------------------
+#
+# The same fake serves AsyncDoclingServiceClient unchanged: a real socket does
+# not care which client library or event loop is on the other end.
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+@pytest.fixture
+def async_client_kwargs(service: FakeHttpService) -> dict[str, object]:
+    return {
+        "url": service.base_url,
+        "status_watcher": StatusWatcherKind.POLLING,
+        "poll_server_wait": 0.01,
+        "poll_client_interval": 0.01,
+    }
+
+
+@pytest.mark.anyio
+async def test_async_client_reaches_health_and_version(async_client_kwargs, service):
+    async with AsyncDoclingServiceClient(**async_client_kwargs) as remote:
+        assert (await remote.health()).status == "ok"
+        assert (await remote.version())["version"] == "0.0.0-fake"
+
+
+@pytest.mark.anyio
+async def test_async_submit_awaits_the_converted_document(async_client_kwargs, serve):
+    serve.polls_before_success = 2
+
+    async with AsyncDoclingServiceClient(**async_client_kwargs) as remote:
+        job = await remote.submit(SOURCE, target=InBodyTarget())
+        result = await job.result(timeout=30)
+
+    assert result.status == ConversionStatus.SUCCESS
+    assert "Fake service result" in result.document.export_to_markdown()
+
+
+@pytest.mark.anyio
+async def test_async_watch_yields_every_status_transition(async_client_kwargs, serve):
+    serve.polls_before_success = 2
+
+    async with AsyncDoclingServiceClient(**async_client_kwargs) as remote:
+        job = await remote.submit(SOURCE, target=InBodyTarget())
+        statuses = [update.task_status async for update in job.watch(timeout=30)]
+
+    assert statuses[-1] == ConversionStatus.SUCCESS
+    assert ConversionStatus.STARTED in statuses
+
+
+@pytest.mark.anyio
+async def test_async_submit_and_retrieve_each_covers_every_item(
+    async_client_kwargs, service
+):
+    items = [
+        ConversionItem(source="https://example.com/a.pdf", metadata="a"),
+        ConversionItem(source="https://example.com/b.pdf", metadata="b"),
+    ]
+
+    async with AsyncDoclingServiceClient(**async_client_kwargs) as remote:
+        pairs = [
+            pair
+            async for pair in remote.submit_and_retrieve_each(
+                items, target=InBodyTarget()
+            )
+        ]
+
+    assert len(pairs) == 2
+    assert {item.metadata for item, _ in pairs} == {"a", "b"}
+    assert not [result for _, result in pairs if isinstance(result, Exception)]
+    assert len(service.requests_for("POST", r"/v1/convert/source/async")) == 2
+
+
+@pytest.mark.anyio
+async def test_async_client_surfaces_submit_errors(async_client_kwargs, service):
+    service.add_route(
+        "POST",
+        r"/v1/convert/source/async",
+        lambda request, match: Response(status=500, body={"detail": "boom"}),
+    )
+
+    async with AsyncDoclingServiceClient(**async_client_kwargs) as remote:
+        with pytest.raises(ServiceError):
+            await remote.submit(SOURCE, target=InBodyTarget())

--- a/tests/test_service_client_fake_service.py
+++ b/tests/test_service_client_fake_service.py
@@ -29,7 +29,7 @@ from docling.service_client import (
 from docling.service_client.client import ConversionItem, StatusWatcherKind
 from docling.service_client.exceptions import ServiceError, TaskNotFoundError
 from tests.fakes.docling_serve import FakeDoclingServe
-from tests.fakes.http_service import FakeHttpService, Response
+from tests.fakes.http_service import FakeService, Response
 
 SOURCE = "https://example.com/report.pdf"
 
@@ -37,21 +37,27 @@ SOURCE = "https://example.com/report.pdf"
 @pytest.fixture
 def serve() -> Iterator[FakeDoclingServe]:
     """A running fake docling-serve; also exposes the underlying HTTP service."""
-    fake_service = FakeHttpService()
-    base_url = fake_service.start()
+    fake_service = FakeService()
+    route_pack = FakeDoclingServe()
+    fake_service.include(route_pack.router)
+    fake_service.start()
+    # Presigned artifact URIs must point back at this server, whose port is
+    # only known once it is bound.
+    route_pack.base_url = fake_service.base_url
+    route_pack.service = fake_service
     try:
-        yield FakeDoclingServe(fake_service, base_url)
+        yield route_pack
     finally:
         fake_service.stop()
 
 
 @pytest.fixture
-def service(serve: FakeDoclingServe) -> FakeHttpService:
+def service(serve: FakeDoclingServe) -> FakeService:
     return serve.service
 
 
 @pytest.fixture
-def client(service: FakeHttpService) -> Iterator[DoclingServiceClient]:
+def client(service: FakeService) -> Iterator[DoclingServiceClient]:
     with DoclingServiceClient(
         url=service.base_url,
         # The fake answers polls immediately rather than long-polling, so drop
@@ -328,7 +334,7 @@ def anyio_backend() -> str:
 
 
 @pytest.fixture
-def async_client_kwargs(service: FakeHttpService) -> dict[str, object]:
+def async_client_kwargs(service: FakeService) -> dict[str, object]:
     return {
         "url": service.base_url,
         "status_watcher": StatusWatcherKind.POLLING,

--- a/tests/test_service_client_payload_fidelity.py
+++ b/tests/test_service_client_payload_fidelity.py
@@ -1,0 +1,319 @@
+"""Does the server receive everything the caller configured on the client?
+
+Motivated by a shipped regression: ``engine_options`` is declared as its base
+class, so Pydantic serialised it against the *base* schema and silently
+dropped every subclass field. A caller who configured a custom engine got a
+request carrying only ``engine_type``; the URL, params and timeout never left
+the process, and nothing failed loudly. The fix was to annotate the field
+``SerializeAsAny``.
+
+These tests assert the shape of the *request* the client puts on the wire, so
+the fake here is only a recorder -- it models no part of the docling-serve
+response contract and cannot drift from it. The one response it does return
+is built from this repo's own ``TaskStatusResponse`` model.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import typing
+from collections.abc import Iterator
+from typing import Any
+
+import pytest
+from pydantic import AnyUrl, BaseModel
+
+from docling.datamodel.base_models import ConversionStatus
+from docling.datamodel.pipeline_options import VlmConvertOptions
+from docling.datamodel.service.options import ConvertDocumentsOptions
+from docling.datamodel.service.responses import TaskStatusResponse
+from docling.datamodel.service.targets import InBodyTarget
+from docling.datamodel.service.tasks import TaskType
+from docling.datamodel.vlm_engine_options import (
+    ApiVlmEngineOptions,
+    MlxVlmEngineOptions,
+    TransformersVlmEngineOptions,
+    VllmVlmEngineOptions,
+    VlmEngineType,
+)
+from docling.service_client import DoclingServiceClient
+from docling.service_client.client import StatusWatcherKind
+from tests.fakes.http_service import FakeHttpService, RecordedRequest, Response
+
+SOURCE = "https://example.com/report.pdf"
+
+
+@pytest.fixture
+def recorder() -> Iterator[FakeHttpService]:
+    """A service that accepts a submission and records nothing else."""
+    service = FakeHttpService()
+    service.start()
+
+    def _accept(request: RecordedRequest, match: re.Match[str]) -> Response:
+        status = TaskStatusResponse(
+            task_id="task-1",
+            task_type=TaskType.CONVERT,
+            task_status=ConversionStatus.PENDING,
+        )
+        return Response(body=json.loads(status.model_dump_json()))
+
+    service.add_route("POST", r"/v1/convert/source/async", _accept)
+    service.add_route("POST", r"/v1/convert/file/async", _accept)
+    try:
+        yield service
+    finally:
+        service.stop()
+
+
+@pytest.fixture
+def client(recorder: FakeHttpService) -> Iterator[DoclingServiceClient]:
+    with DoclingServiceClient(
+        url=recorder.base_url, status_watcher=StatusWatcherKind.POLLING
+    ) as remote:
+        yield remote
+
+
+def _submitted_options(service: FakeHttpService) -> dict[str, Any]:
+    """The options block of the JSON submission the server actually received."""
+    requests = service.requests_for("POST", r"/v1/convert/source/async")
+    assert requests, "no submission reached the server"
+    return requests[-1].json()["options"]
+
+
+def _api_engine() -> ApiVlmEngineOptions:
+    return ApiVlmEngineOptions(
+        engine_type=VlmEngineType.API_OPENAI,
+        url=AnyUrl("https://vlm.example.com/v1/chat/completions"),
+        params={"model": "custom-vlm", "temperature": 0.1},
+        timeout=123.0,
+        headers={"X-Tenant": "acme"},
+        concurrency=4,
+    )
+
+
+# -- the regression this module exists for -------------------------------
+
+
+def test_custom_vlm_engine_options_reach_the_server(client, recorder):
+    """Every field of a custom engine must survive serialisation.
+
+    Without ``SerializeAsAny`` on the field, only ``engine_type`` arrives and
+    the rest is dropped without error -- the caller's configuration is lost.
+    """
+    engine = _api_engine()
+    client.submit(
+        SOURCE,
+        options=ConvertDocumentsOptions(
+            vlm_pipeline_custom_config=VlmConvertOptions.from_preset(
+                "smoldocling", engine_options=engine
+            )
+        ),
+        target=InBodyTarget(),
+    )
+
+    received = _submitted_options(recorder)["vlm_pipeline_custom_config"][
+        "engine_options"
+    ]
+
+    assert received["url"] == "https://vlm.example.com/v1/chat/completions"
+    assert received["params"] == {"model": "custom-vlm", "temperature": 0.1}
+    assert received["timeout"] == 123.0
+    assert received["headers"] == {"X-Tenant": "acme"}
+    assert received["concurrency"] == 4
+    assert received["engine_type"] == VlmEngineType.API_OPENAI.value
+
+
+@pytest.mark.parametrize(
+    ("engine", "expected"),
+    [
+        pytest.param(
+            TransformersVlmEngineOptions(
+                engine_type=VlmEngineType.TRANSFORMERS,
+                torch_dtype="bfloat16",
+                quantized=True,
+                load_in_8bit=False,
+                trust_remote_code=True,
+            ),
+            {
+                "torch_dtype": "bfloat16",
+                "quantized": True,
+                "load_in_8bit": False,
+                "trust_remote_code": True,
+            },
+            id="transformers",
+        ),
+        pytest.param(
+            MlxVlmEngineOptions(engine_type=VlmEngineType.MLX, trust_remote_code=True),
+            {"trust_remote_code": True},
+            id="mlx",
+        ),
+        pytest.param(
+            VllmVlmEngineOptions(
+                engine_type=VlmEngineType.VLLM,
+                tensor_parallel_size=2,
+                gpu_memory_utilization=0.75,
+                trust_remote_code=True,
+            ),
+            {
+                "tensor_parallel_size": 2,
+                "gpu_memory_utilization": 0.75,
+                "trust_remote_code": True,
+            },
+            id="vllm",
+        ),
+    ],
+)
+def test_every_engine_variant_keeps_its_own_fields(client, recorder, engine, expected):
+    """Each engine subclass carries different fields; none may be flattened."""
+    client.submit(
+        SOURCE,
+        options=ConvertDocumentsOptions(
+            vlm_pipeline_custom_config=VlmConvertOptions.from_preset(
+                "smoldocling", engine_options=engine
+            )
+        ),
+        target=InBodyTarget(),
+    )
+
+    received = _submitted_options(recorder)["vlm_pipeline_custom_config"][
+        "engine_options"
+    ]
+
+    for key, value in expected.items():
+        assert received.get(key) == value, f"{key} was lost in serialisation"
+
+
+def test_free_form_custom_config_reaches_the_server_intact(client, recorder):
+    """Nested dict options must not be flattened or stringified on the way out."""
+    ocr_config = {"engine": "custom-ocr", "nested": {"lang": ["en", "de"], "dpi": 300}}
+    client.submit(
+        SOURCE,
+        options=ConvertDocumentsOptions(
+            ocr_custom_config=ocr_config,
+            layout_custom_config={"repo_id": "acme/layout", "threshold": 0.42},
+        ),
+        target=InBodyTarget(),
+    )
+
+    received = _submitted_options(recorder)
+
+    assert received["ocr_custom_config"] == ocr_config
+    assert received["layout_custom_config"] == {
+        "repo_id": "acme/layout",
+        "threshold": 0.42,
+    }
+
+
+def test_secret_values_are_sent_unwrapped(client, recorder):
+    """SecretStr must reach the server as its value, not as '**********'."""
+    client.submit(
+        SOURCE,
+        options=ConvertDocumentsOptions(
+            vlm_pipeline_custom_config=VlmConvertOptions.from_preset(
+                "smoldocling",
+                engine_options=ApiVlmEngineOptions(
+                    engine_type=VlmEngineType.API_OPENAI,
+                    url=AnyUrl("https://vlm.example.com/v1"),
+                    headers={"Authorization": "Bearer sk-not-a-real-key"},
+                ),
+            )
+        ),
+        target=InBodyTarget(),
+    )
+
+    received = _submitted_options(recorder)["vlm_pipeline_custom_config"][
+        "engine_options"
+    ]
+
+    assert received["headers"]["Authorization"] == "Bearer sk-not-a-real-key"
+    assert "*" not in received["headers"]["Authorization"]
+
+
+# -- the file-upload route uses a different encoder ----------------------
+
+
+def test_file_uploads_carry_nested_options_as_json_fields(client, recorder, tmp_path):
+    """Multipart fields take only primitives, so nested options are JSON encoded."""
+    source = tmp_path / "report.pdf"
+    source.write_bytes(b"%PDF-1.4\n%%EOF\n")
+    ocr_config = {"engine": "custom-ocr", "nested": {"lang": ["en"]}}
+
+    client.submit(
+        source,
+        options=ConvertDocumentsOptions(ocr_custom_config=ocr_config),
+        target=InBodyTarget(),
+    )
+
+    uploads = recorder.requests_for("POST", r"/v1/convert/file/async")
+    assert uploads, "the file route was not used for a local path"
+    body = uploads[-1].body.decode("utf-8", errors="replace")
+    # The field is present and holds the JSON encoding of the nested value.
+    assert "ocr_custom_config" in body
+    assert json.dumps(ocr_config) in body
+
+
+# -- a guard against the next occurrence ---------------------------------
+
+
+def _polymorphic_option_fields() -> list[tuple[str, str, str, bool]]:
+    """Walk the request options graph for fields that can hold a subclass.
+
+    Returns ``(model, field, declared base, is SerializeAsAny)`` for every
+    field whose declared type is a Pydantic model that has subclasses.
+    """
+
+    def descendants(cls: type) -> set[type]:
+        found: set[type] = set()
+        for sub in cls.__subclasses__():
+            found.add(sub)
+            found |= descendants(sub)
+        return found
+
+    seen: set[type] = set()
+    todo: list[type] = [ConvertDocumentsOptions]
+    findings: set[tuple[str, str, str, bool]] = set()
+    while todo:
+        model = todo.pop()
+        if model in seen or not (
+            isinstance(model, type) and issubclass(model, BaseModel)
+        ):
+            continue
+        seen.add(model)
+        for name, field in model.model_fields.items():
+            # SerializeAsAny is recorded as a metadata marker; the annotation
+            # itself still reports the bare base class.
+            protected = any(
+                type(marker).__name__ == "SerializeAsAny" for marker in field.metadata
+            )
+            for arg in typing.get_args(field.annotation) or (field.annotation,):
+                if isinstance(arg, type) and issubclass(arg, BaseModel):
+                    todo.append(arg)
+                    if descendants(arg):
+                        findings.add((model.__name__, name, arg.__name__, protected))
+    return sorted(findings)
+
+
+def test_polymorphic_option_fields_are_serialized_as_any():
+    """Any option field holding a subclass must serialise the subclass schema.
+
+    Declaring such a field without ``SerializeAsAny`` makes Pydantic dump it
+    against the base schema, dropping subclass fields silently. Walking the
+    options graph means a newly added field is covered without editing this
+    test -- which is the point, since the failure mode is silent.
+    """
+    fields = _polymorphic_option_fields()
+    assert fields, (
+        "no polymorphic option fields found - this check would pass trivially "
+        "and must be revisited"
+    )
+
+    offenders = [
+        f"{model}.{field} (declared as {base})"
+        for model, field, base, protected in fields
+        if not protected
+    ]
+    assert not offenders, (
+        "these option fields hold subclasses but are not SerializeAsAny, so "
+        "subclass fields will be dropped from the request: " + ", ".join(offenders)
+    )

--- a/tests/test_service_client_payload_fidelity.py
+++ b/tests/test_service_client_payload_fidelity.py
@@ -39,15 +39,15 @@ from docling.datamodel.vlm_engine_options import (
 )
 from docling.service_client import DoclingServiceClient
 from docling.service_client.client import StatusWatcherKind
-from tests.fakes.http_service import FakeHttpService, RecordedRequest, Response
+from tests.fakes.http_service import FakeService, RecordedRequest, Response
 
 SOURCE = "https://example.com/report.pdf"
 
 
 @pytest.fixture
-def recorder() -> Iterator[FakeHttpService]:
+def recorder() -> Iterator[FakeService]:
     """A service that accepts a submission and records nothing else."""
-    service = FakeHttpService()
+    service = FakeService()
     service.start()
 
     def _accept(request: RecordedRequest, match: re.Match[str]) -> Response:
@@ -67,14 +67,14 @@ def recorder() -> Iterator[FakeHttpService]:
 
 
 @pytest.fixture
-def client(recorder: FakeHttpService) -> Iterator[DoclingServiceClient]:
+def client(recorder: FakeService) -> Iterator[DoclingServiceClient]:
     with DoclingServiceClient(
         url=recorder.base_url, status_watcher=StatusWatcherKind.POLLING
     ) as remote:
         yield remote
 
 
-def _submitted_options(service: FakeHttpService) -> dict[str, Any]:
+def _submitted_options(service: FakeService) -> dict[str, Any]:
     """The options block of the JSON submission the server actually received."""
     requests = service.requests_for("POST", r"/v1/convert/source/async")
     assert requests, "no submission reached the server"

--- a/uv.lock
+++ b/uv.lock
@@ -2110,8 +2110,10 @@ dev = [
     { name = "boto3-stubs" },
     { name = "coverage" },
     { name = "dprint-py" },
+    { name = "fastapi" },
     { name = "ipykernel" },
     { name = "ipywidgets" },
+    { name = "uvicorn" },
     { name = "matplotlib", version = "3.10.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "matplotlib", version = "3.11.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "nbqa" },
@@ -2274,6 +2276,7 @@ dev = [
     { name = "boto3-stubs", specifier = "~=1.37" },
     { name = "coverage", specifier = "~=7.6" },
     { name = "dprint-py", specifier = "==0.53.1.0" },
+    { name = "fastapi", specifier = ">=0.115" },
     { name = "ipykernel", specifier = "~=6.29" },
     { name = "ipywidgets", specifier = "~=8.1" },
     { name = "matplotlib", specifier = ">=3.10.9" },
@@ -2294,6 +2297,7 @@ dev = [
     { name = "types-setuptools", specifier = "~=70.3" },
     { name = "types-tqdm", specifier = "~=4.67" },
     { name = "types-urllib3", specifier = "~=1.26" },
+    { name = "uvicorn", specifier = ">=0.30" },
 ]
 docs = [
     { name = "griffe-pydantic", specifier = "~=1.1" },


### PR DESCRIPTION
Third iteration of the coverage work (after #4044 and #4046). Two commits with different justifications, kept together because the second is what makes the first worth having.

## Why: a bug that already shipped

`engine_options` is declared as its base class, so Pydantic serialised it against the **base** schema and silently dropped every subclass field. A caller configuring a custom engine sent only `engine_type` — the url, params and timeout never left the process, and nothing failed:

```
without SerializeAsAny -> ['engine_type']
with    SerializeAsAny -> ['concurrency', 'engine_type', 'headers', 'params', 'timeout', 'url']
```

`tests/test_service_client_payload_fidelity.py` asserts the server receives everything the caller set. Verified to have teeth: temporarily removing the `SerializeAsAny` annotation fails **6 of the 8** tests.

Variations cover the API engine (url / params / timeout / headers / concurrency), transformers / mlx / vllm each with their own distinctive fields, free-form nested dict configs, secret unwrapping, and the multipart file-upload route, which uses a different encoder entirely.

### The part that matters beyond this one case

Only **one field in the repo** carries `SerializeAsAny` today, so the next polymorphic option added is a live repeat. One test walks the request options graph, finds every field whose declared type is a subclassed model, and requires the annotation — currently 3 fields, all `engine_options`. A newly added field is covered without editing the test, which matters because the failure mode is silent. It also asserts the walk is non-empty so it cannot quietly become vacuous.

## The harness

`tests/fakes/http_service.py` is a routing `ThreadingHTTPServer` on an ephemeral localhost port. Being a real socket, it serves `httpx` and `requests`, sync and async, with no library-specific adapter, and faults become responses rather than mock configuration.

The existing tests install an `httpx.MockTransport` onto `client._http_client`, which cannot reach below the request layer — which is where everything still uncovered lived.

**Contract risk:** the docling-serve route pack builds every response from this repo's own response models (`TaskStatusResponse`, `ConvertDocumentResponse`, `PresignedUrlConvertResponse`, `DocumentArtifactItem`, `ArtifactRef`) rather than hand-written dicts, so it is a consumer of the same schema the client validates against instead of a second copy that can drift. The payload-fidelity module goes further and uses the fake purely as a request recorder — it asserts nothing about responses at all.

## Coverage

`docling/service_client`, on top of the existing suite: **79.7% → 85.1% line, 60.1% → 69.5% branch** (+85 statements, +42 branch destinations).

Worth stating plainly: that is ~2% of the statements needed for the 90% target. The justification here is regression protection for a bug class that already cost us once, not the coverage number.

## Behaviour the real socket surfaced

Four initial assertions were wrong about actual behaviour, and each correction became a better test:

- The SSRF guard (`_is_safe_artifact_url`) correctly refuses loopback artifact URLs — now asserted, with a narrowly scoped fixture unblocking the happy path separately.
- The retry policy: 500/502 back off exponentially; 429/503 retry **only** when `Retry-After` is present and are surfaced immediately otherwise; 4xx and 5xx map to different exception types.
- `/v1` in the base URL is rejected, not normalised.
- `convert()` negotiates targets — presigned first, falling back to InBody when the service reports no artifact storage.

## Notes

- 38 tests, ~38s. `poll_client_interval` is set small in fixtures since the fake answers immediately rather than long-polling.
- Tests only; no production code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)