### PR TITLE
fix(webvtt): keep cue text in order after a multi-line span

### DIFF
--- a/docling/backend/webvtt_backend.py
+++ b/docling/backend/webvtt_backend.py
@@ -123,7 +123,6 @@ class WebVTTDocumentBackend(DeclarativeDocumentBackend):
             nonlocal cue_text, parents
             if not cue_text:
                 cue_text.append(AnnotatedPar(items=[]))
-            par = cue_text[-1]
             for comp in payload:
                 item: AnnotatedText = (
                     parents[-1].copy_meta("") if parents else AnnotatedText(text="")
@@ -131,7 +130,9 @@ class WebVTTDocumentBackend(DeclarativeDocumentBackend):
                 component: WebVTTCueComponent = comp.component
                 if isinstance(component, WebVTTCueTextSpan):
                     item.text = component.text
-                    par.items.append(item)
+                    # a line terminator inside a nested span starts a new paragraph,
+                    # so the current paragraph is always the last one
+                    cue_text[-1].items.append(item)
                 else:
                     # configure metadata based on span type
                     if isinstance(component, WebVTTCueBoldSpan):
@@ -156,7 +157,6 @@ class WebVTTDocumentBackend(DeclarativeDocumentBackend):
 
                 if comp.terminator is not None:
                     cue_text.append(AnnotatedPar(items=[]))
-                    par = cue_text[-1]
 
         def _add_text_item(
             text: str,

--- a/tests/test_backend_vtt.py
+++ b/tests/test_backend_vtt.py
@@ -261,6 +261,23 @@ outro
     assert _process_vtt_doc(doc) == expected
 
 
+def test_text_after_multiline_span_stays_in_reading_order(converter):
+    # The voice span wraps a line terminator, so "and afterwards" belongs to the
+    # second line, together with "there".
+    vtt = """
+WEBVTT
+
+00:00:01.000 --> 00:00:05.000
+<v Bob>Hello
+there</v> and afterwards
+"""
+    stream = _create_vtt_stream(vtt)
+    doc = converter.convert(stream).document
+
+    assert [item.text for item in doc.texts] == ["Hello", "there", " and afterwards"]
+    assert _process_vtt_doc(doc) == "Hello there  and afterwards"
+
+
 def test_style_blocks_and_note_between_styles_are_ignored(converter):
     vtt = """
 WEBVTT


### PR DESCRIPTION
`WebVTTDocumentBackend` cached the current cue paragraph in a local variable before walking a cue payload. A nested span (voice, bold, italic, underline) that wraps a line terminator starts a new paragraph inside the recursive call, so after returning the caller was still appending to the paragraph it had cached — text following the span landed on the first line of the cue instead of the line it actually appears on.

For

```
00:00:01.000 --> 00:00:05.000
<v Bob>Hello
there</v> and afterwards
```

the cue used to produce `['Hello', ' and afterwards', 'there']`; it now produces `['Hello', 'there', ' and afterwards']`.

The fix appends to `cue_text[-1]` instead of a cached reference, which is by construction the paragraph the terminator handling last opened, at any nesting depth. No existing ground truth changes; the four WebVTT reference documents are unaffected.

**Issue resolved by this Pull Request:**
Resolves #4104

**Checklist:**

- [x] Documentation has been updated, if necessary. (not necessary — no user-facing API change)
- [x] Examples have been added, if necessary. (not necessary)
- [x] Tests have been added, if necessary.

Verified with `uv run pytest tests/test_backend_vtt.py` (12 passed) and `make check` (ruff clean; the `ty` and max-lines findings it reports are pre-existing and untouched by this change). The new test fails on `main` and passes with the fix.

AI disclosure: the patch and test were written with an AI coding agent (Devin) and reviewed and run locally by me.
