### PR TITLE
fix: silence transformers generation-config deprecation warning and add max_new_tokens CLI overrides

### DIFF
--- a/docling/cli/main.py
+++ b/docling/cli/main.py
@@ -795,6 +795,13 @@ def convert(  # noqa: C901
             help=f"Choose the VLM preset to use with PDF or image files. Available presets: {', '.join(vlm_preset_ids)}",
         ),
     ] = "granite_docling",
+    vlm_max_new_tokens: Annotated[
+        int | None,
+        typer.Option(
+            "--vlm-max-new-tokens",
+            help="Override max_new_tokens for VLM conversion generation.",
+        ),
+    ] = None,
     asr_model: Annotated[
         AsrModelType,
         typer.Option(..., help="Choose the ASR model to use with audio/video files."),
@@ -941,6 +948,13 @@ def convert(  # noqa: C901
         bool,
         typer.Option(..., help="Enable the picture description model in the pipeline."),
     ] = False,
+    picture_description_max_new_tokens: Annotated[
+        int | None,
+        typer.Option(
+            "--picture-description-max-new-tokens",
+            help="Override max_new_tokens for picture description generation.",
+        ),
+    ] = None,
     enrich_chart_extraction: Annotated[
         bool,
         typer.Option(
@@ -1318,6 +1332,10 @@ def convert(  # noqa: C901
             ):
                 pipeline_options.table_structure_options.do_cell_matching = True
                 pipeline_options.table_structure_options.mode = table_mode
+            if picture_description_max_new_tokens is not None:
+                pipeline_options.picture_description_options.generation_config[
+                    "max_new_tokens"
+                ] = picture_description_max_new_tokens
 
             if _should_generate_export_images(
                 image_export_mode,
@@ -1347,6 +1365,10 @@ def convert(  # noqa: C901
             )
             if artifacts_path is not None:
                 simple_format_option.artifacts_path = artifacts_path
+            if picture_description_max_new_tokens is not None:
+                simple_format_option.picture_description_options.generation_config[
+                    "max_new_tokens"
+                ] = picture_description_max_new_tokens
 
             html_backend_options: HTMLBackendOptions | None = None
             if (
@@ -1429,6 +1451,10 @@ def convert(  # noqa: C901
             # Use the new preset system
             try:
                 pipeline_options.vlm_options = VlmConvertOptions.from_preset(vlm_model)
+                if vlm_max_new_tokens is not None:
+                    pipeline_options.vlm_options.model_spec.max_new_tokens = (
+                        vlm_max_new_tokens
+                    )
                 _log.info(f"Using VLM preset: {vlm_model}")
             except KeyError:
                 err_console.print(

--- a/docling/models/extraction/nuextract_transformers_model.py
+++ b/docling/models/extraction/nuextract_transformers_model.py
@@ -18,6 +18,7 @@ from docling.datamodel.accelerator_options import (
 from docling.datamodel.base_models import VlmPrediction, VlmStopReason
 from docling.datamodel.pipeline_options_vlm_model import InlineVlmOptions
 from docling.models.base_model import BaseVlmModel
+from docling.models.utils.generation_utils import build_generation_config
 from docling.models.utils.hf_model_download import (
     HuggingFaceModelDownloadMixin,
 )
@@ -259,17 +260,19 @@ class NuExtractTransformersModel(BaseVlmModel, HuggingFaceModelDownloadMixin):
         processor_inputs = {k: v.to(self.device) for k, v in processor_inputs.items()}
 
         # Generate
+        generation_config = build_generation_config(
+            self.generation_config,
+            overrides=self.vlm_options.extra_generation_config,
+            max_new_tokens=self.max_new_tokens,
+            do_sample=self.temperature > 0,
+            temperature=self.temperature if self.temperature > 0 else None,
+            pad_token_id=getattr(self.processor.tokenizer, "pad_token_id", None),
+            eos_token_id=getattr(self.processor.tokenizer, "eos_token_id", None),
+        )
         gen_kwargs = {
             **processor_inputs,
-            "max_new_tokens": self.max_new_tokens,
-            "generation_config": self.generation_config,
-            **self.vlm_options.extra_generation_config,
+            "generation_config": generation_config,
         }
-        if self.temperature > 0:
-            gen_kwargs["do_sample"] = True
-            gen_kwargs["temperature"] = self.temperature
-        else:
-            gen_kwargs["do_sample"] = False
 
         start_time = time.time()
         with torch.inference_mode():

--- a/docling/models/extraction/transformers_extraction_model.py
+++ b/docling/models/extraction/transformers_extraction_model.py
@@ -23,6 +23,7 @@ from docling.models.extraction.prompt_utils import (
     build_granite_vision_inputs,
     build_nuextract_inputs,
 )
+from docling.models.utils.generation_utils import build_generation_config
 from docling.models.utils.hf_model_download import HuggingFaceModelDownloadMixin
 from docling.utils.accelerator_utils import decide_device
 
@@ -167,21 +168,21 @@ class TransformersExtractionModel(BaseVlmModel, HuggingFaceModelDownloadMixin):
             )
 
         # Generate
+        tokenizer = getattr(self.processor, "tokenizer", None)
+        generation_config = build_generation_config(
+            self.generation_config,
+            overrides=self.vlm_options.extra_generation_config,
+            max_new_tokens=self.max_new_tokens,
+            use_cache=True,
+            do_sample=self.temperature > 0,
+            temperature=self.temperature if self.temperature > 0 else None,
+            pad_token_id=getattr(tokenizer, "pad_token_id", None),
+            eos_token_id=getattr(tokenizer, "eos_token_id", None),
+        )
         gen_kwargs: dict[str, Any] = {
             **processor_inputs,
-            "max_new_tokens": self.max_new_tokens,
+            "generation_config": generation_config,
         }
-        if self.generation_config is not None:
-            gen_kwargs["generation_config"] = self.generation_config
-            gen_kwargs.update(self.vlm_options.extra_generation_config)
-        else:
-            gen_kwargs["use_cache"] = True
-
-        if self.temperature > 0:
-            gen_kwargs["do_sample"] = True
-            gen_kwargs["temperature"] = self.temperature
-        else:
-            gen_kwargs["do_sample"] = False
 
         start_time = time.time()
         with torch.inference_mode():

--- a/docling/models/inference_engines/vlm/transformers_engine.py
+++ b/docling/models/inference_engines/vlm/transformers_engine.py
@@ -42,7 +42,10 @@ from docling.models.inference_engines.vlm.base import (
     VlmEngineInput,
     VlmEngineOutput,
 )
-from docling.models.utils.generation_utils import GenerationStopper
+from docling.models.utils.generation_utils import (
+    GenerationStopper,
+    build_generation_config,
+)
 from docling.models.utils.hf_model_download import HuggingFaceModelDownloadMixin
 from docling.models.utils.hf_stopping_criteria import HFStoppingCriteriaWrapper
 from docling.utils.accelerator_utils import decide_device
@@ -444,19 +447,22 @@ class TransformersVlmEngine(BaseVlmEngine, HuggingFaceModelDownloadMixin):
         }
 
         # Generate
+        merged_generation_config = build_generation_config(
+            self.generation_config,
+            overrides=generation_config,
+            max_new_tokens=first_input.max_new_tokens,
+            use_cache=self.options.use_kv_cache,
+            do_sample=first_input.temperature > 0,
+            temperature=(
+                first_input.temperature if first_input.temperature > 0 else None
+            ),
+            pad_token_id=getattr(tokenizer, "pad_token_id", None),
+            eos_token_id=getattr(tokenizer, "eos_token_id", None),
+        )
         gen_kwargs = {
             **inputs,
-            "max_new_tokens": first_input.max_new_tokens,
-            "use_cache": self.options.use_kv_cache,
-            "generation_config": self.generation_config,
-            **generation_config,
+            "generation_config": merged_generation_config,
         }
-
-        if first_input.temperature > 0:
-            gen_kwargs["do_sample"] = True
-            gen_kwargs["temperature"] = first_input.temperature
-        else:
-            gen_kwargs["do_sample"] = False
 
         if stopping_criteria_list:
             gen_kwargs["stopping_criteria"] = stopping_criteria_list

--- a/docling/models/stages/picture_description/picture_description_vlm_model.py
+++ b/docling/models/stages/picture_description/picture_description_vlm_model.py
@@ -15,6 +15,7 @@ from docling.datamodel.pipeline_options import (
     PictureDescriptionVlmOptions,
 )
 from docling.models.picture_description_base_model import PictureDescriptionBaseModel
+from docling.models.utils.generation_utils import build_generation_config
 from docling.models.utils.hf_model_download import (
     HuggingFaceModelDownloadMixin,
 )
@@ -122,9 +123,15 @@ class PictureDescriptionVlmModel(
 
         from typing import Any, cast
 
+        tokenizer = getattr(self.processor, "tokenizer", None)
+        generation_config = build_generation_config(
+            GenerationConfig(**self.options.generation_config),
+            pad_token_id=getattr(tokenizer, "pad_token_id", None),
+            eos_token_id=getattr(tokenizer, "eos_token_id", None),
+        )
         generated_ids = cast(Any, self.model).generate(
             **inputs,
-            generation_config=GenerationConfig(**self.options.generation_config),
+            generation_config=generation_config,
         )
         generated_texts = self.processor.batch_decode(
             generated_ids[:, inputs["input_ids"].shape[1] :],

--- a/docling/models/utils/generation_utils.py
+++ b/docling/models/utils/generation_utils.py
@@ -6,7 +6,11 @@ import logging
 import re
 import sys
 from abc import abstractmethod
-from typing import List
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any, List
+
+if TYPE_CHECKING:
+    from transformers import GenerationConfig
 
 _log = logging.getLogger(__name__)
 
@@ -24,6 +28,41 @@ class GenerationStopper:
 
     def lookback_tokens(self) -> int:
         return sys.maxsize
+
+
+def build_generation_config(
+    base_config: "GenerationConfig | None",
+    *,
+    overrides: dict[str, Any] | None = None,
+    max_new_tokens: int | None = None,
+    use_cache: bool | None = None,
+    do_sample: bool | None = None,
+    temperature: float | None = None,
+    pad_token_id: int | list[int] | None = None,
+    eos_token_id: int | list[int] | None = None,
+) -> "GenerationConfig":
+    from transformers import GenerationConfig
+
+    config = deepcopy(base_config) if base_config is not None else GenerationConfig()
+
+    if overrides is not None:
+        for key, value in overrides.items():
+            setattr(config, key, value)
+
+    if max_new_tokens is not None:
+        config.max_new_tokens = max_new_tokens
+    if use_cache is not None:
+        config.use_cache = use_cache
+    if do_sample is not None:
+        config.do_sample = do_sample
+    if temperature is not None:
+        config.temperature = temperature
+    if pad_token_id is not None:
+        config.pad_token_id = pad_token_id
+    elif config.pad_token_id is None and eos_token_id is not None:
+        config.pad_token_id = eos_token_id
+
+    return config
 
 
 class DocTagsRepetitionStopper(GenerationStopper):

--- a/docling/models/utils/generation_utils.py
+++ b/docling/models/utils/generation_utils.py
@@ -45,22 +45,34 @@ def build_generation_config(
 
     config = deepcopy(base_config) if base_config is not None else GenerationConfig()
 
-    if overrides is not None:
-        for key, value in overrides.items():
-            setattr(config, key, value)
-
+    # Model-level defaults, kept at the lowest precedence so caller overrides
+    # still win over them -- matching the previous behavior where these were
+    # spread as loose generate() kwargs *before* extra_generation_config.
     if max_new_tokens is not None:
         config.max_new_tokens = max_new_tokens
     if use_cache is not None:
         config.use_cache = use_cache
-    if do_sample is not None:
-        config.do_sample = do_sample
-    if temperature is not None:
-        config.temperature = temperature
+
+    # Default pad_token_id to the tokenizer's, falling back to eos_token_id, to
+    # silence the transformers pad_token_id warning. This only fills a gap, so a
+    # caller override below can still replace it.
     if pad_token_id is not None:
         config.pad_token_id = pad_token_id
     elif config.pad_token_id is None and eos_token_id is not None:
         config.pad_token_id = eos_token_id
+
+    # Caller overrides (e.g. vlm_options.extra_generation_config) win over the
+    # model defaults above. update() validates and preserves custom entries such
+    # as num_logits_to_keep, unlike a raw setattr loop.
+    if overrides:
+        config.update(allow_custom_entries=True, **overrides)
+
+    # The explicit sampling decision has the final say, matching the old ordering
+    # where do_sample/temperature were set after the override spread.
+    if do_sample is not None:
+        config.do_sample = do_sample
+    if temperature is not None:
+        config.temperature = temperature
 
     return config
 

--- a/docling/models/vlm_pipeline_models/hf_transformers_model.py
+++ b/docling/models/vlm_pipeline_models/hf_transformers_model.py
@@ -26,7 +26,10 @@ from docling.datamodel.pipeline_options_vlm_model import (
     TransformersPromptStyle,
 )
 from docling.models.base_model import BaseVlmPageModel
-from docling.models.utils.generation_utils import GenerationStopper
+from docling.models.utils.generation_utils import (
+    GenerationStopper,
+    build_generation_config,
+)
 from docling.models.utils.hf_model_download import (
     HuggingFaceModelDownloadMixin,
 )
@@ -370,18 +373,20 @@ class HuggingFaceTransformersVlmModel(BaseVlmPageModel, HuggingFaceModelDownload
         }
 
         # -- Generate (Image-Text-to-Text class expects these inputs from processor)
+        generation_config = build_generation_config(
+            self.generation_config,
+            overrides=generation_config,
+            max_new_tokens=self.max_new_tokens,
+            use_cache=self.use_cache,
+            do_sample=self.temperature > 0,
+            temperature=self.temperature if self.temperature > 0 else None,
+            pad_token_id=getattr(self.processor.tokenizer, "pad_token_id", None),
+            eos_token_id=getattr(self.processor.tokenizer, "eos_token_id", None),
+        )
         gen_kwargs = {
             **inputs,
-            "max_new_tokens": self.max_new_tokens,
-            "use_cache": self.use_cache,
-            "generation_config": self.generation_config,
-            **generation_config,
+            "generation_config": generation_config,
         }
-        if self.temperature > 0:
-            gen_kwargs["do_sample"] = True
-            gen_kwargs["temperature"] = self.temperature
-        else:
-            gen_kwargs["do_sample"] = False
 
         if stopping_criteria is not None:
             gen_kwargs["stopping_criteria"] = stopping_criteria

--- a/tests/test_build_generation_config.py
+++ b/tests/test_build_generation_config.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+from transformers import GenerationConfig
+
+from docling.models.utils.generation_utils import build_generation_config
+
+
+def test_overrides_win_over_model_defaults() -> None:
+    # extra_generation_config must override the model-level max_new_tokens,
+    # matching the pre-refactor loose-kwarg ordering.
+    config = build_generation_config(
+        GenerationConfig(max_new_tokens=10),
+        overrides={"max_new_tokens": 999, "num_logits_to_keep": 0},
+        max_new_tokens=17,
+    )
+    assert config.max_new_tokens == 999
+    assert config.num_logits_to_keep == 0  # custom entry preserved, not dropped
+
+
+def test_explicit_sampling_wins_over_overrides() -> None:
+    config = build_generation_config(
+        GenerationConfig(),
+        overrides={"do_sample": True, "temperature": 5.0},
+        do_sample=False,
+    )
+    assert config.do_sample is False
+
+
+def test_pad_token_falls_back_to_eos_only_when_unset() -> None:
+    config = build_generation_config(GenerationConfig(), eos_token_id=123)
+    assert config.pad_token_id == 123
+
+    config = build_generation_config(
+        GenerationConfig(), pad_token_id=7, eos_token_id=123
+    )
+    assert config.pad_token_id == 7

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -206,6 +206,111 @@ def test_cli_from_odf_expands_to_open_document_formats(
     ]
 
 
+def test_cli_picture_description_max_new_tokens(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured_pdf_option: PdfFormatOption | None = None
+
+    class _FakeDocumentConverter:
+        def __init__(
+            self,
+            *,
+            allowed_formats: list[InputFormat],
+            format_options: dict[InputFormat, PdfFormatOption],
+        ) -> None:
+            nonlocal captured_pdf_option
+            captured_pdf_option = format_options[InputFormat.PDF]
+
+        def convert_all(
+            self,
+            input_doc_paths: list[Path],
+            headers: dict[str, str] | None = None,
+            raises_on_error: bool = False,
+            page_range: PageRange = DEFAULT_PAGE_RANGE,
+        ) -> list[Any]:
+            assert input_doc_paths
+            return []
+
+    monkeypatch.setattr(
+        "docling.document_converter.DocumentConverter", _FakeDocumentConverter
+    )
+
+    source = "./tests/data/pdf/sources/2305.03393v1-pg9.pdf"
+    output = tmp_path / "out"
+    result = runner.invoke(
+        app,
+        [
+            source,
+            "--output",
+            str(output),
+            "--enrich-picture-description",
+            "--picture-description-max-new-tokens",
+            "321",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured_pdf_option is not None
+    assert (
+        captured_pdf_option.pipeline_options.picture_description_options.generation_config[
+            "max_new_tokens"
+        ]
+        == 321
+    )
+
+
+def test_cli_vlm_max_new_tokens(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured_pdf_option: PdfFormatOption | None = None
+
+    class _FakeDocumentConverter:
+        def __init__(
+            self,
+            *,
+            allowed_formats: list[InputFormat],
+            format_options: dict[InputFormat, PdfFormatOption],
+        ) -> None:
+            nonlocal captured_pdf_option
+            captured_pdf_option = format_options[InputFormat.PDF]
+
+        def convert_all(
+            self,
+            input_doc_paths: list[Path],
+            headers: dict[str, str] | None = None,
+            raises_on_error: bool = False,
+            page_range: PageRange = DEFAULT_PAGE_RANGE,
+        ) -> list[Any]:
+            assert input_doc_paths
+            return []
+
+    monkeypatch.setattr(
+        "docling.document_converter.DocumentConverter", _FakeDocumentConverter
+    )
+
+    source = "./tests/data/pdf/sources/2305.03393v1-pg9.pdf"
+    output = tmp_path / "out"
+    result = runner.invoke(
+        app,
+        [
+            source,
+            "--pipeline",
+            "vlm",
+            "--output",
+            str(output),
+            "--vlm-max-new-tokens",
+            "321",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert captured_pdf_option is not None
+    assert (
+        captured_pdf_option.pipeline_options.vlm_options.model_spec.max_new_tokens
+        == 321
+    )
+
+
 def test_cli_html_fetches_local_images_per_input(tmp_path):
     first_png = _png_bytes((255, 0, 0))
     second_png = _png_bytes((0, 0, 255))

--- a/tests/test_picture_description_vlm_model.py
+++ b/tests/test_picture_description_vlm_model.py
@@ -27,6 +27,7 @@ class _DummyProcessor:
         self.template_calls = 0
         self.process_calls = []
         self.decode_calls = 0
+        self.tokenizer = _DummyTokenizer()
 
     def apply_chat_template(self, messages, add_generation_prompt=True):
         self.template_calls += 1
@@ -74,6 +75,8 @@ class _DummyModel:
 class _DummyTokenizer:
     def __init__(self) -> None:
         self.padding_side = "left"
+        self.pad_token_id = None
+        self.eos_token_id = 123
 
 
 class _InitDummyProcessor:
@@ -117,7 +120,12 @@ def test_legacy_picture_description_vlm_batches_generation() -> None:
     assert model.processor.decode_calls == 1
     assert model.processor.skip_special_tokens is True
     assert len(model.model.generate_calls) == 1
-    assert model.model.generate_calls[0]["generation_config"].max_new_tokens == 17
+    generation_config = model.model.generate_calls[0]["generation_config"]
+    assert generation_config.max_new_tokens == 17
+    assert generation_config.do_sample is False
+    assert generation_config.pad_token_id == 123
+    assert "max_new_tokens" not in model.model.generate_calls[0]
+    assert "do_sample" not in model.model.generate_calls[0]
 
 
 def test_legacy_picture_description_vlm_skips_empty_batch() -> None:


### PR DESCRIPTION
## What this PR does

Two related changes to how Transformers-based VLM/extraction generation is configured.

### 1. Silence the Transformers deprecation warning

Recent Transformers versions warn when generation parameters (`max_new_tokens`, `do_sample`, `temperature`, `use_cache`, `pad_token_id`, …) are passed as loose `generate()` kwargs *alongside* a `generation_config` object. This PR introduces a single helper, `build_generation_config()` in `docling/models/utils/generation_utils.py`, that merges the base config, per-model `extra_generation_config` overrides, and those individual parameters into one `GenerationConfig` instance. Every call site now passes a single `generation_config=` and nothing else:

- `nuextract_transformers_model.py`
- `transformers_extraction_model.py`
- `inference_engines/vlm/transformers_engine.py`
- `stages/picture_description/picture_description_vlm_model.py`
- `vlm_pipeline_models/hf_transformers_model.py`

The helper also defaults `pad_token_id` to `eos_token_id` when the tokenizer leaves it unset, avoiding the separate "Setting pad_token_id to eos_token_id" warning.

### 2. New CLI options to override `max_new_tokens`

- `--vlm-max-new-tokens` — override `max_new_tokens` for VLM conversion.
- `--picture-description-max-new-tokens` — override `max_new_tokens` for picture description.

## Tests

- `test_cli_vlm_max_new_tokens` and `test_cli_picture_description_max_new_tokens` verify the CLI options land in the pipeline options.
- `test_picture_description_vlm_model.py` updated to assert the merged `GenerationConfig` (max_new_tokens, do_sample, pad_token_id) and that loose kwargs are no longer passed to `generate()`.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
