### PR TITLE
chore(base_ocr_model): note that _empty_segmented_page reports angle=0

### DIFF
--- a/docling/models/base_ocr_model.py
+++ b/docling/models/base_ocr_model.py
@@ -47,6 +47,14 @@ def _empty_segmented_page(page: Page) -> SegmentedPdfPage:
         coord_origin=CoordOrigin.BOTTOMLEFT,
     )
     bbox = BoundingBox(l=0, t=height, r=width, b=0, coord_origin=CoordOrigin.BOTTOMLEFT)
+    # NOTE: angle is hardcoded to 0.0 rather than reflecting the page's true
+    # rotation. No PdfPageBackend currently exposes rotation (or the individual
+    # crop/media/art/bleed/trim boxes) without triggering content decoding --
+    # the very work skip_cell_extraction exists to avoid. Left for future work:
+    # add a cheap PdfPageBackend.get_page_geometry() primitive (pypdfium2:
+    # ppage.get_rotation() plus the existing get_pdf_page_geometry() helper;
+    # docling-parse sync/threaded: page_decoder.get_page_dimension()) and
+    # source the dimension from it here.
     return SegmentedPdfPage(
         dimension=PdfPageGeometry(
             angle=0.0,


### PR DESCRIPTION
Follow-up to #4061 (merged): the synthetic `SegmentedPdfPage` built when `skip_cell_extraction` avoids the native parse only knows the page's width and height. The other geometry fields — rotation and the individual crop/media/art/bleed/trim boxes — are hardcoded (angle=0.0, all boxes = the full page rect) because no `PdfPageBackend` currently exposes them without triggering content decoding, which is exactly the work `skip_cell_extraction` exists to skip.

Adds a `NOTE` at the construction site so:

- users of `generate_parsed_pages=True` on rotated PDFs know why `dimension.angle` reads 0.0;
- future work has a pointer to the shape of the fix: a cheap `PdfPageBackend.get_page_geometry()` primitive that each backend can answer from data it already has on hand —
  - pypdfium2: `ppage.get_rotation()` plus the existing `get_pdf_page_geometry()` helper;
  - docling-parse sync/threaded: `page_decoder.get_page_dimension()` (the sync backend already keeps a decoder; the threaded backend's `PageParseResult` also carries one — it's how `page_width/page_height` are computed today).

No behavior change — comment only.