### PR TITLE
fix(csv): drop the UTF-8 BOM instead of keeping it in the first cell

### DIFF
--- a/docling/backend/csv_backend.py
+++ b/docling/backend/csv_backend.py
@@ -47,12 +47,17 @@ class CsvDocumentBackend(DeclarativeDocumentBackend):
     def __init__(self, in_doc: "InputDocument", path_or_stream: Union[BytesIO, Path]):
         super().__init__(in_doc, path_or_stream)
 
-        # Load content
+        # Load content. utf-8-sig drops a leading BOM, which Excel and Google
+        # Sheets both write when exporting "CSV UTF-8"; left in, it becomes part
+        # of the first header cell. It is equivalent to utf-8 when no BOM is
+        # present.
         try:
             if isinstance(self.path_or_stream, BytesIO):
-                self.content = StringIO(self.path_or_stream.getvalue().decode("utf-8"))
+                self.content = StringIO(
+                    self.path_or_stream.getvalue().decode("utf-8-sig")
+                )
             elif isinstance(self.path_or_stream, Path):
-                self.content = StringIO(self.path_or_stream.read_text("utf-8"))
+                self.content = StringIO(self.path_or_stream.read_text("utf-8-sig"))
             self.valid = True
         except Exception as e:
             raise DocumentLoadError(

--- a/tests/test_backend_csv.py
+++ b/tests/test_backend_csv.py
@@ -119,3 +119,29 @@ def test_empty_csv():
     # The empty CSV should result in an empty document (no tables and no texts).
     assert len(getattr(doc, "tables", [])) == 0
     assert len(getattr(doc, "texts", [])) == 0
+
+
+def test_utf8_bom_is_not_part_of_the_first_cell(tmp_path):
+    """A leading UTF-8 BOM must not survive into the first header cell.
+
+    Excel and Google Sheets write a BOM when exporting "CSV UTF-8". Decoding
+    with plain utf-8 kept it, so the first header came back as U+FEFF followed
+    by "Name", and matching on that header silently missed the column. Both the
+    stream and the file path are covered, since each decodes separately.
+    """
+    csv_bytes = "\ufeffName,Age\nAlice,30\n".encode()
+    converter = get_converter()
+
+    stream_doc = converter.convert(
+        DocumentStream(name="bom.csv", stream=BytesIO(csv_bytes)),
+        raises_on_error=True,
+    ).document
+
+    csv_file = tmp_path / "bom.csv"
+    csv_file.write_bytes(csv_bytes)
+    file_doc = converter.convert(csv_file, raises_on_error=True).document
+
+    for doc in (stream_doc, file_doc):
+        cells = doc.tables[0].data.table_cells
+        assert cells[0].text == "Name"
+        assert cells[1].text == "Age"


### PR DESCRIPTION
`CsvDocumentBackend` decoded with plain `utf-8`, so a leading BOM ended up inside the first cell of the header row. Excel and Google Sheets both write one when exporting "CSV UTF-8".

Decoding with `utf-8-sig` strips it when present and behaves exactly like `utf-8` when it isn't, so files without a BOM are unaffected. I checked that across comma, semicolon and single-column inputs. `html_backend.py` already strips `\ufeff` as noise, so this just brings CSV in line.

**Issue resolved by this Pull Request:**
Resolves #4097

### Before and after

```python
data = "\ufeffName,Age\nAlice,30\n".encode("utf-8")  # what Excel writes
doc = converter.convert(DocumentStream(name="bom.csv", stream=BytesIO(data))).document
doc.tables[0].data.table_cells[0].text
```

before `'\ufeffName'`, after `'Name'`. In the exported markdown that was:

```
| \ufeffName   |   Age |
|--------|-------|
| Alice  |    30 |
```

Since the character is invisible, the symptom users actually hit is a header match quietly failing on the first column.

### Scope

Only CSV. `asciidoc_backend`, `boxnote_backend`, `webvtt_backend` and `md_backend` decode the same way, but there a BOM just joins the first text run rather than corrupting a structured field, so I left them out rather than widen the diff. Happy to follow up separately if you want them covered.

### Testing

`test_utf8_bom_is_not_part_of_the_first_cell` covers both the stream and the file path, since each decodes separately. It fails on `main` and passes here. Written against an in-memory `DocumentStream` and `tmp_path` rather than a new fixture, so it doesn't touch `tests/data`.

```
uv run pytest tests/test_backend_csv.py     ->  5 passed
uv run pytest tests/ -k "csv or markdown or html or msword or asciidoc or webvtt"
                                            ->  149 passed, 2 skipped
```

The three existing CSV groundtruth tests pass unchanged, so no exported output moved. `make validate` is clean.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

