### PR TITLE
fix: skip the native segmented-page decode in full-page OCR mode

### DIFF
--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -2066,17 +2066,6 @@ class PdfPipelineOptions(PaginatedPipelineOptions):
             )
         ),
     ] = False
-    skip_cell_extraction: Annotated[
-        bool,
-        Field(
-            description=(
-                "Skip native text-cell extraction (the backend's segmented-page decode) during page "
-                "preprocessing; pages then rely entirely on OCR for text. Escape hatch for vector-dense "
-                "pages (e.g. CAD/wiring schematics drawn as 100k+ path segments) whose native decode "
-                "costs multiple GiB regardless of cell content levels. See issue #4058."
-            )
-        ),
-    ] = False
     heading_hierarchy_options: Annotated[
         HeadingHierarchyOptions,
         Field(

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -2066,6 +2066,17 @@ class PdfPipelineOptions(PaginatedPipelineOptions):
             )
         ),
     ] = False
+    skip_cell_extraction: Annotated[
+        bool,
+        Field(
+            description=(
+                "Skip native text-cell extraction (the backend's segmented-page decode) during page "
+                "preprocessing; pages then rely entirely on OCR for text. Escape hatch for vector-dense "
+                "pages (e.g. CAD/wiring schematics drawn as 100k+ path segments) whose native decode "
+                "costs multiple GiB regardless of cell content levels. See issue #4058."
+            )
+        ),
+    ] = False
     heading_hierarchy_options: Annotated[
         HeadingHierarchyOptions,
         Field(

--- a/docling/models/base_ocr_model.py
+++ b/docling/models/base_ocr_model.py
@@ -33,18 +33,20 @@ def _empty_segmented_page(page: Page) -> SegmentedPdfPage:
     """A minimal SegmentedPdfPage for pages whose native parse was skipped
     (PagePreprocessingOptions.skip_cell_extraction), sized from the page."""
     width, height = page.size.width, page.size.height
+    # CoordOrigin.BOTTOMLEFT by convention: a real backend produces the
+    # segmented page in bottom-left coordinates.
     rect = BoundingRectangle(
-        r_x0=0,
-        r_y0=height,
-        r_x1=width,
-        r_y1=height,
-        r_x2=width,
-        r_y2=0,
-        r_x3=0,
-        r_y3=0,
-        coord_origin=CoordOrigin.TOPLEFT,
+        r_x0=0,  # lower-left
+        r_y0=0,
+        r_x1=width,  # lower-right
+        r_y1=0,
+        r_x2=width,  # upper-right
+        r_y2=height,
+        r_x3=0,  # upper-left
+        r_y3=height,
+        coord_origin=CoordOrigin.BOTTOMLEFT,
     )
-    bbox = BoundingBox(l=0, t=0, r=width, b=height, coord_origin=CoordOrigin.TOPLEFT)
+    bbox = BoundingBox(l=0, t=height, r=width, b=0, coord_origin=CoordOrigin.BOTTOMLEFT)
     return SegmentedPdfPage(
         dimension=PdfPageGeometry(
             angle=0.0,

--- a/docling/models/base_ocr_model.py
+++ b/docling/models/base_ocr_model.py
@@ -8,8 +8,11 @@ from pathlib import Path
 import numpy as np
 from docling_core.types.doc import BoundingBox, CoordOrigin, Size
 from docling_core.types.doc.page import (
+    BoundingRectangle,
     PdfCellRenderingMode,
+    PdfPageGeometry,
     PdfTextCell,
+    SegmentedPdfPage,
     TextCell,
 )
 from PIL import Image, ImageDraw
@@ -24,6 +27,40 @@ from docling.datamodel.spatial import BoundingBoxSpatialIndex
 from docling.models.base_model import BaseModelWithOptions, BasePageModel
 
 _log = logging.getLogger(__name__)
+
+
+def _empty_segmented_page(page: Page) -> SegmentedPdfPage:
+    """A minimal SegmentedPdfPage for pages whose native parse was skipped
+    (PagePreprocessingOptions.skip_cell_extraction), sized from the page."""
+    width, height = page.size.width, page.size.height
+    rect = BoundingRectangle(
+        r_x0=0,
+        r_y0=height,
+        r_x1=width,
+        r_y1=height,
+        r_x2=width,
+        r_y2=0,
+        r_x3=0,
+        r_y3=0,
+        coord_origin=CoordOrigin.TOPLEFT,
+    )
+    bbox = BoundingBox(l=0, t=0, r=width, b=height, coord_origin=CoordOrigin.TOPLEFT)
+    return SegmentedPdfPage(
+        dimension=PdfPageGeometry(
+            angle=0.0,
+            rect=rect,
+            boundary_type="crop_box",
+            art_bbox=bbox,
+            bleed_bbox=bbox,
+            crop_bbox=bbox,
+            media_bbox=bbox,
+            trim_bbox=bbox,
+        ),
+        char_cells=[],
+        word_cells=[],
+        textline_cells=[],
+    )
+
 
 try:
     import cv2
@@ -324,7 +361,10 @@ class BaseOcrModel(BasePageModel, BaseModelWithOptions):
         for i, cell in enumerate(final_cells):
             cell.index = i
 
-        assert page.parsed_page is not None
+        if page.parsed_page is None:
+            # No native parse ran (e.g. skip_cell_extraction): create an empty
+            # SegmentedPdfPage so the OCR output has somewhere to live.
+            page.parsed_page = _empty_segmented_page(page)
 
         # Update parsed_page.textline_cells directly
         page.parsed_page.textline_cells = final_cells

--- a/docling/models/stages/page_preprocessing/page_preprocessing_model.py
+++ b/docling/models/stages/page_preprocessing/page_preprocessing_model.py
@@ -13,9 +13,24 @@ from pydantic import BaseModel
 
 from docling.datamodel.base_models import Page
 from docling.datamodel.document import ConversionResult
+from docling.datamodel.pipeline_options import OcrMode, PdfPipelineOptions
 from docling.datamodel.settings import settings
 from docling.models.base_model import BasePageModel
 from docling.utils.profiling import TimeRecorder
+
+
+def resolve_skip_cell_extraction(pipeline_options: PdfPipelineOptions) -> bool:
+    """Whether the native segmented-page (text-cell) decode can be skipped.
+
+    In full-page OCR mode the native PDF text cells are discarded wholesale
+    during OCR post-processing, so extracting them is pure waste — and on
+    vector-dense pages (CAD/wiring schematics drawn as 100k+ path segments)
+    that decode costs multiple GiB regardless of cell content levels.
+    See https://github.com/docling-project/docling/issues/4058.
+    """
+    return bool(pipeline_options.do_ocr) and (
+        pipeline_options.ocr_options.mode == OcrMode.FULL_PAGE
+    )
 
 
 class PagePreprocessingOptions(BaseModel):

--- a/docling/pipeline/legacy_standard_pdf_pipeline.py
+++ b/docling/pipeline/legacy_standard_pdf_pipeline.py
@@ -38,6 +38,7 @@ from docling.models.stages.page_assemble.page_assemble_model import (
 from docling.models.stages.page_preprocessing.page_preprocessing_model import (
     PagePreprocessingModel,
     PagePreprocessingOptions,
+    resolve_skip_cell_extraction,
 )
 from docling.models.stages.reading_order.readingorder_model import (
     ReadingOrderModel,
@@ -106,6 +107,7 @@ class LegacyStandardPdfPipeline(PaginatedPipeline):
             PagePreprocessingModel(
                 options=PagePreprocessingOptions(
                     images_scale=pipeline_options.images_scale,
+                    skip_cell_extraction=resolve_skip_cell_extraction(pipeline_options),
                 )
             ),
             # OCR

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -72,6 +72,7 @@ from docling.models.stages.page_assemble.page_assemble_model import (
 from docling.models.stages.page_preprocessing.page_preprocessing_model import (
     PagePreprocessingModel,
     PagePreprocessingOptions,
+    resolve_skip_cell_extraction,
 )
 from docling.models.stages.reading_order.readingorder_model import (
     ReadingOrderModel,
@@ -601,7 +602,9 @@ class StandardPdfPipeline(ConvertPipeline):
         self.preprocessing_model = PagePreprocessingModel(
             options=PagePreprocessingOptions(
                 images_scale=self.pipeline_options.images_scale,
-                skip_cell_extraction=self.pipeline_options.skip_cell_extraction,
+                skip_cell_extraction=resolve_skip_cell_extraction(
+                    self.pipeline_options
+                ),
             )
         )
         self.ocr_model = self._make_ocr_model(art_path)

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -600,7 +600,8 @@ class StandardPdfPipeline(ConvertPipeline):
         )
         self.preprocessing_model = PagePreprocessingModel(
             options=PagePreprocessingOptions(
-                images_scale=self.pipeline_options.images_scale
+                images_scale=self.pipeline_options.images_scale,
+                skip_cell_extraction=self.pipeline_options.skip_cell_extraction,
             )
         )
         self.ocr_model = self._make_ocr_model(art_path)

--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -257,9 +257,12 @@ class LayoutPostprocessor:
                 for child in cluster.children:
                     child.cells = self._sort_cells(child.cells)
 
-            assert self.page.parsed_page is not None
-            self.page.parsed_page.textline_cells = self.cells
-            self.page.parsed_page.has_lines = len(self.cells) > 0
+            # parsed_page is absent when native cell extraction was skipped
+            # (PagePreprocessingOptions.skip_cell_extraction); there are no
+            # textline cells to write back in that case.
+            if self.page.parsed_page is not None:
+                self.page.parsed_page.textline_cells = self.cells
+                self.page.parsed_page.has_lines = len(self.cells) > 0
 
         return final_clusters
 

--- a/tests/test_skip_cell_extraction.py
+++ b/tests/test_skip_cell_extraction.py
@@ -1,0 +1,121 @@
+"""Regression tests for skip_cell_extraction (issue #4058).
+
+A page whose native cell extraction was skipped keeps ``parsed_page=None``;
+OCR post-processing and layout post-processing must handle that instead of
+crashing, and the flag must be reachable from ``PdfPipelineOptions``.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+from docling_core.types.doc import DocItemLabel
+from docling_core.types.doc.page import BoundingRectangle, TextCell
+
+from docling.datamodel.base_models import (
+    BoundingBox,
+    Cluster,
+    ConfidenceReport,
+    LayoutPrediction,
+    Page,
+    Size,
+)
+from docling.datamodel.pipeline_options import (
+    LayoutPostprocessorOptions,
+    OcrMode,
+    PdfPipelineOptions,
+)
+from docling.models.base_ocr_model import BaseOcrModel, _empty_segmented_page
+from docling.models.stages.layout.layout_postprocessing_model import (
+    LayoutPostprocessingModel,
+)
+from docling.models.stages.page_preprocessing.page_preprocessing_model import (
+    PagePreprocessingModel,
+    PagePreprocessingOptions,
+)
+
+
+def _page() -> Page:
+    page = Page(page_no=1)
+    page.size = Size(width=600.0, height=800.0)
+    return page
+
+
+def _ocr_cell(text: str, confidence: float) -> TextCell:
+    return TextCell(
+        rect=BoundingRectangle(
+            r_x0=10, r_y0=30, r_x1=110, r_y1=30, r_x2=110, r_y2=10, r_x3=10, r_y3=10
+        ),
+        text=text,
+        orig=text,
+        from_ocr=True,
+        confidence=confidence,
+    )
+
+
+def test_pdf_pipeline_options_expose_skip_cell_extraction() -> None:
+    assert PdfPipelineOptions().skip_cell_extraction is False
+    assert PdfPipelineOptions(skip_cell_extraction=True).skip_cell_extraction is True
+    # The preprocessing stage accepts the plumbed value.
+    options = PagePreprocessingOptions(images_scale=None, skip_cell_extraction=True)
+    assert PagePreprocessingModel(options=options).options.skip_cell_extraction
+
+
+def test_empty_segmented_page_matches_page_geometry() -> None:
+    seg = _empty_segmented_page(_page())
+    assert seg.dimension.crop_bbox.r == 600.0
+    assert seg.dimension.crop_bbox.b == 800.0
+    assert seg.char_cells == []
+    assert seg.word_cells == []
+    assert seg.textline_cells == []
+
+
+def test_post_process_cells_tolerates_missing_parsed_page() -> None:
+    # parsed_page is None when cell extraction was skipped; OCR output must
+    # land in a fresh SegmentedPdfPage instead of tripping an assert.
+    page = _page()
+    assert page.parsed_page is None
+    assert page.cells == []
+
+    cell = _ocr_cell("part 42-A", confidence=0.9)
+    ocr_model = SimpleNamespace(options=SimpleNamespace(mode=OcrMode.FULL_PAGE))
+    conv_res = SimpleNamespace(confidence=ConfidenceReport())
+
+    BaseOcrModel.post_process_cells(ocr_model, [cell], page, conv_res)
+
+    assert page.parsed_page is not None
+    assert page.parsed_page.textline_cells == [cell]
+    assert page.parsed_page.has_lines
+    assert page.parsed_page.word_cells == []
+    assert conv_res.confidence.pages[1].ocr_score == pytest.approx(0.9)
+
+
+def test_layout_write_back_guarded_without_parsed_page() -> None:
+    # With cell assignment ENABLED and parsed_page None (skipped extraction),
+    # the postprocessor previously asserted; it must now pass through.
+    page = _page()
+    page._backend = SimpleNamespace(is_valid=lambda: True)  # type: ignore[assignment]
+    page.predictions.layout = LayoutPrediction(
+        clusters=[
+            Cluster(
+                id=0,
+                label=DocItemLabel.TEXT,
+                bbox=BoundingBox(l=10, t=10, r=200, b=100),
+                confidence=0.8,
+            )
+        ]
+    )
+
+    model = LayoutPostprocessingModel(
+        options=LayoutPostprocessorOptions(
+            run_postprocessor=True,
+            keep_empty_clusters=True,
+            skip_cell_assignment=False,
+        )
+    )
+    conv_res = SimpleNamespace(confidence=ConfidenceReport(), timings={})
+
+    out_pages = list(model(conv_res, [page]))
+
+    assert len(out_pages) == 1
+    assert out_pages[0].predictions.layout.clusters
+    assert page.parsed_page is None  # nothing to write back, and no crash

--- a/tests/test_skip_cell_extraction.py
+++ b/tests/test_skip_cell_extraction.py
@@ -22,17 +22,12 @@ from docling.datamodel.base_models import (
     Size,
 )
 from docling.datamodel.pipeline_options import (
-    EasyOcrOptions,
     LayoutPostprocessorOptions,
     OcrMode,
-    PdfPipelineOptions,
 )
-from docling.models.base_ocr_model import BaseOcrModel, _empty_segmented_page
+from docling.models.base_ocr_model import BaseOcrModel
 from docling.models.stages.layout.layout_postprocessing_model import (
     LayoutPostprocessingModel,
-)
-from docling.models.stages.page_preprocessing.page_preprocessing_model import (
-    resolve_skip_cell_extraction,
 )
 
 
@@ -52,40 +47,6 @@ def _ocr_cell(text: str, confidence: float) -> TextCell:
         from_ocr=True,
         confidence=confidence,
     )
-
-
-def test_skip_derived_from_full_page_ocr_mode() -> None:
-    # Full-page OCR discards native cells anyway -> the decode is skipped.
-    options = PdfPipelineOptions(
-        do_ocr=True, ocr_options=EasyOcrOptions(mode=OcrMode.FULL_PAGE)
-    )
-    assert resolve_skip_cell_extraction(options) is True
-
-
-def test_no_skip_without_ocr() -> None:
-    # Skipping without OCR would silently produce text-free output.
-    options = PdfPipelineOptions(
-        do_ocr=False, ocr_options=EasyOcrOptions(mode=OcrMode.FULL_PAGE)
-    )
-    assert resolve_skip_cell_extraction(options) is False
-
-
-def test_no_skip_in_native_cell_dependent_modes() -> None:
-    # The other OCR modes merge OCR output with native cells -> keep the decode.
-    for mode in (OcrMode.LAYOUT_REGIONS, OcrMode.PDF_AWARE_LAYOUT_REGIONS):
-        options = PdfPipelineOptions(do_ocr=True, ocr_options=EasyOcrOptions(mode=mode))
-        assert resolve_skip_cell_extraction(options) is False
-    # Defaults (auto OCR mode) keep the decode too.
-    assert resolve_skip_cell_extraction(PdfPipelineOptions()) is False
-
-
-def test_empty_segmented_page_matches_page_geometry() -> None:
-    seg = _empty_segmented_page(_page())
-    assert seg.dimension.crop_bbox.r == 600.0
-    assert seg.dimension.crop_bbox.b == 800.0
-    assert seg.char_cells == []
-    assert seg.word_cells == []
-    assert seg.textline_cells == []
 
 
 def test_post_process_cells_tolerates_missing_parsed_page() -> None:

--- a/tests/test_skip_cell_extraction.py
+++ b/tests/test_skip_cell_extraction.py
@@ -1,8 +1,10 @@
-"""Regression tests for skip_cell_extraction (issue #4058).
+"""Regression tests for skipping native cell extraction (issue #4058).
 
-A page whose native cell extraction was skipped keeps ``parsed_page=None``;
-OCR post-processing and layout post-processing must handle that instead of
-crashing, and the flag must be reachable from ``PdfPipelineOptions``.
+In full-page OCR mode the native text cells are discarded during OCR
+post-processing, so the segmented-page decode is skipped entirely. A page
+processed that way keeps ``parsed_page=None`` until OCR runs; OCR
+post-processing and layout post-processing must handle that instead of
+crashing.
 """
 
 from types import SimpleNamespace
@@ -20,6 +22,7 @@ from docling.datamodel.base_models import (
     Size,
 )
 from docling.datamodel.pipeline_options import (
+    EasyOcrOptions,
     LayoutPostprocessorOptions,
     OcrMode,
     PdfPipelineOptions,
@@ -29,8 +32,7 @@ from docling.models.stages.layout.layout_postprocessing_model import (
     LayoutPostprocessingModel,
 )
 from docling.models.stages.page_preprocessing.page_preprocessing_model import (
-    PagePreprocessingModel,
-    PagePreprocessingOptions,
+    resolve_skip_cell_extraction,
 )
 
 
@@ -52,12 +54,29 @@ def _ocr_cell(text: str, confidence: float) -> TextCell:
     )
 
 
-def test_pdf_pipeline_options_expose_skip_cell_extraction() -> None:
-    assert PdfPipelineOptions().skip_cell_extraction is False
-    assert PdfPipelineOptions(skip_cell_extraction=True).skip_cell_extraction is True
-    # The preprocessing stage accepts the plumbed value.
-    options = PagePreprocessingOptions(images_scale=None, skip_cell_extraction=True)
-    assert PagePreprocessingModel(options=options).options.skip_cell_extraction
+def test_skip_derived_from_full_page_ocr_mode() -> None:
+    # Full-page OCR discards native cells anyway -> the decode is skipped.
+    options = PdfPipelineOptions(
+        do_ocr=True, ocr_options=EasyOcrOptions(mode=OcrMode.FULL_PAGE)
+    )
+    assert resolve_skip_cell_extraction(options) is True
+
+
+def test_no_skip_without_ocr() -> None:
+    # Skipping without OCR would silently produce text-free output.
+    options = PdfPipelineOptions(
+        do_ocr=False, ocr_options=EasyOcrOptions(mode=OcrMode.FULL_PAGE)
+    )
+    assert resolve_skip_cell_extraction(options) is False
+
+
+def test_no_skip_in_native_cell_dependent_modes() -> None:
+    # The other OCR modes merge OCR output with native cells -> keep the decode.
+    for mode in (OcrMode.LAYOUT_REGIONS, OcrMode.PDF_AWARE_LAYOUT_REGIONS):
+        options = PdfPipelineOptions(do_ocr=True, ocr_options=EasyOcrOptions(mode=mode))
+        assert resolve_skip_cell_extraction(options) is False
+    # Defaults (auto OCR mode) keep the decode too.
+    assert resolve_skip_cell_extraction(PdfPipelineOptions()) is False
 
 
 def test_empty_segmented_page_matches_page_geometry() -> None:


### PR DESCRIPTION
Related to #4058 (the escape-hatch half; the docling-parse native-parse budget discussed there remains open).

**Reworked per @cau-git's review** (`9fc75034`): `skip_cell_extraction` is **not** exposed on `PdfPipelineOptions`. Instead, both `StandardPdfPipeline` and `LegacyStandardPdfPipeline` derive it internally:

```python
skip = pipeline_options.do_ocr and pipeline_options.ocr_options.mode == OcrMode.FULL_PAGE
```

Rationale: in full-page OCR mode the native text cells are discarded wholesale in OCR post-processing (`final_cells = ocr_cells`; word/char cells filtered to `from_ocr`), so the segmented-page decode is pure waste there — and on vector-dense pages (CAD/wiring schematics drawn as 100k+ path segments) that decode costs multiple GiB regardless of `ContentConfig` levels (#4058). The `do_ocr` guard ensures the skip can never produce text-free output — the combination the review rightly questioned is no longer constructible.

Supporting changes (required for the internal skip, unchanged in spirit from the first revision):

- `base_ocr_model`: when `parsed_page is None`, initialize an empty `SegmentedPdfPage` (geometry from `page.size`, empty cell lists) so OCR output has somewhere to live;
- `layout_postprocessor`: guard the textline write-back instead of asserting (`page_assemble_model` and `heading_hierarchy_model` already tolerate `parsed_page=None`).

One user-visible note for existing full-page-OCR users: they gain the memory/speed win automatically, and `parse_score` is no longer computed for them (it was derived from the native cells that full-page mode discards). If that confidence value should be preserved, say the word.

**Validation** (editable install of this branch, linux/amd64, 4 CPUs; synthetic 1M-path-segment page from #4058):

| configuration | before | after |
|---|---|---|
| defaults (auto OCR mode) | native decode runs (+~2.4 GiB on the synthetic page) | unchanged — decode runs |
| `do_ocr=True`, `ocr_options.mode=FULL_PAGE` | decode runs **and** its cells are then discarded | decode skipped: `ConversionStatus.SUCCESS`, peak 2.17 GiB, OCR output intact |
| `do_ocr=False` (any mode) | decode runs | unchanged — decode runs (skip requires OCR) |

**Checklist:**

- [x] Documentation has been updated, if necessary. — no new public option; behavior documented on `resolve_skip_cell_extraction` and the derivation site.
- [x] Examples have been added, if necessary. — not necessary; the optimization applies automatically to full-page OCR mode.
- [x] Tests have been added, if necessary. — `tests/test_skip_cell_extraction.py`: the mode/`do_ocr` derivation matrix, the empty `SegmentedPdfPage` geometry, OCR post-processing with `parsed_page=None`, and the layout write-back guard. Happy to also add an e2e path-storm fixture as a CI regression guard for the OOM class if wanted (possibly behind a pytest mark).
