### PR TITLE
fix(docx): respect w:numFmt when building list markers

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -166,6 +166,62 @@ _VISIBLE_NUMBERING_FORMATS: Final[frozenset[str]] = frozenset(
 """OOXML numFmt values that produce visible list/heading markers."""
 
 
+_ROMAN_NUMERALS: Final[tuple[tuple[int, str], ...]] = (
+    (1000, "m"),
+    (900, "cm"),
+    (500, "d"),
+    (400, "cd"),
+    (100, "c"),
+    (90, "xc"),
+    (50, "l"),
+    (40, "xl"),
+    (10, "x"),
+    (9, "ix"),
+    (5, "v"),
+    (4, "iv"),
+    (1, "i"),
+)
+
+
+def _counter_to_letter(counter: int) -> str:
+    """Render a 1-based counter as Word does for letter formats: a, b, ... z, aa."""
+    letters = []
+    while counter > 0:
+        counter, remainder = divmod(counter - 1, 26)
+        letters.append(chr(ord("a") + remainder))
+    return "".join(reversed(letters))
+
+
+def _counter_to_roman(counter: int) -> str:
+    """Render a 1-based counter as a lowercase roman numeral."""
+    remaining = counter
+    numeral = []
+    for value, symbol in _ROMAN_NUMERALS:
+        whole, remaining = divmod(remaining, value)
+        numeral.append(symbol * whole)
+    return "".join(numeral)
+
+
+def _format_list_counter(counter: int, num_fmt: str) -> str:
+    """Render a list counter using the level's OOXML ``w:numFmt``.
+
+    Word stores the counter as an integer and the presentation separately, so a
+    level declared ``lowerLetter`` must be shown as ``a``, not ``1``. Formats
+    outside this set, and counters the format cannot express, stay decimal.
+    """
+    if counter < 1:
+        return str(counter)
+    if num_fmt in {"lowerLetter", "upperLetter"}:
+        letter = _counter_to_letter(counter)
+        return letter.upper() if num_fmt == "upperLetter" else letter
+    if num_fmt in {"lowerRoman", "upperRoman"} and counter < 4000:
+        numeral = _counter_to_roman(counter)
+        return numeral.upper() if num_fmt == "upperRoman" else numeral
+    if num_fmt == "decimalZero":
+        return f"{counter:02d}"
+    return str(counter)
+
+
 def _strict_ns_to_transitional(strict_ns: str) -> str:
     """Map a single Strict OOXML namespace/relationship URI to its Transitional form."""
     if strict_ns in _STRICT_OOXML_NS_OVERRIDES:
@@ -1065,7 +1121,9 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                     counter = self.list_counters.get((numid, lvl_idx))
                     if counter is None:
                         counter = self._get_start_value(numid, lvl_idx)
-                    return str(counter)
+                    return _format_list_counter(
+                        counter, self._get_numbering_format(numid, lvl_idx)
+                    )
 
                 return re.sub(r"%(\d+)", _replace, lvl_text)
 
@@ -1075,8 +1133,26 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             counter = self.list_counters.get((numid, lvl))
             if counter is None:
                 counter = self._get_start_value(numid, lvl)
-            parts.append(str(counter))
+            parts.append(
+                _format_list_counter(counter, self._get_numbering_format(numid, lvl))
+            )
         return ".".join(parts) + "."
+
+    def _get_numbering_format(self, numid: int, ilvl: int) -> str:
+        """Return the level's OOXML ``w:numFmt``, defaulting to decimal."""
+        try:
+            lvl_element = self._get_level_element(numid, ilvl)
+            if lvl_element is None:
+                return "decimal"
+            num_fmt_element = lvl_element.find(
+                ".//w:numFmt", namespaces={"w": self._W_NS}
+            )
+            if num_fmt_element is None:
+                return "decimal"
+            return num_fmt_element.get(self.XML_KEY) or "decimal"
+        except Exception as e:
+            _log.debug(f"Error reading numbering format: {e}")
+            return "decimal"
 
     def _has_visible_numbering_format(self, numId: int, ilvl: int) -> bool:
         """Return True when numbering.xml defines a visible marker for numId/ilvl."""

--- a/tests/test_backend_msword_lists.py
+++ b/tests/test_backend_msword_lists.py
@@ -210,6 +210,93 @@ def test_manage_list_structure_no_keyerror_open_indented_list_exceeds_parents(tm
     assert isinstance(backend.parents.get(use_level), ListGroup)
 
 
+def test_list_markers_follow_the_level_numbering_format(tmp_path):
+    """Lettered and roman levels must not be renumbered as decimals.
+
+    Word keeps the counter as an integer and the presentation in the level's
+    ``w:numFmt``, so a level declared ``lowerLetter`` displays ``a``, ``b``, ``c``.
+    Docling built every marker from the raw counter, so those levels silently came
+    out as a fresh decimal sequence and the lettering was lost.
+    """
+
+    doc = Document()
+    numbering = doc.part.numbering_part.element
+
+    def add_numbering(abstract_id: str, num_id: str, levels: list[tuple[str, str]]):
+        abstract_num = OxmlElement("w:abstractNum")
+        abstract_num.set(qn("w:abstractNumId"), abstract_id)
+        for ilvl, (num_fmt, lvl_text) in enumerate(levels):
+            lvl = OxmlElement("w:lvl")
+            lvl.set(qn("w:ilvl"), str(ilvl))
+            start = OxmlElement("w:start")
+            start.set(qn("w:val"), "1")
+            lvl.append(start)
+            fmt = OxmlElement("w:numFmt")
+            fmt.set(qn("w:val"), num_fmt)
+            lvl.append(fmt)
+            text = OxmlElement("w:lvlText")
+            text.set(qn("w:val"), lvl_text)
+            lvl.append(text)
+            abstract_num.append(lvl)
+        numbering.append(abstract_num)
+        num = OxmlElement("w:num")
+        num.set(qn("w:numId"), num_id)
+        ref = OxmlElement("w:abstractNumId")
+        ref.set(qn("w:val"), abstract_id)
+        num.append(ref)
+        numbering.append(num)
+
+    add_numbering(
+        "500",
+        "501",
+        [("decimal", "%1."), ("lowerLetter", "%2)"), ("upperRoman", "%3.")],
+    )
+
+    def add_item(text: str, ilvl_val: int):
+        paragraph = doc.add_paragraph(text, style="List Paragraph")
+        num_pr = OxmlElement("w:numPr")
+        ilvl = OxmlElement("w:ilvl")
+        ilvl.set(qn("w:val"), str(ilvl_val))
+        num_pr.append(ilvl)
+        num_id_elem = OxmlElement("w:numId")
+        num_id_elem.set(qn("w:val"), "501")
+        num_pr.append(num_id_elem)
+        paragraph._element.get_or_add_pPr().append(num_pr)
+
+    add_item("top one", 0)
+    add_item("lettered first", 1)
+    add_item("lettered second", 1)
+    add_item("roman first", 2)
+    add_item("roman second", 2)
+    add_item("top two", 0)
+
+    docx_path = tmp_path / "lettered_list.docx"
+    doc.save(str(docx_path))
+
+    in_doc = InputDocument(
+        path_or_stream=docx_path,
+        format=InputFormat.DOCX,
+        backend=MsWordDocumentBackend,
+        filename=docx_path.name,
+    )
+    converted = MsWordDocumentBackend(in_doc=in_doc, path_or_stream=docx_path).convert()
+
+    markers = [
+        (item.text, item.marker)
+        for item, _ in converted.iterate_items()
+        if isinstance(item, ListItem)
+    ]
+
+    assert markers == [
+        ("top one", "1."),
+        ("lettered first", "1.a."),
+        ("lettered second", "1.b."),
+        ("roman first", "1.b.I."),
+        ("roman second", "1.b.II."),
+        ("top two", "2."),
+    ]
+
+
 def _make_empty_docx():
     """Return an in-memory .docx with no content."""
 


### PR DESCRIPTION
Word stores a list counter as an integer and its presentation separately in the level's `w:numFmt`, so a level declared `lowerLetter` shows as `a`, `b`, `c` while the counter stays `1`, `2`, `3`. `MsWordDocumentBackend._build_enum_marker` rendered every marker straight from the counter, in both the `lvlText` template path and the hierarchical fallback, so lettered and roman levels silently came out as a fresh decimal sequence.

This reads the level's `numFmt` and renders the counter with it: letters for `lowerLetter`/`upperLetter`, roman numerals for `lowerRoman`/`upperRoman`, zero-padded for `decimalZero`, decimal otherwise. `_VISIBLE_NUMBERING_FORMATS` and `_has_visible_numbering_format` already read this attribute, so the marker builder was the only place not consulting it.

**Issue resolved by this Pull Request:**
Resolves #4084

### Before and after

A list whose level 0 is `decimal`, level 1 `lowerLetter`, level 2 `upperRoman`:

| item | before | after |
| --- | --- | --- |
| top one | `1.` | `1.` |
| lettered first | `1.1.` | `1.a.` |
| lettered second | `1.2.` | `1.b.` |
| roman first | `1.2.1.` | `1.b.I.` |
| roman second | `1.2.2.` | `1.b.II.` |
| top two | `2.` | `2.` |

### Scope

This changes how each counter is rendered, not which levels a marker includes. The hierarchical structure is pinned by `test_list_counter_and_enum_marker` (`2.`, `2.3.`, `2.3.1.`) and is left alone.

Worth flagging, since the issue's example expects `a)` rather than `1.a.`: Word derives the whole marker from `lvlText`, so for a level whose `lvlText` is `%2)` it shows just `a)`. Docling only uses `lvlText` when the template carries text beyond the placeholders, and otherwise builds the hierarchical form. Honouring `lvlText` for plain templates too would match Word more closely, but it would change existing markers for any document whose level template omits its parents, so it felt like a separate decision for maintainers rather than something to fold in here. Happy to follow up if you want that behaviour.

Documents whose levels declare no format, and documents with no numbering definitions at all, keep the decimal output they had.

### Testing

Added `test_list_markers_follow_the_level_numbering_format` to `tests/test_backend_msword_lists.py`, building the multi-level list above and asserting the markers end to end through `MsWordDocumentBackend.convert()`. It fails on `main` and passes here.

```
uv run pytest tests/test_backend_msword.py tests/test_backend_msword_lists.py \
              tests/test_backend_msword_outline.py tests/test_backend_msword_spacer.py
66 passed, 1 skipped
```

I also converted the fixtures that declare `lowerLetter`/`lowerRoman` levels and compared against their stored groundtruth: `docx_lists.docx` and `list_after_num_headers.docx` match exactly. `word_sample.docx` differs, but identically on a clean `main` checkout and only in markdown table padding, so it is unrelated to this change and no list marker moved.

`make validate` passes on the changeset (ruff lint, ruff formatter, ty, Tach, max-lines all Passed). `ty check` reports the same 9 pre-existing diagnostics for `msword_backend.py` before and after, none of them from this change.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
