### PR TITLE
fix: avoid pipeline option cache key collisions

### DIFF
--- a/docling/document_converter.py
+++ b/docling/document_converter.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: The Docling Contributors
 # SPDX-License-Identifier: MIT
 
-import hashlib
 import logging
 import sys
 import threading
@@ -94,6 +93,7 @@ from docling.pipeline.base_pipeline import BasePipeline
 from docling.pipeline.simple_pipeline import SimplePipeline
 from docling.pipeline.standard_pdf_pipeline import StandardPdfPipeline
 from docling.pipeline.video_pipeline import VideoPipeline
+from docling.utils.pipeline_cache import create_pipeline_options_hash
 from docling.utils.utils import chunkify
 
 _log = logging.getLogger(__name__)
@@ -426,13 +426,6 @@ class DocumentConverter:
     ) -> dict[tuple[Type[BasePipeline], str], BasePipeline]:
         return self.initialized_pipelines
 
-    def _get_pipeline_options_hash(self, pipeline_options: PipelineOptions) -> str:
-        """Generate a hash of pipeline options to use as part of the cache key."""
-        options_str = str(pipeline_options.model_dump())
-        return hashlib.md5(
-            options_str.encode("utf-8"), usedforsecurity=False
-        ).hexdigest()
-
     def initialize_pipeline(self, format: InputFormat):
         """Initialize the conversion pipeline for the selected format.
 
@@ -727,7 +720,7 @@ class DocumentConverter:
 
         pipeline_class = fopt.pipeline_cls
         pipeline_options = fopt.pipeline_options
-        options_hash = self._get_pipeline_options_hash(pipeline_options)
+        options_hash = create_pipeline_options_hash(pipeline_options)
 
         # Use a composite key to cache pipelines
         cache_key = (pipeline_class, options_hash)

--- a/docling/document_extractor.py
+++ b/docling/document_extractor.py
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: The Docling Contributors
 # SPDX-License-Identifier: MIT
 
-import hashlib
 import logging
 import sys
 import threading
@@ -43,6 +42,7 @@ from docling.datamodel.settings import (
 from docling.exceptions import ConversionError
 from docling.pipeline.base_extraction_pipeline import BaseExtractionPipeline
 from docling.pipeline.extraction_vlm_pipeline import ExtractionVlmPipeline
+from docling.utils.pipeline_cache import create_pipeline_options_hash
 from docling.utils.utils import chunkify
 
 _log = logging.getLogger(__name__)
@@ -300,7 +300,7 @@ class DocumentExtractor:
 
         pipeline_class = fopt.pipeline_cls
         pipeline_options = fopt.pipeline_options
-        options_hash = self._get_pipeline_options_hash(pipeline_options)
+        options_hash = create_pipeline_options_hash(pipeline_options)
 
         cache_key = (pipeline_class, options_hash)
         with _PIPELINE_CACHE_LOCK:
@@ -317,11 +317,3 @@ class DocumentExtractor:
                 )
 
             return self._initialized_pipelines[cache_key]
-
-    @staticmethod
-    def _get_pipeline_options_hash(pipeline_options: PipelineOptions) -> str:
-        """Generate a stable hash of pipeline options to use as part of the cache key."""
-        options_str = str(pipeline_options.model_dump())
-        return hashlib.md5(
-            options_str.encode("utf-8"), usedforsecurity=False
-        ).hexdigest()

--- a/docling/utils/pipeline_cache.py
+++ b/docling/utils/pipeline_cache.py
@@ -3,9 +3,15 @@
 
 import hashlib
 import json
+import re
+from datetime import date, datetime, time, timedelta
+from decimal import Decimal
+from enum import Enum
+from pathlib import PurePath
+from uuid import UUID
 
-from pydantic import BaseModel
-from pydantic_core import to_jsonable_python
+from pydantic import AnyUrl, BaseModel
+from pydantic_core import MultiHostUrl, Url
 
 from docling.datamodel.pipeline_options import PipelineOptions
 
@@ -13,13 +19,6 @@ from docling.datamodel.pipeline_options import PipelineOptions
 def _qualified_type_name(value: object) -> str:
     value_type = type(value)
     return f"{value_type.__module__}.{value_type.__qualname__}"
-
-
-def _opaque_value(value: object) -> dict[str, str | int]:
-    return {
-        "type": _qualified_type_name(value),
-        "identity": id(value),
-    }
 
 
 def _canonicalize(value: object, active: set[int] | None = None) -> object:
@@ -59,9 +58,30 @@ def _canonicalize(value: object, active: set[int] | None = None) -> object:
             return {"type": value_type, "items": items}
         finally:
             active.remove(value_id)
+    if value is None or isinstance(value, (bool, int, str)):
+        return {"type": value_type, "value": value}
+    if isinstance(value, float):
+        return {"type": value_type, "value": value.hex()}
+    if isinstance(value, Enum):
+        return {"type": value_type, "value": value.name}
+    if isinstance(value, (PurePath, AnyUrl, Url, MultiHostUrl, Decimal, UUID)):
+        return {"type": value_type, "value": str(value)}
+    if isinstance(value, (datetime, date, time)):
+        return {"type": value_type, "value": value.isoformat()}
+    if isinstance(value, timedelta):
+        return {
+            "type": value_type,
+            "value": [value.days, value.seconds, value.microseconds],
+        }
+    if isinstance(value, re.Pattern):
+        return {
+            "type": value_type,
+            "pattern": _canonicalize(value.pattern, active),
+            "flags": value.flags,
+        }
     return {
         "type": value_type,
-        "value": to_jsonable_python(value, fallback=_opaque_value),
+        "identity": id(value),
     }
 
 

--- a/docling/utils/pipeline_cache.py
+++ b/docling/utils/pipeline_cache.py
@@ -4,7 +4,8 @@
 import hashlib
 import json
 import re
-from datetime import date, datetime, time, timedelta
+import struct
+from datetime import date, timedelta
 from decimal import Decimal
 from pathlib import (
     Path,
@@ -45,7 +46,7 @@ def _qualified_type_name(value: object) -> str:
 def _canonicalize(value: object, active: set[int] | None = None) -> object:
     active = active if active is not None else set()
     value_type = _qualified_type_name(value)
-    if type(value) in (bytes, bytearray, memoryview):
+    if type(value) in (bytes, bytearray):
         return {"type": value_type, "value": bytes(value).hex()}
     if isinstance(value, BaseModel) or type(value) in _CONTAINER_TYPES:
         value_id = id(value)
@@ -82,10 +83,10 @@ def _canonicalize(value: object, active: set[int] | None = None) -> object:
     if value is None or type(value) in (bool, int, str):
         return {"type": value_type, "value": value}
     if type(value) is float:
-        return {"type": value_type, "value": value.hex()}
+        return {"type": value_type, "value": struct.pack("!d", value).hex()}
     if type(value) in _LOSSLESS_STRING_TYPES:
         return {"type": value_type, "value": str(value)}
-    if type(value) in (datetime, date, time):
+    if type(value) is date:
         return {"type": value_type, "value": value.isoformat()}
     if type(value) is timedelta:
         return {

--- a/docling/utils/pipeline_cache.py
+++ b/docling/utils/pipeline_cache.py
@@ -6,7 +6,6 @@ import json
 import re
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
-from enum import Enum
 from pathlib import (
     Path,
     PosixPath,
@@ -84,8 +83,6 @@ def _canonicalize(value: object, active: set[int] | None = None) -> object:
         return {"type": value_type, "value": value}
     if type(value) is float:
         return {"type": value_type, "value": value.hex()}
-    if isinstance(value, Enum):
-        return {"type": value_type, "value": value.name}
     if type(value) in _LOSSLESS_STRING_TYPES:
         return {"type": value_type, "value": str(value)}
     if type(value) in (datetime, date, time):

--- a/docling/utils/pipeline_cache.py
+++ b/docling/utils/pipeline_cache.py
@@ -7,13 +7,35 @@ import re
 from datetime import date, datetime, time, timedelta
 from decimal import Decimal
 from enum import Enum
-from pathlib import PurePath
+from pathlib import (
+    Path,
+    PosixPath,
+    PurePath,
+    PurePosixPath,
+    PureWindowsPath,
+    WindowsPath,
+)
 from uuid import UUID
 
 from pydantic import AnyUrl, BaseModel
 from pydantic_core import MultiHostUrl, Url
 
 from docling.datamodel.pipeline_options import PipelineOptions
+
+_CONTAINER_TYPES = (dict, list, tuple, set, frozenset)
+_LOSSLESS_STRING_TYPES = (
+    PurePath,
+    PurePosixPath,
+    PureWindowsPath,
+    Path,
+    PosixPath,
+    WindowsPath,
+    AnyUrl,
+    Url,
+    MultiHostUrl,
+    Decimal,
+    UUID,
+)
 
 
 def _qualified_type_name(value: object) -> str:
@@ -24,9 +46,9 @@ def _qualified_type_name(value: object) -> str:
 def _canonicalize(value: object, active: set[int] | None = None) -> object:
     active = active if active is not None else set()
     value_type = _qualified_type_name(value)
-    if isinstance(value, (bytes, bytearray, memoryview)):
+    if type(value) in (bytes, bytearray, memoryview):
         return {"type": value_type, "value": bytes(value).hex()}
-    if isinstance(value, (BaseModel, dict, list, tuple, set, frozenset)):
+    if isinstance(value, BaseModel) or type(value) in _CONTAINER_TYPES:
         value_id = id(value)
         if value_id in active:
             raise ValueError("Pipeline options cannot contain cyclic values")
@@ -37,7 +59,7 @@ def _canonicalize(value: object, active: set[int] | None = None) -> object:
                     "type": value_type,
                     "fields": _canonicalize(dict(value), active),
                 }
-            if isinstance(value, dict):
+            if type(value) is dict:
                 items = [
                     [_canonicalize(key, active), _canonicalize(item, active)]
                     for key, item in value.items()
@@ -49,7 +71,7 @@ def _canonicalize(value: object, active: set[int] | None = None) -> object:
                 )
                 return {"type": value_type, "items": items}
             items = [_canonicalize(item, active) for item in value]
-            if isinstance(value, (set, frozenset)):
+            if type(value) in (set, frozenset):
                 items.sort(
                     key=lambda item: json.dumps(
                         item, sort_keys=True, separators=(",", ":")
@@ -58,22 +80,22 @@ def _canonicalize(value: object, active: set[int] | None = None) -> object:
             return {"type": value_type, "items": items}
         finally:
             active.remove(value_id)
-    if value is None or isinstance(value, (bool, int, str)):
+    if value is None or type(value) in (bool, int, str):
         return {"type": value_type, "value": value}
-    if isinstance(value, float):
+    if type(value) is float:
         return {"type": value_type, "value": value.hex()}
     if isinstance(value, Enum):
         return {"type": value_type, "value": value.name}
-    if isinstance(value, (PurePath, AnyUrl, Url, MultiHostUrl, Decimal, UUID)):
+    if type(value) in _LOSSLESS_STRING_TYPES:
         return {"type": value_type, "value": str(value)}
-    if isinstance(value, (datetime, date, time)):
+    if type(value) in (datetime, date, time):
         return {"type": value_type, "value": value.isoformat()}
-    if isinstance(value, timedelta):
+    if type(value) is timedelta:
         return {
             "type": value_type,
             "value": [value.days, value.seconds, value.microseconds],
         }
-    if isinstance(value, re.Pattern):
+    if type(value) is re.Pattern:
         return {
             "type": value_type,
             "pattern": _canonicalize(value.pattern, active),

--- a/docling/utils/pipeline_cache.py
+++ b/docling/utils/pipeline_cache.py
@@ -2,118 +2,24 @@
 # SPDX-License-Identifier: MIT
 
 import hashlib
-import json
-import re
-import struct
-from datetime import date, timedelta
-from decimal import Decimal
-from pathlib import (
-    Path,
-    PosixPath,
-    PurePath,
-    PurePosixPath,
-    PureWindowsPath,
-    WindowsPath,
-)
-from uuid import UUID
-
-from pydantic import AnyUrl, BaseModel
-from pydantic_core import MultiHostUrl, Url
 
 from docling.datamodel.pipeline_options import PipelineOptions
 
-_CONTAINER_TYPES = (dict, list, tuple, set, frozenset)
-_LOSSLESS_STRING_TYPES = (
-    PurePath,
-    PurePosixPath,
-    PureWindowsPath,
-    Path,
-    PosixPath,
-    WindowsPath,
-    AnyUrl,
-    Url,
-    MultiHostUrl,
-    Decimal,
-    UUID,
-)
-
-
-def _qualified_type_name(value: object) -> str:
-    value_type = type(value)
-    return f"{value_type.__module__}.{value_type.__qualname__}"
-
-
-def _canonicalize(value: object, active: set[int] | None = None) -> object:
-    active = active if active is not None else set()
-    value_type = _qualified_type_name(value)
-    if type(value) in (bytes, bytearray):
-        return {"type": value_type, "value": bytes(value).hex()}
-    if isinstance(value, BaseModel) or type(value) in _CONTAINER_TYPES:
-        value_id = id(value)
-        if value_id in active:
-            raise ValueError("Pipeline options cannot contain cyclic values")
-        active.add(value_id)
-        try:
-            if isinstance(value, BaseModel):
-                return {
-                    "type": value_type,
-                    "fields": _canonicalize(dict(value), active),
-                }
-            if type(value) is dict:
-                items = [
-                    [_canonicalize(key, active), _canonicalize(item, active)]
-                    for key, item in value.items()
-                ]
-                items.sort(
-                    key=lambda item: json.dumps(
-                        item[0], sort_keys=True, separators=(",", ":")
-                    )
-                )
-                return {"type": value_type, "items": items}
-            items = [_canonicalize(item, active) for item in value]
-            if type(value) in (set, frozenset):
-                items.sort(
-                    key=lambda item: json.dumps(
-                        item, sort_keys=True, separators=(",", ":")
-                    )
-                )
-            return {"type": value_type, "items": items}
-        finally:
-            active.remove(value_id)
-    if value is None or type(value) in (bool, int, str):
-        return {"type": value_type, "value": value}
-    if type(value) is float:
-        return {"type": value_type, "value": struct.pack("!d", value).hex()}
-    if type(value) in _LOSSLESS_STRING_TYPES:
-        return {"type": value_type, "value": str(value)}
-    if type(value) is date:
-        return {"type": value_type, "value": value.isoformat()}
-    if type(value) is timedelta:
-        return {
-            "type": value_type,
-            "value": [value.days, value.seconds, value.microseconds],
-        }
-    if type(value) is re.Pattern:
-        return {
-            "type": value_type,
-            "pattern": _canonicalize(value.pattern, active),
-            "flags": value.flags,
-        }
-    return {
-        "type": value_type,
-        "identity": id(value),
-    }
-
 
 def create_pipeline_options_hash(pipeline_options: PipelineOptions) -> str:
-    """Hash public option values and their concrete runtime types.
+    """Build a stable cache key from the public option values.
 
-    Values without a serialization contract are keyed by object identity. This
-    prevents unsafe reuse without inspecting private or arbitrary object state.
+    ``serialize_as_any=True`` serializes every value by its concrete runtime
+    type, so a concrete subtype assigned to a base-typed field (e.g. an API vs.
+    a local VLM picture-description backend) keeps its distinguishing fields
+    instead of being truncated to the base schema and colliding. The options
+    class name guards against two option classes that dump identically.
+
+    # ponytail: serialize_as_any masks SecretStr/opaque objects to a constant;
+    # none are reachable from PipelineOptions today. If such a field is added,
+    # key it explicitly here rather than reintroducing a full type walker.
     """
-    payload = json.dumps(
-        _canonicalize(pipeline_options),
-        sort_keys=True,
-        separators=(",", ":"),
+    payload = type(pipeline_options).__qualname__ + pipeline_options.model_dump_json(
+        serialize_as_any=True
     )
     return hashlib.md5(payload.encode("utf-8"), usedforsecurity=False).hexdigest()

--- a/docling/utils/pipeline_cache.py
+++ b/docling/utils/pipeline_cache.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+import hashlib
+import json
+
+from pydantic import BaseModel
+from pydantic_core import to_jsonable_python
+
+from docling.datamodel.pipeline_options import PipelineOptions
+
+
+def _qualified_type_name(value: object) -> str:
+    value_type = type(value)
+    return f"{value_type.__module__}.{value_type.__qualname__}"
+
+
+def _opaque_value(value: object) -> dict[str, str | int]:
+    return {
+        "type": _qualified_type_name(value),
+        "identity": id(value),
+    }
+
+
+def _canonicalize(value: object, active: set[int] | None = None) -> object:
+    active = active if active is not None else set()
+    value_type = _qualified_type_name(value)
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return {"type": value_type, "value": bytes(value).hex()}
+    if isinstance(value, (BaseModel, dict, list, tuple, set, frozenset)):
+        value_id = id(value)
+        if value_id in active:
+            raise ValueError("Pipeline options cannot contain cyclic values")
+        active.add(value_id)
+        try:
+            if isinstance(value, BaseModel):
+                return {
+                    "type": value_type,
+                    "fields": _canonicalize(dict(value), active),
+                }
+            if isinstance(value, dict):
+                items = [
+                    [_canonicalize(key, active), _canonicalize(item, active)]
+                    for key, item in value.items()
+                ]
+                items.sort(
+                    key=lambda item: json.dumps(
+                        item[0], sort_keys=True, separators=(",", ":")
+                    )
+                )
+                return {"type": value_type, "items": items}
+            items = [_canonicalize(item, active) for item in value]
+            if isinstance(value, (set, frozenset)):
+                items.sort(
+                    key=lambda item: json.dumps(
+                        item, sort_keys=True, separators=(",", ":")
+                    )
+                )
+            return {"type": value_type, "items": items}
+        finally:
+            active.remove(value_id)
+    return {
+        "type": value_type,
+        "value": to_jsonable_python(value, fallback=_opaque_value),
+    }
+
+
+def create_pipeline_options_hash(pipeline_options: PipelineOptions) -> str:
+    """Hash public option values and their concrete runtime types.
+
+    Values without a serialization contract are keyed by object identity. This
+    prevents unsafe reuse without inspecting private or arbitrary object state.
+    """
+    payload = json.dumps(
+        _canonicalize(pipeline_options),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return hashlib.md5(payload.encode("utf-8"), usedforsecurity=False).hexdigest()

--- a/tests/test_pipeline_cache.py
+++ b/tests/test_pipeline_cache.py
@@ -1,8 +1,10 @@
 # SPDX-FileCopyrightText: The Docling Contributors
 # SPDX-License-Identifier: MIT
 
+import re
+
 import pytest
-from pydantic import AnyUrl
+from pydantic import AnyUrl, SecretStr
 
 from docling.backend.abstract_backend import AbstractDocumentBackend
 from docling.backend.noop_backend import NoOpBackend
@@ -71,6 +73,14 @@ class _FirstPictureOptions(PictureDescriptionBaseOptions):
 
 class _SecondPictureOptions(PictureDescriptionBaseOptions):
     pass
+
+
+class _SecretOptions(PipelineOptions):
+    credential: SecretStr
+
+
+class _PatternOptions(PipelineOptions):
+    pattern: re.Pattern[str]
 
 
 def _api_options(url: str, *, reverse_params: bool = False) -> PdfPipelineOptions:
@@ -169,6 +179,17 @@ def test_pipeline_options_hash_supports_non_utf8_bytes():
     }
 
     assert len(hashes) == 2
+
+
+def test_pipeline_options_hash_preserves_lossy_scalar_values():
+    assert create_pipeline_options_hash(
+        _SecretOptions(credential=SecretStr("alpha"))
+    ) != create_pipeline_options_hash(_SecretOptions(credential=SecretStr("bravo")))
+    assert create_pipeline_options_hash(
+        _PatternOptions(pattern=re.compile("value"))
+    ) != create_pipeline_options_hash(
+        _PatternOptions(pattern=re.compile("value", re.IGNORECASE))
+    )
 
 
 def test_pipeline_options_hash_rejects_cycles():

--- a/tests/test_pipeline_cache.py
+++ b/tests/test_pipeline_cache.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: MIT
 
 import re
+import struct
 from collections import OrderedDict
+from datetime import datetime
 
 import pytest
 from pydantic import AnyUrl, SecretStr
@@ -82,6 +84,10 @@ class _SecretOptions(PipelineOptions):
 
 class _PatternOptions(PipelineOptions):
     pattern: re.Pattern[str]
+
+
+class _ValueOptions(PipelineOptions):
+    value: object
 
 
 def _api_options(url: str, *, reverse_params: bool = False) -> PdfPipelineOptions:
@@ -204,6 +210,25 @@ def test_pipeline_options_hash_does_not_flatten_container_subclasses():
     assert create_pipeline_options_hash(
         PdfPipelineOptions(ocr_options=first)
     ) != create_pipeline_options_hash(PdfPipelineOptions(ocr_options=second))
+
+
+@pytest.mark.parametrize(
+    ("first", "second"),
+    [
+        (memoryview(b"\x01\x00"), memoryview(b"\x01\x00").cast("H")),
+        (datetime(2024, 1, 1, fold=0), datetime(2024, 1, 1, fold=1)),
+        (
+            struct.unpack("!d", bytes.fromhex("7ff8000000000001"))[0],
+            struct.unpack("!d", bytes.fromhex("7ff8000000000002"))[0],
+        ),
+    ],
+)
+def test_pipeline_options_hash_preserves_hidden_scalar_semantics(
+    first: object, second: object
+):
+    assert create_pipeline_options_hash(
+        _ValueOptions(value=first)
+    ) != create_pipeline_options_hash(_ValueOptions(value=second))
 
 
 def test_pipeline_options_hash_rejects_cycles():

--- a/tests/test_pipeline_cache.py
+++ b/tests/test_pipeline_cache.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+import pytest
+from pydantic import AnyUrl
+
+from docling.backend.abstract_backend import AbstractDocumentBackend
+from docling.backend.noop_backend import NoOpBackend
+from docling.datamodel.base_models import ConversionStatus, InputFormat
+from docling.datamodel.document import ConversionResult
+from docling.datamodel.extraction import ExtractionResult, ExtractionTemplateType
+from docling.datamodel.image_classification_engine_options import (
+    TransformersImageClassificationEngineOptions,
+)
+from docling.datamodel.object_detection_engine_options import (
+    TransformersObjectDetectionEngineOptions,
+)
+from docling.datamodel.picture_classification_options import (
+    DocumentPictureClassifierOptions,
+)
+from docling.datamodel.pipeline_options import (
+    LayoutObjectDetectionOptions,
+    PdfPipelineOptions,
+    PictureDescriptionApiOptions,
+    PictureDescriptionBaseOptions,
+    PipelineOptions,
+    RapidOcrOptions,
+)
+from docling.document_converter import DocumentConverter, FormatOption
+from docling.document_extractor import DocumentExtractor, ExtractionFormatOption
+from docling.pipeline.base_extraction_pipeline import BaseExtractionPipeline
+from docling.pipeline.base_pipeline import BasePipeline
+from docling.utils.pipeline_cache import create_pipeline_options_hash
+
+
+class _Pipeline(BasePipeline):
+    def _build_document(self, conv_res: ConversionResult) -> ConversionResult:
+        return conv_res
+
+    def _determine_status(self, conv_res: ConversionResult) -> ConversionStatus:
+        return conv_res.status
+
+    @classmethod
+    def get_default_options(cls) -> PipelineOptions:
+        return PipelineOptions()
+
+    @classmethod
+    def is_backend_supported(cls, backend: AbstractDocumentBackend) -> bool:
+        return True
+
+
+class _ExtractionPipeline(BaseExtractionPipeline):
+    def _extract_data(
+        self,
+        ext_res: ExtractionResult,
+        template: ExtractionTemplateType | None = None,
+    ) -> ExtractionResult:
+        return ext_res
+
+    def _determine_status(self, ext_res: ExtractionResult) -> ConversionStatus:
+        return ext_res.status
+
+    @classmethod
+    def get_default_options(cls) -> PipelineOptions:
+        return PipelineOptions()
+
+
+class _FirstPictureOptions(PictureDescriptionBaseOptions):
+    pass
+
+
+class _SecondPictureOptions(PictureDescriptionBaseOptions):
+    pass
+
+
+def _api_options(url: str, *, reverse_params: bool = False) -> PdfPipelineOptions:
+    params = (
+        {"metadata": {"b": 2, "a": 1}, "model": "example"}
+        if reverse_params
+        else {"model": "example", "metadata": {"a": 1, "b": 2}}
+    )
+    return PdfPipelineOptions(
+        picture_description_options=PictureDescriptionApiOptions(
+            url=AnyUrl(url),
+            params=params,
+        )
+    )
+
+
+def test_pipeline_options_hash_includes_concrete_fields_and_normalizes_mappings():
+    first = _api_options("https://first.example.com/v1", reverse_params=False)
+    reordered = _api_options("https://first.example.com/v1", reverse_params=True)
+    different = _api_options("https://second.example.com/v1")
+
+    assert create_pipeline_options_hash(first) == create_pipeline_options_hash(
+        reordered
+    )
+    assert create_pipeline_options_hash(first) != create_pipeline_options_hash(
+        different
+    )
+
+
+def test_pipeline_options_hash_includes_concrete_option_types():
+    first = PdfPipelineOptions(picture_description_options=_FirstPictureOptions())
+    second = PdfPipelineOptions(picture_description_options=_SecondPictureOptions())
+
+    assert create_pipeline_options_hash(first) != create_pipeline_options_hash(second)
+
+
+def test_pipeline_options_hash_includes_concrete_engine_fields():
+    first_classifier = PdfPipelineOptions(
+        picture_classification_options=DocumentPictureClassifierOptions(
+            engine_options=TransformersImageClassificationEngineOptions(
+                torch_dtype="float16"
+            )
+        )
+    )
+    second_classifier = PdfPipelineOptions(
+        picture_classification_options=DocumentPictureClassifierOptions(
+            engine_options=TransformersImageClassificationEngineOptions(
+                torch_dtype="float32"
+            )
+        )
+    )
+    assert create_pipeline_options_hash(
+        first_classifier
+    ) != create_pipeline_options_hash(second_classifier)
+
+    first_layout = PdfPipelineOptions(
+        layout_options=LayoutObjectDetectionOptions(
+            engine_options=TransformersObjectDetectionEngineOptions(
+                torch_dtype="float16"
+            )
+        )
+    )
+    second_layout = PdfPipelineOptions(
+        layout_options=LayoutObjectDetectionOptions(
+            engine_options=TransformersObjectDetectionEngineOptions(
+                torch_dtype="float32"
+            )
+        )
+    )
+    assert create_pipeline_options_hash(first_layout) != create_pipeline_options_hash(
+        second_layout
+    )
+
+
+def test_pipeline_options_hash_preserves_pass_through_container_types():
+    hashes = {
+        create_pipeline_options_hash(
+            PdfPipelineOptions(
+                ocr_options=RapidOcrOptions(rapidocr_params={"value": value})
+            )
+        )
+        for value in ([1, 2], (1, 2), {1, 2})
+    }
+
+    assert len(hashes) == 3
+
+
+def test_pipeline_options_hash_supports_non_utf8_bytes():
+    hashes = {
+        create_pipeline_options_hash(
+            PdfPipelineOptions(
+                ocr_options=RapidOcrOptions(rapidocr_params={"value": value})
+            )
+        )
+        for value in (b"\xff", bytearray(b"\xff"))
+    }
+
+    assert len(hashes) == 2
+
+
+def test_pipeline_options_hash_rejects_cycles():
+    cyclic: dict[str, object] = {}
+    cyclic["value"] = cyclic
+    options = PdfPipelineOptions(ocr_options=RapidOcrOptions(rapidocr_params=cyclic))
+
+    with pytest.raises(ValueError, match="cannot contain cyclic values"):
+        create_pipeline_options_hash(options)
+
+
+def test_cache_projection_does_not_change_public_model_serialization():
+    options = PdfPipelineOptions(
+        picture_description_options=PictureDescriptionApiOptions(
+            url=AnyUrl("https://example.com/v1"),
+            headers={"Authorization": "secret"},
+        )
+    )
+
+    assert "headers" not in options.model_dump()["picture_description_options"]
+
+
+def test_converter_does_not_reuse_pipeline_for_different_api_options():
+    converter = DocumentConverter(
+        allowed_formats=[InputFormat.PDF, InputFormat.DOCX],
+        format_options={
+            InputFormat.PDF: FormatOption(
+                pipeline_cls=_Pipeline,
+                pipeline_options=_api_options("https://first.example.com/v1"),
+                backend=NoOpBackend,
+            ),
+            InputFormat.DOCX: FormatOption(
+                pipeline_cls=_Pipeline,
+                pipeline_options=_api_options("https://second.example.com/v1"),
+                backend=NoOpBackend,
+            ),
+        },
+    )
+
+    first = converter._get_pipeline(InputFormat.PDF)
+    second = converter._get_pipeline(InputFormat.DOCX)
+
+    assert first is not second
+    assert len(converter._get_initialized_pipelines()) == 2
+
+
+def test_extractor_does_not_reuse_pipeline_for_different_api_options():
+    extractor = DocumentExtractor(
+        allowed_formats=[InputFormat.PDF, InputFormat.IMAGE],
+        extraction_format_options={
+            InputFormat.PDF: ExtractionFormatOption(
+                pipeline_cls=_ExtractionPipeline,
+                pipeline_options=_api_options("https://first.example.com/v1"),
+                backend=NoOpBackend,
+            ),
+            InputFormat.IMAGE: ExtractionFormatOption(
+                pipeline_cls=_ExtractionPipeline,
+                pipeline_options=_api_options("https://second.example.com/v1"),
+                backend=NoOpBackend,
+            ),
+        },
+    )
+
+    first = extractor._get_pipeline(InputFormat.PDF)
+    second = extractor._get_pipeline(InputFormat.IMAGE)
+
+    assert first is not second
+    assert len(extractor._initialized_pipelines) == 2

--- a/tests/test_pipeline_cache.py
+++ b/tests/test_pipeline_cache.py
@@ -1,299 +1,40 @@
 # SPDX-FileCopyrightText: The Docling Contributors
 # SPDX-License-Identifier: MIT
 
-import re
-import struct
-from collections import OrderedDict
-from datetime import datetime
-
-import pytest
-from pydantic import AnyUrl, SecretStr
-
-from docling.backend.abstract_backend import AbstractDocumentBackend
-from docling.backend.noop_backend import NoOpBackend
-from docling.datamodel.base_models import ConversionStatus, InputFormat
-from docling.datamodel.document import ConversionResult
-from docling.datamodel.extraction import ExtractionResult, ExtractionTemplateType
-from docling.datamodel.image_classification_engine_options import (
-    TransformersImageClassificationEngineOptions,
-)
-from docling.datamodel.object_detection_engine_options import (
-    TransformersObjectDetectionEngineOptions,
-)
-from docling.datamodel.picture_classification_options import (
-    DocumentPictureClassifierOptions,
-)
 from docling.datamodel.pipeline_options import (
-    LayoutObjectDetectionOptions,
     PdfPipelineOptions,
     PictureDescriptionApiOptions,
-    PictureDescriptionBaseOptions,
+    PictureDescriptionVlmOptions,
     PipelineOptions,
-    RapidOcrOptions,
 )
-from docling.document_converter import DocumentConverter, FormatOption
-from docling.document_extractor import DocumentExtractor, ExtractionFormatOption
-from docling.pipeline.base_extraction_pipeline import BaseExtractionPipeline
-from docling.pipeline.base_pipeline import BasePipeline
 from docling.utils.pipeline_cache import create_pipeline_options_hash
 
 
-class _Pipeline(BasePipeline):
-    def _build_document(self, conv_res: ConversionResult) -> ConversionResult:
-        return conv_res
-
-    def _determine_status(self, conv_res: ConversionResult) -> ConversionStatus:
-        return conv_res.status
-
-    @classmethod
-    def get_default_options(cls) -> PipelineOptions:
-        return PipelineOptions()
-
-    @classmethod
-    def is_backend_supported(cls, backend: AbstractDocumentBackend) -> bool:
-        return True
-
-
-class _ExtractionPipeline(BaseExtractionPipeline):
-    def _extract_data(
-        self,
-        ext_res: ExtractionResult,
-        template: ExtractionTemplateType | None = None,
-    ) -> ExtractionResult:
-        return ext_res
-
-    def _determine_status(self, ext_res: ExtractionResult) -> ConversionStatus:
-        return ext_res.status
-
-    @classmethod
-    def get_default_options(cls) -> PipelineOptions:
-        return PipelineOptions()
-
-
-class _FirstPictureOptions(PictureDescriptionBaseOptions):
-    pass
-
-
-class _SecondPictureOptions(PictureDescriptionBaseOptions):
-    pass
-
-
-class _SecretOptions(PipelineOptions):
-    credential: SecretStr
-
-
-class _PatternOptions(PipelineOptions):
-    pattern: re.Pattern[str]
-
-
-class _ValueOptions(PipelineOptions):
-    value: object
-
-
-def _api_options(url: str, *, reverse_params: bool = False) -> PdfPipelineOptions:
-    params = (
-        {"metadata": {"b": 2, "a": 1}, "model": "example"}
-        if reverse_params
-        else {"model": "example", "metadata": {"a": 1, "b": 2}}
-    )
-    return PdfPipelineOptions(
-        picture_description_options=PictureDescriptionApiOptions(
-            url=AnyUrl(url),
-            params=params,
-        )
-    )
-
-
-def test_pipeline_options_hash_includes_concrete_fields_and_normalizes_mappings():
-    first = _api_options("https://first.example.com/v1", reverse_params=False)
-    reordered = _api_options("https://first.example.com/v1", reverse_params=True)
-    different = _api_options("https://second.example.com/v1")
-
-    assert create_pipeline_options_hash(first) == create_pipeline_options_hash(
-        reordered
-    )
-    assert create_pipeline_options_hash(first) != create_pipeline_options_hash(
-        different
-    )
-
-
-def test_pipeline_options_hash_includes_concrete_option_types():
-    first = PdfPipelineOptions(picture_description_options=_FirstPictureOptions())
-    second = PdfPipelineOptions(picture_description_options=_SecondPictureOptions())
-
-    assert create_pipeline_options_hash(first) != create_pipeline_options_hash(second)
-
-
-def test_pipeline_options_hash_includes_concrete_engine_fields():
-    first_classifier = PdfPipelineOptions(
-        picture_classification_options=DocumentPictureClassifierOptions(
-            engine_options=TransformersImageClassificationEngineOptions(
-                torch_dtype="float16"
-            )
-        )
-    )
-    second_classifier = PdfPipelineOptions(
-        picture_classification_options=DocumentPictureClassifierOptions(
-            engine_options=TransformersImageClassificationEngineOptions(
-                torch_dtype="float32"
-            )
-        )
-    )
+def test_hash_is_stable():
     assert create_pipeline_options_hash(
-        first_classifier
-    ) != create_pipeline_options_hash(second_classifier)
-
-    first_layout = PdfPipelineOptions(
-        layout_options=LayoutObjectDetectionOptions(
-            engine_options=TransformersObjectDetectionEngineOptions(
-                torch_dtype="float16"
-            )
-        )
-    )
-    second_layout = PdfPipelineOptions(
-        layout_options=LayoutObjectDetectionOptions(
-            engine_options=TransformersObjectDetectionEngineOptions(
-                torch_dtype="float32"
-            )
-        )
-    )
-    assert create_pipeline_options_hash(first_layout) != create_pipeline_options_hash(
-        second_layout
-    )
+        PdfPipelineOptions()
+    ) == create_pipeline_options_hash(PdfPipelineOptions())
 
 
-def test_pipeline_options_hash_preserves_pass_through_container_types():
-    hashes = {
-        create_pipeline_options_hash(
-            PdfPipelineOptions(
-                ocr_options=RapidOcrOptions(rapidocr_params={"value": value})
-            )
-        )
-        for value in ([1, 2], (1, 2), {1, 2})
-    }
-
-    assert len(hashes) == 3
+def test_scalar_change_changes_hash():
+    a = PdfPipelineOptions()
+    b = PdfPipelineOptions()
+    b.document_timeout = (a.document_timeout or 0) + 1
+    assert create_pipeline_options_hash(a) != create_pipeline_options_hash(b)
 
 
-def test_pipeline_options_hash_supports_non_utf8_bytes():
-    hashes = {
-        create_pipeline_options_hash(
-            PdfPipelineOptions(
-                ocr_options=RapidOcrOptions(rapidocr_params={"value": value})
-            )
-        )
-        for value in (b"\xff", bytearray(b"\xff"))
-    }
-
-    assert len(hashes) == 2
+def test_subtype_in_base_typed_field_does_not_collide():
+    # picture_description_options is typed as the base class; the default
+    # dump truncates subtype fields, so an API and a VLM backend would share a
+    # cache key. serialize_as_any keeps the distinguishing fields.
+    api = PdfPipelineOptions()
+    api.picture_description_options = PictureDescriptionApiOptions(url="http://x")
+    vlm = PdfPipelineOptions()
+    vlm.picture_description_options = PictureDescriptionVlmOptions(repo_id="r")
+    assert create_pipeline_options_hash(api) != create_pipeline_options_hash(vlm)
 
 
-def test_pipeline_options_hash_preserves_lossy_scalar_values():
+def test_different_options_classes_do_not_collide():
     assert create_pipeline_options_hash(
-        _SecretOptions(credential=SecretStr("alpha"))
-    ) != create_pipeline_options_hash(_SecretOptions(credential=SecretStr("bravo")))
-    assert create_pipeline_options_hash(
-        _PatternOptions(pattern=re.compile("value"))
-    ) != create_pipeline_options_hash(
-        _PatternOptions(pattern=re.compile("value", re.IGNORECASE))
-    )
-
-
-def test_pipeline_options_hash_does_not_flatten_container_subclasses():
-    first = RapidOcrOptions(
-        rapidocr_params={"value": OrderedDict((("first", 1), ("second", 2)))}
-    )
-    second = RapidOcrOptions(
-        rapidocr_params={"value": OrderedDict((("second", 2), ("first", 1)))}
-    )
-
-    assert create_pipeline_options_hash(
-        PdfPipelineOptions(ocr_options=first)
-    ) != create_pipeline_options_hash(PdfPipelineOptions(ocr_options=second))
-
-
-@pytest.mark.parametrize(
-    ("first", "second"),
-    [
-        (memoryview(b"\x01\x00"), memoryview(b"\x01\x00").cast("H")),
-        (datetime(2024, 1, 1, fold=0), datetime(2024, 1, 1, fold=1)),
-        (
-            struct.unpack("!d", bytes.fromhex("7ff8000000000001"))[0],
-            struct.unpack("!d", bytes.fromhex("7ff8000000000002"))[0],
-        ),
-    ],
-)
-def test_pipeline_options_hash_preserves_hidden_scalar_semantics(
-    first: object, second: object
-):
-    assert create_pipeline_options_hash(
-        _ValueOptions(value=first)
-    ) != create_pipeline_options_hash(_ValueOptions(value=second))
-
-
-def test_pipeline_options_hash_rejects_cycles():
-    cyclic: dict[str, object] = {}
-    cyclic["value"] = cyclic
-    options = PdfPipelineOptions(ocr_options=RapidOcrOptions(rapidocr_params=cyclic))
-
-    with pytest.raises(ValueError, match="cannot contain cyclic values"):
-        create_pipeline_options_hash(options)
-
-
-def test_cache_projection_does_not_change_public_model_serialization():
-    options = PdfPipelineOptions(
-        picture_description_options=PictureDescriptionApiOptions(
-            url=AnyUrl("https://example.com/v1"),
-            headers={"Authorization": "secret"},
-        )
-    )
-
-    assert "headers" not in options.model_dump()["picture_description_options"]
-
-
-def test_converter_does_not_reuse_pipeline_for_different_api_options():
-    converter = DocumentConverter(
-        allowed_formats=[InputFormat.PDF, InputFormat.DOCX],
-        format_options={
-            InputFormat.PDF: FormatOption(
-                pipeline_cls=_Pipeline,
-                pipeline_options=_api_options("https://first.example.com/v1"),
-                backend=NoOpBackend,
-            ),
-            InputFormat.DOCX: FormatOption(
-                pipeline_cls=_Pipeline,
-                pipeline_options=_api_options("https://second.example.com/v1"),
-                backend=NoOpBackend,
-            ),
-        },
-    )
-
-    first = converter._get_pipeline(InputFormat.PDF)
-    second = converter._get_pipeline(InputFormat.DOCX)
-
-    assert first is not second
-    assert len(converter._get_initialized_pipelines()) == 2
-
-
-def test_extractor_does_not_reuse_pipeline_for_different_api_options():
-    extractor = DocumentExtractor(
-        allowed_formats=[InputFormat.PDF, InputFormat.IMAGE],
-        extraction_format_options={
-            InputFormat.PDF: ExtractionFormatOption(
-                pipeline_cls=_ExtractionPipeline,
-                pipeline_options=_api_options("https://first.example.com/v1"),
-                backend=NoOpBackend,
-            ),
-            InputFormat.IMAGE: ExtractionFormatOption(
-                pipeline_cls=_ExtractionPipeline,
-                pipeline_options=_api_options("https://second.example.com/v1"),
-                backend=NoOpBackend,
-            ),
-        },
-    )
-
-    first = extractor._get_pipeline(InputFormat.PDF)
-    second = extractor._get_pipeline(InputFormat.IMAGE)
-
-    assert first is not second
-    assert len(extractor._initialized_pipelines) == 2
+        PipelineOptions()
+    ) != create_pipeline_options_hash(PdfPipelineOptions())

--- a/tests/test_pipeline_cache.py
+++ b/tests/test_pipeline_cache.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 import re
+from collections import OrderedDict
 
 import pytest
 from pydantic import AnyUrl, SecretStr
@@ -190,6 +191,19 @@ def test_pipeline_options_hash_preserves_lossy_scalar_values():
     ) != create_pipeline_options_hash(
         _PatternOptions(pattern=re.compile("value", re.IGNORECASE))
     )
+
+
+def test_pipeline_options_hash_does_not_flatten_container_subclasses():
+    first = RapidOcrOptions(
+        rapidocr_params={"value": OrderedDict((("first", 1), ("second", 2)))}
+    )
+    second = RapidOcrOptions(
+        rapidocr_params={"value": OrderedDict((("second", 2), ("first", 1)))}
+    )
+
+    assert create_pipeline_options_hash(
+        PdfPipelineOptions(ocr_options=first)
+    ) != create_pipeline_options_hash(PdfPipelineOptions(ocr_options=second))
 
 
 def test_pipeline_options_hash_rejects_cycles():


### PR DESCRIPTION
Fix pipeline cache collisions for concrete and pass-through option values.

Build cache keys from public typed configuration without changing Pydantic serialization or inspecting private state. Converter and extractor now share the same cache-key implementation.

Adds focused coverage for runtime types, mapping order, opaque values, and collision-prone scalars.