### PR TITLE
fix(models): align table cell grid offsets with cell geometry

### DIFF
--- a/docling/models/stages/table_structure/table_structure_model.py
+++ b/docling/models/stages/table_structure/table_structure_model.py
@@ -32,6 +32,149 @@ from docling.utils.profiling import TimeRecorder
 _log = logging.getLogger(__name__)
 
 
+def _reorder_cells_by_geometry(
+    table_cells: list[TableCell], num_rows: int, num_cols: int
+) -> list[TableCell]:
+    """Realign cell row and column offsets with the cell geometry.
+
+    The table structure prediction can assign grid offsets that disagree with
+    the bounding boxes, e.g. a row header on the geometric left landing in the
+    rightmost column, so the exported table order diverges from the visual
+    order (#3194). For each axis whose offsets are not monotonically aligned
+    with the geometry, cells are reassigned to slots by clustering their box
+    centers with one cluster per slot. The reassignment is kept only when it
+    introduces no slot collisions within a line and strictly reduces the
+    number of misordered lines, so already consistent tables are returned
+    unchanged. The cells are updated in place and returned.
+    """
+
+    def line_violations(
+        spans: list[tuple[int, int]],
+        lines: list[tuple[int, int]],
+        edges: list[Optional[float]],
+        num_lines: int,
+    ) -> int:
+        violations = 0
+        for line in range(num_lines):
+            in_line = sorted(
+                (
+                    (span, edge)
+                    for span, edge, cell_lines in zip(spans, edges, lines)
+                    if cell_lines[0] <= line < cell_lines[1]
+                    and span[1] - span[0] == 1
+                    and edge is not None
+                ),
+                key=lambda span_edge: span_edge[0][0],
+            )
+            values = [edge for _, edge in in_line]
+            if len(values) > 1 and not all(
+                values[i] <= values[i + 1] for i in range(len(values) - 1)
+            ):
+                violations += 1
+        return violations
+
+    def slot_rematch(
+        spans: list[tuple[int, int]],
+        centers: list[Optional[float]],
+        num_slots: int,
+    ) -> Optional[list[tuple[int, int]]]:
+        if num_slots < 2:
+            return None
+        values = sorted(center for center in centers if center is not None)
+        if len(values) < num_slots:
+            return None
+        cluster_centers = [
+            values[round(i * (len(values) - 1) / (num_slots - 1))]
+            for i in range(num_slots)
+        ]
+        for _ in range(20):
+            groups: dict[int, list[float]] = {slot: [] for slot in range(num_slots)}
+            for value in values:
+                slot = min(
+                    range(num_slots), key=lambda s: abs(value - cluster_centers[s])
+                )
+                groups[slot].append(value)
+            if any(len(group) == 0 for group in groups.values()):
+                return None
+            new_centers = [sum(g) / len(g) for g in groups.values()]
+            if new_centers == cluster_centers:
+                break
+            cluster_centers = new_centers
+        rank = {
+            slot: position
+            for position, slot in enumerate(
+                sorted(range(num_slots), key=lambda s: cluster_centers[s])
+            )
+        }
+        remapped = []
+        for (start, end), center in zip(spans, centers):
+            span = end - start
+            if center is None or not 0 <= start < end <= num_slots:
+                remapped.append((start, end))
+                continue
+            if span > num_slots:
+                remapped.append((start, end))
+                continue
+            slot = min(range(num_slots), key=lambda s: abs(center - cluster_centers[s]))
+            new_start = min(rank[slot], num_slots - span)
+            remapped.append((new_start, new_start + span))
+        return remapped
+
+    def remap_axis(
+        spans: list[tuple[int, int]],
+        lines: list[tuple[int, int]],
+        edges: list[Optional[float]],
+        centers: list[Optional[float]],
+        num_slots: int,
+        num_lines: int,
+    ) -> Optional[list[tuple[int, int]]]:
+        before = line_violations(spans, lines, edges, num_lines)
+        if before == 0:
+            return None
+        remapped = slot_rematch(spans, centers, num_slots)
+        if remapped is None:
+            return None
+        occupied: dict[tuple[int, int], int] = {}
+        for (start, end), line_span in zip(remapped, lines):
+            if end - start == 1:
+                occupied[(line_span[0], start)] = (
+                    occupied.get((line_span[0], start), 0) + 1
+                )
+        if any(count > 1 for count in occupied.values()):
+            return None
+        if line_violations(remapped, lines, edges, num_lines) >= before:
+            return None
+        return remapped
+
+    col_spans = [(tc.start_col_offset_idx, tc.end_col_offset_idx) for tc in table_cells]
+    row_spans = [(tc.start_row_offset_idx, tc.end_row_offset_idx) for tc in table_cells]
+    lefts = [tc.bbox.l if tc.bbox is not None else None for tc in table_cells]
+    tops = [tc.bbox.t if tc.bbox is not None else None for tc in table_cells]
+    x_centers = [
+        (tc.bbox.l + tc.bbox.r) / 2 if tc.bbox is not None else None
+        for tc in table_cells
+    ]
+    y_centers = [
+        (tc.bbox.t + tc.bbox.b) / 2 if tc.bbox is not None else None
+        for tc in table_cells
+    ]
+
+    col_remap = remap_axis(col_spans, row_spans, lefts, x_centers, num_cols, num_rows)
+    row_remap = remap_axis(row_spans, col_spans, tops, y_centers, num_rows, num_cols)
+
+    if col_remap is None and row_remap is None:
+        return table_cells
+
+    for tc, (col_start, col_end), (row_start, row_end) in zip(
+        table_cells,
+        col_remap or col_spans,
+        row_remap or row_spans,
+    ):
+        tc.start_col_offset_idx, tc.end_col_offset_idx = col_start, col_end
+        tc.start_row_offset_idx, tc.end_row_offset_idx = row_start, row_end
+    return table_cells
+
+
 class TableStructureModel(BaseTableStructureModel):
     _model_repo_folder = "docling-project--docling-models"
     _model_path = "model_artifacts/tableformer"
@@ -281,6 +424,13 @@ class TableStructureModel(BaseTableStructureModel):
                     # Retrieving cols/rows, after post processing:
                     num_rows = table_out["predict_details"].get("num_rows", 0)
                     num_cols = table_out["predict_details"].get("num_cols", 0)
+
+                    # Align the grid offsets with the cell geometry before
+                    # building the table (#3194).
+                    table_cells = _reorder_cells_by_geometry(
+                        table_cells, num_rows, num_cols
+                    )
+
                     otsl_seq = (
                         table_out["predict_details"]
                         .get("prediction", {})
@@ -399,6 +549,11 @@ class TableStructureModel(BaseTableStructureModel):
 
         num_rows = table_out["predict_details"].get("num_rows", 0)
         num_cols = table_out["predict_details"].get("num_cols", 0)
+
+        # Align the grid offsets with the cell geometry before building the
+        # table (#3194).
+        table_cells = _reorder_cells_by_geometry(table_cells, num_rows, num_cols)
+
         otsl_seq = table_out["predict_details"].get("prediction", {}).get("rs_seq", [])
 
         return Table(

--- a/docling/models/stages/table_structure/table_structure_model.py
+++ b/docling/models/stages/table_structure/table_structure_model.py
@@ -112,9 +112,6 @@ def _reorder_cells_by_geometry(
             if center is None or not 0 <= start < end <= num_slots:
                 remapped.append((start, end))
                 continue
-            if span > num_slots:
-                remapped.append((start, end))
-                continue
             slot = min(range(num_slots), key=lambda s: abs(center - cluster_centers[s]))
             new_start = min(rank[slot], num_slots - span)
             remapped.append((new_start, new_start + span))

--- a/tests/test_table_structure_model.py
+++ b/tests/test_table_structure_model.py
@@ -1,0 +1,114 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+from docling_core.types.doc import BoundingBox, CoordOrigin, TableCell
+
+from docling.models.stages.table_structure.table_structure_model import (
+    _reorder_cells_by_geometry,
+)
+
+
+def _cell(
+    text: str,
+    row: int,
+    col: int,
+    left: float,
+    t: float,
+    r: float,
+    b: float,
+    col_span: int = 1,
+) -> TableCell:
+    return TableCell(
+        text=text,
+        row_span=1,
+        col_span=col_span,
+        start_row_offset_idx=row,
+        end_row_offset_idx=row + 1,
+        start_col_offset_idx=col,
+        end_col_offset_idx=col + col_span,
+        bbox=BoundingBox(l=left, t=t, r=r, b=b, coord_origin=CoordOrigin.TOPLEFT),
+    )
+
+
+def test_reorder_cells_swapped_columns():
+    # #3194: the row header sits on the geometric left but was assigned to the
+    # rightmost column; headers are assigned correctly.
+    cells = [
+        _cell("h0", 0, 0, 90, 20, 150, 40),
+        _cell("h1", 0, 1, 237, 20, 300, 40),
+        _cell("h2", 0, 2, 385, 20, 450, 40),
+        _cell("d0", 1, 0, 237, 40, 300, 60),
+        _cell("d1", 1, 1, 385, 40, 450, 60),
+        _cell("rh", 1, 2, 90, 40, 150, 60),
+    ]
+    reordered = _reorder_cells_by_geometry(cells, num_rows=2, num_cols=3)
+    by_text = {tc.text: tc for tc in reordered}
+    assert by_text["h0"].start_col_offset_idx == 0
+    assert by_text["h1"].start_col_offset_idx == 1
+    assert by_text["h2"].start_col_offset_idx == 2
+    assert by_text["rh"].start_col_offset_idx == 0
+    assert by_text["d0"].start_col_offset_idx == 1
+    assert by_text["d1"].start_col_offset_idx == 2
+
+
+def test_reorder_cells_consistent_table_unchanged():
+    cells = [
+        _cell("a", 0, 0, 90, 20, 150, 40),
+        _cell("b", 0, 1, 237, 20, 300, 40),
+        _cell("c", 1, 0, 90, 40, 150, 60),
+        _cell("d", 1, 1, 237, 40, 300, 60),
+    ]
+    before = [
+        (
+            tc.start_row_offset_idx,
+            tc.end_row_offset_idx,
+            tc.start_col_offset_idx,
+            tc.end_col_offset_idx,
+        )
+        for tc in cells
+    ]
+    reordered = _reorder_cells_by_geometry(cells, num_rows=2, num_cols=2)
+    after = [
+        (
+            tc.start_row_offset_idx,
+            tc.end_row_offset_idx,
+            tc.start_col_offset_idx,
+            tc.end_col_offset_idx,
+        )
+        for tc in reordered
+    ]
+    assert before == after
+
+
+def test_reorder_cells_keeps_span_length():
+    # a spanning header keeps its span while the columns below are renumbered
+    cells = [
+        _cell("span", 0, 0, 90, 20, 450, 40, col_span=3),
+        _cell("d0", 1, 0, 237, 40, 300, 60),
+        _cell("d1", 1, 1, 385, 40, 450, 60),
+        _cell("rh", 1, 2, 90, 40, 150, 60),
+    ]
+    reordered = _reorder_cells_by_geometry(cells, num_rows=2, num_cols=3)
+    by_text = {tc.text: tc for tc in reordered}
+    assert (
+        by_text["span"].end_col_offset_idx - by_text["span"].start_col_offset_idx == 3
+    )
+    assert by_text["span"].start_col_offset_idx == 0
+    assert by_text["span"].end_col_offset_idx == 3
+    assert by_text["rh"].start_col_offset_idx == 0
+    assert by_text["d0"].start_col_offset_idx == 1
+    assert by_text["d1"].start_col_offset_idx == 2
+
+
+def test_reorder_cells_collision_keeps_original():
+    # two cells of one row nearest the same slot cannot be renumbered
+    cells = [
+        _cell("h0", 0, 0, 90, 20, 150, 40),
+        _cell("h1", 0, 1, 237, 20, 300, 40),
+        _cell("x", 1, 0, 90, 40, 300, 60),
+        _cell("y", 1, 1, 95, 40, 310, 60),
+    ]
+    before = [(tc.start_col_offset_idx, tc.end_col_offset_idx) for tc in cells]
+    reordered = _reorder_cells_by_geometry(cells, num_rows=2, num_cols=2)
+    after = [(tc.start_col_offset_idx, tc.end_col_offset_idx) for tc in reordered]
+    assert before == after

--- a/tests/test_table_structure_model.py
+++ b/tests/test_table_structure_model.py
@@ -105,10 +105,71 @@ def test_reorder_cells_collision_keeps_original():
     cells = [
         _cell("h0", 0, 0, 90, 20, 150, 40),
         _cell("h1", 0, 1, 237, 20, 300, 40),
-        _cell("x", 1, 0, 90, 40, 300, 60),
-        _cell("y", 1, 1, 95, 40, 310, 60),
+        _cell("h2", 0, 2, 385, 20, 450, 40),
+        _cell("a", 1, 0, 385, 40, 450, 60),
+        _cell("b", 1, 1, 90, 40, 102, 60),
+        _cell("c", 1, 2, 90, 40, 100, 60),
     ]
     before = [(tc.start_col_offset_idx, tc.end_col_offset_idx) for tc in cells]
+    reordered = _reorder_cells_by_geometry(cells, num_rows=2, num_cols=3)
+    after = [(tc.start_col_offset_idx, tc.end_col_offset_idx) for tc in reordered]
+    assert before == after
+
+
+def test_reorder_rows_by_geometry():
+    # rows are renumbered when their vertical order disagrees with the boxes
+    cells = [
+        _cell("top", 1, 0, 90, 20, 150, 40),
+        _cell("top2", 1, 1, 237, 20, 300, 40),
+        _cell("bottom", 0, 0, 90, 100, 150, 120),
+        _cell("bottom2", 0, 1, 237, 100, 300, 120),
+    ]
     reordered = _reorder_cells_by_geometry(cells, num_rows=2, num_cols=2)
+    by_text = {tc.text: tc for tc in reordered}
+    assert by_text["top"].start_row_offset_idx == 0
+    assert by_text["top2"].start_row_offset_idx == 0
+    assert by_text["bottom"].start_row_offset_idx == 1
+    assert by_text["bottom2"].start_row_offset_idx == 1
+
+
+def test_reorder_cells_invalid_span_kept_as_is():
+    # spans that run past the grid (corrupt input) are passed through
+    cells = [
+        _cell("h0", 0, 0, 90, 20, 150, 40),
+        _cell("h1", 0, 1, 237, 20, 300, 40),
+        _cell("h2", 0, 2, 385, 20, 450, 40),
+        _cell("e", 1, 0, 385, 40, 450, 60),
+        _cell("f", 1, 1, 237, 40, 300, 60),
+        _cell("wide", 1, 1, 90, 40, 450, 60, col_span=3),
+    ]
+    reordered = _reorder_cells_by_geometry(cells, num_rows=2, num_cols=3)
+    by_text = {tc.text: tc for tc in reordered}
+    # the out-of-range span is untouched even while the row is renumbered
+    assert by_text["wide"].start_col_offset_idx == 1
+    assert by_text["wide"].end_col_offset_idx == 4
+    assert by_text["e"].start_col_offset_idx == 2
+    assert by_text["f"].start_col_offset_idx == 1
+    assert by_text["h0"].start_col_offset_idx == 0
+    assert by_text["h2"].start_col_offset_idx == 2
+
+
+def test_reorder_cells_too_few_measured_cells_keeps_original():
+    # when fewer cells carry a box than there are slots, the axis is kept
+    # (the violated row below still triggers the remap attempt)
+    cells = [
+        _cell("a", 0, 0, 385, 20, 450, 40),
+        _cell("b", 0, 1, 90, 20, 150, 40),
+        TableCell(
+            text="c",
+            row_span=1,
+            col_span=1,
+            start_row_offset_idx=1,
+            end_row_offset_idx=2,
+            start_col_offset_idx=2,
+            end_col_offset_idx=3,
+        ),
+    ]
+    before = [(tc.start_col_offset_idx, tc.end_col_offset_idx) for tc in cells]
+    reordered = _reorder_cells_by_geometry(cells, num_rows=2, num_cols=3)
     after = [(tc.start_col_offset_idx, tc.end_col_offset_idx) for tc in reordered]
     assert before == after


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #3194

The table structure prediction can assign grid offsets that disagree with the cell bounding boxes, e.g. a row header on the geometric left landing in the rightmost column, so the exported table order diverges from the visual order.

After the TableFormer call, the cell offsets are realigned with the geometry: when a line's single-slot cells are not ordered by their box position, cells are reassigned to slots by clustering their box centers, with one cluster per slot. The reassignment is kept only when it introduces no slot collisions within a line and strictly reduces the number of misordered lines, so already consistent tables are left untouched.

On the PDF from the issue this fixes the three affected tables (verified with a full markdown diff against unpatched main: no other table changes). Tables whose geometry cannot be re-matched without slot collisions keep their original offsets.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
