### PR TITLE
fix(ebcdic): require record names to be unique

### DIFF
--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -580,6 +580,11 @@ class EbcdicLayout(BaseModel):
             raise ValueError(
                 "record_type_field is required for a layout with several records"
             )
+        names = [item.name for item in self.records]
+        if len(set(names)) != len(names):
+            # The parser buckets decoded rows by name and the name becomes the
+            # table heading, so duplicates silently merge two schemas' rows.
+            raise ValueError("record names must be unique")
         if self.record_type_field is not None:
             selectors = [item.selector for item in self.records]
             if None in selectors:

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -580,11 +580,13 @@ class EbcdicLayout(BaseModel):
             raise ValueError(
                 "record_type_field is required for a layout with several records"
             )
-        names = [item.name for item in self.records]
-        if len(set(names)) != len(names):
-            # The parser buckets decoded rows by name and the name becomes the
-            # table heading, so duplicates silently merge two schemas' rows.
-            raise ValueError("record names must be unique")
+        if len(self.records) > 1:
+            names = [item.name for item in self.records]
+            if len(set(names)) != len(names):
+                # The parser buckets decoded rows by name and the name becomes
+                # the table heading, so duplicates silently merge two schemas'
+                # rows.
+                raise ValueError("record names must be unique")
         if self.record_type_field is not None:
             selectors = [item.selector for item in self.records]
             if None in selectors:

--- a/tests/test_backend_ebcdic.py
+++ b/tests/test_backend_ebcdic.py
@@ -258,6 +258,55 @@ def test_multi_schema_layout_requires_a_record_type_field():
         )
 
 
+def test_record_names_must_be_unique():
+    """Rows are bucketed by record name, so duplicates would merge two schemas.
+
+    `name` defaults to "record", so a two-schema layout that sets only the
+    selectors used to convert cleanly and hand every table both schemas' rows.
+    """
+    fields = [EbcdicField(name="value", size=2)]
+
+    with pytest.raises(ValidationError, match="record names must be unique"):
+        EbcdicLayout(
+            record_type_field=EbcdicField(name="kind", size=1),
+            records=[
+                EbcdicRecordLayout(selector="A", fields=fields),
+                EbcdicRecordLayout(selector="B", fields=fields),
+            ],
+        )
+
+
+def test_record_names_must_be_unique_from_a_layout_file(tmp_path: Path):
+    """A copybook usually arrives as JSON, so the check has to hold on that path."""
+    layout_file = tmp_path / "layout.json"
+    layout_file.write_text(
+        json.dumps(
+            {
+                "record_type_field": {"name": "kind", "size": 1},
+                "records": [
+                    {"selector": "A", "fields": [{"name": "value", "size": 2}]},
+                    {"selector": "B", "fields": [{"name": "value", "size": 2}]},
+                ],
+            }
+        )
+    )
+
+    with pytest.raises(DocumentLoadError, match="Could not read the EBCDIC layout"):
+        _backend(
+            _text("A", 1) + _text("xy", 2),
+            EbcdicBackendOptions(layout_file=layout_file),
+        )
+
+
+def test_a_single_record_keeps_the_default_name():
+    """The default name is only a problem when it collides; one schema is fine."""
+    layout = EbcdicLayout(
+        records=[EbcdicRecordLayout(fields=[EbcdicField(name="v", size=2)])]
+    )
+
+    assert layout.records[0].name == "record"
+
+
 def test_layout_sources_are_mutually_exclusive(employee_layout, tmp_path: Path):
     with pytest.raises(ValidationError, match="not both"):
         EbcdicBackendOptions(


### PR DESCRIPTION
`EbcdicLayout` requires record selectors to be unique but says nothing about record names, and
`EbcdicRecordLayout.name` defaults to `"record"`. A copybook with two schemas, unique selectors and
no names is therefore accepted, and `_RecordParser.parse` buckets the decoded rows by name:

```python
rows = {record.name: [] for record in self._layout.records}
```

Records are selected by `selector` but stored by `name`, so both schemas share one bucket. `convert()`
then hands each schema that combined list while `_build_table` writes the schema's own header over
it, and every table ends up holding every record. The conversion reports `ConversionStatus.SUCCESS`.

This adds the missing check to `_validate_records`, next to the selector one it mirrors. It also
resolves the two identical `## record` headings such a layout produced, since `name` is what
`add_heading` prints.

Before, on `main` at 97bdf30, converting an 84-byte cp037 file holding two customer records tagged
`C` and two transaction records tagged `T`:

```markdown
## record

| customer_name    |   account_no |
|------------------|--------------|
| ACME SUPPLIES    |         0041 |
| BOREALIS TRADING |         0042 |
| INVOICE 88213    |      1250.50 |
| REFUND  88240    |       -49.99 |

## record

| memo             |   amount |
|------------------|----------|
| ACME SUPPLIES    |     0041 |
| BOREALIS TRADING |     0042 |
| INVOICE 88213    |  1250.50 |
| REFUND  88240    |   -49.99 |
```

A transaction amount of `1250.50` is presented as a customer's `account_no`, and the account number
`0041` as a monetary `amount`. After, the same layout raises at construction:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for EbcdicLayout
  Value error, record names must be unique
```

Adding `name="customer"` and `name="transaction"`, changing nothing else, converts to the two
correct tables both before and after this change.

I considered keying `rows` by the schema's index instead, which would fix the data without rejecting
any layout. I went with the validator because `name` is also the table heading, so two schemas
sharing one is ambiguous output even when the rows are right — but say the word if you would rather
not reject layouts that are currently accepted, and I will switch it.

Three tests. `test_record_names_must_be_unique` and `test_record_names_must_be_unique_from_a_layout_file`
cover the two ways a copybook arrives, inline and as JSON; both fail on `main` and pass here.
`test_a_single_record_keeps_the_default_name` guards the case the check must not break — one schema
keeping the `"record"` default — and passes either way, so it is a regression guard rather than a
bug test.

Suite on this branch and on `main` at 97bdf30, same machine: 12 failed / 1777 passed here against
12 failed / 1774 passed there, the three extra passes being the tests above. The twelve failures are
the same twelve on both sides — asr_pipeline, webp, the two e2e conversions and the two extraction
template tests, all model- or network-dependent. `make validate` is clean.

**Issue resolved by this Pull Request:**
Resolves #4125

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
