### PR TITLE
fix(pdf): filter invisible text before page assembly

### DIFF
--- a/docling/models/stages/page_preprocessing/page_preprocessing_model.py
+++ b/docling/models/stages/page_preprocessing/page_preprocessing_model.py
@@ -93,6 +93,10 @@ class PagePreprocessingModel(BasePageModel):
         page.parsed_page = page._backend.get_segmented_page()
         assert page.parsed_page is not None
 
+        visible_text_cells = page._backend.get_visible_text_cells()
+        if visible_text_cells is not None:
+            page.parsed_page.textline_cells = visible_text_cells
+
         # Rate the text quality from the PDF parser, and aggregate on page
         text_scores = []
         for c in page.cells:

--- a/tests/test_skip_cell_extraction.py
+++ b/tests/test_skip_cell_extraction.py
@@ -32,6 +32,10 @@ from docling.models.base_ocr_model import BaseOcrModel
 from docling.models.stages.layout.layout_postprocessing_model import (
     LayoutPostprocessingModel,
 )
+from docling.models.stages.page_preprocessing.page_preprocessing_model import (
+    PagePreprocessingModel,
+    PagePreprocessingOptions,
+)
 
 
 def _page() -> Page:
@@ -102,3 +106,20 @@ def test_layout_write_back_guarded_without_parsed_page() -> None:
     assert len(out_pages) == 1
     assert out_pages[0].predictions.layout.clusters
     assert page.parsed_page is None  # nothing to write back, and no crash
+
+
+def test_page_preprocessing_excludes_invisible_text_cells() -> None:
+    visible = _ocr_cell("visible", confidence=1.0)
+    invisible = _ocr_cell("invisible", confidence=1.0)
+    parsed_page = SimpleNamespace(textline_cells=[visible, invisible])
+    page = _page()
+    page._backend = SimpleNamespace(  # type: ignore[assignment]
+        get_segmented_page=lambda: parsed_page,
+        get_visible_text_cells=lambda: [visible],
+    )
+    conv_res = SimpleNamespace(confidence=ConfidenceReport())
+    model = PagePreprocessingModel(PagePreprocessingOptions(images_scale=None))
+
+    model._parse_page_cells(conv_res, page)
+
+    assert page.cells == [visible]


### PR DESCRIPTION
## Summary

Invisible PDF text cells were filtered only in the OCR path. The regular page-assembly path passed all parsed text cells downstream, allowing rendering-mode-invisible text to appear in exported documents.

This change applies `get_visible_text_cells()` during page preprocessing before layout and assembly consume `page.cells`. Backends that return `None` retain the existing behavior for compatibility.

## Validation

- `python -m compileall -q docling/models/stages/page_preprocessing/page_preprocessing_model.py tests/test_skip_cell_extraction.py`
- `git diff --check`
- Added `test_page_preprocessing_excludes_invisible_text_cells`.

The focused pytest and Ruff commands could not run in the available Python 3.14 environment because dependency synchronization stalled and the existing virtual environment does not contain pytest or Ruff.

Fixes #4053
