### PR TITLE
fix(vlm): preserve spacing for Chandra br tags

### DIFF
--- a/docling/utils/chandra_utils.py
+++ b/docling/utils/chandra_utils.py
@@ -72,6 +72,8 @@ _TAG_RE = re.compile(r"<[^>]+>")
 
 def _strip_tags(html: str) -> str:
     """Remove HTML tags and collapse whitespace."""
+    # Preserve spacing represented by HTML line breaks.
+    html = re.sub(r"<br\s*/?>", " ", html)
     text = _TAG_RE.sub("", html)
     text = re.sub(r"\s+", " ", text).strip()
     return text

--- a/tests/test_chandra_vlm.py
+++ b/tests/test_chandra_vlm.py
@@ -49,6 +49,21 @@ def test_chandra_simple_parsing():
         assert bbox.l >= 0 and bbox.t >= 0, "Bbox coords should be non-negative"
 
 
+def test_chandra_br_spacing():
+    """Test that br tags preserve spacing between text."""
+    content = '<div data-bbox="0 0 1000 1000" data-label="Text">Hello<br/>World</div>'
+
+    doc = parse_chandra_html(
+        content=content,
+        original_page_size=Size(width=1000, height=1000),
+        page_no=1,
+        filename="br.html",
+    )
+
+    assert len(doc.texts) == 1
+    assert doc.texts[0].text == "Hello World"
+
+
 def test_chandra_multiblock_parsing():
     """Test chandra parsing with a saved figure prediction."""
     path = Path("./tests/data/html_chandra/sources/chandra_multiblock.html")


### PR DESCRIPTION

## Summary

Preserve spacing for `<br>` tags in Chandra OCR HTML output.

## Changes

- Replace `<br>` tags with a space before stripping HTML tags.
- Preserve the existing whitespace normalization behavior.
- Add a regression test for `<br/>` between text.

## Testing

Tested with the Chandra VLM parser.

Verified that:

- `Hello<br/>World` is parsed as `Hello World`.
- Existing Chandra VLM tests continue to pass.
- Ruff checks and formatting pass.

## Checklist

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.