### PR TITLE
feat: add terminal task callback event

### DIFF
--- a/docling/datamodel/service/__init__.py
+++ b/docling/datamodel/service/__init__.py
@@ -11,6 +11,7 @@ from docling.datamodel.service.callbacks import (
     ProgressDocumentCompleted,
     ProgressKind,
     ProgressSetNumDocs,
+    ProgressTaskCompleted,
     ProgressUpdateProcessed,
 )
 from docling.datamodel.service.chunking import (
@@ -172,6 +173,7 @@ __all__ = [
     "ProgressDocumentCompleted",
     "ProgressKind",
     "ProgressSetNumDocs",
+    "ProgressTaskCompleted",
     "ProgressUpdateProcessed",
     "PublicFailureInfo",
     "PutTarget",

--- a/docling/datamodel/service/callbacks.py
+++ b/docling/datamodel/service/callbacks.py
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: MIT
 
 import enum
-from typing import Annotated, Literal
+from typing import Annotated, Any, Literal
 
-from pydantic import AnyUrl, BaseModel, Field
+from pydantic import AnyUrl, BaseModel, Field, model_serializer, model_validator
 
 from docling.datamodel.base_models import ConversionStatus, InputFormat
+from docling.datamodel.service.responses import PublicFailureInfo
 
 
 class CallbackSpec(BaseModel):
@@ -19,6 +20,7 @@ class ProgressKind(str, enum.Enum):
     SET_NUM_DOCS = "set_num_docs"
     UPDATE_PROCESSED = "update_processed"
     DOCUMENT_COMPLETED = "document_completed"
+    TASK_COMPLETED = "task_completed"
 
 
 class BaseProgress(BaseModel):
@@ -74,10 +76,36 @@ class ProgressDocumentCompleted(BaseProgress):
     total_docs: int | None = None  # Total docs in task (if known)
 
 
+class ProgressTaskCompleted(BaseProgress):
+    """Terminal task outcome, independent of document outcomes."""
+
+    kind: Literal[ProgressKind.TASK_COMPLETED] = ProgressKind.TASK_COMPLETED
+    task_status: Literal["success", "failure"]
+    failure: PublicFailureInfo | None = None
+
+    @model_validator(mode="after")
+    def validate_failure(self) -> "ProgressTaskCompleted":
+        if (self.task_status == "failure") != (self.failure is not None):
+            raise ValueError(
+                "failure must be present exactly when task_status is failure"
+            )
+        return self
+
+    @model_serializer(mode="wrap")
+    def serialize_without_empty_failure(self, handler: Any) -> dict[str, Any]:
+        data = handler(self)
+        if self.failure is None:
+            data.pop("failure", None)
+        return data
+
+
 class ProgressCallbackRequest(BaseModel):
     task_id: str
     progress: Annotated[
-        ProgressSetNumDocs | ProgressUpdateProcessed | ProgressDocumentCompleted,
+        ProgressSetNumDocs
+        | ProgressUpdateProcessed
+        | ProgressDocumentCompleted
+        | ProgressTaskCompleted,
         Field(discriminator="kind"),
     ]
 

--- a/docling/datamodel/service/callbacks.py
+++ b/docling/datamodel/service/callbacks.py
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: MIT
 
 import enum
-from typing import Annotated, Any, Literal
+from typing import Annotated, Literal
 
-from pydantic import AnyUrl, BaseModel, Field, model_serializer, model_validator
+from pydantic import AnyUrl, BaseModel, Field
 
 from docling.datamodel.base_models import ConversionStatus, InputFormat
 from docling.datamodel.service.responses import PublicFailureInfo
@@ -82,21 +82,6 @@ class ProgressTaskCompleted(BaseProgress):
     kind: Literal[ProgressKind.TASK_COMPLETED] = ProgressKind.TASK_COMPLETED
     task_status: Literal["success", "failure"]
     failure: PublicFailureInfo | None = None
-
-    @model_validator(mode="after")
-    def validate_failure(self) -> "ProgressTaskCompleted":
-        if (self.task_status == "failure") != (self.failure is not None):
-            raise ValueError(
-                "failure must be present exactly when task_status is failure"
-            )
-        return self
-
-    @model_serializer(mode="wrap")
-    def serialize_without_empty_failure(self, handler: Any) -> dict[str, Any]:
-        data = handler(self)
-        if self.failure is None:
-            data.pop("failure", None)
-        return data
 
 
 class ProgressCallbackRequest(BaseModel):

--- a/tests/test_service_callbacks.py
+++ b/tests/test_service_callbacks.py
@@ -1,9 +1,6 @@
 # SPDX-FileCopyrightText: The Docling Contributors
 # SPDX-License-Identifier: MIT
 
-import pytest
-from pydantic import ValidationError
-
 from docling.datamodel.service import (
     FailureCategory,
     FailurePhase,
@@ -33,6 +30,7 @@ def test_progress_task_completed_round_trip_and_discrimination() -> None:
         "progress": {
             "kind": "task_completed",
             "task_status": "success",
+            "failure": None,
         },
     }
 
@@ -49,14 +47,3 @@ def test_progress_task_completed_round_trip_and_discrimination() -> None:
     assert isinstance(failure.progress, ProgressTaskCompleted)
     assert failure.progress.kind == ProgressKind.TASK_COMPLETED
     assert failure.progress.failure == _failure()
-
-
-@pytest.mark.parametrize(
-    ("task_status", "failure"),
-    [("success", _failure()), ("failure", None)],
-)
-def test_progress_task_completed_rejects_invalid_failure_combinations(
-    task_status: str, failure: PublicFailureInfo | None
-) -> None:
-    with pytest.raises(ValidationError):
-        ProgressTaskCompleted(task_status=task_status, failure=failure)  # type: ignore[arg-type]

--- a/tests/test_service_callbacks.py
+++ b/tests/test_service_callbacks.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+import pytest
+from pydantic import ValidationError
+
+from docling.datamodel.service import (
+    FailureCategory,
+    FailurePhase,
+    ProgressCallbackRequest,
+    ProgressKind,
+    ProgressTaskCompleted,
+    PublicFailureInfo,
+)
+
+
+def _failure() -> PublicFailureInfo:
+    return PublicFailureInfo(
+        category=FailureCategory.INTERNAL,
+        message="Internal processing error.",
+        retryable=False,
+        phase=FailurePhase.EXECUTION,
+    )
+
+
+def test_progress_task_completed_round_trip_and_discrimination() -> None:
+    success = ProgressCallbackRequest(
+        task_id="task-1",
+        progress=ProgressTaskCompleted(task_status="success"),
+    )
+    assert success.model_dump(mode="json") == {
+        "task_id": "task-1",
+        "progress": {
+            "kind": "task_completed",
+            "task_status": "success",
+        },
+    }
+
+    failure = ProgressCallbackRequest.model_validate(
+        {
+            "task_id": "task-2",
+            "progress": {
+                "kind": "task_completed",
+                "task_status": "failure",
+                "failure": _failure().model_dump(mode="json"),
+            },
+        }
+    )
+    assert isinstance(failure.progress, ProgressTaskCompleted)
+    assert failure.progress.kind == ProgressKind.TASK_COMPLETED
+    assert failure.progress.failure == _failure()
+
+
+@pytest.mark.parametrize(
+    ("task_status", "failure"),
+    [("success", _failure()), ("failure", None)],
+)
+def test_progress_task_completed_rejects_invalid_failure_combinations(
+    task_status: str, failure: PublicFailureInfo | None
+) -> None:
+    with pytest.raises(ValidationError):
+        ProgressTaskCompleted(task_status=task_status, failure=failure)  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- add `ProgressTaskCompleted` with success/failure status and optional structured failure details
- keep the model consistent with existing progress models and normal Pydantic null serialization
- add the event to callback discrimination, exports, and round-trip tests

## Validation

- focused callback model test passes
- Ruff lint and format checks pass
- all commit hooks pass, including `ty`, Tach, and module coverage