### PR TITLE
fix: drop the UTF-8 BOM when decoding webvtt, markdown and asciidoc

### DIFF
--- a/docling/backend/asciidoc_backend.py
+++ b/docling/backend/asciidoc_backend.py
@@ -40,12 +40,15 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
 
         self.path_or_stream = path_or_stream
 
+        # utf-8-sig drops a leading BOM. Kept, it prefixes the first line, so a
+        # document title ("= Title") is no longer recognized as one and the BOM
+        # reaches the output. Equivalent to utf-8 when no BOM is present.
         try:
             if isinstance(self.path_or_stream, BytesIO):
-                text_stream = self.path_or_stream.getvalue().decode("utf-8")
+                text_stream = self.path_or_stream.getvalue().decode("utf-8-sig")
                 self.lines = text_stream.split("\n")
             if isinstance(self.path_or_stream, Path):
-                with open(self.path_or_stream, encoding="utf-8") as f:
+                with open(self.path_or_stream, encoding="utf-8-sig") as f:
                     self.lines = f.readlines()
             self.valid = True
 

--- a/docling/backend/boxnote_backend.py
+++ b/docling/backend/boxnote_backend.py
@@ -53,12 +53,15 @@ class BoxNoteDocumentBackend(DeclarativeDocumentBackend):
         super().__init__(in_doc, path_or_stream)
 
         self.data: dict[str, Any] = {}
+        # utf-8-sig drops a leading BOM. Kept, it reaches json.loads, which
+        # rejects it as an unexpected character and fails the whole load.
+        # Equivalent to utf-8 when no BOM is present.
         try:
             raw = ""
             if isinstance(self.path_or_stream, BytesIO):
-                raw = self.path_or_stream.getvalue().decode("utf-8")
+                raw = self.path_or_stream.getvalue().decode("utf-8-sig")
             elif isinstance(self.path_or_stream, Path):
-                raw = self.path_or_stream.read_text(encoding="utf-8")
+                raw = self.path_or_stream.read_text(encoding="utf-8-sig")
             if raw.strip():
                 loaded = json.loads(raw)
                 if isinstance(loaded, dict):

--- a/docling/backend/json/docling_json_backend.py
+++ b/docling/backend/json/docling_json_backend.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: The Docling Contributors
 # SPDX-License-Identifier: MIT
 
+import codecs
 from io import BytesIO
 from pathlib import Path
 from typing import Union
@@ -40,13 +41,17 @@ class DoclingJSONBackend(DeclarativeDocumentBackend):
         return {InputFormat.JSON_DOCLING}
 
     def _get_doc_or_err(self) -> Union[DoclingDocument, Exception]:
+        # A leading BOM is rejected by model_validate_json as an unexpected
+        # character, failing the whole load. utf-8-sig drops it when decoding,
+        # and is equivalent to utf-8 when no BOM is present; the stream branch
+        # never decodes, so the bytes are stripped directly instead.
         try:
             json_data: Union[str, bytes]
             if isinstance(self.path_or_stream, Path):
-                with open(self.path_or_stream, encoding="utf-8") as f:
+                with open(self.path_or_stream, encoding="utf-8-sig") as f:
                     json_data = f.read()
             elif isinstance(self.path_or_stream, BytesIO):
-                json_data = self.path_or_stream.getvalue()
+                json_data = self.path_or_stream.getvalue().removeprefix(codecs.BOM_UTF8)
             else:
                 raise RuntimeError(f"Unexpected: {type(self.path_or_stream)=}")
             return DoclingDocument.model_validate_json(json_data=json_data)

--- a/docling/backend/md_backend.py
+++ b/docling/backend/md_backend.py
@@ -248,9 +248,12 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
         self._html_blocks: int = 0
         self._image_loader: Optional[ImageResourceLoader] = None
 
+        # utf-8-sig drops a leading BOM. Kept, it prefixes the first line, so a
+        # leading "# Title" is parsed as paragraph text and the BOM reaches the
+        # output. Equivalent to utf-8 when no BOM is present.
         try:
             if isinstance(self.path_or_stream, BytesIO):
-                text_stream = self.path_or_stream.getvalue().decode("utf-8")
+                text_stream = self.path_or_stream.getvalue().decode("utf-8-sig")
                 # remove invalid sequences
                 # very long sequences of underscores will lead to unnecessary long processing times.
                 # In any proper Markdown files, underscores have to be escaped,
@@ -258,7 +261,7 @@ class MarkdownDocumentBackend(DeclarativeDocumentBackend):
                 self.markdown = self._shorten_underscore_sequences(text_stream)
                 self.markdown = self._shorten_leading_dash_sequences(self.markdown)
             if isinstance(self.path_or_stream, Path):
-                with open(self.path_or_stream, encoding="utf-8") as f:
+                with open(self.path_or_stream, encoding="utf-8-sig") as f:
                     md_content = f.read()
                     # remove invalid sequences
                     # very long sequences of underscores will lead to unnecessary long processing times.

--- a/docling/backend/webvtt_backend.py
+++ b/docling/backend/webvtt_backend.py
@@ -68,11 +68,14 @@ class WebVTTDocumentBackend(DeclarativeDocumentBackend):
         super().__init__(in_doc, path_or_stream)
 
         self.content: str = ""
+        # utf-8-sig drops a leading BOM. The WebVTT file body grammar allows an
+        # optional U+FEFF before the "WEBVTT" signature, and keeping it makes
+        # verify_signature() reject the file. Equivalent to utf-8 without a BOM.
         try:
             if isinstance(self.path_or_stream, BytesIO):
-                self.content = self.path_or_stream.getvalue().decode("utf-8")
+                self.content = self.path_or_stream.getvalue().decode("utf-8-sig")
             if isinstance(self.path_or_stream, Path):
-                with open(self.path_or_stream, encoding="utf-8") as f:
+                with open(self.path_or_stream, encoding="utf-8-sig") as f:
                     self.content = f.read()
         except Exception as e:
             raise DocumentLoadError(

--- a/tests/test_backend_asciidoc.py
+++ b/tests/test_backend_asciidoc.py
@@ -150,3 +150,30 @@ def test_asciidocs_examples():
 
         # Verify markdown export
         assert verify_export(pred_md, str(gt_path) + ".md", generate=GEN_TEST_DATA)
+
+
+def test_utf8_bom_does_not_hide_the_document_title(tmp_path):
+    """A leading UTF-8 BOM must not survive into the first line.
+
+    Decoding with plain utf-8 kept it, so "= Title" started with U+FEFF, was no
+    longer recognized as the document title, and the BOM reached the exported
+    text. Both the stream and the file path are covered, since each decodes
+    separately.
+    """
+    adoc_bytes = "\ufeff= Document Title\n\nSome body text.\n".encode()
+
+    in_doc = InputDocument(
+        path_or_stream=BytesIO(adoc_bytes),
+        format=InputFormat.ASCIIDOC,
+        backend=AsciiDocBackend,
+        filename="bom.adoc",
+    )
+    stream_doc = in_doc._backend.convert()
+
+    adoc_file = tmp_path / "bom.adoc"
+    adoc_file.write_bytes(adoc_bytes)
+    file_doc = _get_backend(adoc_file).convert()
+
+    for doc in (stream_doc, file_doc):
+        assert doc.texts[0].label == "title"
+        assert doc.texts[0].text == "Document Title"

--- a/tests/test_backend_boxnote.py
+++ b/tests/test_backend_boxnote.py
@@ -143,3 +143,28 @@ def test_non_string_hyperlink_is_dropped(href):
     doc = get_converter().convert(_boxnote_stream(_linked_paragraph(href))).document
 
     assert doc.texts[0].hyperlink is None
+
+
+def test_utf8_bom_does_not_fail_the_load(tmp_path):
+    """A leading UTF-8 BOM must not survive into the text handed to json.loads.
+
+    Decoding with plain utf-8 kept it, so the document failed to load outright
+    rather than losing a heading. Both the stream and the file path are covered,
+    since each decodes separately.
+    """
+    source = Path("./tests/data/boxnote/sources/sample.boxnote")
+    boxnote_bytes = b"\xef\xbb\xbf" + source.read_bytes()
+    converter = get_converter()
+
+    stream_doc = converter.convert(
+        DocumentStream(name="bom.boxnote", stream=BytesIO(boxnote_bytes)),
+        raises_on_error=True,
+    ).document
+
+    boxnote_file = tmp_path / "bom.boxnote"
+    boxnote_file.write_bytes(boxnote_bytes)
+    file_doc = converter.convert(boxnote_file, raises_on_error=True).document
+
+    expected = converter.convert(source, raises_on_error=True).document
+    for doc in (stream_doc, file_doc):
+        assert doc.export_to_markdown() == expected.export_to_markdown()

--- a/tests/test_backend_docling_json.py
+++ b/tests/test_backend_docling_json.py
@@ -60,3 +60,29 @@ def test_invalid_docling_json():
 
     with pytest.raises(ValidationError):
         backend.convert()
+
+
+def test_utf8_bom_does_not_fail_the_load(tmp_path):
+    """A leading UTF-8 BOM must not reach model_validate_json.
+
+    It is rejected as an unexpected character, so the document failed to load
+    outright. The path branch decodes and the stream branch hands raw bytes
+    over, so both are covered.
+    """
+    json_bytes = b"\xef\xbb\xbf" + GT_PATH.read_bytes()
+    exp_data = DoclingDocument.load_from_json(GT_PATH).export_to_dict()
+
+    json_file = tmp_path / "bom.json"
+    json_file.write_bytes(json_bytes)
+
+    for path_or_stream in (json_file, BytesIO(json_bytes)):
+        in_doc = InputDocument(
+            path_or_stream=path_or_stream,
+            format=InputFormat.JSON_DOCLING,
+            backend=DoclingJSONBackend,
+            filename="bom.json",
+        )
+        backend = DoclingJSONBackend(in_doc=in_doc, path_or_stream=path_or_stream)
+
+        assert backend.is_valid()
+        assert backend.convert().export_to_dict() == exp_data

--- a/tests/test_backend_markdown.py
+++ b/tests/test_backend_markdown.py
@@ -11,7 +11,7 @@ from PIL import Image
 
 from docling.backend.md_backend import MarkdownDocumentBackend
 from docling.datamodel.backend_options import MarkdownBackendOptions
-from docling.datamodel.base_models import ConversionStatus, InputFormat
+from docling.datamodel.base_models import ConversionStatus, DocumentStream, InputFormat
 from docling.datamodel.document import (
     ConversionResult,
     DoclingDocument,
@@ -482,3 +482,29 @@ def test_convert_table_rows_match_header_cell_count():
         table_data = conv_result.document.tables[0].data
         assert [cell.text for cell in table_data.table_cells] == expected
         assert len(table_data.table_cells) == table_data.num_rows * table_data.num_cols
+
+
+def test_utf8_bom_does_not_hide_the_first_heading(tmp_path):
+    """A leading UTF-8 BOM must not survive into the first line.
+
+    Decoding with plain utf-8 kept it, so "# Title" started with U+FEFF, marko
+    parsed the line as a paragraph instead of a heading, and the BOM reached the
+    exported text. Both the stream and the file path are covered, since each
+    decodes separately.
+    """
+    md_bytes = "\ufeff# Title\n\nSome body text.\n".encode()
+    converter = get_converter()
+
+    stream_doc = converter.convert(
+        DocumentStream(name="bom.md", stream=BytesIO(md_bytes)),
+        raises_on_error=True,
+    ).document
+
+    md_file = tmp_path / "bom.md"
+    md_file.write_bytes(md_bytes)
+    file_doc = converter.convert(md_file, raises_on_error=True).document
+
+    for doc in (stream_doc, file_doc):
+        assert doc.texts[0].label == "title"
+        assert doc.texts[0].text == "Title"
+        assert doc.texts[1].text == "Some body text."

--- a/tests/test_backend_vtt.py
+++ b/tests/test_backend_vtt.py
@@ -293,3 +293,25 @@ Hello <b>world</b>.
     # TODO: temporary ground truth (issue docling-project/docling-core/#371)
     expected = "Hello  world ."
     assert _process_vtt_doc(doc) == expected
+
+
+def test_utf8_bom_does_not_invalidate_the_signature(converter, tmp_path):
+    """The WebVTT file body grammar allows an optional U+FEFF before "WEBVTT".
+
+    Decoding with plain utf-8 kept it, so verify_signature() no longer saw the
+    signature at position 0 and the whole file was rejected as invalid. Both the
+    stream and the file path are covered, since each decodes separately.
+    """
+    vtt_bytes = (
+        "\ufeffWEBVTT\n\n00:00:01.000 --> 00:00:05.000\nHello there\n"
+    ).encode()
+
+    stream = DocumentStream(name="bom.vtt", stream=BytesIO(vtt_bytes))
+    stream_doc = converter.convert(stream, raises_on_error=True).document
+
+    vtt_file = tmp_path / "bom.vtt"
+    vtt_file.write_bytes(vtt_bytes)
+    file_doc = converter.convert(vtt_file, raises_on_error=True).document
+
+    for doc in (stream_doc, file_doc):
+        assert _process_vtt_doc(doc) == "Hello there"


### PR DESCRIPTION
The webvtt, markdown and asciidoc backends decoded their input as plain `utf-8`, so a leading
UTF-8 BOM stayed in the first line. This decodes `utf-8-sig` instead, in both the `BytesIO` and
the `Path` branch of each backend. `utf-8-sig` is identical to `utf-8` when no BOM is present, and
it is what #4098 already did for csv.

WebVTT failed outright: the file body grammar in https://www.w3.org/TR/webvtt1 allows an optional
U+FEFF before the `WEBVTT` string, but `verify_signature()` requires the content to start with
`WEBVTT`, so `is_valid()` was False. Markdown and asciidoc failed silently: `\ufeff# Title` and
`\ufeff= Title` are not headings, so the document title was demoted to body text and the BOM
reached the exported output. `InputFormat.MD` also covers `.txt`/`.qmd`/`.rmd`.

Before, on `main` at 2.123.1:

```
sample.vtt   no BOM  [('TextItem', 'Hello there')]
sample.vtt   BOM     ConversionError: Conversion failed for: sample.vtt with status: failure. Errors: The document backend could not parse the input.
sample.md    no BOM  [('TitleItem', 'Title'), ('TextItem', 'Some body text.')]
sample.md    BOM     [('TextItem', '\ufeff# Title'), ('TextItem', 'Some body text.')]
sample.adoc  no BOM  [('TitleItem', 'Document Title'), ('TextItem', 'Some body text.')]
sample.adoc  BOM     [('TextItem', '\ufeff= Document Title'), ('TextItem', 'Some body text.')]
```

After, same script:

```
sample.vtt   no BOM  [('TextItem', 'Hello there')]
sample.vtt   BOM     [('TextItem', 'Hello there')]
sample.md    no BOM  [('TitleItem', 'Title'), ('TextItem', 'Some body text.')]
sample.md    BOM     [('TitleItem', 'Title'), ('TextItem', 'Some body text.')]
sample.adoc  no BOM  [('TitleItem', 'Document Title'), ('TextItem', 'Some body text.')]
sample.adoc  BOM     [('TitleItem', 'Document Title'), ('TextItem', 'Some body text.')]
```

One regression test per backend, each covering the stream and the file-path branch, and each built
in memory or under `tmp_path` so nothing lands in `tests/data`. Reverting only the three backend
files makes all three fail:

```
FAILED tests/test_backend_vtt.py::test_utf8_bom_does_not_invalidate_the_signature
FAILED tests/test_backend_markdown.py::test_utf8_bom_does_not_hide_the_first_heading
FAILED tests/test_backend_asciidoc.py::test_utf8_bom_does_not_hide_the_document_title
```

Across `test_backend_{vtt,markdown,asciidoc,csv,html,epub,boxnote,doclang,docling_json,email}.py`,
`test_input_doc.py` and `test_invalid_input.py`: 152 passed, 1 skipped, 4 warnings before,
155 passed, 1 skipped, 4 warnings after. `make validate` passes on the changeset. No groundtruth
files changed.

Scope: html and latex are unaffected, and the docling-json and boxnote backends do reject a
BOM-prefixed file, but that only happens for JSON written by something other than docling, so I
left them out rather than widen this.

**Issue resolved by this Pull Request:**
Resolves #4108

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
