### PR TITLE
feat: preserve layout reading order for container children

### DIFF
--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -343,6 +343,9 @@ class Cluster(BaseModel):
     confidence: float = 1.0
     cells: list[TextCell] = []
     children: list["Cluster"] = []  # Add child cluster support
+    reading_order: list[int] = Field(
+        default_factory=list
+    )  # List of child cluster IDs in reading order
 
     @field_serializer("confidence")
     def _serialize(self, value: float, info: FieldSerializationInfo) -> float:

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -721,14 +721,37 @@ class ReadingOrderModel:
                     element
                 )
 
-            ordered_siblings = {
-                parent_ref: (
-                    self.ro_model.predict_reading_order(page_elements=siblings)
-                    if len(siblings) > 1
-                    else siblings
-                )
-                for parent_ref, siblings in siblings_by_parent.items()
-            }
+            ordered_siblings = {}
+
+            for parent_ref, siblings in siblings_by_parent.items():
+                if len(siblings) <= 1:
+                    ordered_siblings[parent_ref] = siblings
+                    continue
+
+                parent_element = assembled_by_ref.get(parent_ref)
+
+                if (
+                    isinstance(parent_element, ContainerElement)
+                    and parent_element.cluster.reading_order
+                ):
+                    order = {
+                        cluster_id: index
+                        for index, cluster_id in enumerate(
+                            parent_element.cluster.reading_order
+                        )
+                    }
+
+                    ordered_siblings[parent_ref] = sorted(
+                        siblings,
+                        key=lambda element: order.get(
+                            element.cid,
+                            len(order),
+                        ),
+                    )
+                else:
+                    ordered_siblings[parent_ref] = self.ro_model.predict_reading_order(
+                        page_elements=siblings
+                    )
 
             def iterate_leaves(
                 parent_ref: str | None,

--- a/tests/test_readingorder_container_children.py
+++ b/tests/test_readingorder_container_children.py
@@ -229,12 +229,12 @@ def test_container_does_not_interrupt_caption_assignment(
     assert len([text for text in doc.texts if text.label == DocItemLabel.CAPTION]) == 1
 
 
-def test_container_children_follow_predicted_reading_order() -> None:
+def test_container_children_follow_explicit_reading_order() -> None:
     container_cluster = _cluster(1, DocItemLabel.FORM, (0, 0, 300, 300))
     lower_cluster = _cluster(2, DocItemLabel.PICTURE, (10, 200, 100, 250))
     upper_cluster = _cluster(3, DocItemLabel.PICTURE, (10, 10, 100, 60))
     container_cluster.children = [lower_cluster, upper_cluster]
-
+    container_cluster.reading_order = [3, 2]
     container = ContainerElement(
         label=DocItemLabel.FORM,
         id=1,


### PR DESCRIPTION
## Description

Preserves the reading order of container children provided by the layout stage.

When a container has an explicit `reading_order`, its children are now ordered according to those cluster IDs instead of being re-predicted by the reading-order model. Containers without an explicit reading order continue to use the existing prediction behavior.

## Testing

- `pytest -q tests/test_readingorder_container_children.py` — 13 passed
- `pytest -q tests/test_readingorder_container_children.py tests/test_layout_postprocessor.py::test_container_direct_text_remains_available_for_reading_order` — 14 passed
- `git diff --check` — passed


**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
