### PR TITLE
feat(cli): add latex output format

### DIFF
--- a/docling/cli/export_utils.py
+++ b/docling/cli/export_utils.py
@@ -17,6 +17,7 @@ _OUTPUT_FORMATS_NOT_SUPPORTING_IMAGE_EMBEDDING = frozenset(
         OutputFormat.VTT,
         OutputFormat.DOCLANG,
         OutputFormat.CHUNKS,
+        OutputFormat.LATEX,
     }
 )
 
@@ -51,6 +52,7 @@ def _export_flags_from_formats(to_formats: list[OutputFormat]) -> dict[str, bool
         "export_doclang": OutputFormat.DOCLANG in to_formats,
         "export_dclx": OutputFormat.DCLX in to_formats,
         "export_chunks": OutputFormat.CHUNKS in to_formats,
+        "export_latex": OutputFormat.LATEX in to_formats,
     }
 
 

--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -40,6 +40,7 @@ from docling_core.transforms.serializer.html import (
     HTMLOutputStyle,
     HTMLParams,
 )
+from docling_core.transforms.serializer.latex import LaTeXDocSerializer
 from docling_core.transforms.visualizer.layout_visualizer import LayoutVisualizer
 from docling_core.types.doc import ImageRefMode
 from docling_core.utils.file import resolve_source_to_path
@@ -462,6 +463,7 @@ def export_documents(
     image_export_mode: ImageRefMode,
     export_dclx: bool = False,
     export_chunks: bool = False,
+    export_latex: bool = False,
     chunker_type: ChunkerType = ChunkerType.HYBRID,
     chunk_max_tokens: int | None = None,
     chunk_tokenizer: str = "sentence-transformers/all-MiniLM-L6-v2",
@@ -608,6 +610,14 @@ def export_documents(
                 fname = output_dir / f"{doc_filename}.dclx"
                 _log.info(f"writing DCLX output to {fname}")
                 conv_res.document.save_as_doclang_archive(filename=fname)
+
+            # Export LaTeX format:
+            if export_latex:
+                fname = output_dir / f"{doc_filename}.tex"
+                _log.info(f"writing LaTeX output to {fname}")
+                ser_res = LaTeXDocSerializer(doc=conv_res.document).serialize()
+                with fname.open("w", encoding="utf-8") as fp:
+                    fp.write(ser_res.text)
 
             # Export Chunks format:
             if export_chunks and chunker_obj is not None:

--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -142,6 +142,7 @@ class OutputFormat(str, Enum):
     DOCLANG = "doclang"
     DCLX = "dclx"
     CHUNKS = "chunks"
+    LATEX = "latex"
 
 
 FormatToExtensions: dict[InputFormat, list[str]] = {

--- a/docs/usage/supported_formats.md
+++ b/docs/usage/supported_formats.md
@@ -51,3 +51,4 @@ Schema-specific support:
 | WebVTT | Web Video Text Tracks format for displaying timed text |
 | DocLang archive | Zipped DocLang bundle including page images; CLI output format: `dclx` |
 | Chunks (JSONL) | Chunked document output for RAG pipelines; configurable via `--chunks-type`, `--chunks-max-tokens`, `--chunks-tokenizer` |
+| LaTeX | Standalone `.tex` document; images are emitted as placeholders |

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -156,6 +156,39 @@ def test_cli_exports_dclx(tmp_path):
     assert b"DCLX CLI" in payload
 
 
+def test_cli_exports_latex(tmp_path):
+    source = tmp_path / "input.md"
+    source.write_text(
+        "# LaTeX CLI\n\nHello from Markdown with 100% special chars.",
+        encoding="utf-8",
+    )
+    output = tmp_path / "out"
+
+    result = runner.invoke(
+        app,
+        [
+            str(source),
+            "--from",
+            "md",
+            "--to",
+            "latex",
+            "--output",
+            str(output),
+        ],
+    )
+
+    assert result.exit_code == 0
+    converted = output / "input.tex"
+    assert converted.exists()
+    content = converted.read_text(encoding="utf-8")
+    assert content.startswith("\\documentclass")
+    assert "\\begin{document}" in content
+    assert "\\end{document}" in content
+    assert "LaTeX CLI" in content
+    # LaTeX special characters must be escaped
+    assert "100\\% special chars" in content
+
+
 def test_cli_from_odf_expands_to_open_document_formats(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
The LaTeX serializer has been available in docling-core since v2.54 (docling-project/docling-core#445), but the docling CLI cannot emit it. This adds `latex` to `OutputFormat` and wires it through `export_documents`, so `docling <source> --to latex` writes `<name>.tex` (standalone document, default serializer params). Addresses the LaTeX part of #343; mathpix-markdown-it is not covered.

Verified against docling-core's own golden files: converting `test/data/doc/{2408.09869v3_enriched,activities,polymers}.json` with `--to latex` reproduces the corresponding `.gt.tex` exactly (43,965 / 1,344 / 10,909 chars). Also smoke-tested end-to-end on `tests/data/pdf/sources/2305.03393v1-pg9.pdf` (sections, table, caption render as expected).

Known limitations, stated upfront: pictures are emitted as `% image` placeholders (referenced-image wiring could follow in a later PR), and `convert-remote` needs a service version that also knows `latex`.

**Checklist:**

- [x] Documentation has been updated, if necessary. (`docs/usage/supported_formats.md`; the CLI reference is auto-generated)
- [x] Examples have been added, if necessary. (none needed)
- [x] Tests have been added, if necessary. (`tests/test_cli.py::test_cli_exports_latex`)