### PR TITLE
fix(tableformer): reconcile predicted rows with drawn rules (#4028)

### DIFF
--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -255,7 +255,6 @@ class DoclingParsePageBackend(ManagedPdfiumPageBackend):
                 try:
                     left, bottom, right, top = obj.get_bounds()
                 except AttributeError:
-                    
                     left, bottom, right, top = obj.get_pos()
                 width = right - left
                 height = top - bottom

--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Optional, Union
 
 import pypdfium2 as pdfium
+import pypdfium2.raw as pdfium_raw
 from docling_core.types.doc import BoundingBox, CoordOrigin, Size
 from docling_core.types.doc.page import (
     PdfCellRenderingMode,
@@ -231,6 +232,56 @@ class DoclingParsePageBackend(ManagedPdfiumPageBackend):
                 cropbox = cropbox.scaled(scale=scale)
 
                 yield cropbox
+
+    _SHAPE_LINE_MAX_THICKNESS = 2.5
+
+    def get_shape_lines(
+        self,
+        *,
+        horizontal: bool = True,
+        vertical: bool = True,
+        tolerance: float = 1e-3,
+    ) -> Optional[list[BoundingBox]]:
+        if not self.is_valid():
+            return []
+
+        page_height = self.get_size().height
+        max_thickness = max(tolerance, self._SHAPE_LINE_MAX_THICKNESS)
+        segments: list[BoundingBox] = []
+        with pypdfium2_lock:
+            for obj in self._ppage.get_objects():
+                if obj.type != pdfium_raw.FPDF_PAGEOBJ_PATH:
+                    continue
+                try:
+                    left, bottom, right, top = obj.get_bounds()
+                except AttributeError:
+                    
+                    left, bottom, right, top = obj.get_pos()
+                width = right - left
+                height = top - bottom
+                if horizontal and height <= max_thickness and width > height:
+                    y = page_height - (bottom + top) / 2
+                    segments.append(
+                        BoundingBox(
+                            l=left,
+                            t=y,
+                            r=right,
+                            b=y,
+                            coord_origin=CoordOrigin.TOPLEFT,
+                        )
+                    )
+                elif vertical and width <= max_thickness and height > width:
+                    x = (left + right) / 2
+                    segments.append(
+                        BoundingBox(
+                            l=x,
+                            t=page_height - top,
+                            r=x,
+                            b=page_height - bottom,
+                            coord_origin=CoordOrigin.TOPLEFT,
+                        )
+                    )
+        return segments
 
     def get_page_image(
         self, scale: float = 1, cropbox: Optional[BoundingBox] = None

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -161,6 +161,17 @@ class TableStructureOptions(BaseTableStructureOptions):
             )
         ),
     ] = TableFormerMode.ACCURATE
+    reconcile_rows_with_rules: Annotated[
+        bool,
+        Field(
+            description=(
+                "Reconcile predicted row boundaries with horizontal rules drawn in the PDF vector layer. "
+                "On ruled tables with dense wrapped cells, the model can cut a row one text line too early; "
+                "when the drawn rules corroborate the predicted row count, matched words are re-binned into "
+                "the ruled bands. Tables without rules are never modified."
+            )
+        ),
+    ] = False
 
 
 class TableStructureV2Options(BaseTableStructureOptions):

--- a/docling/models/stages/table_structure/table_structure_model.py
+++ b/docling/models/stages/table_structure/table_structure_model.py
@@ -25,6 +25,7 @@ from docling.models.base_table_model import BaseTableStructureModel
 from docling.models.utils.hf_model_download import download_hf_model
 from docling.utils.accelerator_utils import decide_device
 from docling.utils.profiling import TimeRecorder
+from docling.utils.table_rule_reconciler import reconcile_table_rows_with_rules
 
 _log = logging.getLogger(__name__)
 
@@ -294,6 +295,19 @@ class TableStructureModel(BaseTableStructureModel):
                         cluster=table_cluster,
                         label=table_cluster.label,
                     )
+
+                    if self.options.reconcile_rows_with_rules:
+                        rules = page._backend.get_shape_lines(
+                            horizontal=True, vertical=False
+                        )
+                        if rules:
+                            reconcile_table_rows_with_rules(
+                                tbl,
+                                rules=rules,
+                                word_cells=[
+                                    c for c in tcells if len(c.text.strip()) > 0
+                                ],
+                            )
 
                     table_prediction.table_map[table_cluster.id] = tbl
 

--- a/docling/utils/table_rule_reconciler.py
+++ b/docling/utils/table_rule_reconciler.py
@@ -1,0 +1,184 @@
+"""Reconcile predicted table rows with rules drawn in the PDF vector layer.
+
+TableFormer predicts row boundaries from a fixed-resolution rendering of the
+table, where a thin drawn rule is sub-pixel and dense wrapped rows are
+visually ambiguous. On ruled tables this can cut a wrapped cell one text line
+too early, so the tail of one row is matched into the head of the next
+(issue #4028). The drawn rules, however, mark the true boundaries exactly.
+
+This module re-bins the word cells of a predicted table into the bands
+delimited by those rules. It only re-assigns cells that already belong to the
+table, so text is conserved by construction — nothing is re-extracted from
+page regions. Whenever the rules do not corroborate the predicted structure
+(no rules, band/row mismatch, spanning cells), it declines and leaves the
+prediction untouched, keeping borderless and scanned tables unaffected.
+"""
+
+from __future__ import annotations
+
+import bisect
+import logging
+from statistics import median
+
+from docling_core.types.doc import BoundingBox
+from docling_core.types.doc.page import TextCell
+
+from docling.datamodel.base_models import Table
+
+_log = logging.getLogger(__name__)
+
+# A rule must span at least this fraction of the table width to count as a
+# row boundary; shorter strokes are underlines or cell decorations.
+_MIN_RULE_SPAN_FRAC = 0.7
+# Rules closer together than this are one double-drawn boundary (pt).
+_RULE_MERGE_TOL = 2.0
+# Rules this close to the table's top/bottom edge duplicate the outer border.
+_EDGE_MARGIN = 3.0
+
+
+def reconcile_table_rows_with_rules(
+    table: Table,
+    rules: list[BoundingBox],
+    word_cells: list[TextCell],
+) -> bool:
+    """Re-bin ``table``'s words into the row bands drawn by ``rules``.
+
+    ``rules`` are horizontal shape lines in page coordinates (top-left
+    origin), as returned by ``PdfPageBackend.get_shape_lines``. ``word_cells``
+    are the text cells that were fed to cell matching, unscaled.
+
+    Returns ``True`` when reconciliation was applied and ``False`` when it
+    declined; declining never modifies the table.
+    """
+    table_bbox = table.cluster.bbox
+    if table.num_rows < 2 or table.num_cols < 1 or not rules or not word_cells:
+        return False
+
+    for cell in table.table_cells:
+        if cell.bbox is None:
+            return False
+        if (cell.end_row_offset_idx - cell.start_row_offset_idx) != 1:
+            return False
+        if (cell.end_col_offset_idx - cell.start_col_offset_idx) != 1:
+            return False
+
+    boundaries = _row_boundaries(table_bbox, rules)
+    if len(boundaries) - 1 != table.num_rows:
+        _log.debug(
+            "Rule reconciliation declined: %d ruled bands vs %d predicted rows",
+            len(boundaries) - 1,
+            table.num_rows,
+        )
+        return False
+
+    column_ranges = _column_ranges(table)
+    assigned: dict[tuple[int, int], list[TextCell]] = {}
+    for word in word_cells:
+        if not word.text.strip():
+            continue
+        word_bbox = word.rect.to_bounding_box()
+        y_center = (word_bbox.t + word_bbox.b) / 2
+        x_center = (word_bbox.l + word_bbox.r) / 2
+        if not (table_bbox.t <= y_center <= table_bbox.b):
+            continue
+        if not (table_bbox.l <= x_center <= table_bbox.r):
+            continue
+        row = min(
+            max(bisect.bisect_right(boundaries, y_center) - 1, 0),
+            table.num_rows - 1,
+        )
+        col = _nearest_column(column_ranges, x_center)
+        assigned.setdefault((row, col), []).append(word)
+
+    for cell in table.table_cells:
+        assert cell.bbox is not None  # guaranteed by the validation loop above
+        key = (cell.start_row_offset_idx, cell.start_col_offset_idx)
+        words = _reading_order(assigned.get(key, []))
+        new_text = " ".join(word.text.strip() for word in words)
+        if new_text != (cell.text or ""):
+            cell.text = new_text
+        if words:
+            cell.bbox = _union(
+                [word.rect.to_bounding_box() for word in words],
+                coord_origin=cell.bbox.coord_origin,
+            )
+    return True
+
+
+def _row_boundaries(table_bbox: BoundingBox, rules: list[BoundingBox]) -> list[float]:
+    """Band boundaries: table edges plus the interior rules that span it.
+
+    The table's own top and bottom edges are admitted as implicit boundaries
+    because a row cut by a page break has a drawn rule on one side only.
+    """
+    width = table_bbox.r - table_bbox.l
+    interior: list[float] = []
+    for y in sorted(
+        (rule.t + rule.b) / 2
+        for rule in rules
+        if min(rule.r, table_bbox.r) - max(rule.l, table_bbox.l)
+        >= _MIN_RULE_SPAN_FRAC * width
+        and table_bbox.t + _EDGE_MARGIN
+        < (rule.t + rule.b) / 2
+        < table_bbox.b - _EDGE_MARGIN
+    ):
+        if not interior or y - interior[-1] > _RULE_MERGE_TOL:
+            interior.append(y)
+    return [table_bbox.t, *interior, table_bbox.b]
+
+
+def _column_ranges(table: Table) -> list[tuple[int, float, float]]:
+    ranges: dict[int, tuple[float, float]] = {}
+    for cell in table.table_cells:
+        col = cell.start_col_offset_idx
+        assert cell.bbox is not None
+        left, right = ranges.get(col, (cell.bbox.l, cell.bbox.r))
+        ranges[col] = (min(left, cell.bbox.l), max(right, cell.bbox.r))
+    return [(col, left, right) for col, (left, right) in sorted(ranges.items())]
+
+
+def _nearest_column(
+    column_ranges: list[tuple[int, float, float]], x_center: float
+) -> int:
+    best_col, best_distance = column_ranges[0][0], float("inf")
+    for col, left, right in column_ranges:
+        if left <= x_center <= right:
+            return col
+        distance = min(abs(x_center - left), abs(x_center - right))
+        if distance < best_distance:
+            best_col, best_distance = col, distance
+    return best_col
+
+
+def _reading_order(words: list[TextCell]) -> list[TextCell]:
+    """Sort words top-to-bottom by text line, left-to-right within a line."""
+    if not words:
+        return []
+    boxes = {id(word): word.rect.to_bounding_box() for word in words}
+    line_step = median(boxes[id(word)].b - boxes[id(word)].t for word in words) / 2
+    ordered = sorted(
+        words, key=lambda word: (boxes[id(word)].t + boxes[id(word)].b) / 2
+    )
+    lines: list[list[TextCell]] = []
+    line_center = float("-inf")
+    for word in ordered:
+        center = (boxes[id(word)].t + boxes[id(word)].b) / 2
+        if center - line_center > line_step:
+            lines.append([])
+        lines[-1].append(word)
+        line_center = center
+    return [
+        word
+        for line in lines
+        for word in sorted(line, key=lambda word: boxes[id(word)].l)
+    ]
+
+
+def _union(boxes: list[BoundingBox], coord_origin) -> BoundingBox:
+    return BoundingBox(
+        l=min(box.l for box in boxes),
+        t=min(box.t for box in boxes),
+        r=max(box.r for box in boxes),
+        b=max(box.b for box in boxes),
+        coord_origin=coord_origin,
+    )

--- a/tests/test_backend_shape_lines.py
+++ b/tests/test_backend_shape_lines.py
@@ -77,7 +77,9 @@ def _load_page(pdf_path: Path):
         format=InputFormat.PDF,
         backend=DoclingParseDocumentBackend,
     )
-    return in_doc._backend.load_page(0)
+    backend = in_doc._backend
+    assert isinstance(backend, DoclingParseDocumentBackend)
+    return backend.load_page(0)
 
 
 def test_reports_filled_and_stroked_horizontal_rules(ruled_page: Path):

--- a/tests/test_backend_shape_lines.py
+++ b/tests/test_backend_shape_lines.py
@@ -1,0 +1,110 @@
+"""Tests for DoclingParsePageBackend.get_shape_lines (issue #4028).
+
+The base-class contract declares get_shape_lines but the docling-parse page
+backend returned None ("cannot answer"). Ruled tables commonly draw their row
+separators either as stroked lines or as thin filled rectangles; both must be
+reported so that table row reconciliation can see them.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.document import InputDocument
+
+PAGE_W, PAGE_H = 595.0, 842.0
+
+
+def _write_pdf(path: Path, content: str) -> None:
+    """Write a single-page PDF with the given content stream (stdlib only)."""
+    stream = content.encode("latin-1")
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        (
+            f"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 {PAGE_W} {PAGE_H}] "
+            "/Resources << >> /Contents 4 0 R >>"
+        ).encode("latin-1"),
+        b"<< /Length "
+        + str(len(stream)).encode()
+        + b" >>\nstream\n"
+        + stream
+        + b"\nendstream",
+    ]
+    out = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for number, body in enumerate(objects, start=1):
+        offsets.append(len(out))
+        out += f"{number} 0 obj\n".encode() + body + b"\nendobj\n"
+    xref_at = len(out)
+    out += f"xref\n0 {len(objects) + 1}\n".encode()
+    out += b"0000000000 65535 f \n"
+    for offset in offsets:
+        out += f"{offset:010d} 00000 n \n".encode()
+    out += (
+        f"trailer\n<< /Size {len(objects) + 1} /Root 1 0 R >>\n"
+        f"startxref\n{xref_at}\n%%EOF\n"
+    ).encode()
+    path.write_bytes(bytes(out))
+
+
+@pytest.fixture
+def ruled_page(tmp_path: Path) -> Path:
+    """One filled-rectangle rule, one stroked rule, and one vertical stroke.
+
+    PDF y-coordinates are bottom-up; a rule at pdf y=742 is at y=100 in
+    docling's top-left origin.
+    """
+    pdf_path = tmp_path / "rules.pdf"
+    _write_pdf(
+        pdf_path,
+        "\n".join(
+            [
+                "70.00 741.75 460.00 0.5 re f",  # filled rect rule, top-left y≈100
+                "70.00 642.00 m 530.00 642.00 l 0.5 w S",  # stroked rule, y=200
+                "70.00 100.00 m 70.00 700.00 l 0.5 w S",  # vertical stroke, x=70
+            ]
+        ),
+    )
+    return pdf_path
+
+
+def _load_page(pdf_path: Path):
+    in_doc = InputDocument(
+        path_or_stream=pdf_path,
+        format=InputFormat.PDF,
+        backend=DoclingParseDocumentBackend,
+    )
+    return in_doc._backend.load_page(0)
+
+
+def test_reports_filled_and_stroked_horizontal_rules(ruled_page: Path):
+    page = _load_page(ruled_page)
+    lines = page.get_shape_lines(horizontal=True, vertical=False)
+    assert lines is not None
+    ys = sorted(line.t for line in lines)
+    assert len(ys) == 2
+    assert ys[0] == pytest.approx(100.0, abs=1.0)
+    assert ys[1] == pytest.approx(200.0, abs=1.0)
+    for line in lines:
+        # Degenerate (zero-height) boxes spanning the drawn width.
+        assert line.b == pytest.approx(line.t, abs=1.0)
+        assert line.r - line.l == pytest.approx(460.0, abs=2.0)
+
+
+def test_reports_vertical_rules_separately(ruled_page: Path):
+    page = _load_page(ruled_page)
+    lines = page.get_shape_lines(horizontal=False, vertical=True)
+    assert lines is not None
+    assert len(lines) == 1
+    assert lines[0].l == pytest.approx(70.0, abs=1.0)
+    assert lines[0].r == pytest.approx(lines[0].l, abs=1.0)
+
+
+def test_text_is_not_reported_as_shape_lines(tmp_path: Path):
+    pdf_path = tmp_path / "no-rules.pdf"
+    _write_pdf(pdf_path, "BT 100 700 Td ET")
+    page = _load_page(pdf_path)
+    assert page.get_shape_lines(horizontal=True, vertical=True) == []

--- a/tests/test_table_rule_reconciler.py
+++ b/tests/test_table_rule_reconciler.py
@@ -1,0 +1,204 @@
+"""Tests for rule-based table row reconciliation (issue #4028).
+
+TableFormer predicts row boundaries visually and, on dense ruled tables, can
+cut a wrapped cell one text line too early, emitting the tail of one row as
+the head of the next. The reconciler re-bins the matched words into the bands
+delimited by the horizontal rules drawn in the PDF's vector layer.
+
+The geometry in these tests mirrors the measured failure: the predicted
+row-0/row-1 boundary sits one text line above the drawn rule, so the last
+wrapped line overlaps only the following row's predicted cell.
+"""
+
+from docling_core.types.doc import BoundingBox, CoordOrigin, DocItemLabel, TableCell
+from docling_core.types.doc.page import BoundingRectangle, TextCell
+
+from docling.datamodel.base_models import Cluster, Table
+from docling.utils.table_rule_reconciler import reconcile_table_rows_with_rules
+
+TABLE_BBOX = BoundingBox(l=60.0, t=60.0, r=540.0, b=260.0)
+
+# Interior rules drawn at the true row boundaries.
+RULES = [
+    BoundingBox(l=62.0, t=120.0, r=538.0, b=120.0),
+    BoundingBox(l=62.0, t=180.0, r=538.0, b=120.0 + 60.0),
+]
+
+
+def _rule(y: float, left: float = 62.0, right: float = 538.0) -> BoundingBox:
+    return BoundingBox(l=left, t=y, r=right, b=y)
+
+
+def _word(
+    index: int, text: str, left: float, t: float, right: float, b: float
+) -> TextCell:
+    return TextCell(
+        index=index,
+        text=text,
+        orig=text,
+        rect=BoundingRectangle.from_bounding_box(
+            BoundingBox(l=left, t=t, r=right, b=b, coord_origin=CoordOrigin.TOPLEFT)
+        ),
+        from_ocr=False,
+    )
+
+
+def _cell(
+    row: int, col: int, bbox: BoundingBox, text: str, row_span: int = 1
+) -> TableCell:
+    return TableCell(
+        start_row_offset_idx=row,
+        end_row_offset_idx=row + row_span,
+        start_col_offset_idx=col,
+        end_col_offset_idx=col + 1,
+        row_span=row_span,
+        col_span=1,
+        bbox=bbox,
+        text=text,
+    )
+
+
+def _words() -> list[TextCell]:
+    """Word cells for a 3-row, 2-column glossary with one wrapped definition."""
+    return [
+        # row 0 (band 60..120)
+        _word(0, "Alpha", 65, 65, 110, 75),
+        _word(1, "first", 200, 65, 240, 75),
+        _word(2, "line", 245, 65, 275, 75),
+        _word(3, "second", 200, 80, 250, 90),
+        _word(4, "line", 255, 80, 285, 90),
+        # the wrapped tail: above the rule at y=120, belongs to row 0
+        _word(5, "stolen", 200, 105, 245, 115),
+        _word(6, "tail", 250, 105, 275, 115),
+        # row 1 (band 120..180)
+        _word(7, "Beta", 65, 125, 100, 135),
+        _word(8, "row", 200, 125, 228, 135),
+        _word(9, "two", 233, 125, 260, 135),
+        _word(10, "text", 265, 125, 295, 135),
+        # row 2 (band 180..260)
+        _word(11, "Gamma", 65, 185, 120, 195),
+        _word(12, "third", 200, 185, 238, 195),
+        _word(13, "row", 243, 185, 270, 195),
+    ]
+
+
+def _mispredicted_table() -> Table:
+    """A table whose predicted row-0/row-1 cut stole the wrapped tail.
+
+    The predicted row-0 definition cell ends above the tail line, and the
+    predicted row-1 definition cell starts inside it, so matching assigned
+    the tail words to row 1 — the exact failure of issue #4028.
+    """
+    cells = [
+        _cell(0, 0, BoundingBox(l=63, t=63, r=192, b=100), "Alpha"),
+        _cell(0, 1, BoundingBox(l=198, t=63, r=537, b=100), "first line second line"),
+        _cell(1, 0, BoundingBox(l=63, t=112, r=192, b=165), "Beta"),
+        _cell(
+            1, 1, BoundingBox(l=198, t=112, r=537, b=165), "stolen tail row two text"
+        ),
+        _cell(2, 0, BoundingBox(l=63, t=182, r=192, b=225), "Gamma"),
+        _cell(2, 1, BoundingBox(l=198, t=182, r=537, b=225), "third row"),
+    ]
+    return Table(
+        otsl_seq=[],
+        table_cells=cells,
+        num_rows=3,
+        num_cols=2,
+        id=0,
+        page_no=0,
+        label=DocItemLabel.TABLE,
+        cluster=Cluster(id=0, label=DocItemLabel.TABLE, bbox=TABLE_BBOX),
+    )
+
+
+def _cell_text(table: Table, row: int, col: int) -> str:
+    for cell in table.table_cells:
+        if cell.start_row_offset_idx == row and cell.start_col_offset_idx == col:
+            return cell.text
+    raise AssertionError(f"no cell at ({row}, {col})")
+
+
+def test_moves_wrapped_tail_into_its_ruled_band():
+    table = _mispredicted_table()
+    changed = reconcile_table_rows_with_rules(
+        table, rules=[_rule(120.0), _rule(180.0)], word_cells=_words()
+    )
+    assert changed is True
+    assert _cell_text(table, 0, 1) == "first line second line stolen tail"
+    assert _cell_text(table, 1, 1) == "row two text"
+    assert _cell_text(table, 1, 0) == "Beta"
+    assert _cell_text(table, 2, 1) == "third row"
+
+
+def test_no_text_lost_or_duplicated():
+    table = _mispredicted_table()
+    reconcile_table_rows_with_rules(
+        table, rules=[_rule(120.0), _rule(180.0)], word_cells=_words()
+    )
+    rebuilt = " ".join(c.text for c in table.table_cells if c.text).split()
+    assert sorted(rebuilt) == sorted(w.text for w in _words())
+
+
+def test_faithful_no_op_on_correctly_predicted_table():
+    table = _mispredicted_table()
+    # Repair the prediction: tail belongs to row 0 and the cell boxes agree
+    # with the ruled bands.
+    for cell in table.table_cells:
+        if cell.start_row_offset_idx == 0 and cell.start_col_offset_idx == 1:
+            cell.text = "first line second line stolen tail"
+            cell.bbox = BoundingBox(l=198, t=63, r=537, b=118)
+        if cell.start_row_offset_idx == 1 and cell.start_col_offset_idx == 1:
+            cell.text = "row two text"
+            cell.bbox = BoundingBox(l=198, t=123, r=537, b=165)
+    before = {
+        (c.start_row_offset_idx, c.start_col_offset_idx): c.text
+        for c in table.table_cells
+    }
+    reconcile_table_rows_with_rules(
+        table, rules=[_rule(120.0), _rule(180.0)], word_cells=_words()
+    )
+    after = {
+        (c.start_row_offset_idx, c.start_col_offset_idx): c.text
+        for c in table.table_cells
+    }
+    assert after == before
+
+
+def test_declines_without_rules():
+    table = _mispredicted_table()
+    changed = reconcile_table_rows_with_rules(table, rules=[], word_cells=_words())
+    assert changed is False
+    assert _cell_text(table, 1, 1) == "stolen tail row two text"
+
+
+def test_declines_when_bands_disagree_with_predicted_row_count():
+    table = _mispredicted_table()
+    # One interior rule -> two bands, but the prediction has three rows.
+    changed = reconcile_table_rows_with_rules(
+        table, rules=[_rule(120.0)], word_cells=_words()
+    )
+    assert changed is False
+    assert _cell_text(table, 1, 1) == "stolen tail row two text"
+
+
+def test_declines_on_spanning_cells():
+    table = _mispredicted_table()
+    table.table_cells[0] = _cell(
+        0, 0, BoundingBox(l=63, t=63, r=192, b=165), "Alpha", row_span=2
+    )
+    changed = reconcile_table_rows_with_rules(
+        table, rules=[_rule(120.0), _rule(180.0)], word_cells=_words()
+    )
+    assert changed is False
+
+
+def test_ignores_short_rules_that_do_not_span_the_table():
+    table = _mispredicted_table()
+    # An underline-like stroke: horizontal but far too short to be a row rule.
+    changed = reconcile_table_rows_with_rules(
+        table,
+        rules=[_rule(120.0), _rule(180.0), _rule(95.0, left=200.0, right=260.0)],
+        word_cells=_words(),
+    )
+    assert changed is True
+    assert _cell_text(table, 0, 1) == "first line second line stolen tail"


### PR DESCRIPTION
Author's correct — you're clear to create it. Paste this into the description box (it replaces the whole template):

On ruled tables with dense wrapped cells, TableFormer can cut a row one
text line too early, emitting the tail of one row's cell as the head of
the next row's cell. The table shape stays correct — right rows, right
columns, no empty cells — so the corruption is silent.

**Root cause** (measured on the issue's fixture): the table crop is
resized to the model's fixed 448×448 input, where a 0.5pt drawn rule is
~0.3px — invisible — and the 1pt difference between row spacing and
wrapped-line spacing is sub-pixel. The model has to guess the boundary
and lands mid-cell: predicted row-0 bottom at y=106.8 / row-1 top at
y=117.4, while the drawn rule sits at y=121.5. The last wrapped line
(y=111.3–118.7) then overlaps only row 1's predicted cell, and cell
matching moves it there. The vector layer is the only place this
information survives, so the model alone cannot recover it.

**Changes**

- Implement `get_shape_lines()` on `DoclingParsePageBackend` (declared
  on the ABC, previously unimplemented there), reading horizontal and
  vertical rules from pdfium path objects — both stroked lines and thin
  filled rectangles. Filled rectangles are how the issue's PDF (and many
  real documents) draw their rules; the existing stroked-only path
  misses them.
- Add `docling/utils/table_rule_reconciler.py`: re-bins the matched
  word cells into the bands delimited by the drawn rules. Only existing
  table words are re-assigned — nothing is re-extracted from page
  regions — so text is conserved by construction. It declines (strict
  no-op) when there are no rules, when the ruled bands disagree with
  the predicted row count, or when the table has spanning cells,
  leaving borderless and scanned tables untouched. The table's own
  top/bottom edges count as implicit boundaries, since a row cut by a
  page break has a rule on one side only.
- New opt-in option `TableStructureOptions.reconcile_rows_with_rules`
  (default `False`), wired into `predict_tables`. Default behavior and
  reference outputs are unchanged.

**Results** on the issue's fixture (4-page ruled glossary, ACCURATE
mode + cell matching): flag off — 1 stolen tail + 1 truncated
definition in 60 rows, identical to current main; flag on — 0 defects,
with the alphanumeric content byte-identical between the two runs.

**Issue resolved by this Pull Request:**
Resolves #4028

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
  the next row's cell. The table shape stays correct — right rows, right
  columns, no