### PR TITLE
fix(uspto): accept CRLF patent headers

### DIFF
--- a/docling/backend/xml/uspto_backend.py
+++ b/docling/backend/xml/uspto_backend.py
@@ -123,13 +123,16 @@ class PatentUsptoDocumentBackend(DeclarativeDocumentBackend):
         try:
             if isinstance(self.path_or_stream, BytesIO):
                 while line := self.path_or_stream.readline().decode("utf-8"):
-                    if line.startswith("<!DOCTYPE") or line == "PATN\n":
+                    if line.startswith("<!DOCTYPE") or line.rstrip("\r\n") == "PATN":
                         self._set_parser(line)
                     self.patent_content += line
             elif isinstance(self.path_or_stream, Path):
                 with open(self.path_or_stream, encoding="utf-8") as file_obj:
                     while line := file_obj.readline():
-                        if line.startswith("<!DOCTYPE") or line == "PATN\n":
+                        if (
+                            line.startswith("<!DOCTYPE")
+                            or line.rstrip("\r\n") == "PATN"
+                        ):
                             self._set_parser(line)
                         self.patent_content += line
         except Exception as exc:
@@ -138,8 +141,8 @@ class PatentUsptoDocumentBackend(DeclarativeDocumentBackend):
             ) from exc
 
     def _set_parser(self, doctype: str) -> None:
-        doctype_line = doctype.lower()
-        if doctype == "PATN\n":
+        doctype_line = doctype.rstrip("\r\n").lower()
+        if doctype_line == "patn":
             self.parser = PatentUsptoGrantAps()
         elif "us-patent-application-v4" in doctype_line:
             self.parser = PatentUsptoIce()

--- a/docling/backend/xml/uspto_backend.py
+++ b/docling/backend/xml/uspto_backend.py
@@ -129,10 +129,7 @@ class PatentUsptoDocumentBackend(DeclarativeDocumentBackend):
             elif isinstance(self.path_or_stream, Path):
                 with open(self.path_or_stream, encoding="utf-8") as file_obj:
                     while line := file_obj.readline():
-                        if (
-                            line.startswith("<!DOCTYPE")
-                            or line.rstrip("\r\n") == "PATN"
-                        ):
+                        if line.startswith("<!DOCTYPE") or line == "PATN\n":
                             self._set_parser(line)
                         self.patent_content += line
         except Exception as exc:

--- a/tests/test_backend_patent_uspto.py
+++ b/tests/test_backend_patent_uspto.py
@@ -5,6 +5,7 @@
 
 import logging
 import os
+from io import BytesIO
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
@@ -13,8 +14,9 @@ from docling_core.types import DoclingDocument
 from docling_core.types.doc import DocItemLabel, TableData, TextItem
 
 from docling.backend.xml.uspto_backend import PatentUsptoDocumentBackend, XmlTable
-from docling.datamodel.base_models import InputFormat
+from docling.datamodel.base_models import ConversionStatus, InputFormat
 from docling.datamodel.document import InputDocument
+from docling.document_converter import DocumentConverter
 
 from .test_data_gen_flag import GEN_TEST_DATA
 from .verify_utils import CONFID_PREC, COORD_PREC, verify_document
@@ -22,6 +24,38 @@ from .verify_utils import CONFID_PREC, COORD_PREC, verify_document
 GENERATE: bool = GEN_TEST_DATA
 DATA_PATH: Path = Path("./tests/data/uspto/sources/")
 GT_PATH: Path = Path("./tests/data/uspto/groundtruth/")
+
+
+@pytest.mark.parametrize("line_ending", [b"\n", b"\r\n"])
+def test_patent_uspto_grant_aps_accepts_common_line_endings(
+    tmp_path: Path,
+    line_ending: bytes,
+) -> None:
+    source = DATA_PATH / "pftaps057006474.txt"
+    content = line_ending.join(source.read_bytes().splitlines()) + line_ending
+    path = tmp_path / "pftaps057006474.txt"
+    path.write_bytes(content)
+
+    result = DocumentConverter(allowed_formats=[InputFormat.XML_USPTO]).convert(path)
+
+    in_doc = InputDocument(
+        path_or_stream=path,
+        format=InputFormat.XML_USPTO,
+        backend=PatentUsptoDocumentBackend,
+    )
+    stream_backend = PatentUsptoDocumentBackend(
+        in_doc=in_doc,
+        path_or_stream=BytesIO(content),
+    )
+    stream_document = stream_backend.convert()
+
+    assert result.status == ConversionStatus.SUCCESS
+    assert result.input.format == InputFormat.XML_USPTO
+    assert len(result.document.texts) == 75
+    assert result.document.texts[0].text == "Carbocation containing cyanine-type dye"
+    assert stream_backend.is_valid()
+    assert len(stream_document.texts) == 75
+    assert stream_document.texts[0].text == "Carbocation containing cyanine-type dye"
 
 
 def _generate_groundtruth(doc: DoclingDocument, file_stem: str) -> None:

--- a/tests/test_backend_patent_uspto.py
+++ b/tests/test_backend_patent_uspto.py
@@ -14,9 +14,8 @@ from docling_core.types import DoclingDocument
 from docling_core.types.doc import DocItemLabel, TableData, TextItem
 
 from docling.backend.xml.uspto_backend import PatentUsptoDocumentBackend, XmlTable
-from docling.datamodel.base_models import ConversionStatus, InputFormat
+from docling.datamodel.base_models import InputFormat
 from docling.datamodel.document import InputDocument
-from docling.document_converter import DocumentConverter
 
 from .test_data_gen_flag import GEN_TEST_DATA
 from .verify_utils import CONFID_PREC, COORD_PREC, verify_document
@@ -26,17 +25,11 @@ DATA_PATH: Path = Path("./tests/data/uspto/sources/")
 GT_PATH: Path = Path("./tests/data/uspto/groundtruth/")
 
 
-@pytest.mark.parametrize("line_ending", [b"\n", b"\r\n"])
-def test_patent_uspto_grant_aps_accepts_common_line_endings(
-    tmp_path: Path,
-    line_ending: bytes,
-) -> None:
+def test_patent_uspto_grant_aps_accepts_crlf_bytesio(tmp_path: Path) -> None:
     source = DATA_PATH / "pftaps057006474.txt"
-    content = line_ending.join(source.read_bytes().splitlines()) + line_ending
+    content = b"\r\n".join(source.read_bytes().splitlines()) + b"\r\n"
     path = tmp_path / "pftaps057006474.txt"
     path.write_bytes(content)
-
-    result = DocumentConverter(allowed_formats=[InputFormat.XML_USPTO]).convert(path)
 
     in_doc = InputDocument(
         path_or_stream=path,
@@ -47,13 +40,10 @@ def test_patent_uspto_grant_aps_accepts_common_line_endings(
         in_doc=in_doc,
         path_or_stream=BytesIO(content),
     )
-    stream_document = stream_backend.convert()
 
-    assert result.status == ConversionStatus.SUCCESS
-    assert result.input.format == InputFormat.XML_USPTO
-    assert len(result.document.texts) == 75
-    assert result.document.texts[0].text == "Carbocation containing cyanine-type dye"
     assert stream_backend.is_valid()
+
+    stream_document = stream_backend.convert()
     assert len(stream_document.texts) == 75
     assert stream_document.texts[0].text == "Carbocation containing cyanine-type dye"
 


### PR DESCRIPTION
Accept CRLF PATN headers when the USPTO backend reads from BytesIO. Normalize the raw header before selecting the APS parser and add a focused regression using the real APS fixture.