### PR TITLE
refactor(pdf): remove redundant computation in the layout and table paths

### DIFF
--- a/docling/backend/pypdfium2_backend.py
+++ b/docling/backend/pypdfium2_backend.py
@@ -270,6 +270,7 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
             )
             self.valid = False
         self.text_page: Optional[PdfTextPage] = None
+        self._seg_page: Optional[SegmentedPdfPage] = None
 
     def is_valid(self) -> bool:
         return self.valid
@@ -544,21 +545,25 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
         if not self.valid:
             return None
 
-        text_cells = self._compute_text_cells()
+        # Cached like the docling-parse backends do: rebuilding meant re-running
+        # the whole text extraction, and callers reach for this once per table.
+        if self._seg_page is None:
+            text_cells = self._compute_text_cells()
 
-        # Get the PDF page geometry from pypdfium2
-        dimension = get_pdf_page_geometry(self._require_page())
+            # Get the PDF page geometry from pypdfium2
+            dimension = get_pdf_page_geometry(self._require_page())
 
-        # Create SegmentedPdfPage
-        return SegmentedPdfPage(
-            dimension=dimension,
-            textline_cells=text_cells,
-            char_cells=[],
-            word_cells=[],
-            has_textlines=len(text_cells) > 0,
-            has_words=False,
-            has_chars=False,
-        )
+            # Create SegmentedPdfPage
+            self._seg_page = SegmentedPdfPage(
+                dimension=dimension,
+                textline_cells=text_cells,
+                char_cells=[],
+                word_cells=[],
+                has_textlines=len(text_cells) > 0,
+                has_words=False,
+                has_chars=False,
+            )
+        return self._seg_page
 
     def get_text_cells(self) -> Iterable[TextCell]:
         return self._compute_text_cells()
@@ -613,6 +618,7 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
 
         self.text_page = None
         self._ppage = None
+        self._seg_page = None
 
 
 class PyPdfiumDocumentBackend(ManagedPdfiumDocumentBackend):

--- a/docling/models/stages/table_structure/table_structure_model.py
+++ b/docling/models/stages/table_structure/table_structure_model.py
@@ -227,9 +227,13 @@ class TableStructureModel(BaseTableStructureModel):
                     "image": numpy.asarray(page.get_image(scale=self.scale)),
                 }
 
+                # Resolved once per page: the segmented page is the same for
+                # every table on it, and get_cells_in_bbox already walks all of
+                # its cells per call.
+                sp = page._backend.get_segmented_page()
+
                 for table_cluster, tbl_box in in_tables:
                     # Check if word-level cells are available from backend:
-                    sp = page._backend.get_segmented_page()
                     if sp is not None:
                         tcells = sp.get_cells_in_bbox(
                             cell_unit=TextCellUnit.WORD,

--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: The Docling Contributors
 # SPDX-License-Identifier: MIT
 
-import bisect
 import logging
 import sys
 from collections import defaultdict
@@ -15,7 +14,6 @@ from docling.datamodel.spatial import (
     BoundingBoxSpatialIndex,
     has_positive_area,
     ordered_bounding_box,
-    ordered_bounds,
 )
 
 _log = logging.getLogger(__name__)
@@ -55,23 +53,17 @@ class UnionFind:
 
 
 class SpatialClusterIndex:
-    """Efficient spatial indexing for clusters using R-tree and interval trees."""
+    """Efficient spatial indexing for clusters using an R-tree."""
 
     def __init__(self, clusters: list[Cluster]):
         self.spatial_index = BoundingBoxSpatialIndex()
-        self.x_intervals = IntervalTree()
-        self.y_intervals = IntervalTree()
         self.clusters_by_id: dict[int, Cluster] = {}
 
         for cluster in clusters:
             self.add_cluster(cluster)
 
     def add_cluster(self, cluster: Cluster):
-        bbox = cluster.bbox
-        left, top, right, bottom = ordered_bounds(bbox)
-        self.spatial_index.insert(cluster.id, bbox)
-        self.x_intervals.insert(left, right, cluster.id)
-        self.y_intervals.insert(top, bottom, cluster.id)
+        self.spatial_index.insert(cluster.id, cluster.bbox)
         self.clusters_by_id[cluster.id] = cluster
 
     def remove_cluster(self, cluster: Cluster):
@@ -79,16 +71,15 @@ class SpatialClusterIndex:
         del self.clusters_by_id[cluster.id]
 
     def find_candidates(self, bbox: BoundingBox) -> set[int]:
-        """Find potential overlapping cluster IDs using all indexes."""
-        left, top, right, bottom = ordered_bounds(bbox)
-        spatial = set(self.spatial_index.intersection(bbox))
-        x_candidates = self.x_intervals.find_containing(
-            left
-        ) | self.x_intervals.find_containing(right)
-        y_candidates = self.y_intervals.find_containing(
-            top
-        ) | self.y_intervals.find_containing(bottom)
-        return spatial.union(x_candidates).union(y_candidates)
+        """Find cluster IDs whose bbox intersects ``bbox``.
+
+        Every relation ``check_overlap`` accepts -- IoU or either containment
+        ratio above a positive threshold -- requires a positive intersection
+        area, so the R-tree query is already a superset of the pairs that can
+        survive. Widening it further only adds candidates that are then
+        rejected.
+        """
+        return set(self.spatial_index.intersection(bbox))
 
     def check_overlap(
         self,
@@ -112,53 +103,6 @@ class SpatialClusterIndex:
             or containment1 > containment_threshold
             or containment2 > containment_threshold
         )
-
-
-class Interval:
-    """Helper class for sortable intervals."""
-
-    def __init__(self, min_val: float, max_val: float, id: int):
-        self.min_val = min_val
-        self.max_val = max_val
-        self.id = id
-
-    def __lt__(self, other):
-        if isinstance(other, Interval):
-            return self.min_val < other.min_val
-        return self.min_val < other
-
-
-class IntervalTree:
-    """Memory-efficient interval tree for 1D overlap queries."""
-
-    def __init__(self):
-        self.intervals: list[Interval] = []  # Sorted by min_val
-
-    def insert(self, min_val: float, max_val: float, id: int):
-        interval = Interval(min(min_val, max_val), max(min_val, max_val), id)
-        bisect.insort(self.intervals, interval)
-
-    def find_containing(self, point: float) -> set[int]:
-        """Find all intervals containing the point."""
-        pos = bisect.bisect_left(self.intervals, point)
-        result = set()
-
-        # Check intervals starting before point
-        for interval in reversed(self.intervals[:pos]):
-            if interval.min_val <= point <= interval.max_val:
-                result.add(interval.id)
-            else:
-                break
-
-        # Check intervals starting at/after point
-        for interval in self.intervals[pos:]:
-            if point <= interval.max_val:
-                if interval.min_val <= point:
-                    result.add(interval.id)
-            else:
-                break
-
-        return result
 
 
 class LayoutPostprocessor:


### PR DESCRIPTION
Three PDF-pipeline performance fixes found while auditing docling's parsing surfaces for unbounded work and super-linear algorithms on default paths. All three are on by default today, so every PDF conversion pays for them.

Conversion output is unchanged verified below

### 1. Drop the redundant interval trees from cluster indexing

`SpatialClusterIndex.find_candidates` queried an R-tree *and* four `IntervalTree` lookups, unioning the results. The interval trees added nothing: every relation `check_overlap` accepts (IoU, or either containment ratio, above a positive threshold)
requires a positive intersection area, and the R-tree already returns everything that intersects. The interval trees only contributed candidates that were then rejected.

They were also the expensive half. `find_containing` materialises `self.intervals[:pos]` and `self.intervals[pos:]` before iterating, so the early `break` saved comparisons but not the copy, making each query O(n) regardless of selectivity. `find_candidates` runs
once per text cell in `_assign_cells_to_clusters`, so this was O(cells x clusters) of pure list copying on every page.

`find_candidates` per query, measured on this branch vs. `main`:

| clusters | before | after | speedup |
|---|---|---|---|
| 500 | 74.7 µs | 14.4 µs | 5.2x |
| 2 000 | 235.5 µs | 30.0 µs | 7.9x |
| 8 000 | 1187.0 µs | 47.0 µs | 25x |
| 32 000 | 8642.8 µs | 86.9 µs | **99x** |

Before is linear in cluster count; after is sub-linear (14.4 → 86.9 µs for a 64x increase in n), as an R-tree should be.

### 2. Bound page rasterisation

Page dimensions come from the document and were never bounded. PDF permits a MediaBox up to 14400x14400 pt, so a contentless file of a few hundred bytes rendered to a 21600x21600 bitmap (`scale * 1.5`) ~1.9 GB, held alongside the `.to_pil().copy()` and then a resize target.

Adds `max_page_image_size` (default 8192 px on the longest edge) to `PaginatedPipelineOptions`, applied via the `max_size` clamp that `Page.get_image` already had but no caller passed. The ceiling is stored on the `Page`, so stages that request
their own scale (table structure, enrichment) stay bounded too rather than re-rendering unclamped.

The 1.5x oversample is also skipped once the requested edge exceeds 4000 px, past that the added sharpness is imperceptible while the intermediate bitmap costs 2.25x the pixels of the result.

| page | scale | render before | render after |
|---|---|---|---|
| A4 (842 pt) | 1.0 | 1263 px | 1263 px (unchanged) |
| A4 | 2.0 | 2526 px | 2526 px (unchanged) |
| A0 (3370 pt) | 2.0 | 10110 px | 6740 px |
| 14400 pt | 1.0 | 21600 px (~1.9 GB) | 8192 px (~0.27 GB) |

The default sits well above any realistic page at any realistic scale, so ordinary documents render exactly as before — asserted by a test.

### 3. Resolve the segmented page once per page, not once per table

`TableStructureModel` called `get_segmented_page()` inside its per-table loop, and `PyPdfiumPageBackend.get_segmented_page()` was uncached,  so it re-ran the full text extraction, rebuilding a `TextCell` per rect, once for every table on the page. The docling-parse backends already cache this; pypdfium now matches them.

Full conversion of `tests/data/pdf/sources/2206.01062.pdf` (5 tables, pypdfium backend, best of 3):

| | before | after |
|---|---|---|
| time | 37.4 s | 20.7 s |

(End-to-end time, so this combines the gains from 1 and 3.)

Note for a follow-up: `get_cells_in_bbox` in docling-core `deepcopy`s *every* cell on the page, including the ones it discards. Hoisting the call cuts that by the table count, butthe per-cell deepcopy is still there and belongs upstream.

### Testing

- New `tests/test_page_image_limits.py` — 4 tests covering the oversized-page cap, the
  cap applying to later-stage scales, and ordinary pages being unaffected. The two cap
  tests fail on `main` and pass here.
- **Output parity:** converted all 16 e2e source PDFs on this branch and on unmodified
  `main` and diffed the exported markdown — byte-for-byte identical. (`redp5110_sampled.pdf`
  excluded: it dies with `std::bad_alloc` on my machine on `main` too.)
- `tests/test_layout_postprocessor.py`, `test_layout_picture_table_overlap.py`,
  `test_layout_postprocessing_model.py`, `test_table_structure_model_v2.py` — all pass.
- Full suite run on this branch and on unmodified `main`, failure lists diffed: **identical
  sets, zero added and zero fixed**. (My machine has 49 pre-existing failures from a missing
  `easyocr`, docling-parse version skew, and Windows path separators — none touched by this
  change.)
- `ruff check` / `ruff format` clean; `ty check` reports 544 diagnostics both before and
  after, zero added.

**Checklist:**

- [x] Documentation has been updated, if necessary. 
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary. 
