### PR TITLE
test: ignore embedded image bytes in fixture comparisons

### DIFF
--- a/tests/test_verify_utils.py
+++ b/tests/test_verify_utils.py
@@ -1,13 +1,15 @@
 # SPDX-FileCopyrightText: The Docling Contributors
 # SPDX-License-Identifier: MIT
 
+from pathlib import Path
+
 import pytest
 from docling_core.types.doc import DoclingDocument, ImageRef, ProvenanceItem
 from docling_core.types.doc.base import BoundingBox, Size
 from docling_core.types.doc.labels import DocItemLabel
 from PIL import Image
 
-from tests.verify_utils import verify_docitems
+from tests.verify_utils import verify_docitems, verify_export
 
 
 def _make_doc_with_bbox(
@@ -179,4 +181,17 @@ def test_verify_docitems_fuzzy_skips_image_size_check() -> None:
         doc_true=doc_true,
         fuzzy=True,
         pdf_filename="fixture.pdf",
+    )
+
+
+def test_verify_export_ignores_embedded_image_data(tmp_path: Path) -> None:
+    fixture = tmp_path / "fixture.html"
+    groundtruth = '<img src="data:image/png;base64,AAAA">'
+    prediction = '<img src="data:image/png;base64,BBBB">'
+
+    assert verify_export(groundtruth, str(fixture), generate=True)
+    assert fixture.read_text(encoding="utf-8") == groundtruth
+    assert verify_export(prediction, str(fixture))
+    assert not verify_export(
+        prediction.replace("image/png", "image/jpeg"), str(fixture)
     )

--- a/tests/verify_utils.py
+++ b/tests/verify_utils.py
@@ -4,6 +4,7 @@
 import json
 import math
 import os
+import re
 from collections.abc import Callable
 from pathlib import Path
 from typing import Optional
@@ -33,6 +34,7 @@ FUZZY_BBOX_TOL_RATIO = (
     0.08  # OCR/image output varies more, but gross shifts should fail
 )
 IMAGE_SIZE_TOL_RATIO = 0.015  # allow ~1.5% cross-platform image size variance
+_EMBEDDED_IMAGE_DATA = re.compile(r"(data:image/[^;,]+;base64,)[A-Za-z0-9+/]+={0,2}")
 
 
 def _normalize_newlines(text: str) -> str:
@@ -43,6 +45,10 @@ def _normalize_newlines(text: str) -> str:
     on both the generate and the verify path.
     """
     return text.replace("\r\n", "\n").replace("\r", "\n")
+
+
+def _strip_embedded_image_data(text: str) -> str:
+    return _EMBEDDED_IMAGE_DATA.sub(r"\1", text)
 
 
 class _TestPagesMeta(BaseModel):
@@ -623,6 +629,9 @@ def verify_export(
 
     with file.open(encoding="utf-8", newline="") as fr:
         true_text = fr.read()
+
+    pred_text = _strip_embedded_image_data(pred_text)
+    true_text = _strip_embedded_image_data(true_text)
 
     if fuzzy:
         return verify_text(true_text, pred_text, fuzzy=True)


### PR DESCRIPTION
## Summary

- remove base64 image payloads only when comparing serialized ground-truth output
- leave generated fixture content unchanged
- add a regression test covering both behaviors and preserving MIME-type comparison

## Validation

- make validate
- focused pytest collection was blocked locally by a native mlx_whisper abort before tests ran; CI will provide the runtime result

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.