### PR TITLE
fix(cli): defer heavy imports so CLI works on lightweight installs

### DIFF
--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -11,7 +11,7 @@ import warnings
 from collections.abc import Iterable
 from enum import Enum
 from pathlib import Path
-from typing import Annotated, Literal, cast
+from typing import TYPE_CHECKING, Annotated, Literal, cast
 from urllib.parse import urlparse
 
 from docling.datamodel.service.responses import ChunkedDocumentResultItem
@@ -137,29 +137,25 @@ from docling.datamodel.pipeline_options import (
 )
 from docling.datamodel.pipeline_options_asr_model import InlineAsrOptions
 from docling.datamodel.settings import DEFAULT_PAGE_RANGE, settings
-from docling.document_converter import (
-    AudioFormatOption,
-    DocumentConverter,
-    EpubFormatOption,
-    ExcelFormatOption,
-    FormatOption,
-    HTMLFormatOption,
-    LatexFormatOption,
-    MarkdownFormatOption,
-    OdpFormatOption,
-    OdsFormatOption,
-    OdtFormatOption,
-    PdfFormatOption,
-    PowerpointFormatOption,
-    WordFormatOption,
-)
-from docling.models.factories import (
-    get_layout_factory,
-    get_ocr_factory,
-    get_table_structure_factory,
-)
-from docling.models.factories.base_factory import BaseFactory
 from docling.utils.profiling import ProfilingItem
+
+# The local model stack (scipy, torch, …) is absent on lightweight installs
+# (docling-slim[service-client] / docling-client).  Guard these imports so the
+# CLI module — and `convert-remote` — remain importable without them.
+_local_model_stack_available: bool
+try:
+    from docling.models.factories import (
+        get_layout_factory,
+        get_ocr_factory,
+        get_table_structure_factory,
+    )
+
+    _local_model_stack_available = True
+except ImportError:
+    _local_model_stack_available = False
+
+if TYPE_CHECKING:
+    from docling.models.factories.base_factory import BaseFactory
 
 warnings.filterwarnings(action="ignore", category=UserWarning, module="pydantic|torch")
 warnings.filterwarnings(action="ignore", category=FutureWarning, module="easyocr")
@@ -247,16 +243,21 @@ def _expand_from_formats(from_formats: list[str] | None) -> list[InputFormat]:
     return list(dict.fromkeys(expanded_formats))
 
 
-ocr_factory_internal = get_ocr_factory(allow_external_plugins=False)
-ocr_engines_enum_internal = ocr_factory_internal.get_enum()
+if _local_model_stack_available:
+    ocr_factory_internal = get_ocr_factory(allow_external_plugins=False)
+    ocr_engines_enum_internal = ocr_factory_internal.get_enum()
 
-layout_factory_internal = get_layout_factory(allow_external_plugins=False)
-layout_engines_enum_internal = layout_factory_internal.get_enum()
+    layout_factory_internal = get_layout_factory(allow_external_plugins=False)
+    layout_engines_enum_internal = layout_factory_internal.get_enum()
 
-table_structure_factory_internal = get_table_structure_factory(
-    allow_external_plugins=False
-)
-table_structure_engines_enum_internal = table_structure_factory_internal.get_enum()
+    table_structure_factory_internal = get_table_structure_factory(
+        allow_external_plugins=False
+    )
+    table_structure_engines_enum_internal = table_structure_factory_internal.get_enum()
+else:
+    ocr_engines_enum_internal = []
+    layout_engines_enum_internal = []
+    table_structure_engines_enum_internal = []
 
 # Get available VLM presets from the registry
 vlm_preset_ids = VlmConvertOptions.list_preset_ids()
@@ -1098,6 +1099,9 @@ def convert(  # noqa: C901
         IWorkPagesFormatOption,
         LatexFormatOption,
         MarkdownFormatOption,
+        OdpFormatOption,
+        OdsFormatOption,
+        OdtFormatOption,
         PdfFormatOption,
         PowerpointFormatOption,
         WordFormatOption,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1124,6 +1124,34 @@ def test_cli_invalid_table_structure_engine_is_rejected(tmp_path):
     assert result.exit_code != 0
 
 
+def test_cli_main_importable_without_local_model_stack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Importing docling.cli.main must not require pypdfium2 or scipy.
+
+    Ensure that CLI does not crash in `docling convert-remote`
+    on lightweight `docling-client` / `docling-slim[service-client]` installs.
+    """
+    import importlib
+    import sys
+
+    monkeypatch.setitem(sys.modules, "pypdfium2", None)  # type: ignore[arg-type]
+    monkeypatch.setitem(sys.modules, "scipy", None)  # type: ignore[arg-type]
+    monkeypatch.setitem(sys.modules, "scipy.ndimage", None)  # type: ignore[arg-type]
+
+    for mod in list(sys.modules):
+        if mod.startswith(
+            (
+                "docling.cli.main",
+                "docling.document_converter",
+                "docling.models.factories",
+            )
+        ):
+            monkeypatch.delitem(sys.modules, mod)
+
+    importlib.import_module("docling.cli.main")
+
+
 def test_cli_invalid_ocr_engine_is_rejected(tmp_path):
     """Test that invalid --ocr-engine is rejected."""
     result = runner.invoke(


### PR DESCRIPTION
## Summary

`docling-client` (i.e. `docling-slim[service-client]`) installs do not include `pypdfium2`,
`docling-parse`, or `scipy` — they only need the lightweight HTTP client stack to offload
conversion to a remote Docling Serve endpoint.  Running any `docling` CLI subcommand (including
`convert-remote`) on such an install crashed immediately at startup, before any subcommand was
parsed.

Resolves #4099 

## Root cause

`docling/cli/main.py` contained two groups of unconditional module-level imports that pulled in
the full local model stack:

1. `from docling.document_converter import (DocumentConverter, *FormatOption, …)` — which
   transitively imports `ThreadedDoclingParseDocumentBackend` → `pypdfium2`.
2. `from docling.models.factories import (get_ocr_factory, …)` — which transitively imports
   `BaseOcrModel` → `scipy`.

Both executed on every `docling` invocation.  A comment already present in the file made the
intent clear: *"Heavy backend/converter/pipeline imports are deferred to here so the CLI (and
`convert-remote`) stay importable without the local PDF stack."*  Both import blocks were
oversights that defeated that intent.

## Changes

- **Removed** the module-level `from docling.document_converter import (...)` block.  All
  symbols it provided (`DocumentConverter`, `*FormatOption`) are used exclusively inside the
  `convert()` command body, where an equivalent deferred import block already existed.  
  `OdpFormatOption`, `OdsFormatOption`, and `OdtFormatOption` — which were silently relying on
  the removed block and missing from the deferred one — are added to it.

- **Guarded** the `from docling.models.factories import (…)` block behind a
  `try/except ImportError`, setting `_local_model_stack_available: bool`.  The three
  engine-enum variables that feed into Typer `--help` strings are built inside the `if` branch;
  the `else` branch provides empty-list fallbacks so the f-string interpolations degrade
  gracefully.  `BaseFactory` (used only as a type annotation) is moved under `TYPE_CHECKING`.

## Testing

- `make validate` passes cleanly (ruff, ty, tach, all hooks).
- The Python SDK path (`from docling.service_client import DoclingServiceClient`) was unaffected
  throughout — it never imports `docling.document_converter` or the model factories.
- `docling convert-remote` can now be invoked on a `docling-client` /
  `docling-slim[service-client]` install without triggering the local PDF stack.


**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
