### PR TITLE
fix(pdf): rejoin a drop cap with the word it begins

### DIFF
--- a/docling/backend/docling_parse_backend.py
+++ b/docling/backend/docling_parse_backend.py
@@ -34,6 +34,7 @@ from docling.backend.managed_pdfium_backend import (
     ManagedPdfiumPageBackend,
 )
 from docling.backend.pdf_backend import PdfDocumentBackend, PdfPageBackend
+from docling.backend.utils.word_spacing import repair_drop_caps
 from docling.datamodel.accelerator_options import AcceleratorOptions
 from docling.datamodel.backend_options import (
     PdfBackendOptions,
@@ -167,6 +168,8 @@ class DoclingParsePageBackend(ManagedPdfiumPageBackend):
         ]
         [tc.to_top_left_origin(seg_page.dimension.height) for tc in seg_page.char_cells]
         [tc.to_top_left_origin(seg_page.dimension.height) for tc in seg_page.word_cells]
+
+        repair_drop_caps(seg_page.textline_cells, seg_page.word_cells)
 
         self._dpage = seg_page
 
@@ -454,6 +457,9 @@ class ThreadedDoclingParsePageBackend(PdfPageBackend):
                 tc.to_top_left_origin(page_height)
             for tc in seg_page.word_cells:
                 tc.to_top_left_origin(page_height)
+
+            repair_drop_caps(seg_page.textline_cells, seg_page.word_cells)
+
             self._seg_page = seg_page
         return self._seg_page
 

--- a/docling/backend/utils/word_spacing.py
+++ b/docling/backend/utils/word_spacing.py
@@ -1,0 +1,122 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+"""Rejoin a drop cap with the word it begins.
+
+A PDF has no notion of a word. The parser groups glyphs into word cells and then
+joins those cells into a text line, putting a space at every boundary. That is
+right when the boundary is a real gap, and wrong when the two runs are separate
+only because the PDF switched font size in the middle of a word.
+
+A drop cap is exactly that case. The oversized initial letter is always its own
+text run, so "Realized" is parsed as a 34pt "R" abutting a 12pt "ealized" and
+emitted as "R ealized".
+
+The signature is narrow on purpose: a line-initial run of one letter, far taller
+than the run beside it, with no gap between their boxes. Horizontal gap alone is
+not enough evidence -- in rotated or diagrammatic text the boxes of two genuinely
+separate words routinely touch -- so the height jump and the single letter are
+what make this safe to act on. A line is rewritten only by deleting that one
+space, never by inserting or altering anything.
+"""
+
+from docling_core.types.doc.page import TextCell
+
+#: How much taller the initial letter must be than the text beside it. The issue
+#: reports drop caps at roughly 2x body height; this leaves a little headroom.
+DROP_CAP_HEIGHT_RATIO = 1.8
+
+#: The largest gap between the two boxes, as a fraction of the body run's height,
+#: that still counts as no gap at all. A real inter-word space runs to about a
+#: quarter of the font size, well above this.
+DROP_CAP_GAP_RATIO = 0.05
+
+
+def _squash(text: str) -> str:
+    return text.replace(" ", "")
+
+
+def _align(
+    line: TextCell, words: list[TextCell], start: int
+) -> tuple[list[TextCell], int]:
+    """Take the word cells that spell out ``line``, starting at ``words[start]``.
+
+    Word cells and line cells share one reading order, so the words belonging to a
+    line are consecutive. Returns the cells and the index to resume from; an empty
+    list means the two lists disagreed and the line must be left alone.
+    """
+    target = _squash(line.text)
+    taken: list[TextCell] = []
+    acc = ""
+    i = start
+    while i < len(words) and len(acc) < len(target):
+        acc += _squash(words[i].text)
+        taken.append(words[i])
+        i += 1
+    if acc != target:
+        # The lists have drifted apart. Give up on this line rather than guess,
+        # and resume where we started so one odd line cannot desync the rest.
+        return [], start
+    return taken, i
+
+
+def _is_drop_cap(initial: TextCell, following: TextCell) -> bool:
+    """Is ``initial`` an oversized first letter of the word ``following`` finishes?"""
+    if len(initial.text) != 1 or not initial.text.isalpha():
+        return False
+    if not following.text or not following.text[0].isalpha():
+        return False
+
+    initial_box = initial.rect.to_bounding_box()
+    following_box = following.rect.to_bounding_box()
+    if following_box.height <= 0:
+        return False
+    if initial_box.height < DROP_CAP_HEIGHT_RATIO * following_box.height:
+        return False
+
+    gap = following_box.l - initial_box.r
+    return gap <= DROP_CAP_GAP_RATIO * following_box.height
+
+
+def repair_drop_caps(lines: list[TextCell], words: list[TextCell]) -> int:
+    """Rejoin drop caps with their words, in place.
+
+    Args:
+        lines: The page's text line cells. Mutated in place.
+        words: The page's word cells, used only as geometric evidence.
+
+    Returns:
+        How many lines were rewritten.
+    """
+    if not lines or not words:
+        return 0
+
+    ordered_lines = sorted(lines, key=lambda c: c.index)
+    ordered_words = sorted(words, key=lambda c: c.index)
+
+    repaired = 0
+    cursor = 0
+    for line in ordered_lines:
+        in_line, cursor = _align(line, ordered_words, cursor)
+        if len(in_line) < 2:
+            continue
+
+        initial, following = in_line[0], in_line[1]
+        if not _is_drop_cap(initial, following):
+            continue
+
+        # Delete only the one space between the two runs, by walking the line's
+        # own characters. Nothing else in the line can be touched.
+        head = line.text.find(initial.text)
+        if head < 0:
+            continue
+        after = head + len(initial.text)
+        if line.text[after : after + 1] != " ":
+            continue
+        if not line.text.startswith(following.text, after + 1):
+            continue
+
+        line.text = line.text[:after] + line.text[after + 1 :]
+        repaired += 1
+
+    return repaired

--- a/tests/test_backend_docling_parse.py
+++ b/tests/test_backend_docling_parse.py
@@ -599,6 +599,9 @@ def test_non_threaded_page_backend_disables_bitmap_byte_materialization() -> Non
     captured_content_config: Any | None = None
 
     class _FakeCell:
+        index = 0
+        text = ""
+
         def to_top_left_origin(self, _page_height: float) -> "_FakeCell":
             return self
 
@@ -693,6 +696,9 @@ def test_threaded_page_backend_delegates_image_access() -> None:
 
 def test_threaded_page_backend_disables_bitmap_materialization() -> None:
     class _FakeCell:
+        index = 0
+        text = ""
+
         def to_top_left_origin(self, _page_height: float) -> "_FakeCell":
             return self
 

--- a/tests/test_drop_cap_repair.py
+++ b/tests/test_drop_cap_repair.py
@@ -1,0 +1,138 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+"""Rejoining a drop cap with the word it begins.
+
+The fixtures are written as raw PDF bytes rather than shipped as binary files so
+that the content stream under test is visible in the diff: what matters is that
+the oversized initial letter is a separate text run set at a separate font size,
+and a checked-in PDF would hide that.
+"""
+
+from pathlib import Path
+
+import pytest
+
+from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
+from docling.datamodel.base_models import InputFormat
+from docling.datamodel.document import InputDocument
+
+BODY_SIZE = 12
+DROP_SIZE = 34
+LEFT = 72.0
+BODY_BASELINE = 690.0
+#: A drop cap sits on a lower baseline than the text beside it, which is what
+#: makes it span two lines. Runs that share a baseline are merged by the parser
+#: itself, so the offset is what puts the case under test in reach.
+DROP_BASELINE = 676.0
+#: Where text set beside the drop cap starts. Helvetica "R" at 34pt is 24.55pt
+#: wide, so this abuts the letter with no gap, exactly as a real drop cap does.
+BESIDE = 96.0
+
+TAIL = "ealized through a combination of careful engineering"
+
+
+def _show(x: float, y: float, size: int, text: str) -> str:
+    """A single positioned text run."""
+    return f"BT\n/F1 {size} Tf\n{x:.2f} {y:.2f} Td\n({text}) Tj\nET\n"
+
+
+def _write_pdf(path: Path, content: str) -> Path:
+    """Write a one-page Helvetica PDF whose content stream is ``content``."""
+    objects = [
+        "<< /Type /Catalog /Pages 2 0 R >>",
+        "<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        "<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+        "/Resources << /Font << /F1 5 0 R >> >> /Contents 4 0 R >>",
+        f"<< /Length {len(content)} >>\nstream\n{content}endstream",
+        "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
+    ]
+
+    out = bytearray(b"%PDF-1.4\n")
+    offsets = []
+    for number, body in enumerate(objects, start=1):
+        offsets.append(len(out))
+        out += f"{number} 0 obj\n{body}\nendobj\n".encode("latin-1")
+
+    startxref = len(out)
+    size = len(objects) + 1
+    out += f"xref\n0 {size}\n0000000000 65535 f \n".encode("latin-1")
+    for offset in offsets:
+        out += f"{offset:010d} 00000 n \n".encode("latin-1")
+    out += (
+        f"trailer\n<< /Size {size} /Root 1 0 R >>\nstartxref\n{startxref}\n%%EOF\n"
+    ).encode("latin-1")
+
+    path.write_bytes(bytes(out))
+    return path
+
+
+def _line_texts(path: Path) -> list[str]:
+    """The text of every line cell the PDF backend produces for page one."""
+    in_doc = InputDocument(
+        path_or_stream=path,
+        format=InputFormat.PDF,
+        backend=DoclingParseDocumentBackend,
+        filename=path.name,
+    )
+    backend = DoclingParseDocumentBackend(in_doc, path)
+    try:
+        return [cell.text for cell in backend.load_page(0).get_text_cells()]
+    finally:
+        backend.unload()
+
+
+def test_drop_cap_rejoins_with_its_word(tmp_path: Path) -> None:
+    """An oversized initial letter is not a word of its own."""
+    content = _show(LEFT, DROP_BASELINE, DROP_SIZE, "R") + _show(
+        BESIDE, BODY_BASELINE, BODY_SIZE, TAIL
+    )
+    lines = _line_texts(_write_pdf(tmp_path / "drop_cap.pdf", content))
+
+    assert any(line.startswith("Realized through") for line in lines), lines
+    assert not any("R ealized" in line for line in lines), lines
+
+
+def test_body_size_paragraph_is_untouched(tmp_path: Path) -> None:
+    """The same sentence set as one run must survive unchanged."""
+    content = _show(LEFT, BODY_BASELINE, BODY_SIZE, "R" + TAIL)
+    lines = _line_texts(_write_pdf(tmp_path / "plain.pdf", content))
+
+    assert any(line.startswith("Realized through") for line in lines), lines
+
+
+def test_modest_size_jump_keeps_its_space(tmp_path: Path) -> None:
+    """A letter half again as tall as the body text is not a drop cap.
+
+    Runs whose boxes touch turn up throughout ordinary layout -- the test corpus
+    has them in rotated diagram labels, where two genuinely separate words abut.
+    The jump in height is what tells a drop cap apart from those, so an 18pt
+    letter against 12pt body text keeps its space.
+    """
+    content = _show(LEFT, 681, 18, "R") + _show(
+        LEFT + 13, BODY_BASELINE, BODY_SIZE, TAIL
+    )
+    lines = _line_texts(_write_pdf(tmp_path / "modest.pdf", content))
+
+    assert any(line.startswith("R ealized") for line in lines), lines
+
+
+def test_large_initial_separated_by_a_real_gap_keeps_its_space(tmp_path: Path) -> None:
+    """A big letter with white space after it is a heading, not a drop cap."""
+    content = _show(LEFT, DROP_BASELINE, DROP_SIZE, "R") + _show(
+        BESIDE + 12, BODY_BASELINE, BODY_SIZE, TAIL
+    )
+    lines = _line_texts(_write_pdf(tmp_path / "gapped.pdf", content))
+
+    assert any(line.startswith("R ealized") for line in lines), lines
+
+
+@pytest.mark.parametrize("initial", ["1", "-"])
+def test_only_letters_are_treated_as_drop_caps(tmp_path: Path, initial: str) -> None:
+    """A digit or a dash at the head of a line is a list marker, not a drop cap."""
+    content = _show(LEFT, DROP_BASELINE, DROP_SIZE, initial) + _show(
+        BESIDE, BODY_BASELINE, BODY_SIZE, TAIL
+    )
+    lines = _line_texts(_write_pdf(tmp_path / "marker.pdf", content))
+
+    assert not any(line.startswith(f"{initial}ealized") for line in lines), lines


### PR DESCRIPTION
closes #3883

a drop cap, the oversized initial letter that opens a paragraph, is always its own text run in a pdf, set at its own font size and on a lower baseline. the parser reads it as a separate word and joins it to the rest with a space, so a drop-capped paragraph comes out as

```
R ealized through a combination of careful engineering
```

instead of

```
Realized through a combination of careful engineering
```

### what it does

word cells carry both the text and the box, and they share one reading order with the line cells, so the two lists can be walked together to find the boundary and close it up.

a line is repaired only when its first run is all three of:

- a single letter
- at least 1.8x the height of the run beside it
- touching or overlapping that run, with no gap

the repair deletes that one space from the line's own text, after re-checking that the space and the following run are where the word cells said they would be. a rewrite can never insert, reorder or alter a character.

### why the rule is this narrow

horizontal proximity alone is not enough evidence. measured over the pdfs in `tests/data`, a gap-only rule rewrites 90 of 11018 lines and essentially all of them wrongly: the lowered E of a TeX logo, and subscript runs in table notation like `[x1, y2, x2, y2]`. adding the height and single-letter conditions takes the same corpus scan to zero rewrites.

zero rewrites also means no groundtruth changes in this pr.

### cost

this reads `word_cells`, which the backend already materializes by default. it does not touch `char_cells_content_level`, so there is no new memory or serialization expense. the pass costs 0.14% of parse time over that same corpus.

### tests

`tests/test_drop_cap_repair.py` writes its fixtures as raw pdf bytes rather than shipping binaries, so the content stream under test is visible in the diff: what matters is that the initial letter is a separate text run at a separate font size. it covers the positive case and the negatives that must stay untouched, namely body-size initials, modest size jumps, a large initial separated by a real gap, and non-letter initials.

the fixtures reproduce the drop cap layout the issue describes, an oversized initial on its own lowered baseline abutting the rest of the word. alongside them i scanned the full `tests/data` corpus to confirm the rule fires nowhere it should not.
