### PR TITLE
fix: load VLM processors from the model repository

### DIFF
--- a/docling/models/inference_engines/vlm/transformers_engine.py
+++ b/docling/models/inference_engines/vlm/transformers_engine.py
@@ -227,7 +227,7 @@ class TransformersVlmEngine(BaseVlmEngine, HuggingFaceModelDownloadMixin):
             model_cls = AutoModelForImageTextToText  # type: ignore[assignment]
 
         self.processor = AutoProcessor.from_pretrained(
-            artifacts_path,
+            repo_id,
             trust_remote_code=self.options.trust_remote_code,
             revision=revision,
         )

--- a/tests/test_vlm_presets_and_runtime_options.py
+++ b/tests/test_vlm_presets_and_runtime_options.py
@@ -11,6 +11,8 @@ This test suite validates:
 5. All three stage types (VlmConvert, PictureDescription, CodeFormula)
 """
 
+from pathlib import Path
+
 import pytest
 from pydantic import ValidationError
 
@@ -196,6 +198,7 @@ class TestRuntimeOptions:
         import docling.models.inference_engines.vlm.transformers_engine as tf_engine
 
         captured_kwargs = {}
+        processor_sources = []
 
         class FakeProcessor:
             tokenizer = None
@@ -221,10 +224,16 @@ class TestRuntimeOptions:
             "resolve_model_artifacts_path",
             lambda **kwargs: "artifacts",
         )
+        def fake_processor_from_pretrained(source, *args, **kwargs):
+            processor_sources.append(source)
+            if isinstance(source, Path):
+                raise AttributeError("'dict' object has no attribute 'model_type'")
+            return FakeProcessor()
+
         monkeypatch.setattr(
             tf_engine.AutoProcessor,
             "from_pretrained",
-            lambda *args, **kwargs: FakeProcessor(),
+            fake_processor_from_pretrained,
         )
         monkeypatch.setattr(tf_engine, "AutoModelForCausalLM", FakeModel)
         monkeypatch.setattr(
@@ -255,6 +264,11 @@ class TestRuntimeOptions:
         assert ("torch_dtype" in captured_kwargs) is (
             expected_dtype_arg == "torch_dtype"
         )
+        assert processor_sources == [
+            "rednote-hilab/dots.ocr"
+            if transformers_version.startswith("4.")
+            else "test/model"
+        ]
 
     def test_dots_mocr_requires_flash_attn(self, monkeypatch):
         """dots.mocr remote code imports flash_attn even when SDPA is selected."""

--- a/tests/test_vlm_presets_and_runtime_options.py
+++ b/tests/test_vlm_presets_and_runtime_options.py
@@ -224,6 +224,7 @@ class TestRuntimeOptions:
             "resolve_model_artifacts_path",
             lambda **kwargs: "artifacts",
         )
+
         def fake_processor_from_pretrained(source, *args, **kwargs):
             processor_sources.append(source)
             if isinstance(source, Path):


### PR DESCRIPTION
**Description:**

When formula enrichment loads a Transformers VLM from cached artifacts, passing the local artifacts path to the processor can raise an AttributeError while Transformers reads the model config. Load the processor from the model repository identifier while keeping the resolved local artifacts path for model and generation configuration.

**Issue resolved by this Pull Request:**
Resolves #2681

---

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [ ] Tests have been added, if necessary.