### PR TITLE
fix(docx): detect headings from paragraph-level w:outlineLvl (#3312)

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -1105,6 +1105,38 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             numid, ilvl or 0
         )
 
+    def _get_outline_level_from_paragraph(self, paragraph: Paragraph) -> int | None:
+        """Extract outlineLvl from a paragraph's direct formatting.
+
+        In OOXML, outlineLvl is 0-indexed: 0-8 are heading levels 1-9 and 9 is
+        the "body text" sentinel. This method returns the 1-indexed value
+        (outlineLvl + 1), so heading levels are 1-9 and body text is 10.
+        """
+
+        if paragraph is None:
+            return None
+
+        p_pr = paragraph._p.pPr
+        if p_pr is None:
+            return None
+
+        # Look for outlineLvl in the paragraph properties
+        outline_elem = p_pr.find(f"{self._W_NS_CLARK}outlineLvl")
+        val = (
+            outline_elem.get(f"{self._W_NS_CLARK}val")
+            if outline_elem is not None
+            else None
+        )
+
+        if val is not None:
+            try:
+                # Convert 0-indexed outlineLvl to 1-indexed heading level
+                return int(val) + 1
+            except ValueError:
+                pass
+
+        return None
+
     def _get_outline_level_from_style(self, style: ParagraphStyle | None) -> int | None:
         """Extract outlineLvl from a paragraph style definition.
 
@@ -1370,7 +1402,9 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         )
 
         # 1-9 are real heading levels; 10 is the "body text" sentinel.
-        outline_level = self._get_outline_level_from_style(style)
+        outline_level = self._get_outline_level_from_paragraph(paragraph)
+        if outline_level is None:
+            outline_level = self._get_outline_level_from_style(style)
         if outline_level is not None and not 1 <= outline_level <= 9:
             outline_level = None
 

--- a/tests/test_backend_msword_outline.py
+++ b/tests/test_backend_msword_outline.py
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: The Docling Contributors
 # SPDX-License-Identifier: MIT
 
-"""Tests for Word heading detection via the ``w:outlineLvl`` style property.
+"""Tests for Word heading detection via ``w:outlineLvl``.
+
+The level can be carried by the paragraph's style or set directly on the
+paragraph itself; both are covered here.
 
 Kept separate from ``test_backend_msword.py`` so that file stays under the
 repository's per-file line limit.

--- a/tests/test_backend_msword_outline.py
+++ b/tests/test_backend_msword_outline.py
@@ -24,6 +24,14 @@ def _set_outline_level(style, outline_lvl: int):
     return style
 
 
+def _set_paragraph_outline_level(paragraph, outline_lvl: int):
+    """Pin an explicit ``w:outlineLvl`` directly onto an existing paragraph."""
+    lvl = OxmlElement("w:outlineLvl")
+    lvl.set(qn("w:val"), str(outline_lvl))
+    paragraph._p.get_or_add_pPr().append(lvl)
+    return paragraph
+
+
 def _add_style_with_outline_level(doc, style_id: str, name: str, outline_lvl: int):
     """Register a paragraph style carrying an explicit ``w:outlineLvl``."""
     style = doc.styles.add_style(name, WD_STYLE_TYPE.PARAGRAPH)
@@ -133,3 +141,15 @@ def test_heading_style_with_the_body_text_sentinel_falls_back_to_its_name(tmp_pa
     pinned = build(pinned=True)
     assert pinned == build(pinned=False)
     assert pinned.strip().startswith("#")
+
+
+def test_outline_level_on_the_paragraph_is_detected_without_a_heading_style(tmp_path):
+    doc = Document()
+    para = doc.add_paragraph("Larger channel bandwidth")
+    _set_paragraph_outline_level(para, 1)
+    doc.add_paragraph("Body text.")
+
+    markdown = _markdown(doc, tmp_path, "paragraph_level")
+
+    lines = [line for line in markdown.splitlines() if line.strip()]
+    assert lines == ["### Larger channel bandwidth", "Body text."]


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

**Issue resolved by this Pull Request:**
Resolves #3312

## The problem

`_get_label_and_level()` decides whether a paragraph is a heading via `_get_outline_level_from_style`, which fails when the heading information is not on the paragraph's style. Converting a `.docx` document to `markdown` can result in a lack of correct classification of headings as described in #3312. Following the same steps in the report, a 3GPP contribution document (R1-2602579) is obtained and used in the following root cause analysis:

For the heading "2.2 Larger channel bandwidth": the paragraph has `w:outlineLvl = 1`, no `w:pStyle`, so its style resolves to Normal, and Normal carries no `w:outlineLvl`. `_get_outline_level_from_style` correctly returns None — the level was never in the style. `is_heading` is also `False`, since neither the style id nor its name contains "heading". The paragraph falls through to `("a", None)` and is emitted as body text. Because the same paragraphs carry `w:numPr`, they surface as list items rather than headings.

Reproduced on `2.120.1` and on current `main`.

## The change

This adds `_get_outline_level_from_paragraph` and resolves it before the style in `_get_label_and_level`. Per OOXML's rule, paragraph wins over style when both exist, so the change reflects that. 

#3961 added `w:outlineLvl` as a fallback for styles whose names don't identify them as headings; this extends the same signal to direct paragraph formatting. Similarly:
- `outline_level` is clamped once.  
- `_get_outline_level_from_paragraph` is only called once.

R1-2602579 produces zero markdown headings on `main`; with this change it produces six, at the levels the document defines:

```
## 1 Introduction
## 2 Discussion on RS for tracking
### 2.1 General design
### 2.2 Larger channel bandwidth
## 3 Conclusion
## 4 References
```
Every heading in that class of document sets the level as direct formatting with no `pStyle`, which is why the style-only lookup never sees it.

**Blast radius:** Full suite: 1770 passed, 2 failed, 49 skipped, 1 xfailed. The two failures are `tesserocr` configuration on the local machine and reproduce identically on an unmodified tree. **No reference test data changed:** the new path only fires when a paragraph carries `w:outlineLvl` itself, which no existing fixture does.

## Tests
- Added a new test case to `test_backend_msword_outline.py` to test detection of an `outline_level` of a paragraph without a heading style.
- Added a new method to `test_backend_msword_outline.py` called `_set_paragraph_outline_level` to pin an explicit `w:outlineLvl` directly onto an existing paragraph to be used in the test case above.
- The new test fails on `main` and passes with the change; the other four in that module pass in both states.

## Scope

This fix addresses the heading detection reported in #3312. Two other differences in that document — textbox content appearing before the paragraph that precedes it in Word, and body paragraphs emitted as list items — are separate defects and are not touched here.

## Note

Verified against the open #4124: headings preserved, full outline suite green on the combination.

Further, #4124 narrows the style-level outline path because outline participation over-fires as a heading signal. The same question applies to this path: a template that pins `w:outlineLvl` directly onto body paragraphs would classify them as headings. I haven't seen such a document, so I've kept the change minimal rather than pre-emptively guarding it — but the adjacency discriminator in #4124 would extend to this path naturally if a case turns up.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
