### PR TITLE
fix: enable CUDA for RapidOCR ONNX Runtime

### DIFF
--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -410,6 +410,8 @@ class RapidOcrModel(BaseOcrModel):
                 "Global.font_path": font_path,
                 # Engine-level ONNXRuntime settings
                 "EngineConfig.onnxruntime.intra_op_num_threads": intra_op_num_threads,
+                "EngineConfig.onnxruntime.use_cuda": use_cuda,
+                "EngineConfig.onnxruntime.cuda_ep_cfg.device_id": gpu_id,
                 # Engine-level OpenVINO settings
                 "EngineConfig.openvino.inference_num_threads": intra_op_num_threads,
                 # "Global.verbose": self.options.print_verbose,

--- a/docs/usage/gpu.md
+++ b/docs/usage/gpu.md
@@ -47,7 +47,47 @@ For a complete example see [gpu_standard_pipeline.py](../examples/gpu_standard_p
 
 The current Docling OCR engines rely on third-party libraries, hence GPU support depends on the availability in the respective engines.
 
-The only setup which is known to work at the moment is RapidOCR with the torch backend, which can be enabled via
+RapidOCR supports GPU acceleration through both its Torch and ONNX Runtime
+backends. The ONNX Runtime backend also supports PP-OCRv5 recognition models
+which are unavailable through the Torch backend, such as `eslav` and
+`cyrillic`.
+
+On Linux and Windows, install the GPU-enabled ONNX Runtime extra:
+
+```sh
+pip install "docling[onnxruntime]"
+```
+
+Before processing documents, verify that ONNX Runtime can load its CUDA
+execution provider:
+
+```python
+import onnxruntime as ort
+
+assert "CUDAExecutionProvider" in ort.get_available_providers()
+```
+
+Then select a CUDA device and configure RapidOCR with the ONNX Runtime backend:
+
+```python
+from docling.datamodel.accelerator_options import (
+    AcceleratorDevice,
+    AcceleratorOptions,
+)
+from docling.datamodel.pipeline_options import PdfPipelineOptions, RapidOcrOptions
+
+pipeline_options = PdfPipelineOptions(
+    accelerator_options=AcceleratorOptions(
+        device=AcceleratorDevice.CUDA,  # or "cuda:N" for a specific GPU
+    ),
+    ocr_options=RapidOcrOptions(
+        backend="onnxruntime",
+        lang=["eslav"],
+    ),
+)
+```
+
+The Torch backend can be enabled instead with:
 
 ```py
 pipeline_options = PdfPipelineOptions()

--- a/tests/test_rapid_ocr_model.py
+++ b/tests/test_rapid_ocr_model.py
@@ -14,7 +14,10 @@ pytestmark = pytest.mark.ml_ocr
 
 
 def _capture_params(
-    monkeypatch: pytest.MonkeyPatch, options: RapidOcrOptions, artifacts_path: Path
+    monkeypatch: pytest.MonkeyPatch,
+    options: RapidOcrOptions,
+    artifacts_path: Path,
+    resolved_device: str = "cpu",
 ) -> dict[str, object]:
     """Build a RapidOcrModel with real rapidocr resolution but faked inference
     and downloading, returning the params dict handed to RapidOCR.
@@ -30,6 +33,10 @@ def _capture_params(
             captured["params"] = params
 
     monkeypatch.setattr(rapidocr, "RapidOCR", FakeRapidOCR)
+    monkeypatch.setattr(
+        "docling.models.stages.ocr.rapid_ocr_model.decide_device",
+        lambda device: resolved_device,
+    )
     monkeypatch.setattr(
         "docling.models.stages.ocr.rapid_ocr_model.download_url_with_progress",
         lambda url, *, progress: BytesIO(b"dummy content"),
@@ -68,16 +75,23 @@ def test_rapidocr_num_threads_propagated_per_engine(
     assert params[engine_key] == 4
 
 
-@pytest.mark.parametrize("backend", ["paddle", "torch"])
+@pytest.mark.parametrize("backend", ["onnxruntime", "paddle", "torch"])
 def test_rapidocr_gpu_device_uses_cuda_ep_cfg_key(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
     backend: str,
 ):
-    params = _capture_params(monkeypatch, RapidOcrOptions(backend=backend), tmp_path)
+    params = _capture_params(
+        monkeypatch,
+        RapidOcrOptions(backend=backend),
+        tmp_path,
+        resolved_device="cuda:2",
+    )
     # The GPU device id must use the engine's real key; the legacy top-level
     # `gpu_id` key is not read by RapidOCR (see #3049 for the torch fix).
     assert f"EngineConfig.{backend}.cuda_ep_cfg.device_id" in params
+    assert params[f"EngineConfig.{backend}.cuda_ep_cfg.device_id"] == 2
+    assert params[f"EngineConfig.{backend}.use_cuda"] is True
     assert f"EngineConfig.{backend}.gpu_id" not in params
 
 


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #4102

This change forwards the CUDA selection to RapidOCR's ONNX Runtime engine configuration:

- sets `EngineConfig.onnxruntime.use_cuda`
- forwards the selected `cuda:N` device through `EngineConfig.onnxruntime.cuda_ep_cfg.device_id`
- extends the existing backend regression test to cover ONNX Runtime and the selected device ID
- documents the ONNX Runtime GPU setup, provider preflight check, and PP-OCRv5 language use case

Without the engine-level settings, RapidOCR 3.9.x leaves its ONNX Runtime CUDA provider disabled even when Docling resolves a CUDA accelerator.

**Validation:**

- `pytest tests/test_rapid_ocr_model.py -q`: 7 passed
- `ruff check`: passed
- `ruff format --check`: passed
- `git diff --check`: passed

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary. (The GPU guide includes the complete configuration snippet.)
- [x] Tests have been added, if necessary.
