### PR TITLE
fix(pptx): keep EMF/WMF pictures instead of dropping them

### DIFF
--- a/.github/max-lines-ignore
+++ b/.github/max-lines-ignore
@@ -14,6 +14,7 @@ tests/data/**
 CHANGELOG.md
 docling/backend/html_backend.py
 docling/backend/msexcel_backend.py
+docling/backend/mspowerpoint_backend.py
 docling/backend/msword_backend.py
 docling/backend/xml/uspto_backend.py
 docling/backend/opendocument_backend.py

--- a/docling/backend/mspowerpoint_backend.py
+++ b/docling/backend/mspowerpoint_backend.py
@@ -87,6 +87,21 @@ _CHART_RENDER_HINT = (
     "data without it."
 )
 
+_IMAGE_RENDER_HINT = (
+    "LibreOffice is required to rasterize EMF/WMF pictures embedded in slides. "
+    "Install LibreOffice and make sure `soffice` is on PATH. Such pictures are "
+    "still recorded with their position on the slide without it, but carry no "
+    "image data."
+)
+
+# Windows metafile signatures. A placeable WMF opens with the Aldus magic and an
+# EMF carries " EMF" in the dSignature field of its EMR_HEADER, 40 bytes in.
+# These are the two Pillow itself identifies, so a bare WMF never reaches here.
+_WMF_PLACEABLE_MAGIC: Final = b"\xd7\xcd\xc6\x9a"
+_EMF_SIGNATURE: Final = b" EMF"
+_EMF_SIGNATURE_OFFSET: Final = 40
+
+
 _SAFE_XML_PARSER: Final = etree.XMLParser(
     resolve_entities=False,
     load_dtd=False,
@@ -94,6 +109,25 @@ _SAFE_XML_PARSER: Final = etree.XMLParser(
     dtd_validation=False,
 )
 """Safe XML parser to prevent XXE, DTD-over-network and entity-expansion attacks."""
+
+
+def _is_metafile(image_bytes: bytes) -> bool:
+    """Return True when the bytes are a Windows metafile (WMF or EMF).
+
+    Pillow renders metafiles only on Windows, where it delegates to the GDI
+    ``PlayEnhMetaFile`` API; the wheels for every other platform carry a stub
+    that raises on load. Telling a metafile apart from a genuinely broken
+    image decides whether a picture is worth rasterizing externally.
+
+    Args:
+        image_bytes: Raw bytes of an embedded picture.
+
+    Returns:
+        True when the bytes carry a placeable WMF or an EMF signature.
+    """
+    return image_bytes[:4] == _WMF_PLACEABLE_MAGIC or (
+        image_bytes[_EMF_SIGNATURE_OFFSET : _EMF_SIGNATURE_OFFSET + 4] == _EMF_SIGNATURE
+    )
 
 
 class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBackend):
@@ -156,6 +190,7 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
         self.pptx_to_pdf_converter: Optional[Callable] = None
         self.pptx_to_pdf_converter_init: bool = False
         self._render_charts: bool = False
+        self._metafile_hint_emitted: bool = False
 
         self.pptx_obj: Optional[presentation.Presentation] = None
         self.valid: bool = False
@@ -783,36 +818,103 @@ class MsPowerpointDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentB
                 )
         return
 
-    def _handle_pictures(self, shape, parent_slide, slide_ind, doc, slide_size):
-        # Open it with PIL
+    def _rasterize_metafile(self, image_bytes: bytes) -> Optional[Image.Image]:
+        """Rasterize a raw EMF or WMF picture via LibreOffice.
+
+        LibreOffice converts a standalone ``.emf``/``.wmf`` to PDF directly, so
+        no wrapper document is needed; the first page is then rendered with
+        pypdfium2. This is the same route ``_render_chart_image`` already takes
+        for native charts.
+
+        Args:
+            image_bytes: Raw metafile data.
+
+        Returns:
+            A PIL Image, or None when LibreOffice is unavailable or the
+            conversion fails.
+        """
+        converter = self._get_libreoffice_converter()
+        if converter is None:
+            if not self._metafile_hint_emitted:
+                self._metafile_hint_emitted = True
+                _log.warning(_IMAGE_RENDER_HINT)
+            return None
+
+        suffix = ".wmf" if image_bytes[:4] == _WMF_PLACEABLE_MAGIC else ".emf"
+        temp_dir = Path(mkdtemp())
         try:
-            # Get the image bytes
+            input_path = temp_dir / f"image{suffix}"
+            output_path = temp_dir / "image.pdf"
+            input_path.write_bytes(image_bytes)
+            converter(input_path, output_path)
+            if not output_path.exists():
+                _log.debug("LibreOffice produced no PDF output for %s", input_path.name)
+                return None
+            pdf = pypdfium2.PdfDocument(str(output_path))
+            page = pdf[0]
+            pil_image = crop_whitespace(page.render(scale=2).to_pil())
+            page.close()
+            pdf.close()
+            return pil_image
+        except Exception as exc:
+            _log.debug("EMF/WMF rasterization via LibreOffice failed: %s", exc)
+            return None
+        finally:
+            shutil.rmtree(temp_dir, ignore_errors=True)
+
+    def _handle_pictures(self, shape, parent_slide, slide_ind, doc, slide_size):
+        # Read the picture out of the package. A shape that slips past other
+        # tools' parsers can still fail here, and there is nothing to record.
+        try:
             image = shape.image
             image_bytes = image.blob
             im_dpi, _ = image.dpi
-            pil_image = Image.open(BytesIO(image_bytes))
-
-            # shape has picture
             prov = self._generate_prov(shape, slide_ind, "", slide_size)
-            doc.add_picture(
-                parent=parent_slide,
-                image=ImageRef.from_pil(image=pil_image, dpi=im_dpi),
-                caption=None,
-                prov=prov,
-            )
         except (
             UnidentifiedImageError,
-            OSError,
-            ValueError,
             InvalidXmlError,
             KeyError,
             AttributeError,
+            ValueError,
+            OSError,
         ) as e:
             warnings.warn(
                 f"Skipping malformed picture shape: {e}",
                 UserWarning,
                 stacklevel=2,
             )
+            return
+
+        # Open it with PIL
+        image_ref: Optional[ImageRef] = None
+        try:
+            pil_image = Image.open(BytesIO(image_bytes))
+            image_ref = ImageRef.from_pil(image=pil_image, dpi=im_dpi)
+        except (UnidentifiedImageError, OSError, ValueError) as e:
+            if not _is_metafile(image_bytes):
+                warnings.warn(
+                    f"Skipping malformed picture shape: {e}",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                return
+            # A metafile Pillow cannot draw on this platform. Rasterize it
+            # externally when possible, and otherwise still record the picture
+            # so its place on the slide survives -- only the pixels are lost.
+            _log.debug("Pillow cannot render this metafile: %s", e)
+            rasterized = self._rasterize_metafile(image_bytes)
+            if rasterized is not None:
+                # Rendered from a PDF rather than decoded from the original
+                # picture, so the metafile's own dpi no longer describes it;
+                # 72 matches the other LibreOffice-rendered images.
+                image_ref = ImageRef.from_pil(image=rasterized, dpi=72)
+
+        doc.add_picture(
+            parent=parent_slide,
+            image=image_ref,
+            caption=None,
+            prov=prov,
+        )
         return
 
     def _handle_tables(self, shape, parent_slide, slide_ind, doc, slide_size):

--- a/tests/test_backend_pptx.py
+++ b/tests/test_backend_pptx.py
@@ -1,6 +1,10 @@
 # SPDX-FileCopyrightText: The Docling Contributors
 # SPDX-License-Identifier: MIT
 
+import logging
+import struct
+import warnings
+import zlib
 from collections.abc import Iterable
 from pathlib import Path
 from types import SimpleNamespace
@@ -16,7 +20,10 @@ from docling_core.types.doc import (
 )
 
 from docling.backend.docx.drawingml.utils import get_libreoffice_cmd
-from docling.backend.mspowerpoint_backend import MsPowerpointDocumentBackend
+from docling.backend.mspowerpoint_backend import (
+    MsPowerpointDocumentBackend,
+    _is_metafile,
+)
 from docling.datamodel.backend_options import MsPowerpointBackendOptions
 from docling.datamodel.base_models import InputFormat, ItemAndImageEnrichmentElement
 from docling.datamodel.document import ConversionResult, DoclingDocument, InputDocument
@@ -503,3 +510,206 @@ def test_pptx_row_grouping_uses_sliding_window():
 
     # a, b, c are in the same row sorted left-to-right; d is in its own row.
     assert ordered == ["b", "a", "c", "d"]
+
+
+def _emf_bytes(width: int = 200, height: int = 100, drawable: bool = False) -> bytes:
+    """Build a structurally valid EMF.
+
+    python-pptx reads the header for the picture's dimensions, and the backend
+    only has to recognize the " EMF" signature 40 bytes in, so the header and
+    EMR_EOF are enough on their own. ``drawable`` adds a rectangle and an
+    ellipse for the cases that rasterize the picture for real and need it to
+    produce visible ink. Synthesizing the bytes keeps a binary fixture out of
+    ``tests/data``.
+
+    Args:
+        width: Picture width in device units.
+        height: Picture height in device units.
+        drawable: Whether to emit drawing records.
+
+    Returns:
+        The bytes of a complete EMF.
+    """
+    records = b""
+    record_count = 2
+    if drawable:
+        records += struct.pack("<II4i", 43, 24, 10, 10, width - 10, height - 10)
+        records += struct.pack("<II4i", 42, 24, 30, 20, width - 30, height - 20)
+        record_count += 2
+
+    header = struct.pack(
+        "<II4i4i4sIIIHHIII2i2i",
+        1,
+        88,
+        0,
+        0,
+        width,
+        height,
+        0,
+        0,
+        width * 100,
+        height * 100,
+        b" EMF",
+        0x10000,
+        88 + len(records) + 20,
+        record_count,
+        0,
+        0,
+        0,
+        0,
+        0,
+        1920,
+        1080,
+        508,
+        286,
+    )
+    eof = struct.pack("<IIIII", 14, 20, 0, 16, 20)
+    return header + records + eof
+
+
+def _deck_with_picture(tmp_path: Path, image_bytes: bytes, suffix: str) -> Path:
+    """Save a one-slide deck holding a title and a single picture."""
+    from pptx import Presentation
+    from pptx.util import Inches
+
+    image_path = tmp_path / f"picture{suffix}"
+    image_path.write_bytes(image_bytes)
+
+    prs = Presentation()
+    slide = prs.slides.add_slide(prs.slide_layouts[5])
+    slide.shapes.title.text = "Quarterly results"
+    slide.shapes.add_picture(str(image_path), Inches(1), Inches(2), width=Inches(4))
+
+    deck_path = tmp_path / f"deck{suffix}.pptx"
+    prs.save(deck_path)
+    return deck_path
+
+
+@pytest.mark.parametrize(
+    ("image_bytes", "expected"),
+    [
+        (_emf_bytes(), True),
+        (b"\xd7\xcd\xc6\x9a" + b"\x00" * 60, True),
+        (b"\x89PNG\r\n\x1a\n" + b"\x00" * 60, False),
+        (b"\xff\xd8\xff\xe0" + b"\x00" * 60, False),
+        (b"\x01\x00\x09\x00" + b"\x00" * 60, False),
+        (b"", False),
+    ],
+    ids=["emf", "placeable-wmf", "png", "jpeg", "bare-wmf", "empty"],
+)
+def test_metafile_detection(image_bytes: bytes, expected: bool):
+    """Only the metafile flavours Pillow identifies count as metafiles.
+
+    The signature check decides whether an undecodable picture is worth
+    rasterizing externally or is simply broken, so a raster format must never
+    match — otherwise a corrupt JPEG would be silently turned into an empty
+    picture instead of being reported.
+
+    A bare (non-placeable) WMF is deliberately excluded: Pillow's ``_accept``
+    only recognizes the placeable magic and EMF, so python-pptx raises while
+    reading the picture and the bytes never reach this check.
+    """
+    assert _is_metafile(image_bytes) is expected
+
+
+def test_pptx_emf_picture_survives_without_pillow_metafile_support(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+):
+    """An EMF picture stays in the document when nothing can rasterize it.
+
+    Pillow only draws metafiles on Windows, where it delegates to the GDI
+    ``PlayEnhMetaFile`` API; every other platform gets a stub that raises on
+    load. Dropping the shape there loses the picture -- commonly a chart pasted
+    in from Excel -- from an otherwise successful conversion, and does so on
+    Linux only. Clearing the handler reproduces a non-Windows Pillow, and
+    emptying PATH reproduces a machine without LibreOffice, so the picture has
+    to survive on structure alone.
+    """
+    from PIL import WmfImagePlugin
+
+    # The plugin registers a GDI-backed handler at import time on Windows only;
+    # on other platforms this attribute is already None.
+    monkeypatch.setattr(WmfImagePlugin, "_handler", None)
+    # LibreOffice is found with shutil.which, so an empty PATH hides it whether
+    # or not the machine running the tests happens to have it installed.
+    monkeypatch.setenv("PATH", str(tmp_path))
+
+    deck_path = _deck_with_picture(tmp_path, _emf_bytes(), ".emf")
+
+    with caplog.at_level(
+        logging.WARNING, logger="docling.backend.mspowerpoint_backend"
+    ):
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", UserWarning)
+            doc = get_converter().convert(deck_path).document
+
+    assert len(doc.pictures) == 1, "the EMF picture should survive the conversion"
+    picture = doc.pictures[0]
+    assert picture.prov, "the picture should keep its place on the slide"
+    assert picture.prov[0].page_no == 1
+    assert picture.get_image(doc=doc) is None, (
+        "without a rasterizer the picture is recorded without image data"
+    )
+    assert "LibreOffice is required" in caplog.text, (
+        "the user should be told how to recover the picture's pixels"
+    )
+
+    assert "Quarterly results" in [t.text for t in doc.texts]
+
+
+def test_pptx_undecodable_raster_picture_is_still_skipped(tmp_path: Path):
+    """A truncated raster picture is skipped, not turned into a placeholder.
+
+    Recovering metafiles must not quietly widen into recovering every image
+    Pillow rejects: a genuinely broken raster carries no position worth keeping
+    and should still be reported to the caller.
+    """
+
+    def chunk(tag: bytes, data: bytes) -> bytes:
+        crc = zlib.crc32(tag + data) & 0xFFFFFFFF
+        return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", crc)
+
+    # Identifies as an 8x8 PNG, so python-pptx accepts it, but the pixel data
+    # is not a zlib stream, so decoding it raises.
+    broken_png = (
+        b"\x89PNG\r\n\x1a\n"
+        + chunk(b"IHDR", struct.pack(">IIBBBBB", 8, 8, 8, 2, 0, 0, 0))
+        + chunk(b"IDAT", b"not-a-zlib-stream")
+        + chunk(b"IEND", b"")
+    )
+    deck_path = _deck_with_picture(tmp_path, broken_png, ".png")
+
+    with pytest.warns(UserWarning, match="Skipping malformed picture shape"):
+        doc = get_converter().convert(deck_path).document
+
+    assert len(doc.pictures) == 0
+    assert "Quarterly results" in [t.text for t in doc.texts]
+
+
+def test_pptx_emf_picture_rasterized_via_libreoffice(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, libreoffice_available: bool
+):
+    """LibreOffice recovers the actual pixels of a metafile Pillow cannot draw.
+
+    Keeping the picture without image data preserves the document structure,
+    but the drawing itself is recoverable whenever LibreOffice is installed —
+    the same tool the chart path already shells out to. Its output is not
+    byte-stable across versions, so this asserts the picture carries a
+    plausibly sized image rather than comparing pixels.
+    """
+    if not libreoffice_available:
+        pytest.skip("LibreOffice is not installed — rasterization cannot be tested")
+
+    from PIL import WmfImagePlugin
+
+    monkeypatch.setattr(WmfImagePlugin, "_handler", None)
+
+    deck_path = _deck_with_picture(tmp_path, _emf_bytes(drawable=True), ".emf")
+    doc = get_converter().convert(deck_path).document
+
+    assert len(doc.pictures) == 1
+    image = doc.pictures[0].get_image(doc=doc)
+    assert image is not None, "the metafile should have been rasterized"
+    assert image.width > 50 and image.height > 20, (
+        f"rasterized metafile is implausibly small: {image.size}"
+    )


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #3980

pptx pictures stored as emf or wmf are silently dropped on linux and macos.

### what happens

pillow only draws windows metafiles on windows, where `WmfImagePlugin` registers a handler backed by the gdi `PlayEnhMetaFile` api. that registration is guarded by `hasattr(Image.core, "drawwmf")`, which is false on every linux and macos wheel, so `load()` raises `cannot find loader for this WMF file`.

`_handle_pictures` caught that `OSError` and returned without adding anything, so the picture disappeared from an otherwise successful conversion. emf is what office writes when a chart is pasted in from excel or a diagram from visio, so the pictures that go missing are usually the charts.

measured on a three slide deck holding one png and five emf pictures:

| | main | this pr |
|---|---|---|
| pictures in the document | 1 of 6 | 6 of 6 |
| warnings | 5 x `Skipping malformed picture shape` | none |

the files are not malformed, so that warning also sends anyone debugging it in the wrong direction.

### what this changes

the other two office backends already handle this:

* `MsExcelDocumentBackend._convert_emf_to_pil` rasterizes the metafile through libreoffice
* `MsWordDocumentBackend` does the same, and when libreoffice is unavailable it still calls `_add_picture_to_doc(..., pil_image=None)` so the figure keeps its place in the document

powerpoint had neither, although `_render_chart_image` already describes libreoffice as "the same external tool already used for EMF/WMF images", which was not true of this backend until now.

so this follows the existing pattern rather than inventing one:

1. pillow first, unchanged
2. on failure, if the bytes carry a placeable wmf or an emf signature, rasterize through the libreoffice converter this backend already holds for charts
3. if libreoffice is unavailable, still record the picture without image data so its position on the slide survives
4. anything undecodable that is not a metafile is still skipped with the existing warning

`_IMAGE_RENDER_HINT` follows the shape of the existing `_CHART_RENDER_HINT` and is logged once per document rather than once per picture.

### notes for review

* no new dependencies, and no changes to the docx or xlsx backends
* blast radius is zero: all eight decks under `tests/data/pptx/sources` were converted to markdown and json on main and on this branch, and the sixteen outputs are byte identical
* the tests synthesize the emf with `struct` instead of adding a binary fixture
* `_is_metafile` deliberately does not match a bare, non placeable wmf. pillow's `_accept` only recognizes the placeable magic and emf, so python-pptx raises while reading such a picture and those bytes never reach the check
* the rasterized image is given `dpi=72` to match the other libreoffice rendered images, since it comes from a pdf render rather than from the original picture
* `_convert_emf_to_pil` in the xlsx backend is close to `_rasterize_metafile` here. happy to extract both into `docx/drawingml/utils.py` if you would prefer, i kept them separate because `_get_libreoffice_converter` is already duplicated per backend

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
