### PR TITLE
fix: Handle various cross-type overlap cleanups in layout processing

### DIFF
--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -399,30 +399,29 @@ class LayoutPostprocessor:
         """
         clusters_to_remove = set()
 
+        # TABLE is part of WRAPPER_TYPES and therefore always ends up in special_clusters,
+        # never in regular_clusters. Build the list from special_clusters so the check
+        # below can actually find TABLE proposals to compare against.
+        tables = [c for c in special_clusters if c.label == DocItemLabel.TABLE]
+
         for wrapper in special_clusters:
             if wrapper.label not in self.WRAPPER_TYPES:
-                continue  # only treat KEY_VALUE_REGION for now.
+                continue
+            if wrapper.label == DocItemLabel.TABLE:
+                continue  # TABLE cannot be a candidate for removal here
 
-            for regular in self.regular_clusters:
-                if regular.label == DocItemLabel.TABLE:
-                    # Calculate overlap
-                    overlap_ratio = wrapper.bbox.intersection_over_self(regular.bbox)
-
-                    conf_diff = wrapper.confidence - regular.confidence
-
-                    # If wrapper is mostly overlapping with a TABLE, remove the wrapper
-                    if (
-                        overlap_ratio > 0.9 and conf_diff < 0.1
-                    ):  # self.OVERLAP_PARAMS["wrapper"]["conf_threshold"]):  # 80% overlap threshold
-                        clusters_to_remove.add(wrapper.id)
-                        break
+            for table in tables:
+                overlap_ratio = wrapper.bbox.intersection_over_self(table.bbox)
+                conf_diff = wrapper.confidence - table.confidence
+                if overlap_ratio > 0.9 and conf_diff < 0.1:
+                    clusters_to_remove.add(wrapper.id)
+                    break
 
         # The picture/table buckets are de-overlapped independently elsewhere, so a
         # region the layout model proposes as BOTH a PICTURE and a TABLE survives twice.
         # When a PICTURE nearly coincides with a TABLE (high IoU), keep the structured
         # TABLE and drop the PICTURE. IoU (not containment) is used so a genuine small
         # figure fully inside a large table region is not removed.
-        tables = [c for c in special_clusters if c.label == DocItemLabel.TABLE]
         for picture in special_clusters:
             if picture.label != DocItemLabel.PICTURE:
                 continue

--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -390,54 +390,64 @@ class LayoutPostprocessor:
 
         return picture_clusters + wrapper_clusters
 
-    def _handle_cross_type_overlaps(self, special_clusters) -> list[Cluster]:
-        """Handle overlaps between regular and wrapper clusters before child assignment.
+    @staticmethod
+    def _resolve_coincident_pairs(
+        losers: list[Cluster],
+        winners: list[Cluster],
+        iou_threshold: float = 0.8,
+        conf_tolerance: float = 0.1,
+    ) -> set[int]:
+        """Elect a winner for near-identical (loser, winner) label pairs.
 
-        In particular, KEY_VALUE_REGION proposals that are almost identical to a TABLE
-        should be removed. A PICTURE proposal that nearly coincides with a TABLE is also
-        removed, keeping the structured TABLE.
+        For each pair whose bboxes are near-identical (``IoU > iou_threshold``)
+        AND whose confidences are within ``conf_tolerance`` of each other, the
+        loser label is dropped so the winner label survives. Nothing else --
+        containment, area, downstream behaviour -- is considered.
+
+        Pairs outside this envelope (low IoU, or a clearly more confident
+        loser) are left alone for other passes to handle.
         """
-        clusters_to_remove = set()
+        to_drop: set[int] = set()
+        for loser in losers:
+            for winner in winners:
+                if loser.bbox.intersection_over_union(winner.bbox) <= iou_threshold:
+                    continue
+                if (loser.confidence - winner.confidence) < conf_tolerance:
+                    to_drop.add(loser.id)
+                    break
+        return to_drop
 
-        # TABLE is part of WRAPPER_TYPES and therefore always ends up in special_clusters,
-        # never in regular_clusters. Build the list from special_clusters so the check
-        # below can actually find TABLE proposals to compare against.
+    def _handle_cross_type_overlaps(self, special_clusters) -> list[Cluster]:
+        """Elect a winner for cross-type label pairs at near-identical bboxes.
+
+        The layout model can emit the same grounded region under several
+        labels. When two labels sit at near-identical bboxes with similar
+        confidence, this step picks the label carrying the richer downstream
+        semantic. Anything outside that envelope is out of scope here.
+
+        | pair                       | loser   | winner          |
+        |----------------------------|---------|-----------------|
+        | FORM / KVR vs TABLE        | wrapper | TABLE           |
+        | DOCUMENT_INDEX vs TABLE    | TABLE   | DOCUMENT_INDEX  |
+        | PICTURE vs TABLE           | PICTURE | TABLE           |
+        """
         tables = [c for c in special_clusters if c.label == DocItemLabel.TABLE]
-
-        for wrapper in special_clusters:
-            if wrapper.label not in self.WRAPPER_TYPES:
-                continue
-            if wrapper.label == DocItemLabel.TABLE:
-                continue  # TABLE cannot be a candidate for removal here
-
-            for table in tables:
-                overlap_ratio = wrapper.bbox.intersection_over_self(table.bbox)
-                conf_diff = wrapper.confidence - table.confidence
-                if overlap_ratio > 0.9 and conf_diff < 0.1:
-                    clusters_to_remove.add(wrapper.id)
-                    break
-
-        # The picture/table buckets are de-overlapped independently elsewhere, so a
-        # region the layout model proposes as BOTH a PICTURE and a TABLE survives twice.
-        # When a PICTURE nearly coincides with a TABLE (high IoU), keep the structured
-        # TABLE and drop the PICTURE. IoU (not containment) is used so a genuine small
-        # figure fully inside a large table region is not removed.
-        for picture in special_clusters:
-            if picture.label != DocItemLabel.PICTURE:
-                continue
-            for table in tables:
-                if picture.bbox.intersection_over_union(table.bbox) > 0.8:
-                    clusters_to_remove.add(picture.id)
-                    break
-
-        # Filter out the identified clusters
-        special_clusters = [
-            cluster
-            for cluster in special_clusters
-            if cluster.id not in clusters_to_remove
+        doc_indices = [
+            c for c in special_clusters if c.label == DocItemLabel.DOCUMENT_INDEX
+        ]
+        pictures = [c for c in special_clusters if c.label == DocItemLabel.PICTURE]
+        wrappers = [
+            c
+            for c in special_clusters
+            if c.label in (DocItemLabel.FORM, DocItemLabel.KEY_VALUE_REGION)
         ]
 
-        return special_clusters
+        clusters_to_remove: set[int] = set()
+        clusters_to_remove |= self._resolve_coincident_pairs(wrappers, tables)
+        clusters_to_remove |= self._resolve_coincident_pairs(tables, doc_indices)
+        clusters_to_remove |= self._resolve_coincident_pairs(pictures, tables)
+
+        return [c for c in special_clusters if c.id not in clusters_to_remove]
 
     def _should_prefer_cluster(
         self, candidate: Cluster, other: Cluster, params: dict

--- a/tests/test_layout_postprocessor.py
+++ b/tests/test_layout_postprocessor.py
@@ -170,3 +170,34 @@ def test_cross_type_overlaps_keeps_small_picture_inside_table() -> None:
 
     ids = {c.id for c in result}
     assert ids == {1, 2}
+
+
+def test_cross_type_overlaps_removes_kvregion_coinciding_with_table() -> None:
+    # A KEY_VALUE_REGION that nearly covers the same area as a TABLE should be
+    # dropped in favour of the TABLE. Previously this check was unreachable because
+    # TABLE is in WRAPPER_TYPES and therefore never appears in regular_clusters.
+    processor = object.__new__(LayoutPostprocessor)
+
+    table = _cluster(1, DocItemLabel.TABLE, (10, 10, 200, 150), confidence=0.85)
+    kvr = _cluster(
+        2, DocItemLabel.KEY_VALUE_REGION, (10, 10, 200, 150), confidence=0.80
+    )
+
+    result = processor._handle_cross_type_overlaps([table, kvr])
+
+    labels = {c.label for c in result}
+    assert DocItemLabel.TABLE in labels
+    assert DocItemLabel.KEY_VALUE_REGION not in labels
+
+
+def test_cross_type_overlaps_keeps_kvregion_not_overlapping_table() -> None:
+    # A KEY_VALUE_REGION on a different part of the page should not be affected.
+    processor = object.__new__(LayoutPostprocessor)
+
+    table = _cluster(1, DocItemLabel.TABLE, (10, 10, 200, 150))
+    kvr = _cluster(2, DocItemLabel.KEY_VALUE_REGION, (10, 300, 200, 450))
+
+    result = processor._handle_cross_type_overlaps([table, kvr])
+
+    ids = {c.id for c in result}
+    assert ids == {1, 2}

--- a/tests/test_layout_postprocessor.py
+++ b/tests/test_layout_postprocessor.py
@@ -155,6 +155,30 @@ def test_cross_type_overlaps_keeps_picture_not_overlapping_table() -> None:
     assert ids == {1, 2}
 
 
+def test_cross_type_overlaps_keeps_both_when_picture_clearly_more_confident() -> None:
+    # The near-tie label preference only fires when confidences are within 0.1.
+    # A near-identical PICTURE that is clearly more confident than the TABLE is
+    # outside our envelope, so we leave both in place. Downstream (or a future
+    # dedicated PICTURE/TABLE sieve) can decide what to do with the pair.
+    processor = object.__new__(LayoutPostprocessor)
+    processor.regular_clusters = []
+
+    table = _cluster(
+        1, BoundingBox(l=10, t=10, r=200, b=150), DocItemLabel.TABLE, confidence=0.55
+    )
+    picture = _cluster(
+        2,
+        BoundingBox(l=10, t=10, r=200, b=150),
+        DocItemLabel.PICTURE,
+        confidence=0.95,
+    )
+
+    result = processor._handle_cross_type_overlaps([table, picture])
+
+    ids = {c.id for c in result}
+    assert ids == {1, 2}
+
+
 def test_cross_type_overlaps_keeps_small_picture_inside_table() -> None:
     # A small figure fully contained in a large table (high containment but low IoU)
     # must NOT be removed -- only a near-coinciding picture is a true mislabel.
@@ -178,9 +202,14 @@ def test_cross_type_overlaps_removes_kvregion_coinciding_with_table() -> None:
     # TABLE is in WRAPPER_TYPES and therefore never appears in regular_clusters.
     processor = object.__new__(LayoutPostprocessor)
 
-    table = _cluster(1, DocItemLabel.TABLE, (10, 10, 200, 150), confidence=0.85)
+    table = _cluster(
+        1, BoundingBox(l=10, t=10, r=200, b=150), DocItemLabel.TABLE, confidence=0.85
+    )
     kvr = _cluster(
-        2, DocItemLabel.KEY_VALUE_REGION, (10, 10, 200, 150), confidence=0.80
+        2,
+        BoundingBox(l=10, t=10, r=200, b=150),
+        DocItemLabel.KEY_VALUE_REGION,
+        confidence=0.80,
     )
 
     result = processor._handle_cross_type_overlaps([table, kvr])
@@ -194,10 +223,114 @@ def test_cross_type_overlaps_keeps_kvregion_not_overlapping_table() -> None:
     # A KEY_VALUE_REGION on a different part of the page should not be affected.
     processor = object.__new__(LayoutPostprocessor)
 
-    table = _cluster(1, DocItemLabel.TABLE, (10, 10, 200, 150))
-    kvr = _cluster(2, DocItemLabel.KEY_VALUE_REGION, (10, 300, 200, 450))
+    table = _cluster(1, BoundingBox(l=10, t=10, r=200, b=150), DocItemLabel.TABLE)
+    kvr = _cluster(
+        2, BoundingBox(l=10, t=300, r=200, b=450), DocItemLabel.KEY_VALUE_REGION
+    )
 
     result = processor._handle_cross_type_overlaps([table, kvr])
+
+    ids = {c.id for c in result}
+    assert ids == {1, 2}
+
+
+def test_cross_type_overlaps_removes_form_coinciding_with_table() -> None:
+    # A FORM whose bbox is near-identical to a TABLE should lose to the structured
+    # TABLE.
+    processor = object.__new__(LayoutPostprocessor)
+
+    table = _cluster(
+        1, BoundingBox(l=10, t=10, r=200, b=150), DocItemLabel.TABLE, confidence=0.80
+    )
+    form = _cluster(
+        2, BoundingBox(l=10, t=10, r=200, b=150), DocItemLabel.FORM, confidence=0.75
+    )
+
+    result = processor._handle_cross_type_overlaps([table, form])
+
+    labels = {c.label for c in result}
+    assert DocItemLabel.TABLE in labels
+    assert DocItemLabel.FORM not in labels
+
+
+def test_cross_type_overlaps_keeps_form_containing_small_table() -> None:
+    # A TABLE that only overlaps a portion of a larger FORM must NOT drop the FORM.
+    # This is the guard-rail against the previous intersection_over_self behaviour,
+    # which would have removed the FORM whenever a TABLE landed anywhere inside it.
+    processor = object.__new__(LayoutPostprocessor)
+
+    form = _cluster(
+        1, BoundingBox(l=0, t=0, r=400, b=400), DocItemLabel.FORM, confidence=0.80
+    )
+    table = _cluster(
+        2, BoundingBox(l=20, t=20, r=120, b=120), DocItemLabel.TABLE, confidence=0.80
+    )
+
+    result = processor._handle_cross_type_overlaps([form, table])
+
+    ids = {c.id for c in result}
+    assert ids == {1, 2}
+
+
+def test_cross_type_overlaps_keeps_form_when_clearly_more_confident() -> None:
+    # Label preference only applies when the two heads are similarly confident.
+    # A near-identical FORM proposal that is clearly more confident than the TABLE
+    # must survive.
+    processor = object.__new__(LayoutPostprocessor)
+
+    table = _cluster(
+        1, BoundingBox(l=10, t=10, r=200, b=150), DocItemLabel.TABLE, confidence=0.55
+    )
+    form = _cluster(
+        2, BoundingBox(l=10, t=10, r=200, b=150), DocItemLabel.FORM, confidence=0.95
+    )
+
+    result = processor._handle_cross_type_overlaps([table, form])
+
+    ids = {c.id for c in result}
+    assert ids == {1, 2}
+
+
+def test_cross_type_overlaps_keeps_document_index_over_coinciding_table() -> None:
+    # DOCUMENT_INDEX carries the "this is an index/TOC" semantic and is treated as
+    # a table downstream anyway, so a near-identical TABLE proposal must lose.
+    processor = object.__new__(LayoutPostprocessor)
+
+    table = _cluster(
+        1, BoundingBox(l=10, t=10, r=200, b=150), DocItemLabel.TABLE, confidence=0.80
+    )
+    doc_index = _cluster(
+        2,
+        BoundingBox(l=10, t=10, r=200, b=150),
+        DocItemLabel.DOCUMENT_INDEX,
+        confidence=0.75,
+    )
+
+    result = processor._handle_cross_type_overlaps([table, doc_index])
+
+    labels = {c.label for c in result}
+    assert DocItemLabel.DOCUMENT_INDEX in labels
+    assert DocItemLabel.TABLE not in labels
+
+
+def test_cross_type_overlaps_keeps_table_when_clearly_more_confident_than_docindex() -> (
+    None
+):
+    # Same confidence gate in the DocIndex direction: a clearly-more-confident
+    # TABLE proposal is not overridden by a low-confidence DOCUMENT_INDEX.
+    processor = object.__new__(LayoutPostprocessor)
+
+    table = _cluster(
+        1, BoundingBox(l=10, t=10, r=200, b=150), DocItemLabel.TABLE, confidence=0.95
+    )
+    doc_index = _cluster(
+        2,
+        BoundingBox(l=10, t=10, r=200, b=150),
+        DocItemLabel.DOCUMENT_INDEX,
+        confidence=0.55,
+    )
+
+    result = processor._handle_cross_type_overlaps([table, doc_index])
 
     ids = {c.id for c in result}
     assert ids == {1, 2}


### PR DESCRIPTION
## Summary

`_handle_cross_type_overlaps` in `layout_postprocessor.py` had accumulated three ad-hoc cross-type dedup branches, each with a slightly different metric and gate. This PR consolidates them behind one helper and tightens the semantics where the previous choices were wrong.

Builds on **#3701** by @charlesaurav13 (included as the first commit of this branch), which fixes the unreachable `for regular in self.regular_clusters: if regular.label == DocItemLabel.TABLE` — TABLE is a `WRAPPER_TYPES` member and always lands in `special_clusters`, so that KEY_VALUE_REGION-vs-TABLE branch never fired. With that fix in place, the branch is reachable and the semantics matter.

## The rule

All three cross-type pairs share one rule: when two labels land at near-identical bboxes with similar confidence, elect the label carrying the richer downstream semantic. Envelope:

- `IoU > 0.8` (near-identical shape)
- `loser.confidence − winner.confidence < 0.1` (similar confidence)

Anything outside that envelope — containment, area, a clearly-more-confident loser — is out of scope here and left to other passes.

## What changed

Factored into `_resolve_coincident_pairs(losers, winners)` and called once per pair:

| pair | loser (dropped) | winner (kept) |
|---|---|---|
| FORM / KEY_VALUE_REGION vs TABLE | wrapper | TABLE |
| TABLE vs DOCUMENT_INDEX | TABLE | DOCUMENT_INDEX |
| PICTURE vs TABLE | PICTURE | TABLE |

Concrete deltas vs `main`:

- **FORM/KVR vs TABLE**: metric changed from `intersection_over_self > 0.9` to `IoU > 0.8`. The old metric would drop a large FORM when a small TABLE was nested inside it; nesting-worthy pairs are now left alone.
- **DOCUMENT_INDEX vs TABLE**: new branch. DOCUMENT_INDEX carries the richer semantic (structured index with links), so the TABLE proposal is the loser.
- **PICTURE vs TABLE**: same TABLE-wins direction as before (from #3523), but now goes through the shared helper and picks up the `<0.1` confidence gate — a clearly-more-confident PICTURE against a low-confidence TABLE now survives.

## What is deliberately not in scope

- Nesting, containment, and area-based tie-breaking remain the responsibility of the existing passes.
- Changes proposed in #3789 (to be updated afterwards)

## Attribution

- First commit — @charlesaurav13, #3701, fixes #3495.
- Second commit — unification on top.