### PR TITLE
fix(xlsx): do not absorb disconnected content into a neighboring table's flood-filled bounds

### DIFF
--- a/docling/backend/msexcel_backend.py
+++ b/docling/backend/msexcel_backend.py
@@ -1063,21 +1063,20 @@ class MsExcelDocumentBackend(DeclarativeDocumentBackend, PaginatedDocumentBacken
         # --- Phase 2: Extract Data (Semantic Grid) ---
         data = []
 
-        # We iterate the bounding box of the found region
-        # Gaps inside the bounding box become empty cells (preserving layout)
+        # We iterate the bounding box of the found region. A cell the flood
+        # fill never reached stays out of table_cells and is emitted empty, so
+        # the outer loop in _find_data_tables gives it its own table later.
         for ri in range(min_r, max_r + 1):
             for rj in range(min_c, max_c + 1):
-                # If this cell was part of the flood-fill OR is inside the bounds
-                # (We include gaps inside the bounds to keep the table rectangular)
-
-                # Logic: If we found a "U" shape, do we fill the middle?
-                # Yes, Excel tables are typically treated as rectangular bounding boxes.
-
                 cell = sheet.cell(row=ri + 1, column=rj + 1)
                 if merged_cell_index.is_shadow(cell):
                     continue
 
-                cell_text = str(cell.value) if cell.value is not None else ""
+                cell_text = (
+                    str(cell.value)
+                    if (ri, rj) in table_cells and cell.value is not None
+                    else ""
+                )
 
                 # Compute Spans
                 row_span, col_span = merged_cell_index.span_at(ri, rj)

--- a/tests/test_backend_msexcel.py
+++ b/tests/test_backend_msexcel.py
@@ -679,6 +679,63 @@ def test_merged_cells_are_indexed_once_and_preserve_semantics(tmp_path: Path) ->
     assert comment_map[(3, 3)] == ("Codex", "Synthetic note", None)
 
 
+def test_disconnected_pocket_inside_bounding_box_is_not_duplicated(
+    tmp_path: Path,
+) -> None:
+    """A cell inside the flood-filled bounding box but never reached by the BFS
+    (separated from the ring by more than gap_tolerance empty cells) must not be
+    absorbed into the ring's own table data, since it is not actually connected
+    to it. It must instead surface once, as its own separate table.
+    """
+    workbook = Workbook()
+    sheet = workbook.active
+    # A 5x5 ring border, all filled, plus one disconnected marker cell in the
+    # interior (2,2 / 0-based) separated from the border by an empty gap of 1
+    # cell on every side, i.e. unreachable at gap_tolerance=0.
+    for row in range(1, 6):
+        for col in range(1, 6):
+            is_border = row in (1, 5) or col in (1, 5)
+            if is_border:
+                sheet.cell(row=row, column=col, value=f"border-{row}-{col}")
+    sheet.cell(row=3, column=3, value="island-marker")
+    file_path = tmp_path / "disconnected-pocket.xlsx"
+    workbook.save(file_path)
+
+    in_doc = InputDocument(
+        path_or_stream=file_path,
+        format=InputFormat.XLSX,
+        filename=file_path.stem,
+        backend=MsExcelDocumentBackend,
+    )
+    backend = MsExcelDocumentBackend(in_doc=in_doc, path_or_stream=file_path)
+    loaded_sheet = backend.workbook.active
+
+    tables, _ = backend._find_data_tables(loaded_sheet)
+
+    marker_occurrences = [
+        (t_idx, cell)
+        for t_idx, table in enumerate(tables)
+        for cell in table.data
+        if cell.text == "island-marker"
+    ]
+    assert len(marker_occurrences) == 1, (
+        f"'island-marker' must surface exactly once, found {len(marker_occurrences)} "
+        f"times across {len(tables)} table(s)"
+    )
+
+    marker_table_idx, marker_cell = marker_occurrences[0]
+    marker_table = tables[marker_table_idx]
+    assert (marker_table.num_rows, marker_table.num_cols) == (1, 1), (
+        "the disconnected marker must form its own single-cell table, not be "
+        "folded into the ring table"
+    )
+
+    ring_table = next(t for t in tables if t is not marker_table)
+    assert all(cell.text != "island-marker" for cell in ring_table.data), (
+        "the ring table's own grid must not carry the disconnected marker's text"
+    )
+
+
 def test_split_leading_section_label_helper() -> None:
     backend = object.__new__(MsExcelDocumentBackend)
 


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #3685

A repro shouldn't be needed here since the mechanism is general, not specific to any one file: `_find_table_bounds` flood-fills a table by BFS, then a second pass rescans the whole rectangular bounding box and emits every cell it finds there, whether the BFS reached it or not. For a non-rectangular shape (an L, a ring, any concave outline), a disconnected pocket inside that bounding box gets pulled into the first table, and since it's never marked visited, the outer loop in `_find_data_tables` starts a fresh flood fill on it and emits it again as its own table.

This is option 1 from the issue thread: a cell the BFS never reached is now left empty in the first table's grid, same as a true gap, and the outer loop picks it up as its own table. Smallest change, doesn't touch the existing L-shape/staggered-column coverage.

Added `test_disconnected_pocket_inside_bounding_box_is_not_duplicated`: a 5x5 ring border plus one interior cell separated from it by an empty gap on every side. The new test fails without the change, the interior cell shows up in both the ring's table and its own. Rest of `tests/test_backend_msexcel.py` is unaffected.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
