### PR TITLE
feat(pdf): read the MathML embedded in tagged PDFs instead of reconstructing formulas

### DIFF
--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -46,6 +46,10 @@ from docling.utils.pdf_outline import (
     _PdfOutlineItem,
     extract_outline_from_docling_parse,
 )
+from docling.utils.pdf_struct_tree import (
+    _PdfFormulaStruct,
+    extract_formula_structs_from_pdfium,
+)
 
 if TYPE_CHECKING:
     from docling.datamodel.document import InputDocument
@@ -376,6 +380,17 @@ class DoclingParseDocumentBackend(ManagedPdfiumDocumentBackend):
             return []
         return extract_outline_from_docling_parse(self.dp_doc)
 
+    def get_formula_structures(
+        self, page_nos: Iterable[int]
+    ) -> list[_PdfFormulaStruct]:
+        """Read the structure tree from the pypdfium2 handle this backend already holds.
+
+        docling-parse exposes no structure-tree accessor, so pypdfium2 does the work.
+        """
+        if self._pdoc is None:
+            return []
+        return extract_formula_structs_from_pdfium(self._pdoc, page_nos)
+
     def _close_native_document(self) -> None:
         if self.dp_doc is not None:
             self.dp_doc.unload()
@@ -646,6 +661,29 @@ class ThreadedDoclingParseDocumentBackend(PdfDocumentBackend):
             return extract_outline_from_docling_parse(dp_doc)
         finally:
             dp_doc.unload()
+
+    def get_formula_structures(
+        self, page_nos: Iterable[int]
+    ) -> list[_PdfFormulaStruct]:
+        """Extract the structure tree via a short-lived pypdfium2 document.
+
+        This backend holds no pypdfium2 handle, and docling-parse exposes no structure-tree
+        accessor, so one is opened purely for this read -- the same approach
+        :meth:`get_document_outline` takes for the table of contents. Called at most once
+        per conversion, and only when native formula extraction is enabled.
+        """
+        password = (
+            self.options.password.get_secret_value() if self.options.password else None
+        )
+        if isinstance(self.path_or_stream, BytesIO):
+            self.path_or_stream.seek(0)
+        with pypdfium2_lock:
+            pdoc = pdfium.PdfDocument(self.path_or_stream, password=password)
+        try:
+            return extract_formula_structs_from_pdfium(pdoc, page_nos)
+        finally:
+            with pypdfium2_lock:
+                pdoc.close()
 
     def load_page(self, page_no: int) -> PdfPageBackend:
         raise NotImplementedError(

--- a/docling/backend/pdf_backend.py
+++ b/docling/backend/pdf_backend.py
@@ -16,6 +16,7 @@ from docling.datamodel.backend_options import PdfBackendOptions
 from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
 from docling.utils.pdf_outline import _PdfOutlineItem
+from docling.utils.pdf_struct_tree import _PdfFormulaStruct
 
 
 class PdfPageBackend(ABC):
@@ -144,6 +145,17 @@ class PdfDocumentBackend(PaginatedDocumentBackend):
         A flat, document-ordered list where each entry carries its own depth (``level``). The
         default returns an empty list; PDFium-backed backends override this with the real
         outline. Backends without an embedded outline (e.g. OCR/image) keep the default.
+        """
+        return []
+
+    def get_formula_structures(
+        self, page_nos: Iterable[int]
+    ) -> list[_PdfFormulaStruct]:
+        """Return the ``Formula`` structure elements on the given 1-based pages.
+
+        Only tagged (accessible / PDF-UA) PDFs carry these. The default returns an empty
+        list; PDFium-backed backends override it. Backends with no access to the structure
+        tree (e.g. OCR/image) keep the default.
         """
         return []
 

--- a/docling/backend/pypdfium2_backend.py
+++ b/docling/backend/pypdfium2_backend.py
@@ -32,6 +32,10 @@ from docling.datamodel.backend_options import PdfBackendOptions
 from docling.exceptions import DocumentLoadError
 from docling.utils.locks import pypdfium2_lock
 from docling.utils.pdf_outline import _PdfOutlineItem, extract_outline_from_pdfium
+from docling.utils.pdf_struct_tree import (
+    _PdfFormulaStruct,
+    extract_formula_structs_from_pdfium,
+)
 
 
 def _merge_overlapping_boxes(
@@ -653,6 +657,14 @@ class PyPdfiumDocumentBackend(ManagedPdfiumDocumentBackend):
         if self._pdoc is None:
             return []
         return extract_outline_from_pdfium(self._pdoc)
+
+    def get_formula_structures(
+        self, page_nos: Iterable[int]
+    ) -> list[_PdfFormulaStruct]:
+        """Extract the ``Formula`` structure elements from the pypdfium2 document."""
+        if self._pdoc is None:
+            return []
+        return extract_formula_structs_from_pdfium(self._pdoc, page_nos)
 
     def _close_native_document(self) -> None:
         with pypdfium2_lock:

--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -929,6 +929,16 @@ def convert(  # noqa: C901
         bool,
         typer.Option(..., help="Enable the formula enrichment model in the pipeline."),
     ] = False,
+    native_formula: Annotated[
+        bool,
+        typer.Option(
+            ...,
+            help=(
+                "Use the MathML embedded in a tagged PDF's Formula structure elements "
+                "instead of reconstructing those equations with the enrichment model."
+            ),
+        ),
+    ] = False,
     enrich_picture_classes: Annotated[
         bool,
         typer.Option(
@@ -1304,6 +1314,7 @@ def convert(  # noqa: C901
                 table_structure_options=table_structure_options,
                 do_code_enrichment=enrich_code,
                 do_formula_enrichment=enrich_formula,
+                do_native_formula_extraction=native_formula,
                 do_picture_description=enrich_picture_description,
                 do_picture_classification=enrich_picture_classes,
                 do_chart_extraction=enrich_chart_extraction,

--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -76,6 +76,7 @@ from docling.datamodel.base_models import (
 from docling.datamodel.settings import DocumentLimits
 from docling.exceptions import DocumentLoadError
 from docling.utils.pdf_outline import _PdfOutlineItem
+from docling.utils.pdf_struct_tree import _PdfFormulaStruct
 from docling.utils.profiling import ProfilingItem
 from docling.utils.utils import create_file_hash, safe_version
 
@@ -595,6 +596,10 @@ class ConversionResult(ConversionAssets):
     # Private transient plumbing: a Pydantic private attr (not a model field, never serialized);
     # the heading stage resets it to None once consumed.
     _pdf_outline: Optional[list[_PdfOutlineItem]] = PrivateAttr(default=None)
+
+    # Formula structure elements read from a tagged PDF, surfaced from the backend for the
+    # native-formula stage. Same transient plumbing as _pdf_outline above.
+    _pdf_formula_structs: Optional[list[_PdfFormulaStruct]] = PrivateAttr(default=None)
 
 
 class _DummyBackend(AbstractDocumentBackend):

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1976,6 +1976,17 @@ class PdfPipelineOptions(PaginatedPipelineOptions):
             )
         ),
     ] = False
+    do_native_formula_extraction: Annotated[
+        bool,
+        Field(
+            description=(
+                "Read the MathML a tagged (accessible / PDF-UA) PDF already carries on its Formula structure "
+                "elements, instead of reconstructing the equation from the rendered glyphs. When a formula is "
+                "matched, its MathML is stored on the item and the formula enrichment model is skipped for it; "
+                "formulas with no embedded MathML are unaffected. Untagged PDFs are unchanged."
+            )
+        ),
+    ] = False
     force_backend_text: Annotated[
         bool,
         Field(

--- a/docling/models/stages/code_formula/code_formula_model.py
+++ b/docling/models/stages/code_formula/code_formula_model.py
@@ -23,6 +23,7 @@ from docling.datamodel.base_models import ItemAndImageEnrichmentElement
 from docling.models.base_model import BaseItemAndImageEnrichmentModel
 from docling.models.utils.hf_model_download import download_hf_model
 from docling.utils.accelerator_utils import decide_device
+from docling.utils.formula_meta import has_native_mathml
 
 
 class CodeFormulaModelOptions(BaseModel):
@@ -152,6 +153,10 @@ class CodeFormulaModel(BaseItemAndImageEnrichmentModel):
         bool
             True if the element can be processed, False otherwise.
         """
+        # A formula whose MathML was read from the source document is already resolved more
+        # faithfully than this model could reconstruct it.
+        if has_native_mathml(element):
+            return False
         return self.enabled and (
             (isinstance(element, CodeItem) and self.options.do_code_enrichment)
             or (

--- a/docling/models/stages/code_formula/code_formula_vlm_model.py
+++ b/docling/models/stages/code_formula/code_formula_vlm_model.py
@@ -33,6 +33,7 @@ from docling.models.inference_engines.vlm import (
     VlmEngineInput,
     create_vlm_engine,
 )
+from docling.utils.formula_meta import has_native_mathml
 
 _log = logging.getLogger(__name__)
 
@@ -126,6 +127,10 @@ class CodeFormulaVlmModel(BaseItemAndImageEnrichmentModel):
         Returns:
             True if the element is a code block or formula that should be processed
         """
+        # A formula whose MathML was read from the source document is already resolved more
+        # faithfully than this model could reconstruct it.
+        if has_native_mathml(element):
+            return False
         return self.enabled and (
             (isinstance(element, CodeItem) and self.options.extract_code)
             or (

--- a/docling/models/stages/native_formula/__init__.py
+++ b/docling/models/stages/native_formula/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT

--- a/docling/models/stages/native_formula/native_formula_model.py
+++ b/docling/models/stages/native_formula/native_formula_model.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+"""Attach the MathML a tagged PDF already carries to the formulas detected on the page.
+
+The layout model finds *where* the equations are; a tagged PDF's structure tree says what
+they *are*. When both are available the author's own MathML is the better answer, so this
+stage matches the two by position and records the MathML on the matching ``FormulaItem``.
+
+It runs right after the reading-order model, on the assembled document, and only ever
+writes to ``FormulaItem``\\ s -- it never adds, removes, relabels or reorders items.
+Structure elements that match no detected formula are dropped: recovering equations the
+layout model missed entirely is a separate problem.
+
+Once an item carries MathML the formula understanding model skips it (see
+:func:`docling.utils.formula_meta.has_native_mathml`), which leaves ``text`` empty, so the
+structure element's ``/ActualText`` or ``/Alt`` is used to fill it. Neither is guaranteed to
+be present; ``orig`` (the raw extracted text) is the last resort.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+
+from docling_core.types.doc import BoundingBox, DoclingDocument
+from docling_core.types.doc.common.meta import FormulaMeta, FormulaMetaField
+from docling_core.types.doc.document import FormulaItem
+
+from docling.datamodel.document import ConversionResult
+from docling.utils.pdf_struct_tree import _PdfFormulaStruct
+
+_log = logging.getLogger(__name__)
+
+# Recorded on the meta field so consumers can tell an authored representation from a
+# predicted one.
+NATIVE_FORMULA_SOURCE = "pdf_struct_tree"
+
+# A confident overlap between the detected formula and the structure element.
+_MIN_IOU = 0.5
+
+# Structure ``BBox`` attributes are frequently padded relative to the detected layout box
+# (and marked-content bounds are frequently tighter), which drags IoU down even on an
+# obvious match. Fall back to how much of the smaller box the larger one swallows.
+_MIN_CONTAINMENT = 0.8
+
+
+def _overlap_score(a: BoundingBox, b: BoundingBox) -> float:
+    """Return how confidently *a* and *b* describe the same region, 0.0 when they do not."""
+    iou = a.intersection_over_union(b)
+    if iou >= _MIN_IOU:
+        return iou
+    containment = max(a.intersection_over_self(b), b.intersection_over_self(a))
+    # Scaled below the IoU band so a containment match never outranks a genuine IoU match.
+    return containment * _MIN_IOU if containment >= _MIN_CONTAINMENT else 0.0
+
+
+class NativeFormulaModel:
+    """Records embedded MathML on the formulas of an already-assembled ``DoclingDocument``."""
+
+    def __init__(self, enabled: bool):
+        self.enabled = enabled
+
+    def __call__(self, conv_res: ConversionResult) -> DoclingDocument:
+        document = conv_res.document
+        structs = conv_res._pdf_formula_structs
+        if not self.enabled or not structs:
+            return document
+
+        try:
+            return self.apply_native_formulas(document, structs)
+        finally:
+            # Release the transient records once consumed.
+            conv_res._pdf_formula_structs = None
+
+    def apply_native_formulas(
+        self, document: DoclingDocument, structs: list[_PdfFormulaStruct]
+    ) -> DoclingDocument:
+        """Match *structs* to the document's formulas and record their MathML.
+
+        Works on a bare ``DoclingDocument`` so it can be reused outside the pipeline.
+        """
+        by_page: dict[int, list[_PdfFormulaStruct]] = defaultdict(list)
+        for struct in structs:
+            # Records without MathML carry nothing this stage can add.
+            if struct.mathml and struct.bbox is not None:
+                by_page[struct.page_no].append(struct)
+        if not by_page:
+            return document
+
+        items_by_page: dict[int, list[tuple[FormulaItem, BoundingBox]]] = defaultdict(
+            list
+        )
+        for item, _level in document.iterate_items(with_groups=False):
+            if not isinstance(item, FormulaItem) or not item.prov:
+                continue
+            prov = item.prov[0]
+            page = document.pages.get(prov.page_no)
+            if page is None or page.size is None or prov.page_no not in by_page:
+                continue
+            items_by_page[prov.page_no].append(
+                (item, prov.bbox.to_top_left_origin(page_height=page.size.height))
+            )
+
+        matched = 0
+        for page_no, page_items in items_by_page.items():
+            matched += self._apply_page(page_items, by_page[page_no])
+
+        if matched:
+            _log.debug("Recorded embedded MathML on %d formula(s)", matched)
+        return document
+
+    def _apply_page(
+        self,
+        page_items: list[tuple[FormulaItem, BoundingBox]],
+        page_structs: list[_PdfFormulaStruct],
+    ) -> int:
+        """Greedily pair the formulas and structure elements on one page, best match first."""
+        candidates = [
+            (_overlap_score(item_bbox, struct.bbox), item_idx, struct_idx)
+            for item_idx, (_item, item_bbox) in enumerate(page_items)
+            for struct_idx, struct in enumerate(page_structs)
+            if struct.bbox is not None
+        ]
+        # Ties are broken by document order so the pairing does not depend on dict ordering.
+        candidates.sort(key=lambda c: (-c[0], c[1], c[2]))
+
+        used_items: set[int] = set()
+        used_structs: set[int] = set()
+        matched = 0
+        for score, item_idx, struct_idx in candidates:
+            if score <= 0.0:
+                break
+            if item_idx in used_items or struct_idx in used_structs:
+                continue
+            used_items.add(item_idx)
+            used_structs.add(struct_idx)
+
+            item, _bbox = page_items[item_idx]
+            struct = page_structs[struct_idx]
+            item.meta = FormulaMeta(
+                formula=FormulaMetaField(
+                    mathml=struct.mathml, created_by=NATIVE_FORMULA_SOURCE
+                )
+            )
+            if not item.text:
+                item.text = (
+                    struct.actual_text or struct.alt_text or item.orig or ""
+                ).strip()
+            matched += 1
+
+        return matched

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -68,6 +68,9 @@ from docling.models.stages.heading_hierarchy.heading_hierarchy_model import (
 from docling.models.stages.layout.layout_postprocessing_model import (
     LayoutPostprocessingModel,
 )
+from docling.models.stages.native_formula.native_formula_model import (
+    NativeFormulaModel,
+)
 from docling.models.stages.page_assemble.page_assemble_model import (
     PageAssembleModel,
     PageAssembleOptions,
@@ -647,6 +650,9 @@ class StandardPdfPipeline(ConvertPipeline):
         self.heading_hierarchy_model = HeadingHierarchyModel(
             options=self.pipeline_options.heading_hierarchy_options
         )
+        self.native_formula_model = NativeFormulaModel(
+            enabled=self.pipeline_options.do_native_formula_extraction
+        )
 
         # --- optional enrichment ------------------------------------------------
         # Create a copy to avoid mutating pipeline_options in-place,
@@ -817,6 +823,13 @@ class StandardPdfPipeline(ConvertPipeline):
         if not expected_page_nos:
             conv_res.status = ConversionStatus.FAILURE
             return conv_res
+
+        # Surface the tagged PDF's Formula structure elements for the native-formula stage,
+        # while the backend is still open. Only read when the feature is enabled.
+        if self.pipeline_options.do_native_formula_extraction:
+            conv_res._pdf_formula_structs = backend.get_formula_structures(
+                expected_page_nos
+            )
 
         page_by_no: dict[int, Page] = {}
         for page_no in expected_page_nos:
@@ -1045,6 +1058,7 @@ class StandardPdfPipeline(ConvertPipeline):
             )
             conv_res.document = self.reading_order_model(conv_res)
             conv_res.document = self.heading_hierarchy_model(conv_res)
+            conv_res.document = self.native_formula_model(conv_res)
 
             # Generate page images in the output
             if self.pipeline_options.generate_page_images:

--- a/docling/utils/formula_meta.py
+++ b/docling/utils/formula_meta.py
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+"""Helpers for the structured mathematical representation carried on a formula item."""
+
+from __future__ import annotations
+
+from docling_core.types.doc import NodeItem
+from docling_core.types.doc.document import FormulaItem
+
+
+def has_native_mathml(element: NodeItem) -> bool:
+    """True when *element* already carries MathML read from the source document.
+
+    Used by the formula understanding stages to skip an equation whose authored
+    representation is already known, and by tests to assert that skip.
+    """
+    if not isinstance(element, FormulaItem) or element.meta is None:
+        return False
+    return element.meta.formula is not None and bool(element.meta.formula.mathml)

--- a/docling/utils/pdf_struct_tree.py
+++ b/docling/utils/pdf_struct_tree.py
@@ -1,0 +1,381 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+"""Read formula structure elements out of a tagged PDF's structure tree.
+
+A tagged (accessible / PDF-UA) PDF marks each equation with a ``Formula`` structure element,
+and producers may attach the author's own MathML to it. That representation is more faithful
+than anything reconstructed from the rendered glyphs, so it is worth preferring over the
+formula understanding model when it is there.
+
+Only what PDFium's public API can reach is covered:
+
+* **producer attributes** on the structure element -- Microsoft's PDF/UA output writes the
+  MathML into an ``MSFT_MathML`` attribute, which is the mechanism seen in the wild;
+* ``/ActualText`` and ``/Alt``, used as the item's text once the model is skipped.
+
+MathML delivered as an *associated file* (``/AF`` on the structure element, the PDF 2.0 /
+PDF-UA-2 route) is **not** reachable: PDFium exposes only document-level
+``/Names/EmbeddedFiles``, with no way to tie an attachment back to a structure element.
+Supporting it needs a raw object-model reader (pikepdf/pypdf), which is not a dependency.
+
+``pypdfium2`` is imported lazily, inside the functions that use it, never at module level:
+``datamodel.document`` imports this module for the ``_PdfFormulaStruct`` model, which places it
+on the ``docling.service_client`` import chain. That chain must stay importable on any
+docling-slim install that does not enable the PDF pipeline (and therefore ships no
+``pypdfium2``) -- the same constraint documented in :mod:`docling.utils.pdf_outline`.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import logging
+import re
+from typing import TYPE_CHECKING, Any, Iterable
+from xml.etree import ElementTree
+
+from docling_core.types.doc import BoundingBox, CoordOrigin
+from pydantic import BaseModel
+
+from docling.utils.locks import pypdfium2_lock
+
+if TYPE_CHECKING:
+    import pypdfium2 as pdfium
+
+_log = logging.getLogger(__name__)
+
+# Structure element type that marks an equation (PDF 32000-1, table 333).
+_FORMULA_TAG = "Formula"
+
+# Attribute keys known to carry MathML. Microsoft's PDF/UA export writes ``MSFT_MathML``;
+# the suffix match leaves room for other producers using the same convention.
+_MATHML_ATTR_RE = re.compile(r"(?:^|_)mathml$", re.IGNORECASE)
+
+# Element names rejected outright: MathML that carries these is either not MathML or is
+# being used to smuggle markup. The accepted string is emitted verbatim into exported HTML,
+# so it must not become a script-injection vector.
+_MATHML_FORBIDDEN_TAGS = {"script", "annotation-xml"}
+
+# Cap on how much of a structure tree is walked per page, so a pathological (or hostile)
+# document cannot spin here.
+_MAX_STRUCT_ELEMENTS_PER_PAGE = 10_000
+
+
+class _PdfFormulaStruct(BaseModel):
+    """One ``Formula`` structure element found in a tagged PDF (internal).
+
+    Internal data-passing structure between a PDF backend's ``get_formula_structures()`` and
+    the native-formula stage; not part of the public datamodel or the serialized output.
+    """
+
+    # 1-based page number, matching ``ProvenanceItem.page_no``.
+    page_no: int
+    # Top-left origin, in 72-DPI document points; None when neither the ``BBox`` attribute
+    # nor the element's marked content could give one.
+    bbox: BoundingBox | None = None
+    mathml: str | None = None
+    actual_text: str | None = None
+    alt_text: str | None = None
+
+
+def _utf16_text(fn: Any, *args: Any) -> str:
+    """Read one of PDFium's ``(buffer, buflen) -> byte length`` UTF-16LE string getters."""
+    length = fn(*args, None, 0)
+    if not length or length <= 0:
+        return ""
+    buf = ctypes.create_string_buffer(length)
+    fn(*args, buf, length)
+    # The reported length covers the NUL terminator, and some producers pad further.
+    return buf.raw[:length].decode("utf-16-le", errors="replace").rstrip("\x00")
+
+
+def _attr_names(pdfium_c: Any, attr: Any) -> list[str]:
+    """Return the keys of one structure-element attribute dictionary."""
+    count = pdfium_c.FPDF_StructElement_Attr_GetCount(attr)
+    names: list[str] = []
+    for i in range(max(count, 0)):
+        out_len = ctypes.c_ulong(0)
+        if not pdfium_c.FPDF_StructElement_Attr_GetName(
+            attr, i, None, 0, ctypes.byref(out_len)
+        ):
+            continue
+        buf = ctypes.create_string_buffer(out_len.value)
+        pdfium_c.FPDF_StructElement_Attr_GetName(
+            attr, i, buf, out_len.value, ctypes.byref(out_len)
+        )
+        names.append(buf.value.decode("utf-8", errors="replace"))
+    return names
+
+
+def _attr_string(pdfium_c: Any, attr: Any, name: str) -> str | None:
+    """Read a string-valued attribute, or None when it is absent or not a string."""
+    value = pdfium_c.FPDF_StructElement_Attr_GetValue(attr, name.encode())
+    if not value:
+        return None
+    if pdfium_c.FPDF_StructElement_Attr_GetType(value) != pdfium_c.FPDF_OBJECT_STRING:
+        return None
+    out_len = ctypes.c_ulong(0)
+    if not pdfium_c.FPDF_StructElement_Attr_GetStringValue(
+        value, None, 0, ctypes.byref(out_len)
+    ):
+        return None
+    buf = ctypes.create_string_buffer(out_len.value)
+    pdfium_c.FPDF_StructElement_Attr_GetStringValue(
+        value, buf, out_len.value, ctypes.byref(out_len)
+    )
+    text = buf.raw[: out_len.value].decode("utf-16-le", errors="replace").rstrip("\x00")
+    return text or None
+
+
+def _attr_rect(pdfium_c: Any, attr: Any, name: str) -> tuple[float, ...] | None:
+    """Read a 4-number array attribute (e.g. ``BBox``) in PDF bottom-left coordinates."""
+    value = pdfium_c.FPDF_StructElement_Attr_GetValue(attr, name.encode())
+    if not value:
+        return None
+    if pdfium_c.FPDF_StructElement_Attr_GetType(value) != pdfium_c.FPDF_OBJECT_ARRAY:
+        return None
+    if pdfium_c.FPDF_StructElement_Attr_CountChildren(value) != 4:
+        return None
+    numbers: list[float] = []
+    for i in range(4):
+        child = pdfium_c.FPDF_StructElement_Attr_GetChildAtIndex(value, i)
+        if not child:
+            return None
+        out = ctypes.c_float(0)
+        if not pdfium_c.FPDF_StructElement_Attr_GetNumberValue(
+            child, ctypes.byref(out)
+        ):
+            return None
+        numbers.append(out.value)
+    return tuple(numbers)
+
+
+def _sanitize_mathml(text: str) -> str | None:
+    """Return *text* when it is usable MathML, else None.
+
+    The value comes from the PDF and is emitted verbatim by the HTML serializer, so it is
+    accepted only when it parses as XML, is rooted at ``math``, and carries none of the
+    elements that would let it smuggle non-MathML markup into an exported page.
+    """
+    candidate = text.strip()
+    if not candidate:
+        return None
+    try:
+        root = ElementTree.fromstring(candidate)
+    except ElementTree.ParseError as exc:
+        _log.debug("Ignoring malformed MathML in structure tree: %s", exc)
+        return None
+
+    def _local_name(tag: object) -> str:
+        return str(tag).rsplit("}", 1)[-1].lower() if isinstance(tag, str) else ""
+
+    if _local_name(root.tag) != "math":
+        _log.debug("Ignoring structure-tree MathML with root %r", root.tag)
+        return None
+    for element in root.iter():
+        if _local_name(element.tag) in _MATHML_FORBIDDEN_TAGS:
+            _log.debug("Ignoring structure-tree MathML containing %r", element.tag)
+            return None
+    return candidate
+
+
+def _mcid_boxes(pdfium_c: Any, page: pdfium.PdfPage) -> dict[int, BoundingBox]:
+    """Map each marked-content id on *page* to the union of its page objects' bounds.
+
+    This is the fallback for locating a structure element that carries no ``BBox``
+    attribute: the element names its marked-content ids, and the page objects tagged with
+    those ids are what it actually covers. Coordinates stay in PDF bottom-left space.
+    """
+    boxes: dict[int, BoundingBox] = {}
+    for index in range(pdfium_c.FPDFPage_CountObjects(page.raw)):
+        obj = pdfium_c.FPDFPage_GetObject(page.raw, index)
+        if not obj:
+            continue
+        mcid = pdfium_c.FPDFPageObj_GetMarkedContentID(obj)
+        if mcid < 0:
+            continue
+        left, bottom, right, top = (ctypes.c_float() for _ in range(4))
+        if not pdfium_c.FPDFPageObj_GetBounds(
+            obj,
+            ctypes.byref(left),
+            ctypes.byref(bottom),
+            ctypes.byref(right),
+            ctypes.byref(top),
+        ):
+            continue
+        box = BoundingBox(
+            l=left.value,
+            b=bottom.value,
+            r=right.value,
+            t=top.value,
+            coord_origin=CoordOrigin.BOTTOMLEFT,
+        )
+        previous = boxes.get(mcid)
+        boxes[mcid] = (
+            box if previous is None else BoundingBox.enclosing_bbox([previous, box])
+        )
+    return boxes
+
+
+def _element_mcids(pdfium_c: Any, element: Any) -> list[int]:
+    count = pdfium_c.FPDF_StructElement_GetMarkedContentIdCount(element)
+    mcids = [
+        pdfium_c.FPDF_StructElement_GetMarkedContentIdAtIndex(element, i)
+        for i in range(max(count, 0))
+    ]
+    return [mcid for mcid in mcids if mcid >= 0]
+
+
+def _formula_from_element(
+    pdfium_c: Any,
+    element: Any,
+    *,
+    page_no: int,
+    page_height: float,
+    mcid_boxes: dict[int, BoundingBox],
+) -> _PdfFormulaStruct:
+    """Build the record for one ``Formula`` structure element."""
+    mathml: str | None = None
+    bbox_pdf: tuple[float, ...] | None = None
+
+    for i in range(max(pdfium_c.FPDF_StructElement_GetAttributeCount(element), 0)):
+        attr = pdfium_c.FPDF_StructElement_GetAttributeAtIndex(element, i)
+        if not attr:
+            continue
+        for name in _attr_names(pdfium_c, attr):
+            if mathml is None and _MATHML_ATTR_RE.search(name):
+                raw_value = _attr_string(pdfium_c, attr, name)
+                if raw_value:
+                    mathml = _sanitize_mathml(raw_value)
+            elif bbox_pdf is None and name == "BBox":
+                bbox_pdf = _attr_rect(pdfium_c, attr, name)
+
+    if bbox_pdf is not None:
+        left, bottom, right, top = bbox_pdf
+        box: BoundingBox | None = BoundingBox(
+            l=left, b=bottom, r=right, t=top, coord_origin=CoordOrigin.BOTTOMLEFT
+        )
+    else:
+        covered = [
+            mcid_boxes[mcid]
+            for mcid in _element_mcids(pdfium_c, element)
+            if mcid in mcid_boxes
+        ]
+        box = BoundingBox.enclosing_bbox(covered) if covered else None
+
+    return _PdfFormulaStruct(
+        page_no=page_no,
+        bbox=box.to_top_left_origin(page_height=page_height)
+        if box is not None
+        else None,
+        mathml=mathml,
+        actual_text=_utf16_text(pdfium_c.FPDF_StructElement_GetActualText, element)
+        or None,
+        alt_text=_utf16_text(pdfium_c.FPDF_StructElement_GetAltText, element) or None,
+    )
+
+
+def _collect_page(
+    pdfium_c: Any, page: pdfium.PdfPage, page_no: int
+) -> list[_PdfFormulaStruct]:
+    """Walk one page's structure tree and return its ``Formula`` elements."""
+    tree = pdfium_c.FPDF_StructTree_GetForPage(page.raw)
+    if not tree:
+        return []
+
+    found: list[_PdfFormulaStruct] = []
+    try:
+        page_height = page.get_height()
+        # Marked-content bounds are only needed by elements without a BBox attribute, and
+        # scanning every page object is not free -- so build the map on first use.
+        mcid_boxes: dict[int, BoundingBox] | None = None
+
+        # Iterative pre-order walk via an explicit stack, avoiding Python's call-stack
+        # recursion limit on deeply nested (or malformed) structure trees.
+        stack = [
+            pdfium_c.FPDF_StructTree_GetChildAtIndex(tree, i)
+            for i in reversed(range(pdfium_c.FPDF_StructTree_CountChildren(tree)))
+        ]
+        visited = 0
+        while stack:
+            element = stack.pop()
+            if not element:
+                continue
+            visited += 1
+            if visited > _MAX_STRUCT_ELEMENTS_PER_PAGE:
+                _log.debug(
+                    "Stopped structure-tree walk on page %d after %d elements",
+                    page_no,
+                    _MAX_STRUCT_ELEMENTS_PER_PAGE,
+                )
+                break
+
+            if (
+                _utf16_text(pdfium_c.FPDF_StructElement_GetType, element)
+                == _FORMULA_TAG
+            ):
+                if mcid_boxes is None:
+                    mcid_boxes = _mcid_boxes(pdfium_c, page)
+                found.append(
+                    _formula_from_element(
+                        pdfium_c,
+                        element,
+                        page_no=page_no,
+                        page_height=page_height,
+                        mcid_boxes=mcid_boxes,
+                    )
+                )
+                # A Formula element is a leaf as far as this stage cares; nested structure
+                # below it is part of the same equation.
+                continue
+
+            stack.extend(
+                pdfium_c.FPDF_StructElement_GetChildAtIndex(element, i)
+                for i in reversed(
+                    range(pdfium_c.FPDF_StructElement_CountChildren(element))
+                )
+            )
+    finally:
+        pdfium_c.FPDF_StructTree_Close(tree)
+
+    return found
+
+
+def extract_formula_structs_from_pdfium(
+    pdoc: pdfium.PdfDocument, page_nos: Iterable[int]
+) -> list[_PdfFormulaStruct]:
+    """Return the ``Formula`` structure elements on the requested pages.
+
+    Args:
+        pdoc: An open pypdfium2 document.
+        page_nos: 1-based page numbers to inspect.
+
+    Returns:
+        One record per ``Formula`` element found, in page order. Empty when the document
+        is not tagged, has no formula elements, or could not be read.
+    """
+    # lazy import (see module docstring)
+    import pypdfium2.raw as pdfium_c
+    from pypdfium2._helpers.misc import PdfiumError
+
+    results: list[_PdfFormulaStruct] = []
+    with pypdfium2_lock:
+        page_count = len(pdoc)
+        for page_no in page_nos:
+            if not 1 <= page_no <= page_count:
+                continue
+            try:
+                page = pdoc[page_no - 1]
+            except (PdfiumError, IndexError) as exc:
+                _log.debug(
+                    "Could not load page %d for structure tree: %s", page_no, exc
+                )
+                continue
+            try:
+                results.extend(_collect_page(pdfium_c, page, page_no))
+            except (PdfiumError, OSError, ValueError) as exc:
+                _log.debug("Could not read structure tree on page %d: %s", page_no, exc)
+            finally:
+                page.close()
+
+    return results

--- a/docs/usage/enrichments.md
+++ b/docs/usage/enrichments.md
@@ -8,6 +8,7 @@ The following table provides an overview of the default enrichment models availa
 | ------- | --------- | ---------------| ----------- |
 | Code understanding | `do_code_enrichment` | `CodeItem` | See [docs below](#code-understanding). |
 | Formula understanding | `do_formula_enrichment` | `TextItem` with label `FORMULA` | See [docs below](#formula-understanding). |
+| Native formula MathML | `do_native_formula_extraction` | `FormulaItem` | See [docs below](#using-the-mathml-embedded-in-a-tagged-pdf). |
 | Picture classification | `do_picture_classification` | `PictureItem` | See [docs below](#picture-classification). |
 | Picture description | `do_picture_description` | `PictureItem` | See [docs below](#picture-description). |
 
@@ -75,6 +76,46 @@ converter = DocumentConverter(format_options={
 result = converter.convert("https://arxiv.org/pdf/2501.17887")
 doc = result.document
 ```
+
+#### Using the MathML embedded in a tagged PDF
+
+A tagged (accessible / PDF-UA) PDF marks each equation with a `Formula` structure element, and
+some producers attach the author's own MathML to it — Microsoft Word's PDF/UA export writes it
+into an `MSFT_MathML` attribute. That representation is more faithful than one reconstructed
+from the rendered glyphs, so `do_native_formula_extraction` prefers it:
+
+```py
+pipeline_options = PdfPipelineOptions()
+pipeline_options.do_native_formula_extraction = True
+```
+
+or on the command line:
+
+```sh
+docling --native-formula FILE
+```
+
+When a `Formula` structure element is matched to a detected formula, its MathML is recorded on
+`FormulaItem.meta.formula.mathml` (with `created_by="pdf_struct_tree"`), the formula understanding
+model is skipped for that item, and the HTML export emits the embedded MathML verbatim instead of
+converting the predicted LaTeX. Formulas with no embedded MathML are untouched and still go to the
+model, so the two options combine:
+
+```py
+pipeline_options.do_formula_enrichment = True
+pipeline_options.do_native_formula_extraction = True
+```
+
+Both are off by default, and untagged PDFs are unaffected.
+
+Two limitations worth knowing:
+
+- Only formulas the layout model already detected are enriched. A `Formula` structure element that
+  matches no detected formula is ignored — recovering equations the layout model missed is a
+  separate problem.
+- MathML delivered as an *associated file* (`/AF` on the structure element, the PDF 2.0 / PDF-UA-2
+  route) is not read. PDFium exposes only document-level embedded files, with no way to tie one back
+  to a structure element.
 
 ### Picture classification
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ requires-python = '>=3.10,<4.0'
 # MINIMAL BASE (8 packages) - ~50MB
 dependencies = [
   'pydantic>=2.0.0,<3.0.0',
-  'docling-core>=2.91.0,<3.0.0',
+  'docling-core>=2.93.0,<3.0.0',
   'pydantic-settings>=2.3.0,<3.0.0',
   'filetype>=1.2.0,<2.0.0',
   'requests>=2.32.2,<3.0.0',

--- a/tach.toml
+++ b/tach.toml
@@ -346,6 +346,11 @@ layer = "models"
 depends_on = ["docling.datamodel"]
 
 [[modules]]
+path = "docling.models.stages.native_formula"
+layer = "models"
+depends_on = ["docling.datamodel", "docling.utils"]
+
+[[modules]]
 path = "docling.models.stages.reading_order"
 layer = "models"
 depends_on = ["docling.datamodel", "docling.utils"]

--- a/tests/data/pdf/struct_tree/formula_mathml_tagged.pdf
+++ b/tests/data/pdf/struct_tree/formula_mathml_tagged.pdf
@@ -1,0 +1,53 @@
+%PDF-1.7
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 6 0 R /MarkInfo << /Marked true >> /Lang (en-US) >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> /StructParents 0 >>
+endobj
+4 0 obj
+<< /Length 127 >>
+stream
+/Formula <</MCID 0>> BDC BT /F1 12 Tf 20 150 Td (x/y) Tj ET EMC
+/Formula <</MCID 1>> BDC BT /F1 12 Tf 20 100 Td (a+b) Tj ET EMC
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+6 0 obj
+<< /Type /StructTreeRoot /K [7 0 R] /ParentTree 9 0 R >>
+endobj
+7 0 obj
+<< /Type /StructElem /S /Document /P 6 0 R /K [8 0 R 10 0 R] >>
+endobj
+8 0 obj
+<< /Type /StructElem /S /Formula /P 7 0 R /Pg 3 0 R /K [0] /Alt (x over y) /A [ << /O /MSFT_MathML /MSFT_MathML (<math xmlns="http://www.w3.org/1998/Math/MathML"><mfrac><mi>x</mi><mi>y</mi></mfrac></math>) >> << /O /Layout /BBox [15 140 85 170] /Placement /Block >> ] >>
+endobj
+9 0 obj
+<< /Nums [0 [8 0 R 10 0 R]] >>
+endobj
+10 0 obj
+<< /Type /StructElem /S /Formula /P 7 0 R /Pg 3 0 R /K [1] /ActualText (a plus b) /A << /O /MSFT_MathML /MSFT_MathML (<math xmlns="http://www.w3.org/1998/Math/MathML"><mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow></math>) >> >>
+endobj
+xref
+0 11
+0000000000 65535 f 
+0000000009 00000 n 
+0000000123 00000 n 
+0000000180 00000 n 
+0000000323 00000 n 
+0000000501 00000 n 
+0000000571 00000 n 
+0000000643 00000 n 
+0000000722 00000 n 
+0000001008 00000 n 
+0000001054 00000 n 
+trailer
+<< /Size 11 /Root 1 0 R >>
+startxref
+1295
+%%EOF

--- a/tests/data/pdf/struct_tree/formula_mathml_untagged_struct.pdf
+++ b/tests/data/pdf/struct_tree/formula_mathml_untagged_struct.pdf
@@ -1,0 +1,48 @@
+%PDF-1.7
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 6 0 R /MarkInfo << /Marked true >> >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> /StructParents 0 >>
+endobj
+4 0 obj
+<< /Length 59 >>
+stream
+/P <</MCID 0>> BDC BT /F1 12 Tf 20 150 Td (hello) Tj ET EMC
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+6 0 obj
+<< /Type /StructTreeRoot /K [7 0 R] /ParentTree 9 0 R >>
+endobj
+7 0 obj
+<< /Type /StructElem /S /Document /P 6 0 R /K [8 0 R] >>
+endobj
+8 0 obj
+<< /Type /StructElem /S /P /P 7 0 R /Pg 3 0 R /K [0] >>
+endobj
+9 0 obj
+<< /Nums [0 [8 0 R]] >>
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000009 00000 n 
+0000000109 00000 n 
+0000000166 00000 n 
+0000000309 00000 n 
+0000000418 00000 n 
+0000000488 00000 n 
+0000000560 00000 n 
+0000000632 00000 n 
+0000000703 00000 n 
+trailer
+<< /Size 10 /Root 1 0 R >>
+startxref
+742
+%%EOF

--- a/tests/data/pdf/struct_tree/make_struct_tree_fixtures.py
+++ b/tests/data/pdf/struct_tree/make_struct_tree_fixtures.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+"""Regenerate the tagged-PDF fixtures used by ``tests/test_pdf_struct_tree.py``.
+
+Run with ``python tests/data/pdf/struct_tree/make_struct_tree_fixtures.py``. The PDFs are
+written by hand rather than by a library so the structure tree is explicit and reviewable:
+what matters is the ``/StructTreeRoot``, the ``Formula`` structure elements, and where the
+MathML sits, and no PDF writer available here emits those.
+
+``formula_mathml_tagged.pdf`` mimics Microsoft's PDF/UA output: the MathML rides in an
+``MSFT_MathML`` attribute. Its first formula also carries a ``/BBox`` layout attribute while
+the second does not, so both ways of locating an element on the page are covered.
+"""
+
+from pathlib import Path
+
+MATHML_FRAC = (
+    '<math xmlns="http://www.w3.org/1998/Math/MathML">'
+    "<mfrac><mi>x</mi><mi>y</mi></mfrac></math>"
+)
+MATHML_SUM = (
+    '<math xmlns="http://www.w3.org/1998/Math/MathML">'
+    "<mrow><mi>a</mi><mo>+</mo><mi>b</mi></mrow></math>"
+)
+
+
+def _pdf_string(text: str) -> str:
+    """Escape a value for a PDF literal string."""
+    return text.replace("\\", r"\\").replace("(", r"\(").replace(")", r"\)")
+
+
+def _build(objs: dict[int, str | None], stream_obj: int, stream: bytes) -> bytes:
+    """Assemble numbered objects into a PDF with a correct xref table."""
+    out = bytearray(b"%PDF-1.7\n")
+    offsets: dict[int, int] = {}
+    for num in sorted(objs):
+        offsets[num] = len(out)
+        if num == stream_obj:
+            out += f"{num} 0 obj\n<< /Length {len(stream)} >>\nstream\n".encode()
+            out += stream + b"\nendstream\nendobj\n"
+        else:
+            out += f"{num} 0 obj\n{objs[num]}\nendobj\n".encode()
+    xref = len(out)
+    out += f"xref\n0 {len(objs) + 1}\n0000000000 65535 f \n".encode()
+    for num in sorted(objs):
+        out += f"{offsets[num]:010d} 00000 n \n".encode()
+    out += (
+        f"trailer\n<< /Size {len(objs) + 1} /Root 1 0 R >>\nstartxref\n{xref}\n%%EOF\n"
+    ).encode()
+    return bytes(out)
+
+
+def tagged_with_formulas() -> bytes:
+    """Two ``Formula`` elements: the first carries /BBox, the second only marked content."""
+    stream = (
+        b"/Formula <</MCID 0>> BDC BT /F1 12 Tf 20 150 Td (x/y) Tj ET EMC\n"
+        b"/Formula <</MCID 1>> BDC BT /F1 12 Tf 20 100 Td (a+b) Tj ET EMC"
+    )
+    objs: dict[int, str | None] = {
+        1: (
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 6 0 R "
+            "/MarkInfo << /Marked true >> /Lang (en-US) >>"
+        ),
+        2: "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        3: (
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R "
+            "/Resources << /Font << /F1 5 0 R >> >> /StructParents 0 >>"
+        ),
+        4: None,
+        5: "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        6: "<< /Type /StructTreeRoot /K [7 0 R] /ParentTree 9 0 R >>",
+        7: "<< /Type /StructElem /S /Document /P 6 0 R /K [8 0 R 10 0 R] >>",
+        8: (
+            "<< /Type /StructElem /S /Formula /P 7 0 R /Pg 3 0 R /K [0] "
+            "/Alt (x over y) /A [ "
+            f"<< /O /MSFT_MathML /MSFT_MathML ({_pdf_string(MATHML_FRAC)}) >> "
+            "<< /O /Layout /BBox [15 140 85 170] /Placement /Block >> ] >>"
+        ),
+        9: "<< /Nums [0 [8 0 R 10 0 R]] >>",
+        10: (
+            "<< /Type /StructElem /S /Formula /P 7 0 R /Pg 3 0 R /K [1] "
+            "/ActualText (a plus b) /A << /O /MSFT_MathML "
+            f"/MSFT_MathML ({_pdf_string(MATHML_SUM)}) >> >>"
+        ),
+    }
+    return _build(objs, 4, stream)
+
+
+def tagged_without_formulas() -> bytes:
+    """Tagged, but the only structure element is a paragraph."""
+    stream = b"/P <</MCID 0>> BDC BT /F1 12 Tf 20 150 Td (hello) Tj ET EMC"
+    objs: dict[int, str | None] = {
+        1: (
+            "<< /Type /Catalog /Pages 2 0 R /StructTreeRoot 6 0 R "
+            "/MarkInfo << /Marked true >> >>"
+        ),
+        2: "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        3: (
+            "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 200 200] /Contents 4 0 R "
+            "/Resources << /Font << /F1 5 0 R >> >> /StructParents 0 >>"
+        ),
+        4: None,
+        5: "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+        6: "<< /Type /StructTreeRoot /K [7 0 R] /ParentTree 9 0 R >>",
+        7: "<< /Type /StructElem /S /Document /P 6 0 R /K [8 0 R] >>",
+        8: "<< /Type /StructElem /S /P /P 7 0 R /Pg 3 0 R /K [0] >>",
+        9: "<< /Nums [0 [8 0 R]] >>",
+    }
+    return _build(objs, 4, stream)
+
+
+def main() -> None:
+    here = Path(__file__).parent
+    (here / "formula_mathml_tagged.pdf").write_bytes(tagged_with_formulas())
+    (here / "formula_mathml_untagged_struct.pdf").write_bytes(tagged_without_formulas())
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_native_formula.py
+++ b/tests/test_native_formula.py
@@ -1,0 +1,290 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+"""Recording a tagged PDF's MathML on the formulas the layout model detected."""
+
+from pathlib import Path
+
+import pypdfium2 as pdfium
+import pytest
+from docling_core.types.doc import (
+    BoundingBox,
+    CoordOrigin,
+    DoclingDocument,
+    ProvenanceItem,
+    Size,
+)
+from docling_core.types.doc.common.meta import FormulaMeta, FormulaMetaField
+
+from docling.datamodel.accelerator_options import AcceleratorOptions
+from docling.datamodel.pipeline_options import (
+    CodeFormulaVlmOptions,
+    PdfPipelineOptions,
+)
+from docling.models.stages.code_formula.code_formula_model import (
+    CodeFormulaModel,
+    CodeFormulaModelOptions,
+)
+from docling.models.stages.code_formula.code_formula_vlm_model import (
+    CodeFormulaVlmModel,
+)
+from docling.models.stages.native_formula.native_formula_model import (
+    NATIVE_FORMULA_SOURCE,
+    NativeFormulaModel,
+)
+from docling.utils.formula_meta import has_native_mathml
+from docling.utils.pdf_struct_tree import (
+    _PdfFormulaStruct,
+    extract_formula_structs_from_pdfium,
+)
+
+TAGGED = Path("tests/data/pdf/struct_tree/formula_mathml_tagged.pdf")
+
+PAGE_HEIGHT = 200.0
+MATHML = "<math><mfrac><mi>x</mi><mi>y</mi></mfrac></math>"
+
+
+def _doc_with_formula(bbox: BoundingBox, text: str = "", orig: str = "x/y"):
+    """A one-page document holding a single formula at *bbox* (bottom-left origin)."""
+    doc = DoclingDocument(name="test")
+    doc.add_page(page_no=1, size=Size(width=200.0, height=PAGE_HEIGHT))
+    item = doc.add_formula(
+        text=text,
+        orig=orig,
+        prov=ProvenanceItem(page_no=1, charspan=(0, 0), bbox=bbox),
+    )
+    return doc, item
+
+
+def _struct(bbox_top_left: BoundingBox, **kwargs) -> _PdfFormulaStruct:
+    payload = {"mathml": MATHML, "page_no": 1, "bbox": bbox_top_left}
+    payload.update(kwargs)
+    return _PdfFormulaStruct(**payload)
+
+
+def _bl(left, bottom, right, top) -> BoundingBox:
+    return BoundingBox(
+        l=left, b=bottom, r=right, t=top, coord_origin=CoordOrigin.BOTTOMLEFT
+    )
+
+
+def _tl(left, top, right, bottom) -> BoundingBox:
+    return BoundingBox(
+        l=left, t=top, r=right, b=bottom, coord_origin=CoordOrigin.TOPLEFT
+    )
+
+
+def _apply(doc, structs) -> DoclingDocument:
+    return NativeFormulaModel(enabled=True).apply_native_formulas(doc, structs)
+
+
+def test_matching_formula_gets_the_mathml():
+    doc, item = _doc_with_formula(_bl(15, 140, 85, 170))
+
+    _apply(doc, [_struct(_tl(15, 30, 85, 60))])
+
+    assert item.meta is not None and item.meta.formula is not None
+    assert item.meta.formula.mathml == MATHML
+    assert item.meta.formula.created_by == NATIVE_FORMULA_SOURCE
+
+
+def test_padded_structure_bbox_still_matches():
+    """A /BBox attribute is often looser than the detected box; IoU alone would miss it."""
+    doc, item = _doc_with_formula(_bl(40, 145, 60, 160))
+
+    _apply(doc, [_struct(_tl(10, 20, 90, 70))])
+
+    assert has_native_mathml(item)
+
+
+def test_unrelated_region_does_not_match():
+    doc, item = _doc_with_formula(_bl(15, 140, 85, 170))
+
+    _apply(doc, [_struct(_tl(120, 150, 190, 190))])
+
+    assert item.meta is None
+
+
+def test_each_structure_element_is_used_at_most_once():
+    """Two formulas, two elements: the pairing must be one-to-one, best match first."""
+    doc = DoclingDocument(name="test")
+    doc.add_page(page_no=1, size=Size(width=200.0, height=PAGE_HEIGHT))
+    top = doc.add_formula(
+        text="",
+        orig="x/y",
+        prov=ProvenanceItem(page_no=1, charspan=(0, 0), bbox=_bl(15, 140, 85, 170)),
+    )
+    bottom = doc.add_formula(
+        text="",
+        orig="a+b",
+        prov=ProvenanceItem(page_no=1, charspan=(0, 0), bbox=_bl(15, 90, 85, 120)),
+    )
+
+    _apply(
+        doc,
+        [
+            _struct(_tl(15, 30, 85, 60), mathml="<math><mi>top</mi></math>"),
+            _struct(_tl(15, 80, 85, 110), mathml="<math><mi>bottom</mi></math>"),
+        ],
+    )
+
+    assert top.meta.formula.mathml == "<math><mi>top</mi></math>"
+    assert bottom.meta.formula.mathml == "<math><mi>bottom</mi></math>"
+
+
+def test_records_without_mathml_are_ignored():
+    doc, item = _doc_with_formula(_bl(15, 140, 85, 170))
+
+    _apply(doc, [_struct(_tl(15, 30, 85, 60), mathml=None, alt_text="x over y")])
+
+    assert item.meta is None
+    assert item.text == ""
+
+
+def test_records_without_a_bbox_are_ignored():
+    doc, item = _doc_with_formula(_bl(15, 140, 85, 170))
+
+    _apply(doc, [_struct(None)])
+
+    assert item.meta is None
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        ({"actual_text": "a plus b", "alt_text": "alt"}, "a plus b"),
+        ({"alt_text": "x over y"}, "x over y"),
+        ({}, "x/y"),  # falls back to the item's own orig
+    ],
+)
+def test_empty_text_is_filled_from_the_structure_element(kwargs, expected):
+    """The enrichment model is skipped, so text has to come from somewhere."""
+    doc, item = _doc_with_formula(_bl(15, 140, 85, 170))
+
+    _apply(doc, [_struct(_tl(15, 30, 85, 60), **kwargs)])
+
+    assert item.text == expected
+
+
+def test_existing_text_is_not_overwritten():
+    doc, item = _doc_with_formula(_bl(15, 140, 85, 170), text="\\frac{x}{y}")
+
+    _apply(doc, [_struct(_tl(15, 30, 85, 60), alt_text="x over y")])
+
+    assert item.text == "\\frac{x}{y}"
+
+
+def test_disabled_stage_changes_nothing():
+    doc, item = _doc_with_formula(_bl(15, 140, 85, 170))
+
+    class _Res:
+        document = doc
+        _pdf_formula_structs = [_struct(_tl(15, 30, 85, 60))]
+
+    NativeFormulaModel(enabled=False)(_Res())
+
+    assert item.meta is None
+
+
+def test_stage_releases_the_records_after_consuming_them():
+    doc, _item = _doc_with_formula(_bl(15, 140, 85, 170))
+
+    class _Res:
+        document = doc
+        _pdf_formula_structs = [_struct(_tl(15, 30, 85, 60))]
+
+    res = _Res()
+    NativeFormulaModel(enabled=True)(res)
+
+    assert res._pdf_formula_structs is None
+
+
+# --- the guard that keeps the enrichment model off a resolved formula -------------------
+
+
+def test_has_native_mathml_only_fires_on_a_recorded_mathml():
+    doc, item = _doc_with_formula(_bl(15, 140, 85, 170))
+    assert not has_native_mathml(item)
+
+    item.meta = FormulaMeta(formula=FormulaMetaField(latex="\\frac{x}{y}"))
+    assert not has_native_mathml(item)
+
+    item.meta = FormulaMeta(formula=FormulaMetaField(mathml=MATHML))
+    assert has_native_mathml(item)
+
+
+def test_legacy_enrichment_model_skips_a_resolved_formula():
+    doc, item = _doc_with_formula(_bl(15, 140, 85, 170))
+    model = CodeFormulaModel(
+        enabled=False,
+        artifacts_path=None,
+        options=CodeFormulaModelOptions(),
+        accelerator_options=AcceleratorOptions(),
+    )
+    assert not model.is_processable(doc, item)  # disabled anyway
+
+    model.enabled = True
+    assert model.is_processable(doc, item)
+
+    item.meta = FormulaMeta(formula=FormulaMetaField(mathml=MATHML))
+    assert not model.is_processable(doc, item)
+
+
+def test_vlm_enrichment_model_skips_a_resolved_formula():
+    doc, item = _doc_with_formula(_bl(15, 140, 85, 170))
+    model = CodeFormulaVlmModel(
+        enabled=False,
+        enable_remote_services=False,
+        artifacts_path=None,
+        options=CodeFormulaVlmOptions.from_preset("codeformulav2"),
+        accelerator_options=AcceleratorOptions(),
+    )
+    model.enabled = True
+    model.options = model.options.model_copy(update={"extract_formulas": True})
+    assert model.is_processable(doc, item)
+
+    item.meta = FormulaMeta(formula=FormulaMetaField(mathml=MATHML))
+    assert not model.is_processable(doc, item)
+
+
+# --- the whole data path, minus the layout model -----------------------------------------
+
+
+def test_mathml_read_from_a_real_pdf_reaches_the_html_export():
+    """Extractor -> stage -> serializer, using the boxes the fixture actually declares."""
+    pdoc = pdfium.PdfDocument(TAGGED)
+    try:
+        records = extract_formula_structs_from_pdfium(pdoc, [1])
+    finally:
+        pdoc.close()
+    assert len(records) == 2
+
+    doc = DoclingDocument(name="test")
+    doc.add_page(page_no=1, size=Size(width=200.0, height=PAGE_HEIGHT))
+    items = [
+        doc.add_formula(
+            text="",
+            orig="",
+            prov=ProvenanceItem(
+                page_no=1,
+                charspan=(0, 0),
+                bbox=record.bbox.to_bottom_left_origin(page_height=PAGE_HEIGHT),
+            ),
+        )
+        for record in records
+    ]
+
+    _apply(doc, records)
+
+    assert all(has_native_mathml(item) for item in items)
+    assert items[0].text == "x over y"  # from /Alt
+    assert items[1].text == "a plus b"  # from /ActualText
+
+    html = doc.export_to_html()
+    assert "<mfrac><mi>x</mi><mi>y</mi></mfrac>" in html
+    # latex2mathml would have added a TeX annotation; the authored MathML went out as-is.
+    assert 'encoding="TeX"' not in html
+
+
+def test_option_is_off_by_default():
+    assert PdfPipelineOptions().do_native_formula_extraction is False

--- a/tests/test_pdf_streaming_foundation.py
+++ b/tests/test_pdf_streaming_foundation.py
@@ -157,6 +157,7 @@ def test_standard_pipeline_bounds_live_streaming_backends() -> None:
     pipeline.keep_backend = False
     pipeline.pipeline_options = SimpleNamespace(
         heading_hierarchy_options=SimpleNamespace(enabled=False, use_bookmarks=False),
+        do_native_formula_extraction=False,
         document_timeout=None,
         stage_shutdown_timeout_seconds=1.0,
         generate_parsed_pages=False,

--- a/tests/test_pdf_struct_tree.py
+++ b/tests/test_pdf_struct_tree.py
@@ -1,0 +1,172 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+"""Reading ``Formula`` structure elements out of a tagged PDF.
+
+The fixtures under ``tests/data/pdf/struct_tree/`` are minimal hand-built tagged PDFs; see
+``make_struct_tree_fixtures.py`` in the same directory for how they are produced. They live
+outside ``tests/data/pdf/sources/`` on purpose -- that tree is swept by the end-to-end
+conversion test, which would demand groundtruth for them and run the layout model over two
+lines of text to no purpose.
+"""
+
+from pathlib import Path
+
+import pypdfium2 as pdfium
+import pytest
+from docling_core.types.doc import CoordOrigin
+
+from docling.backend.docling_parse_backend import (
+    DoclingParseDocumentBackend,
+    ThreadedDoclingParseDocumentBackend,
+)
+from docling.backend.pypdfium2_backend import PyPdfiumDocumentBackend
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.document import InputDocument
+from docling.utils.pdf_struct_tree import (
+    _sanitize_mathml,
+    extract_formula_structs_from_pdfium,
+)
+
+TAGGED = Path("tests/data/pdf/struct_tree/formula_mathml_tagged.pdf")
+TAGGED_NO_FORMULA = Path(
+    "tests/data/pdf/struct_tree/formula_mathml_untagged_struct.pdf"
+)
+UNTAGGED = Path("tests/data/pdf/sources/2203.01017v2.pdf")
+
+
+def _extract(path: Path, page_nos=(1,)):
+    doc = pdfium.PdfDocument(path)
+    try:
+        return extract_formula_structs_from_pdfium(doc, page_nos)
+    finally:
+        doc.close()
+
+
+def test_extracts_both_formula_elements():
+    records = _extract(TAGGED)
+
+    assert len(records) == 2
+    assert all(r.page_no == 1 for r in records)
+    assert "<mfrac><mi>x</mi><mi>y</mi></mfrac>" in records[0].mathml
+    assert "<mi>a</mi><mo>+</mo><mi>b</mi>" in records[1].mathml
+
+
+def test_reads_alt_and_actual_text():
+    first, second = _extract(TAGGED)
+
+    # The fixture gives the first element /Alt and the second /ActualText, so both getters
+    # are exercised. PDFium NUL-pads these buffers; the decode must strip that.
+    assert first.alt_text == "x over y"
+    assert first.actual_text is None
+    assert second.actual_text == "a plus b"
+    assert second.alt_text is None
+
+
+def test_bbox_attribute_is_converted_to_top_left_origin():
+    """The first element carries ``/BBox [15 140 85 170]`` on a 200pt-high page."""
+    first = _extract(TAGGED)[0]
+
+    assert first.bbox is not None
+    assert first.bbox.coord_origin == CoordOrigin.TOPLEFT
+    assert (first.bbox.l, first.bbox.t, first.bbox.r, first.bbox.b) == (15, 30, 85, 60)
+
+
+def test_bbox_falls_back_to_marked_content_bounds():
+    """The second element has no ``BBox``; its box comes from the text it marks."""
+    second = _extract(TAGGED)[1]
+
+    assert second.bbox is not None
+    assert second.bbox.coord_origin == CoordOrigin.TOPLEFT
+    # The run is drawn at (20, 100) in PDF space on a 200pt page.
+    assert 18 < second.bbox.l < 25
+    assert 88 < second.bbox.t < 102
+
+
+def test_tagged_pdf_without_formula_elements_yields_nothing():
+    assert _extract(TAGGED_NO_FORMULA) == []
+
+
+def test_untagged_pdf_yields_nothing():
+    assert _extract(UNTAGGED, page_nos=(1, 2)) == []
+
+
+def test_pages_outside_the_document_are_ignored():
+    assert _extract(TAGGED, page_nos=(0, 5, 99)) == []
+
+
+def test_only_requested_pages_are_read():
+    assert _extract(TAGGED, page_nos=()) == []
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "",
+        "   ",
+        "<math><mfrac>",  # not well formed
+        "<div><p>not mathml</p></div>",  # wrong root
+        "<math><script>alert(1)</script></math>",  # script smuggling
+        '<math><annotation-xml encoding="text/html"><b>x</b></annotation-xml></math>',
+    ],
+)
+def test_unusable_mathml_is_rejected(payload: str):
+    assert _sanitize_mathml(payload) is None
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "<math><mi>x</mi></math>",
+        '<math xmlns="http://www.w3.org/1998/Math/MathML"><mi>x</mi></math>',
+        "  <math><mi>x</mi></math>  ",
+    ],
+)
+def test_usable_mathml_is_accepted(payload: str):
+    assert _sanitize_mathml(payload) == payload.strip()
+
+
+def _backend(cls, path: Path):
+    in_doc = InputDocument(
+        path_or_stream=path,
+        format=InputFormat.PDF,
+        backend=cls,
+        filename=path.name,
+    )
+    return cls(in_doc, path)
+
+
+@pytest.mark.parametrize(
+    "backend_cls",
+    [
+        DoclingParseDocumentBackend,
+        ThreadedDoclingParseDocumentBackend,
+        PyPdfiumDocumentBackend,
+    ],
+)
+def test_every_pdf_backend_exposes_the_same_records(backend_cls):
+    """Including the threaded backend, which holds no pypdfium2 handle of its own."""
+    backend = _backend(backend_cls, TAGGED)
+    try:
+        records = backend.get_formula_structures([1])
+    finally:
+        backend.unload()
+
+    assert len(records) == 2
+    assert [r.mathml for r in records] == [r.mathml for r in _extract(TAGGED)]
+
+
+@pytest.mark.parametrize(
+    "backend_cls",
+    [
+        DoclingParseDocumentBackend,
+        ThreadedDoclingParseDocumentBackend,
+        PyPdfiumDocumentBackend,
+    ],
+)
+def test_backends_return_nothing_for_a_tagged_pdf_without_formulas(backend_cls):
+    backend = _backend(backend_cls, TAGGED_NO_FORMULA)
+    try:
+        assert backend.get_formula_structures([1]) == []
+    finally:
+        backend.unload()


### PR DESCRIPTION
> [!IMPORTANT]
> **Do not merge before the companion docling-core PR https://github.com/docling-project/docling-core/pull/730 is merged *and* released as 2.93.0.**
> This PR depends on `FormulaItem.meta.formula`, which lands in
> docling-project/docling-core#<PR> — so it bumps the floor to `docling-core>=2.93.0`.
> Until that version is on PyPI:
>
> - `uv lock` cannot resolve, so **`uv.lock` is deliberately left unregenerated here** and the
>   `uv-lock` hook / CI will fail. It needs a `uv lock` re-run and a push once 2.93.0 ships.
> - `ty` reports 4 transient `unresolved-import` warnings for `FormulaMeta` / `.formula`.
>
> Both clear on their own with that release. Everything else is green against the current tree.

**Issue resolved by this Pull Request:**
Resolves #4081

---
For the question the issue opens with: Docling does not currently look at the PDF structure tree at all. Searching the repo for `StructTreeRoot`, `MarkedContent` or `MathML` turns up nothing outside the JATS/USPTO *XML* backends. Every formula goes
`rendered glyphs -> CodeFormula model -> LaTeX`, and the MathML in the HTML export is `latex2mathml` run over that prediction — so an equation the author wrote as MathML is reconstructed twice over, and the original is discarded.

This adds the priority order the issue proposes, opt-in behind `do_native_formula_extraction` (`--native-formula`): embedded MathML first, the formula understanding model as the fallback. Both are off by default and untagged PDFs are unaffected.

## How it works

1. **`docling/utils/pdf_struct_tree.py`** walks a page's structure tree with pypdfium2 —
   already a hard dependency of the `format-pdf` extra, so nothing new is pulled in — and
   returns each `Formula` element's MathML, `/ActualText`, `/Alt` and bounding box. The box
   comes from the `BBox` layout attribute when present, otherwise from the bounds of the page
   objects the element's marked-content ids cover. It is modelled on the existing
   `utils/pdf_outline.py`, down to the lazy `pypdfium2` import that keeps the module
   importable on a docling-slim install without the PDF extra.
2. **`PdfDocumentBackend.get_formula_structures()`** exposes it, defaulting to `[]`. The
   docling-parse and pypdfium2 backends delegate to the handle they already hold. The
   threaded docling-parse backend — now the default after #3764 — holds no pypdfium2 handle,
   so it opens a short-lived one, exactly as its `get_document_outline()` already does for the
   table of contents.
3. **`NativeFormulaModel`** runs right after the reading-order model, pairs structure elements
   with detected formulas by bounding-box overlap (one-to-one, best match first), and records
   the MathML on `FormulaItem.meta.formula` with `created_by="pdf_struct_tree"`.
4. **Both `CodeFormula` stages skip** a formula that already has MathML, via a shared
   `has_native_mathml()` guard. That leaves `text` empty, so the stage fills it from
   `/ActualText` -> `/Alt` -> `orig`.

`docling-core` then emits the embedded MathML verbatim from `export_to_html()` instead of converting the predicted LaTeX.

The MathML is emitted verbatim into exported HTML, so the extractor only accepts a value that parses as XML, is rooted at `math`, and contains no `script` or `annotation-xml` element, without that, a hostile PDF could inject markup into an exported page.

## Not covered

MathML delivered as an **associated file** (`/AF` on the structure element, the PDF 2.0 / PDF-UA-2 route), the first mechanism the issue lists. PDFium's public API exposes only document-level `/Names/EmbeddedFiles`, with no way to tie an attachment back to a structure element, so reading it needs a raw object-model reader (pikepdf/pypdf) that is not a
dependency today. Happy to do a follow up if needed!

Also, only formulas the layout model already detected are enriched. A `Formula` structure element matching no detected formula is dropped rather than used to create or relabel an item; recovering equations the layout model missed is a bigger change than this.

## Verification

- **No reference test data was regenerated.** The new fixtures live in
  `tests/data/pdf/struct_tree/`, deliberately outside `tests/data/pdf/sources/` — that tree is
  swept by `test_e2e_conversion.py`, which would demand groundtruth and run the layout model
  over two lines of text to no purpose. So no double review is needed on that front.
- `ruff check` / `ruff format`, `tach check`, tach module coverage and max-lines all pass.
  `ty` reports no new diagnostics beyond the 4 transient ones noted at the top.
- Full non-ML suite: 1448 passed. The 32 failures are an identical set to the same tree
  *without* this change — verified by stashing and re-running every failing module. They are
  pre-existing local/Windows issues (groundtruth encoding, path separators, a missing optional
  dependency) in backends this PR does not touch.
- One existing test needed updating: `test_pdf_streaming_foundation.py` stubs
  `pipeline_options` as a `SimpleNamespace`, so the new option had to be added there, exactly
  as `heading_hierarchy_options` already is.
- 40 new tests, none of which need an ML model:
  - `tests/test_pdf_struct_tree.py` — extraction from tagged fixtures, both bbox paths,
    `/Alt` vs `/ActualText`, the MathML rejection cases, and all three PDF backends returning
    the same records (including the threaded one's transient-handle path).
  - `tests/test_native_formula.py` — matching, one-to-one pairing, the text fallbacks, the
    enrichment skip on both CodeFormula stages, and extractor -> stage -> HTML end to end.
- Fixtures are two ~1 KB hand-built tagged PDFs, with the generator committed next to them so
  they can be regenerated and audited.


**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
