### PR TITLE
fix: coerce MLX bfloat16 logprobs to float in VlmPredictionToken

### DIFF
--- a/docling/models/vlm_pipeline_models/mlx_model.py
+++ b/docling/models/vlm_pipeline_models/mlx_model.py
@@ -256,7 +256,7 @@ class HuggingFaceMlxModel(BaseVlmPageModel, HuggingFaceModelDownloadMixin):
                             VlmPredictionToken(
                                 text=token.text,
                                 token=token.token,
-                                logprob=token.logprobs[token.token],
+                                logprob=float(token.logprobs[token.token]),
                             )
                         )
                     elif (
@@ -266,7 +266,7 @@ class HuggingFaceMlxModel(BaseVlmPageModel, HuggingFaceModelDownloadMixin):
                             VlmPredictionToken(
                                 text=token.text,
                                 token=token.token,
-                                logprob=token.logprobs[0, token.token],
+                                logprob=float(token.logprobs[0, token.token]),
                             )
                         )
                     else:

--- a/tests/test_vlm_prediction_token_coercion.py
+++ b/tests/test_vlm_prediction_token_coercion.py
@@ -1,0 +1,34 @@
+"""Regression test for VlmPredictionToken logprob type coercion (#4002).
+
+MLX stream_generate returns bfloat16 scalar arrays for logprobs, which
+pydantic rejects because VlmPredictionToken.logprob expects a Python float.
+The fix is to wrap the indexing result with float() in mlx_model.py.
+"""
+
+import numpy as np
+import pytest
+from pydantic import ValidationError
+
+from docling.datamodel.base_models import VlmPredictionToken
+
+
+class TestVlmPredictionTokenLogprobCoercion:
+    def test_accepts_python_float(self):
+        token = VlmPredictionToken(text="a", token=1, logprob=-0.5)
+        assert token.logprob == -0.5
+
+    def test_rejects_raw_numpy_scalar_array(self):
+        raw = np.array(-0.5, dtype=np.float16)
+        with pytest.raises(ValidationError):
+            VlmPredictionToken(text="a", token=1, logprob=raw)
+
+    def test_float_coercion_fixes_numpy_scalar(self):
+        raw = np.array(-0.5, dtype=np.float16)
+        token = VlmPredictionToken(text="a", token=1, logprob=float(raw))
+        assert isinstance(token.logprob, float)
+        assert token.logprob == pytest.approx(-0.5, abs=1e-3)
+
+    def test_float_coercion_on_zero_dim_array(self):
+        raw = np.float16(0.0)
+        token = VlmPredictionToken(text="a", token=1, logprob=float(raw))
+        assert token.logprob == 0.0


### PR DESCRIPTION
## Summary

- Added `float()` coercion to MLX bfloat16 logprob values before constructing `VlmPredictionToken`
- MLX `stream_generate` returns 0-dim bfloat16 arrays that pydantic rejects as non-float, causing intermittent `ValidationError` on certain documents

**File changed:** `docling/models/vlm_pipeline_models/mlx_model.py`

Fixes #4002

## Test plan

- [x] 4 new tests in `tests/test_vlm_prediction_token_coercion.py`:
  - Python float passthrough
  - Raw numpy scalar rejection (confirms the bug)
  - float() coercion fix
  - Zero-dim array coercion
- [x] All existing tests pass

Signed-off-by: 72004 <syahra2014@gmail.com>