### PR TITLE
feat: integrate native AcroForm widgets as typed fields

### DIFF
--- a/docling/.agents/skills/docling/references/python-sdk.md
+++ b/docling/.agents/skills/docling/references/python-sdk.md
@@ -61,6 +61,7 @@ Useful `PdfPipelineOptions` / base fields:
 |---|---|
 | `do_ocr` | Run OCR (default engine EasyOCR) |
 | `do_table_structure` | Detect table structure |
+| `extract_form_fields` | Convert docling-parse PDF widgets into keyless, format-neutral fillable fields |
 | `do_code_enrichment` / `do_formula_enrichment` | Enrich code / formulas |
 | `ocr_options` | Choose/parametrize the OCR engine (see below) |
 | `table_structure_options` | e.g. `TableFormerMode.ACCURATE` vs `FAST` |
@@ -69,6 +70,11 @@ Useful `PdfPipelineOptions` / base fields:
 | `accelerator_options` | Pick device / thread count |
 | `artifacts_path` | Use pre-downloaded model artifacts (offline) |
 | `enable_remote_services` | Gate all outbound HTTP (required for any remote model) |
+
+`extract_form_fields=True` does not infer visible labels or store PDF-specific
+widget metadata in the `DoclingDocument`. Use `generate_parsed_pages=True` to
+retain raw widgets on parsed pages when needed. Backends without page-local
+widgets produce no fields.
 
 ### Choosing an OCR engine
 

--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -5,7 +5,7 @@ from collections import defaultdict
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Optional, Type, Union
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Optional, Type, Union
 
 import numpy as np
 from docling_core.types.doc import (
@@ -403,6 +403,10 @@ class FieldValuePrediction(BaseModel):
     text: str
     orig: str
     bbox: BoundingBox
+    # Selection state for a checkbox/radio widget; None for text-like fields.
+    # When set, the value is materialized as an empty field value that nests a
+    # CHECKBOX_SELECTED/UNSELECTED child (state lives on the child, not the text).
+    checkbox: Literal["selected", "unselected"] | None = None
 
 
 class FieldRegionPrediction(BaseModel):

--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -399,10 +399,26 @@ class ApiImageStreamingRequestResult:
     logprobs: Any | None = None
 
 
+class FieldValuePrediction(BaseModel):
+    text: str
+    orig: str
+    bbox: BoundingBox
+
+
+class FieldRegionPrediction(BaseModel):
+    source_container_id: int | None = None
+    bbox: BoundingBox
+    values: list[FieldValuePrediction] = []
+
+
 class ContainerElement(
     BasePageElement
 ):  # Used for Form and Key-Value-Regions, only for typing.
     pass
+
+
+class FieldRegionElement(ContainerElement):
+    values: list[FieldValuePrediction] = []
 
 
 class Table(BasePageElement):
@@ -451,13 +467,16 @@ class EquationPrediction(BaseModel):
 
 class PagePredictions(BaseModel):
     layout: LayoutPrediction | None = None
+    field_regions: list[FieldRegionPrediction] = []
     tablestructure: TableStructurePrediction | None = None
     figures_classification: FigureClassificationPrediction | None = None
     equations_prediction: EquationPrediction | None = None
     vlm_response: VlmPrediction | None = None
 
 
-PageElement = Union[TextElement, Table, FigureElement, ContainerElement]
+PageElement = Union[
+    TextElement, Table, FigureElement, ContainerElement, FieldRegionElement
+]
 
 
 class AssembledUnit(BaseModel):

--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -453,6 +453,12 @@ class TableStructurePrediction(BaseModel):
 class TextElement(BasePageElement):
     text: str
     hyperlink: Optional[Union[AnyUrl, Path]] = None
+    # Set when this paragraph inlines AcroForm widgets (e.g. a sentence with an
+    # inline checkbox and a fillable amount). The paragraph then materializes as
+    # a field_item -- its text becomes the key, the widgets its values -- in the
+    # paragraph's own place in the reading order (its list, its container), rather
+    # than being pulled out into a separate field_region.
+    field_item: Optional["FieldItemPrediction"] = None
 
 
 class FigureElement(BasePageElement):

--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -412,10 +412,20 @@ class FieldValuePrediction(BaseModel):
     checkbox_label: str = ""
 
 
+class FieldItemPrediction(BaseModel):
+    # A keyed item groups several values under one key (e.g. an inline checkbox
+    # and a fillable amount that share a sentence). key_bbox is the prov of the
+    # key -- the enclosing text cluster. Keyless items (key_text == "") carry a
+    # single value and reproduce the flat field_item shape.
+    key_text: str = ""
+    key_bbox: BoundingBox | None = None
+    values: list[FieldValuePrediction] = []
+
+
 class FieldRegionPrediction(BaseModel):
     source_container_id: int | None = None
     bbox: BoundingBox
-    values: list[FieldValuePrediction] = []
+    items: list[FieldItemPrediction] = []
 
 
 class ContainerElement(
@@ -425,7 +435,7 @@ class ContainerElement(
 
 
 class FieldRegionElement(ContainerElement):
-    values: list[FieldValuePrediction] = []
+    items: list[FieldItemPrediction] = []
 
 
 class Table(BasePageElement):

--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -407,6 +407,9 @@ class FieldValuePrediction(BaseModel):
     # When set, the value is materialized as an empty field value that nests a
     # CHECKBOX_SELECTED/UNSELECTED child (state lives on the child, not the text).
     checkbox: Literal["selected", "unselected"] | None = None
+    # Option label of the matched layout checkbox cluster (e.g. "4797"), placed
+    # on the nested checkbox child. Empty when no cluster matched the widget.
+    checkbox_label: str = ""
 
 
 class FieldRegionPrediction(BaseModel):

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1948,6 +1948,17 @@ class PdfPipelineOptions(PaginatedPipelineOptions):
             )
         ),
     ] = True
+    extract_form_fields: Annotated[
+        bool,
+        Field(
+            description=(
+                "Extract native interactive PDF widgets as keyless, format-neutral fillable field values. "
+                "The docling-parse backend currently supplies page widgets; labels are not inferred. Raw widget "
+                "metadata remains available only on retained parsed pages. Scanned or flattened forms and backends "
+                "without page widgets are unaffected."
+            )
+        ),
+    ] = False
     do_ocr: Annotated[
         bool,
         Field(

--- a/docling/models/stages/form_field/__init__.py
+++ b/docling/models/stages/form_field/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT

--- a/docling/models/stages/form_field/form_field_model.py
+++ b/docling/models/stages/form_field/form_field_model.py
@@ -34,11 +34,6 @@ class PdfFormFieldModel(BasePageModel):
     # before tightening. Unselected boxes usually have no overlapping cluster and
     # fall through to the widget-only path (see docs handoff prereq B.5).
     _CHECKBOX_OVERLAP_THRESHOLD = 0.5
-    # Cells whose whole text is one of these are the checkbox mark, not the option
-    # label; dropped when lifting the label onto the nested checkbox child.
-    _CHECKBOX_MARK_GLYPHS = frozenset(
-        {"x", "X", "✓", "✔", "✗", "✘", "☑", "☒", "☐", "□", "■", "●", "○", "•"}
-    )
 
     def __init__(self, *, enabled: bool) -> None:
         self.enabled = enabled
@@ -79,11 +74,9 @@ class PdfFormFieldModel(BasePageModel):
 
     @classmethod
     def _cluster_label_text(cls, cluster: Cluster) -> str:
-        """Option label of a checkbox cluster, minus the mark glyph."""
+        """Option label of a checkbox cluster (mark glyph included, if detected)."""
         return " ".join(
-            cell.text.strip()
-            for cell in cluster.cells
-            if cell.text.strip() and cell.text.strip() not in cls._CHECKBOX_MARK_GLYPHS
+            cell.text.strip() for cell in cluster.cells if cell.text.strip()
         )
 
     @classmethod
@@ -174,6 +167,11 @@ class PdfFormFieldModel(BasePageModel):
                         cluster = self._match_checkbox_cluster(bbox, checkbox_clusters)
                         if cluster is not None:
                             value.checkbox_label = self._cluster_label_text(cluster)
+                            # The layout cluster encloses both the widget square
+                            # and its option label; take its bbox as the field
+                            # item's prov so the box wraps the whole checkbox, not
+                            # just the tiny widget rect.
+                            value.bbox = cluster.bbox
                             promoted_cluster_ids.add(cluster.id)
                     form = self._match_form(bbox, forms)
                     if form is None:

--- a/docling/models/stages/form_field/form_field_model.py
+++ b/docling/models/stages/form_field/form_field_model.py
@@ -39,6 +39,19 @@ class PdfFormFieldModel(BasePageModel):
     def __init__(self, *, enabled: bool) -> None:
         self.enabled = enabled
 
+    @classmethod
+    def _is_skipped(cls, widget: PdfWidget, bbox: BoundingBox) -> bool:
+        """Widgets that carry no field value for the document.
+
+        A widget of zero height or width is an artifact (Well-Tagged PDF 1.0,
+        8.9.2.4.13). Push buttons trigger actions and hold no value.
+        """
+        if bbox.width <= 0 or bbox.height <= 0:
+            return True
+        return widget.widget_field_type == "/Btn" and bool(
+            widget.widget_field_flags & cls._PUSHBUTTON_FLAG
+        )
+
     @staticmethod
     def _normalize_text(text: str) -> str:
         return "".join(text.split())
@@ -186,6 +199,8 @@ class PdfFormFieldModel(BasePageModel):
                     bbox = widget.rect.to_bounding_box().to_top_left_origin(
                         page.size.height
                     )
+                    if self._is_skipped(widget, bbox):
+                        continue
                     value = self._normalize_widget(widget, bbox)
                     if value.checkbox is not None:
                         # Lift the visual checkbox's option label onto the value

--- a/docling/models/stages/form_field/form_field_model.py
+++ b/docling/models/stages/form_field/form_field_model.py
@@ -25,6 +25,20 @@ class PdfFormFieldModel(BasePageModel):
     # of it sits inside the widget rect. Guards against deleting ordinary printed
     # text that merely equals a field value by coincidence.
     _DUPLICATE_CONTAINMENT_THRESHOLD = 0.6
+    # A layout CHECKBOX_* cluster is the visual twin of a /Btn widget when this
+    # much of the (small) widget rect sits inside the cluster. The mark glyph the
+    # layout model detects overlaps the widget square only partially and the
+    # cluster also absorbs the neighbouring option label, so the gate is well
+    # below full containment; on f1040s1_filled the real match measures ~0.70.
+    # ponytail: overlap-only heuristic, single filled fixture -- widen the corpus
+    # before tightening. Unselected boxes usually have no overlapping cluster and
+    # fall through to the widget-only path (see docs handoff prereq B.5).
+    _CHECKBOX_OVERLAP_THRESHOLD = 0.5
+    # Cells whose whole text is one of these are the checkbox mark, not the option
+    # label; dropped when lifting the label onto the nested checkbox child.
+    _CHECKBOX_MARK_GLYPHS = frozenset(
+        {"x", "X", "✓", "✔", "✗", "✘", "☑", "☒", "☐", "□", "■", "●", "○", "•"}
+    )
 
     def __init__(self, *, enabled: bool) -> None:
         self.enabled = enabled
@@ -62,6 +76,34 @@ class PdfFormFieldModel(BasePageModel):
             )
 
         return FieldValuePrediction(text=source_value, orig=source_value, bbox=bbox)
+
+    @classmethod
+    def _cluster_label_text(cls, cluster: Cluster) -> str:
+        """Option label of a checkbox cluster, minus the mark glyph."""
+        return " ".join(
+            cell.text.strip()
+            for cell in cluster.cells
+            if cell.text.strip() and cell.text.strip() not in cls._CHECKBOX_MARK_GLYPHS
+        )
+
+    @classmethod
+    def _match_checkbox_cluster(
+        cls, widget_bbox: BoundingBox, clusters: list[Cluster]
+    ) -> Cluster | None:
+        """Find the CHECKBOX_* cluster whose detected mark hosts this widget.
+
+        Match on the widget rect sitting inside the cluster (``IoS(widget,
+        cluster)``), not the reverse: the cluster is larger because it absorbs the
+        neighbouring option label, so the widget is the subset.
+        """
+        best: tuple[float, Cluster] | None = None
+        for cluster in clusters:
+            ios = widget_bbox.intersection_over_self(cluster.bbox)
+            if ios > cls._CHECKBOX_OVERLAP_THRESHOLD and (
+                best is None or ios > best[0]
+            ):
+                best = (ios, cluster)
+        return best[1] if best else None
 
     @classmethod
     def _match_form(
@@ -104,15 +146,35 @@ class PdfFormFieldModel(BasePageModel):
                     for cluster in page.predictions.layout.clusters
                     if cluster.label == DocItemLabel.FORM
                 ]
+                checkbox_clusters = [
+                    cluster
+                    for cluster in page.predictions.layout.clusters
+                    if cluster.label
+                    in {
+                        DocItemLabel.CHECKBOX_SELECTED,
+                        DocItemLabel.CHECKBOX_UNSELECTED,
+                    }
+                ]
                 matched_values: dict[int, list[FieldValuePrediction]] = {}
                 matched_forms: dict[int, Cluster] = {}
                 unmatched_values: list[FieldValuePrediction] = []
+                promoted_cluster_ids: set[int] = set()
 
                 for widget in page.parsed_page.widgets:
                     bbox = widget.rect.to_bounding_box().to_top_left_origin(
                         page.size.height
                     )
                     value = self._normalize_widget(widget, bbox)
+                    if value.checkbox is not None:
+                        # Lift the visual checkbox's option label onto the value
+                        # and take it out of the plain-text stream: state stays
+                        # from /AS (already on value.checkbox), the label rides
+                        # on the nested child. The classifier's own state guess
+                        # is discarded -- /AS is authoritative.
+                        cluster = self._match_checkbox_cluster(bbox, checkbox_clusters)
+                        if cluster is not None:
+                            value.checkbox_label = self._cluster_label_text(cluster)
+                            promoted_cluster_ids.add(cluster.id)
                     form = self._match_form(bbox, forms)
                     if form is None:
                         unmatched_values.append(value)
@@ -142,6 +204,9 @@ class PdfFormFieldModel(BasePageModel):
                 all_values = [
                     value for values in matched_values.values() for value in values
                 ] + unmatched_values
+                # Promote matched checkbox clusters (now hosted inside a field
+                # item) out of the body before suppressing raster duplicates.
+                self._drop_clusters(page, promoted_cluster_ids)
                 self._suppress_duplicate_text(page, all_values)
 
             yield page
@@ -185,11 +250,18 @@ class PdfFormFieldModel(BasePageModel):
             for cluster in page.predictions.layout.clusters
             if is_duplicate(cluster)
         }
+        cls._drop_clusters(page, dropped_ids)
+
+    @staticmethod
+    def _drop_clusters(page: Page, dropped_ids: set[int]) -> None:
+        """Remove clusters (and any container child refs to them) from the page.
+
+        Shared by raster-duplicate suppression and checkbox promotion so
+        reading-order assembly never references a removed cluster.
+        """
         if not dropped_ids:
             return
-
-        # Prune both the top-level clusters and any container's child list, so
-        # reading-order assembly does not reference a removed cluster.
+        assert page.predictions.layout is not None
         for cluster in page.predictions.layout.clusters:
             if cluster.children:
                 cluster.children = [

--- a/docling/models/stages/form_field/form_field_model.py
+++ b/docling/models/stages/form_field/form_field_model.py
@@ -217,10 +217,10 @@ class PdfFormFieldModel(BasePageModel):
                     ):
                         text_containers[text_cluster.id] = text_cluster
                         text_values.setdefault(text_cluster.id, []).append(value)
-                        # Promote the paragraph out of the plain-text stream; it
-                        # becomes the field item's key instead (same mechanism as
-                        # a matched checkbox cluster).
-                        promoted_cluster_ids.add(text_cluster.id)
+                        # The paragraph cluster stays in the body: it materializes
+                        # in place as a field_item (key = its text, values = these
+                        # widgets), keeping its position in its list/container.
+                        # page_assemble attaches the item onto the text element.
                         continue
                     if form is not None:
                         matched_forms[form.id] = form

--- a/docling/models/stages/form_field/form_field_model.py
+++ b/docling/models/stages/form_field/form_field_model.py
@@ -8,6 +8,7 @@ from docling_core.types.doc.page import PdfWidget
 
 from docling.datamodel.base_models import (
     Cluster,
+    FieldItemPrediction,
     FieldRegionPrediction,
     FieldValuePrediction,
     Page,
@@ -119,6 +120,27 @@ class PdfFormFieldModel(BasePageModel):
             ),
         )[1]
 
+    @classmethod
+    def _match_text_container(
+        cls, widget_bbox: BoundingBox, text_clusters: list[Cluster]
+    ) -> Cluster | None:
+        """Smallest text cluster that inlines this widget (the paragraph key).
+
+        Precedence after FORM: a widget with no FORM host may sit inside a text
+        paragraph (e.g. "check here [] and enter amount: 1221.00"). The smallest
+        enclosing cluster is the guard against attaching to a big wrapping block
+        -- it is the whole "is this widget really inlined in this paragraph"
+        decision.
+        """
+        best: tuple[float, Cluster] | None = None
+        for cluster in text_clusters:
+            ios = widget_bbox.intersection_over_self(cluster.bbox)
+            if ios >= cls._FORM_COVERAGE_THRESHOLD and (
+                best is None or cluster.bbox.area() < best[1].bbox.area()
+            ):
+                best = (ios, cluster)
+        return best[1] if best else None
+
     def __call__(
         self, conv_res: ConversionResult, page_batch: Iterable[Page]
     ) -> Iterable[Page]:
@@ -148,8 +170,15 @@ class PdfFormFieldModel(BasePageModel):
                         DocItemLabel.CHECKBOX_UNSELECTED,
                     }
                 ]
+                text_clusters = [
+                    cluster
+                    for cluster in page.predictions.layout.clusters
+                    if cluster.label in TEXT_ELEM_LABELS
+                ]
                 matched_values: dict[int, list[FieldValuePrediction]] = {}
                 matched_forms: dict[int, Cluster] = {}
+                text_values: dict[int, list[FieldValuePrediction]] = {}
+                text_containers: dict[int, Cluster] = {}
                 unmatched_values: list[FieldValuePrediction] = []
                 promoted_cluster_ids: set[int] = set()
 
@@ -173,35 +202,77 @@ class PdfFormFieldModel(BasePageModel):
                             # just the tiny widget rect.
                             value.bbox = cluster.bbox
                             promoted_cluster_ids.add(cluster.id)
+                    # Precedence: smallest enclosing container wins. A FORM cluster
+                    # usually wraps the whole page, so a widget inlined in a
+                    # paragraph (IRS Sch.1 line 7: "check here [] and enter amount:
+                    # 1221.00") sits inside both the FORM and a much smaller
+                    # list_item -- the paragraph is the more specific host and
+                    # becomes the item's key. Only a strictly-smaller text cluster
+                    # beats the FORM; otherwise the widget stays a keyless FORM
+                    # field, reproducing today's output.
                     form = self._match_form(bbox, forms)
-                    if form is None:
-                        unmatched_values.append(value)
+                    text_cluster = self._match_text_container(bbox, text_clusters)
+                    if text_cluster is not None and (
+                        form is None or text_cluster.bbox.area() < form.bbox.area()
+                    ):
+                        text_containers[text_cluster.id] = text_cluster
+                        text_values.setdefault(text_cluster.id, []).append(value)
+                        # Promote the paragraph out of the plain-text stream; it
+                        # becomes the field item's key instead (same mechanism as
+                        # a matched checkbox cluster).
+                        promoted_cluster_ids.add(text_cluster.id)
                         continue
-                    matched_forms[form.id] = form
-                    matched_values.setdefault(form.id, []).append(value)
+                    if form is not None:
+                        matched_forms[form.id] = form
+                        matched_values.setdefault(form.id, []).append(value)
+                        continue
+                    unmatched_values.append(value)
 
                 regions = [
                     FieldRegionPrediction(
                         source_container_id=form_id,
                         bbox=matched_forms[form_id].bbox,
-                        values=values,
+                        items=[FieldItemPrediction(values=[value]) for value in values],
                     )
                     for form_id, values in matched_values.items()
                 ]
+                # Widgets sharing one enclosing paragraph accumulate into a single
+                # keyed item; the key text/bbox is the paragraph cluster.
+                regions.extend(
+                    FieldRegionPrediction(
+                        source_container_id=cluster_id,
+                        bbox=text_containers[cluster_id].bbox,
+                        items=[
+                            FieldItemPrediction(
+                                key_text=self._cluster_label_text(
+                                    text_containers[cluster_id]
+                                ),
+                                key_bbox=text_containers[cluster_id].bbox,
+                                values=values,
+                            )
+                        ],
+                    )
+                    for cluster_id, values in text_values.items()
+                )
                 if unmatched_values:
                     regions.append(
                         FieldRegionPrediction(
                             bbox=BoundingBox.enclosing_bbox(
                                 [value.bbox for value in unmatched_values]
                             ),
-                            values=unmatched_values,
+                            items=[
+                                FieldItemPrediction(values=[value])
+                                for value in unmatched_values
+                            ],
                         )
                     )
                 page.predictions.field_regions = regions
 
-                all_values = [
-                    value for values in matched_values.values() for value in values
-                ] + unmatched_values
+                all_values = (
+                    [value for values in matched_values.values() for value in values]
+                    + [value for values in text_values.values() for value in values]
+                    + unmatched_values
+                )
                 # Promote matched checkbox clusters (now hosted inside a field
                 # item) out of the body before suppressing raster duplicates.
                 self._drop_clusters(page, promoted_cluster_ids)

--- a/docling/models/stages/form_field/form_field_model.py
+++ b/docling/models/stages/form_field/form_field_model.py
@@ -13,6 +13,7 @@ from docling.datamodel.base_models import (
     Page,
 )
 from docling.datamodel.document import ConversionResult
+from docling.models.base_layout_model import TEXT_ELEM_LABELS
 from docling.models.base_model import BasePageModel
 from docling.utils.profiling import TimeRecorder
 
@@ -20,9 +21,23 @@ from docling.utils.profiling import TimeRecorder
 class PdfFormFieldModel(BasePageModel):
     _FORM_COVERAGE_THRESHOLD = 0.8
     _PUSHBUTTON_FLAG = 1 << 16
+    # A rendered-text cluster counts as a widget's duplicate only when this much
+    # of it sits inside the widget rect. Guards against deleting ordinary printed
+    # text that merely equals a field value by coincidence.
+    _DUPLICATE_CONTAINMENT_THRESHOLD = 0.6
 
     def __init__(self, *, enabled: bool) -> None:
         self.enabled = enabled
+
+    @staticmethod
+    def _normalize_text(text: str) -> str:
+        return "".join(text.split())
+
+    @classmethod
+    def _cluster_text(cls, cluster: Cluster) -> str:
+        return cls._normalize_text(
+            " ".join(cell.text for cell in cluster.cells if cell.text.strip())
+        )
 
     @classmethod
     def _normalize_widget(
@@ -116,4 +131,64 @@ class PdfFormFieldModel(BasePageModel):
                     )
                 page.predictions.field_regions = regions
 
+                all_values = [
+                    value for values in matched_values.values() for value in values
+                ] + unmatched_values
+                self._suppress_duplicate_text(page, all_values)
+
             yield page
+
+    @classmethod
+    def _suppress_duplicate_text(
+        cls, page: Page, values: list[FieldValuePrediction]
+    ) -> None:
+        """Drop plain text clusters that merely re-render a native field value.
+
+        A filled widget's appearance stream is painted into the page raster, so
+        the layout model also detects it as an ordinary text cluster -- producing
+        a duplicate of the widget's native ``/V``. Suppress such a cluster only
+        when its text equals a field value's *and* it sits inside that widget's
+        rect; the containment gate keeps ordinary printed text that coincidentally
+        matches a value from being deleted.
+
+        ponytail: leaves the ~10% of values the layout model glues onto a
+        neighbouring label (value is a substring of a larger line, not an equal
+        twin); excising a suffix mid-string is the risky over-editing we avoid.
+        """
+        assert page.predictions.layout is not None
+        by_text: dict[str, list[BoundingBox]] = {}
+        for value in values:
+            text = cls._normalize_text(value.text)
+            if text:
+                by_text.setdefault(text, []).append(value.bbox)
+
+        if not by_text:
+            return
+
+        def is_duplicate(cluster: Cluster) -> bool:
+            return cluster.label in TEXT_ELEM_LABELS and any(
+                cluster.bbox.intersection_over_self(widget_bbox)
+                > cls._DUPLICATE_CONTAINMENT_THRESHOLD
+                for widget_bbox in by_text.get(cls._cluster_text(cluster), [])
+            )
+
+        dropped_ids = {
+            cluster.id
+            for cluster in page.predictions.layout.clusters
+            if is_duplicate(cluster)
+        }
+        if not dropped_ids:
+            return
+
+        # Prune both the top-level clusters and any container's child list, so
+        # reading-order assembly does not reference a removed cluster.
+        for cluster in page.predictions.layout.clusters:
+            if cluster.children:
+                cluster.children = [
+                    child for child in cluster.children if child.id not in dropped_ids
+                ]
+        page.predictions.layout.clusters = [
+            cluster
+            for cluster in page.predictions.layout.clusters
+            if cluster.id not in dropped_ids
+        ]

--- a/docling/models/stages/form_field/form_field_model.py
+++ b/docling/models/stages/form_field/form_field_model.py
@@ -48,12 +48,20 @@ class PdfFormFieldModel(BasePageModel):
             widget.widget_field_type == "/Btn"
             and not widget.widget_field_flags & cls._PUSHBUTTON_FLAG
         ):
+            # A checkbox/radio widget carries state, not text. Encode the state
+            # as a nested checkbox child (see FieldValuePrediction.checkbox) and
+            # keep the value text empty -- the serializer only inlines the
+            # <checkbox> token when the hosting value has no text of its own.
             source_value = widget.widget_appearance_state or source_value
-            text = "unchecked" if source_value in {"", "/Off", "Off"} else "checked"
-        else:
-            text = source_value
+            off = source_value in {"", "/Off", "Off"}
+            return FieldValuePrediction(
+                text="",
+                orig=source_value,
+                bbox=bbox,
+                checkbox="unselected" if off else "selected",
+            )
 
-        return FieldValuePrediction(text=text, orig=source_value, bbox=bbox)
+        return FieldValuePrediction(text=source_value, orig=source_value, bbox=bbox)
 
     @classmethod
     def _match_form(

--- a/docling/models/stages/form_field/form_field_model.py
+++ b/docling/models/stages/form_field/form_field_model.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+from collections.abc import Iterable
+
+from docling_core.types.doc import BoundingBox, DocItemLabel
+from docling_core.types.doc.page import PdfWidget
+
+from docling.datamodel.base_models import (
+    Cluster,
+    FieldRegionPrediction,
+    FieldValuePrediction,
+    Page,
+)
+from docling.datamodel.document import ConversionResult
+from docling.models.base_model import BasePageModel
+from docling.utils.profiling import TimeRecorder
+
+
+class PdfFormFieldModel(BasePageModel):
+    _FORM_COVERAGE_THRESHOLD = 0.8
+    _PUSHBUTTON_FLAG = 1 << 16
+
+    def __init__(self, *, enabled: bool) -> None:
+        self.enabled = enabled
+
+    @classmethod
+    def _normalize_widget(
+        cls, widget: PdfWidget, bbox: BoundingBox
+    ) -> FieldValuePrediction:
+        source_value = widget.widget_text or ""
+        if (
+            widget.widget_field_type == "/Btn"
+            and not widget.widget_field_flags & cls._PUSHBUTTON_FLAG
+        ):
+            source_value = widget.widget_appearance_state or source_value
+            text = "unchecked" if source_value in {"", "/Off", "Off"} else "checked"
+        else:
+            text = source_value
+
+        return FieldValuePrediction(text=text, orig=source_value, bbox=bbox)
+
+    @classmethod
+    def _match_form(
+        cls, widget_bbox: BoundingBox, forms: list[Cluster]
+    ) -> Cluster | None:
+        matches = [
+            (widget_bbox.intersection_over_self(form.bbox), form)
+            for form in forms
+            if widget_bbox.intersection_over_self(form.bbox)
+            > cls._FORM_COVERAGE_THRESHOLD
+        ]
+        if not matches:
+            return None
+        return max(
+            matches,
+            key=lambda match: (
+                match[0],
+                -match[1].bbox.area(),
+                -match[1].id,
+            ),
+        )[1]
+
+    def __call__(
+        self, conv_res: ConversionResult, page_batch: Iterable[Page]
+    ) -> Iterable[Page]:
+        for page in page_batch:
+            if (
+                not self.enabled
+                or page.parsed_page is None
+                or not page.parsed_page.widgets
+            ):
+                yield page
+                continue
+
+            with TimeRecorder(conv_res, "form_field"):
+                assert page.size is not None
+                assert page.predictions.layout is not None
+                forms = [
+                    cluster
+                    for cluster in page.predictions.layout.clusters
+                    if cluster.label == DocItemLabel.FORM
+                ]
+                matched_values: dict[int, list[FieldValuePrediction]] = {}
+                matched_forms: dict[int, Cluster] = {}
+                unmatched_values: list[FieldValuePrediction] = []
+
+                for widget in page.parsed_page.widgets:
+                    bbox = widget.rect.to_bounding_box().to_top_left_origin(
+                        page.size.height
+                    )
+                    value = self._normalize_widget(widget, bbox)
+                    form = self._match_form(bbox, forms)
+                    if form is None:
+                        unmatched_values.append(value)
+                        continue
+                    matched_forms[form.id] = form
+                    matched_values.setdefault(form.id, []).append(value)
+
+                regions = [
+                    FieldRegionPrediction(
+                        source_container_id=form_id,
+                        bbox=matched_forms[form_id].bbox,
+                        values=values,
+                    )
+                    for form_id, values in matched_values.items()
+                ]
+                if unmatched_values:
+                    regions.append(
+                        FieldRegionPrediction(
+                            bbox=BoundingBox.enclosing_bbox(
+                                [value.bbox for value in unmatched_values]
+                            ),
+                            values=unmatched_values,
+                        )
+                    )
+                page.predictions.field_regions = regions
+
+            yield page

--- a/docling/models/stages/page_assemble/page_assemble_model.py
+++ b/docling/models/stages/page_assemble/page_assemble_model.py
@@ -8,12 +8,14 @@ from pathlib import Path
 from typing import Dict, List, Optional, Union
 
 import numpy as np
-from docling_core.types.doc import BoundingBox
+from docling_core.types.doc import BoundingBox, DocItemLabel
 from pydantic import AnyUrl, BaseModel, ValidationError
 
 from docling.datamodel.base_models import (
     AssembledUnit,
+    Cluster,
     ContainerElement,
+    FieldRegionElement,
     FigureElement,
     Page,
     PageElement,
@@ -193,6 +195,12 @@ class PageAssembleModel(BasePageModel):
                     elements: List[PageElement] = []
                     headers: List[PageElement] = []
                     body: List[PageElement] = []
+                    field_regions_by_source = {
+                        region.source_container_id: region
+                        for region in page.predictions.field_regions
+                        if region.source_container_id is not None
+                    }
+                    assembled_field_sources: set[int] = set()
 
                     for cluster in page.predictions.layout.clusters:
                         # _log.info("Cluster label seen:", cluster.label)
@@ -255,14 +263,56 @@ class PageAssembleModel(BasePageModel):
                             elements.append(fig)
                             body.append(fig)
                         elif cluster.label in CONTAINER_LABELS:
-                            container_el = ContainerElement(
-                                label=cluster.label,
-                                id=cluster.id,
-                                page_no=page.page_no,
-                                cluster=cluster,
-                            )
+                            field_region = field_regions_by_source.get(cluster.id)
+                            if field_region is None:
+                                container_el = ContainerElement(
+                                    label=cluster.label,
+                                    id=cluster.id,
+                                    page_no=page.page_no,
+                                    cluster=cluster,
+                                )
+                            else:
+                                container_el = FieldRegionElement(
+                                    label=DocItemLabel.FIELD_REGION,
+                                    id=cluster.id,
+                                    page_no=page.page_no,
+                                    cluster=cluster.model_copy(
+                                        update={"bbox": field_region.bbox}
+                                    ),
+                                    values=field_region.values,
+                                )
+                                assembled_field_sources.add(cluster.id)
                             elements.append(container_el)
                             body.append(container_el)
+
+                    next_id = (
+                        max(
+                            (
+                                cluster.id
+                                for cluster in page.predictions.layout.clusters
+                            ),
+                            default=0,
+                        )
+                        + 1
+                    )
+                    for field_region in page.predictions.field_regions:
+                        if field_region.source_container_id in assembled_field_sources:
+                            continue
+                        cluster = Cluster(
+                            id=next_id,
+                            label=DocItemLabel.FIELD_REGION,
+                            bbox=field_region.bbox,
+                        )
+                        field_element = FieldRegionElement(
+                            label=DocItemLabel.FIELD_REGION,
+                            id=next_id,
+                            page_no=page.page_no,
+                            cluster=cluster,
+                            values=field_region.values,
+                        )
+                        elements.append(field_element)
+                        body.append(field_element)
+                        next_id += 1
 
                     page.assembled = AssembledUnit(
                         elements=elements, headers=headers, body=body

--- a/docling/models/stages/page_assemble/page_assemble_model.py
+++ b/docling/models/stages/page_assemble/page_assemble_model.py
@@ -212,6 +212,15 @@ class PageAssembleModel(BasePageModel):
                             ]
                             text = self.sanitize_text(textlines)
                             hyperlink = self._match_hyperlink(cluster.bbox, page)
+                            # A paragraph that inlines AcroForm widgets carries a
+                            # single keyed field item; attach it so it materializes
+                            # as a field_item in place (see TextElement.field_item)
+                            # instead of being pulled into a separate field_region.
+                            inline_region = field_regions_by_source.get(cluster.id)
+                            field_item = None
+                            if inline_region is not None and inline_region.items:
+                                field_item = inline_region.items[0]
+                                assembled_field_sources.add(cluster.id)
                             text_el = TextElement(
                                 label=cluster.label,
                                 id=cluster.id,
@@ -219,6 +228,7 @@ class PageAssembleModel(BasePageModel):
                                 hyperlink=hyperlink,
                                 page_no=page.page_no,
                                 cluster=cluster,
+                                field_item=field_item,
                             )
                             elements.append(text_el)
 

--- a/docling/models/stages/page_assemble/page_assemble_model.py
+++ b/docling/models/stages/page_assemble/page_assemble_model.py
@@ -279,7 +279,7 @@ class PageAssembleModel(BasePageModel):
                                     cluster=cluster.model_copy(
                                         update={"bbox": field_region.bbox}
                                     ),
-                                    values=field_region.values,
+                                    items=field_region.items,
                                 )
                                 assembled_field_sources.add(cluster.id)
                             elements.append(container_el)
@@ -308,7 +308,7 @@ class PageAssembleModel(BasePageModel):
                             id=next_id,
                             page_no=page.page_no,
                             cluster=cluster,
-                            values=field_region.values,
+                            items=field_region.items,
                         )
                         elements.append(field_element)
                         body.append(field_element)

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -29,6 +29,7 @@ from docling.datamodel.base_models import (
     Cluster,
     ContainerElement,
     FieldRegionElement,
+    FieldValuePrediction,
     FigureElement,
     PageElement,
     Table,
@@ -519,11 +520,12 @@ class ReadingOrderModel:
                         page_height=page_height,
                     )
 
-                    for merged_cid in el_merges_mapping.get(rel.cid, []):
-                        merged_elem = id_to_elem[cid_to_rels[merged_cid].ref.cref]
-                        self._merge_elements(
-                            element, merged_elem, new_item, page_height
-                        )
+                    if element.field_item is None:
+                        for merged_cid in el_merges_mapping.get(rel.cid, []):
+                            merged_elem = id_to_elem[cid_to_rels[merged_cid].ref.cref]
+                            self._merge_elements(
+                                element, merged_elem, new_item, page_height
+                            )
 
                 elif isinstance(element, Table):
                     table_item = self._add_table_element(element, out_doc, parent)
@@ -583,34 +585,13 @@ class ReadingOrderModel:
                                 parent=field_item,
                             )
                         for value in item.values:
-                            prov = ProvenanceItem(
-                                page_no=element.page_no,
-                                charspan=(0, len(value.text)),
-                                bbox=value.bbox.to_bottom_left_origin(page_height),
-                            )
-                            field_value = out_doc.add_field_value(
-                                text=value.text,
-                                orig=value.orig,
-                                prov=prov,
+                            self._add_field_value(
+                                value,
+                                out_doc=out_doc,
                                 parent=field_item,
-                                kind="fillable",
+                                page_no=element.page_no,
+                                page_height=page_height,
                             )
-                            if value.checkbox is not None:
-                                # State rides on a nested checkbox child; the
-                                # value text is empty so the token inlines into
-                                # <value>. No prov on the child: it shares the
-                                # value's rect, and the serializer flattens child
-                                # locations into <value>, so a duplicate prov
-                                # would emit the same location twice.
-                                out_doc.add_text(
-                                    label=(
-                                        DocItemLabel.CHECKBOX_SELECTED
-                                        if value.checkbox == "selected"
-                                        else DocItemLabel.CHECKBOX_UNSELECTED
-                                    ),
-                                    text=value.checkbox_label,
-                                    parent=field_value,
-                                )
 
                 elif isinstance(element, ContainerElement):
                     group_label = (
@@ -642,6 +623,43 @@ class ReadingOrderModel:
         )
         return new_item
 
+    def _add_field_value(
+        self,
+        value: FieldValuePrediction,
+        *,
+        out_doc: DoclingDocument,
+        parent: NodeItem,
+        page_no: int,
+        page_height: float,
+    ) -> NodeItem:
+        prov = ProvenanceItem(
+            page_no=page_no,
+            charspan=(0, len(value.text)),
+            bbox=value.bbox.to_bottom_left_origin(page_height),
+        )
+        field_value = out_doc.add_field_value(
+            text=value.text,
+            orig=value.orig,
+            prov=prov,
+            parent=parent,
+            kind="fillable",
+        )
+        if value.checkbox is not None:
+            # State rides on a nested checkbox child; the value text is empty so
+            # the token inlines into <value>. No prov on the child: it shares the
+            # value's rect, and the serializer flattens child locations into
+            # <value>, so a duplicate prov would emit the same location twice.
+            out_doc.add_text(
+                label=(
+                    DocItemLabel.CHECKBOX_SELECTED
+                    if value.checkbox == "selected"
+                    else DocItemLabel.CHECKBOX_UNSELECTED
+                ),
+                text=value.checkbox_label,
+                parent=field_value,
+            )
+        return field_value
+
     def _handle_text_element(
         self,
         element: TextElement,
@@ -650,7 +668,7 @@ class ReadingOrderModel:
         current_list: GroupItem | None,
         parent: NodeItem | None,
         page_height: float,
-    ) -> tuple[TextItem, GroupItem | None]:
+    ) -> tuple[NodeItem, GroupItem | None]:
         cap_text = element.text
 
         prov = ProvenanceItem(
@@ -659,6 +677,31 @@ class ReadingOrderModel:
             bbox=element.cluster.bbox.to_bottom_left_origin(page_height),
         )
         label = element.label
+        if element.field_item is not None:
+            # The paragraph inlines widgets: emit a field_item in this paragraph's
+            # own place -- inside its list when it is a list item, else under the
+            # current parent -- with its text as the key and the widgets as values.
+            # No separate field_region: the item stays where the paragraph was.
+            if label == DocItemLabel.LIST_ITEM:
+                if current_list is None:
+                    current_list = out_doc.add_group(
+                        label=GroupLabel.LIST, name="list", parent=parent
+                    )
+                item_parent: NodeItem | None = current_list
+            else:
+                current_list = None
+                item_parent = parent
+            field_item = out_doc.add_field_item(parent=item_parent)
+            out_doc.add_field_key(text=cap_text, prov=prov, parent=field_item)
+            for value in element.field_item.values:
+                self._add_field_value(
+                    value,
+                    out_doc=out_doc,
+                    parent=field_item,
+                    page_no=element.page_no,
+                    page_height=page_height,
+                )
+            return field_item, current_list
         if label == DocItemLabel.LIST_ITEM:
             if current_list is None:
                 current_list = out_doc.add_group(

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -595,7 +595,7 @@ class ReadingOrderModel:
                                     if value.checkbox == "selected"
                                     else DocItemLabel.CHECKBOX_UNSELECTED
                                 ),
-                                text="",
+                                text=value.checkbox_label,
                                 parent=field_value,
                             )
 

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -28,6 +28,7 @@ from docling.datamodel.base_models import (
     BasePageElement,
     Cluster,
     ContainerElement,
+    FieldRegionElement,
     FigureElement,
     PageElement,
     Table,
@@ -483,7 +484,7 @@ class ReadingOrderModel:
         ) -> None:
             split_lists_on_non_list = (
                 isinstance(parent, GroupItem) and parent.label == GroupLabel.FORM_AREA
-            )
+            ) or (parent is not None and parent.label == DocItemLabel.FIELD_REGION)
             current_list: GroupItem | None = None
             for rel in ordered_siblings[parent_ref]:
                 if rel.cid in skippable_cids:
@@ -554,6 +555,32 @@ class ReadingOrderModel:
                         el_to_footnotes_mapping=el_to_footnotes_mapping,
                     )
                     self._add_child_elements(element, picture_item, out_doc)
+
+                elif isinstance(element, FieldRegionElement):
+                    field_region = out_doc.add_field_region(
+                        prov=ProvenanceItem(
+                            page_no=element.page_no,
+                            charspan=(0, 0),
+                            bbox=element.cluster.bbox.to_bottom_left_origin(
+                                page_height
+                            ),
+                        ),
+                        parent=parent,
+                    )
+                    materialize_siblings(rel.ref.cref, field_region)
+                    for value in element.values:
+                        field_item = out_doc.add_field_item(parent=field_region)
+                        out_doc.add_field_value(
+                            text=value.text,
+                            orig=value.orig,
+                            prov=ProvenanceItem(
+                                page_no=element.page_no,
+                                charspan=(0, len(value.text)),
+                                bbox=value.bbox.to_bottom_left_origin(page_height),
+                            ),
+                            parent=field_item,
+                            kind="fillable",
+                        )
 
                 elif isinstance(element, ContainerElement):
                     group_label = (

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -568,36 +568,49 @@ class ReadingOrderModel:
                         parent=parent,
                     )
                     materialize_siblings(rel.ref.cref, field_region)
-                    for value in element.values:
+                    for item in element.items:
                         field_item = out_doc.add_field_item(parent=field_region)
-                        prov = ProvenanceItem(
-                            page_no=element.page_no,
-                            charspan=(0, len(value.text)),
-                            bbox=value.bbox.to_bottom_left_origin(page_height),
-                        )
-                        field_value = out_doc.add_field_value(
-                            text=value.text,
-                            orig=value.orig,
-                            prov=prov,
-                            parent=field_item,
-                            kind="fillable",
-                        )
-                        if value.checkbox is not None:
-                            # State rides on a nested checkbox child; the value
-                            # text is empty so the token inlines into <value>.
-                            # No prov on the child: it shares the value's rect,
-                            # and the serializer flattens child locations into
-                            # <value>, so a duplicate prov would emit the same
-                            # location twice inside the element.
-                            out_doc.add_text(
-                                label=(
-                                    DocItemLabel.CHECKBOX_SELECTED
-                                    if value.checkbox == "selected"
-                                    else DocItemLabel.CHECKBOX_UNSELECTED
+                        if item.key_text and item.key_bbox is not None:
+                            out_doc.add_field_key(
+                                text=item.key_text,
+                                prov=ProvenanceItem(
+                                    page_no=element.page_no,
+                                    charspan=(0, len(item.key_text)),
+                                    bbox=item.key_bbox.to_bottom_left_origin(
+                                        page_height
+                                    ),
                                 ),
-                                text=value.checkbox_label,
-                                parent=field_value,
+                                parent=field_item,
                             )
+                        for value in item.values:
+                            prov = ProvenanceItem(
+                                page_no=element.page_no,
+                                charspan=(0, len(value.text)),
+                                bbox=value.bbox.to_bottom_left_origin(page_height),
+                            )
+                            field_value = out_doc.add_field_value(
+                                text=value.text,
+                                orig=value.orig,
+                                prov=prov,
+                                parent=field_item,
+                                kind="fillable",
+                            )
+                            if value.checkbox is not None:
+                                # State rides on a nested checkbox child; the
+                                # value text is empty so the token inlines into
+                                # <value>. No prov on the child: it shares the
+                                # value's rect, and the serializer flattens child
+                                # locations into <value>, so a duplicate prov
+                                # would emit the same location twice.
+                                out_doc.add_text(
+                                    label=(
+                                        DocItemLabel.CHECKBOX_SELECTED
+                                        if value.checkbox == "selected"
+                                        else DocItemLabel.CHECKBOX_UNSELECTED
+                                    ),
+                                    text=value.checkbox_label,
+                                    parent=field_value,
+                                )
 
                 elif isinstance(element, ContainerElement):
                     group_label = (

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -570,17 +570,34 @@ class ReadingOrderModel:
                     materialize_siblings(rel.ref.cref, field_region)
                     for value in element.values:
                         field_item = out_doc.add_field_item(parent=field_region)
-                        out_doc.add_field_value(
+                        prov = ProvenanceItem(
+                            page_no=element.page_no,
+                            charspan=(0, len(value.text)),
+                            bbox=value.bbox.to_bottom_left_origin(page_height),
+                        )
+                        field_value = out_doc.add_field_value(
                             text=value.text,
                             orig=value.orig,
-                            prov=ProvenanceItem(
-                                page_no=element.page_no,
-                                charspan=(0, len(value.text)),
-                                bbox=value.bbox.to_bottom_left_origin(page_height),
-                            ),
+                            prov=prov,
                             parent=field_item,
                             kind="fillable",
                         )
+                        if value.checkbox is not None:
+                            # State rides on a nested checkbox child; the value
+                            # text is empty so the token inlines into <value>.
+                            # No prov on the child: it shares the value's rect,
+                            # and the serializer flattens child locations into
+                            # <value>, so a duplicate prov would emit the same
+                            # location twice inside the element.
+                            out_doc.add_text(
+                                label=(
+                                    DocItemLabel.CHECKBOX_SELECTED
+                                    if value.checkbox == "selected"
+                                    else DocItemLabel.CHECKBOX_UNSELECTED
+                                ),
+                                text="",
+                                parent=field_value,
+                            )
 
                 elif isinstance(element, ContainerElement):
                     group_label = (

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -783,9 +783,9 @@ class StandardPdfPipeline(ConvertPipeline):
         output_q = ThreadedQueue(opts.queue_max_size)
         preprocess.add_output_queue(layout.input_queue)  # PDF parsing
         layout.add_output_queue(ocr.input_queue)  # Layout prediction
-        ocr.add_output_queue(form_field.input_queue)  # OCR
-        form_field.add_output_queue(layout_postprocess.input_queue)  # Form fields
-        layout_postprocess.add_output_queue(table.input_queue)  # Layout post-processing
+        ocr.add_output_queue(layout_postprocess.input_queue)  # OCR
+        layout_postprocess.add_output_queue(form_field.input_queue)  # Layout post-proc
+        form_field.add_output_queue(table.input_queue)  # Form fields
         table.add_output_queue(assemble.input_queue)  # Table model
         assemble.add_output_queue(output_q)  # Assembly
 
@@ -793,8 +793,8 @@ class StandardPdfPipeline(ConvertPipeline):
             preprocess,
             ocr,
             layout,
-            form_field,
             layout_postprocess,
+            form_field,
             table,
             assemble,
         ]

--- a/docling/pipeline/standard_pdf_pipeline.py
+++ b/docling/pipeline/standard_pdf_pipeline.py
@@ -62,6 +62,7 @@ from docling.models.factories import (
 from docling.models.stages.code_formula.code_formula_vlm_model import (
     CodeFormulaVlmModel,
 )
+from docling.models.stages.form_field.form_field_model import PdfFormFieldModel
 from docling.models.stages.heading_hierarchy.heading_hierarchy_model import (
     HeadingHierarchyModel,
 )
@@ -631,6 +632,9 @@ class StandardPdfPipeline(ConvertPipeline):
                 run_postprocessor=self.layout_model.requires_layout_postprocessing,
             )
         )
+        self.form_field_model = PdfFormFieldModel(
+            enabled=self.pipeline_options.extract_form_fields
+        )
 
         table_factory = get_table_structure_factory(
             allow_external_plugins=self.pipeline_options.allow_external_plugins
@@ -746,6 +750,15 @@ class StandardPdfPipeline(ConvertPipeline):
             shutdown_timeout=opts.stage_shutdown_timeout_seconds,
             timed_out_run_ids=timed_out_run_ids,
         )
+        form_field = ThreadedPipelineStage(
+            name="form_field",
+            model=self.form_field_model,
+            batch_size=1,
+            batch_timeout=opts.batch_polling_interval_seconds,
+            queue_max_size=opts.queue_max_size,
+            shutdown_timeout=opts.stage_shutdown_timeout_seconds,
+            timed_out_run_ids=timed_out_run_ids,
+        )
         table = ThreadedPipelineStage(
             name="table",
             model=self.table_model,
@@ -770,12 +783,21 @@ class StandardPdfPipeline(ConvertPipeline):
         output_q = ThreadedQueue(opts.queue_max_size)
         preprocess.add_output_queue(layout.input_queue)  # PDF parsing
         layout.add_output_queue(ocr.input_queue)  # Layout prediction
-        ocr.add_output_queue(layout_postprocess.input_queue)  # OCR
+        ocr.add_output_queue(form_field.input_queue)  # OCR
+        form_field.add_output_queue(layout_postprocess.input_queue)  # Form fields
         layout_postprocess.add_output_queue(table.input_queue)  # Layout post-processing
         table.add_output_queue(assemble.input_queue)  # Table model
         assemble.add_output_queue(output_q)  # Assembly
 
-        stages = [preprocess, ocr, layout, layout_postprocess, table, assemble]
+        stages = [
+            preprocess,
+            ocr,
+            layout,
+            form_field,
+            layout_postprocess,
+            table,
+            assemble,
+        ]
         return RunContext(
             stages=stages,
             first_stage=preprocess,

--- a/docs/acroform-widget-text-collision-handoff.md
+++ b/docs/acroform-widget-text-collision-handoff.md
@@ -1,0 +1,304 @@
+# AcroForm widget/layout-text collision — experiment handoff
+
+Status snapshot: 2026-09-03
+
+This documents a follow-up experiment run against the branch implementing
+`docs/acroform-field-items-replacement-handoff.md` (Docling branch
+`feat/acroform-field-items`, head `b54c2d0b` at experiment time). It is a
+record of an observed regression, not an implementation plan. No production
+code was changed while writing this.
+
+## Question
+
+The replacement design extracts fillable field values from native PDF widget
+state (`/V`, `/AS`) rather than from rendered pixels. But a PDF's widget
+appearance stream is still painted onto the page raster that the layout model
+and OCR run against. What happens when a widget actually has visible filled-in
+text, i.e. the two extraction paths — native widget state and visual layout —
+both have something to say about the same screen region?
+
+## Inputs (persisted, not in a session temp dir)
+
+All experiment inputs and outputs are at
+`/private/tmp/docling-acroform-collision-experiment/`, which is outside any
+Claude session scratch directory and will not be swept:
+
+```text
+/private/tmp/docling-acroform-collision-experiment/
+├── f1040s1_filled.pdf          # filled fixture (see below), sha256 3627057b6c7e58ad4abdd9b0dc9d6886f889de6504162cab53b2b88307b724ed
+├── fill_irs_form.py             # script that produced it from the source fixture
+└── outputs/
+    ├── branch/                  # feat/acroform-field-items @ b54c2d0b results
+    │   ├── f1040s1_filled.dclx
+    │   ├── f1040s1_filled.json
+    │   ├── f1040s1_filled_page1.png
+    │   └── f1040s1_filled_page2.png
+    └── main/                    # origin/main (no AcroForm support) results
+        ├── f1040s1_filled.dclx
+        ├── f1040s1_filled.json
+        ├── f1040s1_filled_page1.png
+        └── f1040s1_filled_page2.png
+```
+
+The unfilled source fixture is the same IRS Schedule 1 reproduction used by
+the original handoff:
+`/private/tmp/docling-acord-analysis/f1040s1.pdf`, sha256
+`8dafec719f6a4716c259a2bdaca546d9bb9e262d1eabef885fe116a7327458fa`.
+
+### How the filled fixture was built
+
+`fill_irs_form.py` uses `pypdf` (`uv run --with pypdf`, not a project
+dependency) to set values on all 68 `/Tx` fields (`"111.00"`, `"222.00"`, ...
+incrementing) and check 2 of the 5 `/Btn` fields
+(`topmostSubform[0].Page1[0].c1_1[0]`,
+`topmostSubform[0].Page2[0].c2_1[0]`), with
+`writer.update_page_form_field_values(page, values, auto_regenerate=True)`.
+
+`auto_regenerate=True` is required: this fixture is an XFA form
+(`pypdfium2.PdfDocument.get_formtype()` returns `3`,
+`FPDF_FORMTYPE_XFA_FULL`), and without regeneration the written `/V` has no
+baked `/AP` appearance stream, so nothing renders. With regeneration,
+`pypdfium2` confirmed (after `init_forms()`, ignoring its XFA-unsupported
+warning and falling back to plain AcroForm rendering) that the appearance
+streams paint correctly. Separately, and more importantly:
+**docling-parse's own page rasterization also paints the filled widget text**,
+visible directly in `outputs/branch/f1040s1_filled_page1.png` — this is not a
+pypdfium2-only artifact, it is what the layout model actually sees.
+
+### Conversion settings
+
+Both runs used the same `PdfPipelineOptions`:
+
+```python
+PdfPipelineOptions(
+    do_ocr=False,
+    do_table_structure=False,
+    extract_form_fields=True,       # branch only; option does not exist on main
+    generate_page_images=True,
+    images_scale=2.0,
+    layout_options=LayoutOptions(create_orphan_clusters=False),
+)
+```
+
+`DOCLING_DEVICE=cpu`.
+
+## Results
+
+### Branch (`feat/acroform-field-items`)
+
+| | unfilled `f1040s1.pdf` | filled `f1040s1_filled.pdf` |
+|---|---:|---:|
+| field regions | 2 (one `FORM` cluster per page) | **7** |
+| field items | 73 | 73 (unchanged — correct) |
+| plain document text items that duplicate a fillable value's text | 0 | **60+** |
+
+Region detail for the filled run:
+
+- Page 1: 2 regions. One keeps `source_container_id` matching the original
+  `FORM` cluster; the other has `source_container_id=129`, i.e. a different
+  cluster than the page's single detected `FORM` — the filled visual content
+  changed what the layout model segmented.
+- Page 2: 5 regions (`source_container_id` = 107, 94, 98, 10, 29), where the
+  unfilled run had exactly 1.
+
+Duplicate text: values such as `"111.00"`, `"1554.00"`, `"1998.00"`, etc.
+appear both as an ordinary text item in `doc.texts` (because the layout model
+detected the rendered blue appearance-stream text as a normal `TEXT`/table
+cluster) and as the `FieldValueItem` extracted from the same widget's native
+`/V`. `outputs/branch/f1040s1_filled.json` and `.dclx` contain this
+duplication as delivered; no suppression was attempted.
+
+### Main (`origin/main`, no AcroForm support)
+
+| | unfilled | filled |
+|---|---:|---:|
+| document text items | 72 | 196 |
+
+No duplication is possible on main because there is no separate
+widget-derived channel to collide with — the rendered appearance text is the
+only representation of the field content. This is the expected, uninteresting
+baseline; it confirms the collision is specific to running two extraction
+paths (native widget + visual layout) over the same filled region, not an
+artifact of the fixture itself.
+
+## Diagnosis
+
+Two distinct failure modes, both downstream of the fact that widget
+appearance streams are part of the page raster the layout model consumes:
+
+1. **Duplicate text.** The field-mapping stage (per
+   `docs/acroform-field-items-replacement-handoff.md`, "Narrow duplicate
+   suppression") only suppresses proven-equivalent `CHECKBOX_SELECTED` /
+   `CHECKBOX_UNSELECTED` leaves against a native checkable widget. There is no
+   corresponding suppression for text, and the handoff explicitly rejected
+   attempting one ("Do not attempt text-field duplicate suppression by
+   deleting overlapping text ... not enough evidence"). This experiment
+   supplies a concrete case where that gap produces visible duplication, but
+   does not by itself argue the rejection was wrong — a filled and an
+   unfilled text field are visually indistinguishable to the layout model
+   from ordinary printed text, so any suppression heuristic risks the same
+   over-deletion risk the handoff was avoiding.
+
+2. **Region fragmentation.** The "Region construction" matching (raw `FORM`
+   cluster vs. widget bboxes, by strongest coverage) runs on layout output
+   that already reflects the filled appearance text. When that text changes
+   what the layout model detects as containers on the page, one raw `FORM`
+   cluster can be perceived as several smaller clusters, so widgets that
+   would otherwise all match one region instead scatter across multiple
+   matched regions plus the fallback. Field *items* stay correct (73/73 in
+   both runs — native order and count are preserved), but the region
+   *grouping* becomes unstable and no longer reflects the form's actual
+   layout structure. This is a more clear-cut defect than (1): the design's
+   invariant "layout predictions themselves remain unchanged by field
+   assembly" is preserved, but the invariant that a single retained `FORM`
+   with native controls produces one corresponding `FieldRegionItem` is
+   violated purely as a side effect of the widgets being filled in.
+
+## Non-conclusions
+
+- This does not show the branch's field-*item* extraction is wrong — item
+  count, order, and values were correct in both the filled and unfilled runs.
+- This does not reopen the "no text-field duplicate suppression" decision by
+  itself; it is evidence for the region-fragmentation half of the gap, which
+  is a narrower and more mechanical problem (cluster matching stability) than
+  duplicate-content suppression (which requires provenance/semantic
+  judgment).
+- Not evaluated: whether disabling page-image generation, or otherwise
+  keeping the layout model from seeing filled appearance streams, is a viable
+  mitigation — that would presumably also blind normal OCR/layout to
+  legitimately handwritten/typed content on scanned filled forms, which are a
+  realistic real-world input for this feature.
+
+## Possible follow-up (not scoped or designed here)
+
+- Reproduce region fragmentation with a synthetic single-`FORM` fixture with
+  filled vs. unfilled widgets, to isolate it from IRS-specific layout
+  quirks, matching the existing "Multiple-region unit fixture" test style in
+  the original handoff.
+- Investigate whether region matching (`docling/models/stages/form_field/`)
+  can key off the *raw* `FORM` cluster bbox pre-postprocessing consistently
+  regardless of visual content, rather than depending on the postprocessed
+  layout that filled-in text can perturb.
+
+## Solution proposals (2026-09-03 follow-up analysis)
+
+Added after re-examining the branch output in
+`outputs/branch/f1040s1_filled.json`. Two independent fixes, one per failure
+mode. Neither was implemented here.
+
+### Idea 1 — text duplicate suppression (the safe rule the data supports)
+
+Addresses failure mode (1), "Duplicate text".
+
+The original handoff rejected text-field duplicate suppression for fear of
+over-deletion (a filled and an unfilled text field are visually
+indistinguishable from ordinary printed text). Re-measuring the filled fixture
+shows a suppression rule that carries almost no over-deletion risk, because it
+gates string equality on *geometric containment inside the widget rectangle*.
+
+Measured on the 68 filled `/Tx` widgets in `f1040s1_filled.json`:
+
+| Case | Count | Payload identical? | Geometry |
+|---|---:|---|---|
+| Clean twin | **61 / 68** | yes, byte-for-byte | rendered-text bbox **fully inside** the widget rect (containment > 0.6; zero partials) |
+| Merged into label | **6 / 68** | **no** — value is a *suffix* of a larger line, e.g. `"7 Unemployment compensation. … 1221.00"`, `"( ) 1443.00"`, `"z Other income. List type and amount: 3885.00"` | line only partially overlaps the widget |
+| Not detected as text | **1 / 68** (`5328.00`) | n/a | no overlapping plain item at all |
+
+So the assumption behind any "identical + overlapping" dedup — identical text
+payload *and* spatial overlap — **holds for 61/68 but is not universal**: ~10%
+of the time the layout model glues the filled value onto the neighbouring
+label cluster, so there is no clean twin to match.
+
+**Rule.** Suppress a plain text item iff both hold:
+
+1. its normalized text `==` a `field_value`'s normalized text, and
+2. its bbox is contained in that field_value's **widget rect**
+   (`intersection_over_self` > ~0.6).
+
+On this fixture that removes exactly the 61 real duplicates with **zero** false
+positives. The containment predicate is what makes it safe: an ordinary
+printed label does not simultaneously sit inside a known widget rectangle and
+equal that widget's native `/V`. Empty/unfilled widgets have `/V = ""`, match
+nothing, and are inert. This is the same shape as the existing checkbox
+suppression (string-equivalence gated by geometry), extended to text.
+
+**Deliberately left behind** (worth a `ponytail:`-style note): the ~7
+merged-into-label cases. There the value is a substring of a larger line;
+excising just the suffix means editing text content mid-string, which is
+exactly the risky over-editing the original handoff rightly avoided. Leaving
+them cleans 90 %+ of duplicates; the residual is a trailing value on a label
+line.
+
+### Idea 2 — don't inflate a `FORM` bbox from loose text children
+
+Addresses failure mode (2), "Region fragmentation".
+
+**Root cause (more precise than the original diagnosis).** The fragmentation
+is *not* the layout model emitting many overlapping forms that dedup fails to
+collapse. Postprocessing already deduplicates overlapping `FORM` clusters:
+`container_clusters` go through
+`_remove_overlapping_clusters(..., "wrapper")`
+(`docling/utils/layout_postprocessor.py:312`), merging any two forms with
+`IoU > 0.8` **or** `containment > 0.8`. That dedup ran in the experiment branch
+(`b54c2d0b`; the dedup landed earlier in `aaa4e28e`, 2026-08-25).
+
+The overlap is created **after** dedup, by the child-enclosure bbox rewrite in
+`_set_cluster_children` (`layout_postprocessor.py:404-410`): for
+`CONTAINER_TYPES` it overwrites the cluster bbox with the enclosing box of its
+assigned children. Sequence:
+
+1. Dedup runs on the **compact detector** form bboxes → several distinct forms
+   correctly survive (they do not overlap past threshold yet).
+2. Regular text clusters are assigned as children (`> 0.8` containment).
+3. Each form's bbox is rewritten to enclose those children.
+
+On a filled page the appearance-stream text spawns many scattered `TEXT`
+clusters; different surviving forms adopt different scattered children and each
+balloons to a near-page-spanning rectangle. *Then* they overlap heavily —
+measured on page 2: region #5 ⊂ #6 at containment 1.00, IoU 0.90 — but dedup
+already ran on the pre-inflation boxes and had no reason to merge them. On the
+unfilled page there is almost no interior text, the enclosure barely grows, and
+forms stay compact and distinct. Confirmed the region bboxes are these
+post-enclosure boxes, not the widget spans: region #5 encloses
+`(39.5, 240.4, 527.1, 740.0)` while its two widgets span only
+`(64.8…481.6, 276…300)`.
+
+**Fix.** In `_set_cluster_children`, restrict the container bbox rewrite so it
+encloses only **nested tables/pictures**, not loose regular-text children —
+which is exactly what the enclosure was introduced for (#4064, "nest tables and
+pictures in form regions"). Tables/pictures are stable layout objects, so the
+box no longer drifts with rendered field text and the "one retained `FORM` →
+one `FieldRegionItem`" invariant is restored at the source.
+
+**Restrict to `FORM`, not all `CONTAINER_TYPES`.** The rewrite branch currently
+fires for `CONTAINER_TYPES = {FORM, KEY_VALUE_REGION}`
+(`layout_postprocessor.py:404`). For a **key-value region the text enclosure is
+the point** — its bbox is meant to cover the key/value pairs, which are regular
+text, and KVRs rarely contain tables/pictures. Applying the restriction to KVR
+would shrink KVR boxes to nothing and regress key-value extraction. The change
+must therefore be scoped to `DocItemLabel.FORM` only; KVR keeps the current
+all-children enclosure.
+
+**Downstream consequences (uncovered during analysis):**
+
+- *No text is lost.* Forms never consumed their text children — the
+  contained-child removal at `layout_postprocessor.py:187-193` applies only to
+  `TABLE_TYPES`/`PICTURE` wrappers, never to `FORM`/`KVR`. Nested text remains
+  as ordinary `TEXT` in the output regardless of the form bbox. Idea 1 is
+  therefore orthogonal and unaffected.
+- *Child assignment is unchanged.* Only the bbox rewrite input changes; nesting
+  decisions are computed before the rewrite (against the detector bbox), so the
+  same tables/pictures still nest and the parent/child structure is preserved.
+- *Region completeness now rides on detector-box quality* — the one real risk.
+  `_match_form` admits a widget only when it is `> 0.8` covered by the form
+  bbox; the old text-enclosure could *rescue* a too-tight detector box by
+  growing it over the field text. Removing that means a widget near a poorly
+  drawn form edge could drop out of its form into the fallback region. In
+  practice form detector boxes are drawn around their fields so this should be
+  rare, but it is the thing to verify on the filled IRS fixture: **all 73
+  widgets still match a form and the fallback region does not grow.**
+
+**Suggested validation:** re-run the filled fixture with the FORM-only
+enclosure change and compare against `outputs/branch/`: expect page-2 regions
+to collapse from 5 toward 1, field-item count to stay 73/73, and no increase in
+unmatched/fallback widgets.

--- a/docs/usage/advanced_options.md
+++ b/docs/usage/advanced_options.md
@@ -103,6 +103,17 @@ The options in this list require the explicit `enable_remote_services=True` when
 The example file [custom_convert.py](../examples/custom_convert.py) contains multiple ways
 one can adjust the conversion pipeline and features.
 
+### Extract native PDF form fields
+
+Set `PdfPipelineOptions(extract_form_fields=True)` to convert native PDF widgets
+into keyless, format-neutral `FieldItem` and fillable `FieldValueItem` objects.
+The docling-parse backend currently supplies this data. Scanned or flattened
+forms and backends without page widgets produce no field items.
+
+This option does not infer labels from layout geometry or PDF field names. Raw
+widget metadata is not stored in the `DoclingDocument`; keep parsed pages with
+`generate_parsed_pages=True` when that PDF-specific data is needed.
+
 ### Image resolution and scale
 
 Page coordinates use 72 points per inch. For image inputs, embedded DPI metadata

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -385,8 +385,8 @@ members = ["packages/docling", "packages/docling-client"]
 
 [tool.uv.sources]
 docling = { workspace = true }
-# docling-core = { git = "https://github.com/docling-project/docling-core/", rev = "main" }
-# docling-ibm-models = { git = "https://github.com/docling-project/docling-ibm-models", branch = "main" }
+docling-parse = { git = "https://github.com/docling-project/docling-parse.git", branch = "feat/acroform-widget-extraction" }
+docling-core = { git = "https://github.com/docling-project/docling-core.git", branch = "feat/acroform-widget-extraction" }
 
 [tool.uv]
 package = true

--- a/tach.toml
+++ b/tach.toml
@@ -304,6 +304,11 @@ depends_on = [
 ]
 
 [[modules]]
+path = "docling.models.stages.form_field"
+layer = "models"
+depends_on = ["docling.datamodel", "docling.models", "docling.utils"]
+
+[[modules]]
 path = "docling.models.stages.page_assemble"
 layer = "models"
 depends_on = [
@@ -508,6 +513,7 @@ depends_on = [
   "docling.datamodel",
   "docling.models.factories",
   "docling.models.stages.code_formula",
+  "docling.models.stages.form_field",
   "docling.models.stages.heading_hierarchy",
   "docling.models.stages.page_assemble",
   "docling.models.stages.page_preprocessing",

--- a/tests/data/pdf/sources/acroform_sample.pdf
+++ b/tests/data/pdf/sources/acroform_sample.pdf
@@ -1,0 +1,66 @@
+%PDF-1.6
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R /AcroForm << /Fields [6 0 R 7 0 R 8 0 R 10 0 R] /DR << /Font << /Helv 5 0 R >> >> /DA (/Helv 0 Tf 0 g) >> >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> /Annots [6 0 R 7 0 R 8 0 R 9 0 R 10 0 R] >>
+endobj
+4 0 obj
+<< /Length 258 >>
+stream
+BT /F1 12 Tf 72 695 Td (Full name:) Tj ET BT /F1 12 Tf 95 643 Td (I agree to the terms) Tj ET BT /F1 12 Tf 95 613 Td (Subscribe to newsletter) Tj ET BT /F1 12 Tf 95 583 Td (Monthly mail digest) Tj ET BT /F1 12 Tf 72 563 Td (See example.org for details) Tj ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+6 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Tx /T (applicant_name) /TU (Full legal name) /V (Ada Lovelace) /Ff 2 /F 4 /Rect [150 690 400 710] /P 3 0 R /DA (/Helv 12 Tf 0 g) >>
+endobj
+7 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Btn /T (agree_terms) /TU (I agree to the terms) /V /Yes /AS /Yes /F 4 /Rect [72 638 86 652] /P 3 0 R >>
+endobj
+8 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Btn /T (newsletter) /V /Off /AS /Off /F 4 /Rect [72 608 86 622] /P 3 0 R >>
+endobj
+9 0 obj
+<< /Type /Annot /Subtype /Link /Rect [72 558 230 573] /Border [0 0 0] /A << /S /URI /URI (https://example.org) >> >>
+endobj
+10 0 obj
+<< /Type /Annot /Subtype /Widget /FT /Btn /T (mail_optin) /AS /On /F 4 /Rect [72 578 86 592] /P 3 0 R /AP << /N << /On 11 0 R /Off 12 0 R >> >> >>
+endobj
+11 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 14 14] /Length 0 >>
+stream
+
+endstream
+endobj
+12 0 obj
+<< /Type /XObject /Subtype /Form /BBox [0 0 14 14] /Length 0 >>
+stream
+
+endstream
+endobj
+xref
+0 13
+0000000000 65535 f 
+0000000009 00000 n 
+0000000164 00000 n 
+0000000221 00000 n 
+0000000388 00000 n 
+0000000697 00000 n 
+0000000767 00000 n 
+0000000952 00000 n 
+0000001109 00000 n 
+0000001238 00000 n 
+0000001370 00000 n 
+0000001533 00000 n 
+0000001631 00000 n 
+trailer
+<< /Size 13 /Root 1 0 R >>
+startxref
+1729
+%%EOF

--- a/tests/test_form_extraction.py
+++ b/tests/test_form_extraction.py
@@ -70,6 +70,7 @@ def _widget(
     *,
     field_type: str = "/Tx",
     appearance_state: str | None = None,
+    field_flags: int = 0,
 ) -> PdfWidget:
     return PdfWidget(
         index=index,
@@ -79,6 +80,7 @@ def _widget(
         widget_text=text,
         widget_field_type=field_type,
         widget_appearance_state=appearance_state,
+        widget_field_flags=field_flags,
     )
 
 
@@ -147,6 +149,16 @@ def test_field_mapping_assembly_and_materialization_preserve_regions_and_order()
             field_type="/Btn",
             appearance_state="/Off",
         ),
+        # Zero-size widgets are artifacts (Well-Tagged PDF 1.0, 8.9.2.4.13).
+        _widget(6, BoundingBox(l=30, t=30, r=30, b=30), "ghost"),
+        # Push buttons carry no value.
+        _widget(
+            7,
+            BoundingBox(l=60, t=80, r=90, b=90),
+            "Submit",
+            field_type="/Btn",
+            field_flags=PdfFormFieldModel._PUSHBUTTON_FLAG,
+        ),
     ]
     page = Page(page_no=1, size=Size(width=100, height=100))
     page.parsed_page = MagicMock(widgets=widgets)
@@ -182,6 +194,13 @@ def test_field_mapping_assembly_and_materialization_preserve_regions_and_order()
     )
     assert page.predictions.field_regions[2].items[0].values[0].orig == "/On"
     assert page.predictions.field_regions[3].items[0].values[0].orig == "/Off"
+    # The zero-size and push-button widgets are dropped: no extra region and
+    # neither their text nor orig reaches any value.
+    assert not any(
+        value.orig in {"ghost", "Submit"}
+        for region in page.predictions.field_regions
+        for value in _region_values(region)
+    )
 
     visible_child = Cluster(
         id=4,

--- a/tests/test_form_extraction.py
+++ b/tests/test_form_extraction.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 
 from docling_core.types.doc import BoundingBox, DocItemLabel, Size
 from docling_core.types.doc.items.form import FieldItem, FieldValueItem
-from docling_core.types.doc.page import BoundingRectangle, PdfWidget
+from docling_core.types.doc.page import BoundingRectangle, PdfWidget, TextCell
 
 from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
 from docling.datamodel.base_models import (
@@ -229,6 +229,43 @@ def test_field_mapping_assembly_and_materialization_preserve_regions_and_order()
     assert ["checked"] in values_by_region
     assert ["unchecked"] in values_by_region
     doc.validate_document()
+
+
+def _text_cluster(cluster_id: int, bbox: BoundingBox, text: str) -> Cluster:
+    cell = TextCell(
+        index=0,
+        rect=BoundingRectangle.from_bounding_box(bbox),
+        text=text,
+        orig=text,
+        from_ocr=False,
+    )
+    return Cluster(id=cluster_id, label=DocItemLabel.TEXT, bbox=bbox, cells=[cell])
+
+
+def test_suppresses_rendered_duplicate_of_filled_widget() -> None:
+    # A filled widget paints its /V into the raster; the layout model re-detects
+    # it as a plain text cluster inside the widget rect -> suppress it.
+    widget_bbox = BoundingBox(l=10, t=10, r=90, b=20)
+    form = Cluster(
+        id=1, label=DocItemLabel.FORM, bbox=BoundingBox(l=0, t=0, r=100, b=60)
+    )
+    inside = _text_cluster(2, BoundingBox(l=12, t=11, r=30, b=19), "111.00")
+    # same string but well outside any widget rect -> ordinary printed text, keep
+    outside = _text_cluster(3, BoundingBox(l=10, t=80, r=30, b=90), "111.00")
+    form.children = [inside]
+
+    widgets = [_widget(0, widget_bbox, "111.00")]
+    page = Page(page_no=1, size=Size(width=100, height=100))
+    page.parsed_page = MagicMock(widgets=widgets)
+    page.predictions.layout = LayoutPrediction(clusters=[form, inside, outside])
+    conv_res = _conversion_result(page)
+
+    list(PdfFormFieldModel(enabled=True)(conv_res, [page]))
+
+    remaining = page.predictions.layout.clusters
+    assert inside not in remaining  # contained duplicate dropped
+    assert outside in remaining  # coincidental match kept
+    assert form.children == []  # child ref pruned so assembly stays consistent
 
 
 def test_pipeline_materializes_keyless_format_neutral_fields() -> None:

--- a/tests/test_form_extraction.py
+++ b/tests/test_form_extraction.py
@@ -316,13 +316,12 @@ def _checkbox_cluster(
 
 def test_checkbox_widget_lifts_cluster_label_and_lets_as_override_classifier() -> None:
     # The widget rect sits inside a CHECKBOX_SELECTED cluster that also absorbed
-    # the option label "4797" and the mark glyph. The cluster's option label is
-    # lifted onto the value and the cluster is promoted out of the plain-text
+    # the option label "4797" and the mark glyph. The cluster's text is lifted
+    # verbatim onto the value and the cluster is promoted out of the plain-text
     # stream; but /AS ("/Off") -- not the classifier's "selected" -- decides state.
     widget_bbox = BoundingBox(l=10, t=10, r=18, b=18)
-    cb_cluster = _checkbox_cluster(
-        2, BoundingBox(l=8, t=8, r=40, b=20), label="4797", mark="✔"
-    )
+    cluster_bbox = BoundingBox(l=8, t=8, r=40, b=20)
+    cb_cluster = _checkbox_cluster(2, cluster_bbox, label="4797", mark="✔")
     widget = _widget(0, widget_bbox, "/Off", field_type="/Btn", appearance_state="/Off")
     page = Page(page_no=1, size=Size(width=100, height=100))
     page.parsed_page = MagicMock(widgets=[widget])
@@ -334,7 +333,8 @@ def test_checkbox_widget_lifts_cluster_label_and_lets_as_override_classifier() -
     value = page.predictions.field_regions[0].values[0]
     assert value.text == ""
     assert value.checkbox == "unselected"  # from /AS, overriding the classifier
-    assert value.checkbox_label == "4797"  # mark glyph stripped
+    assert value.checkbox_label == "4797 ✔"  # cluster text lifted as-is
+    assert value.bbox == cluster_bbox  # prov wraps the whole cluster, not the widget
     assert cb_cluster not in page.predictions.layout.clusters  # promoted, not left
 
 

--- a/tests/test_form_extraction.py
+++ b/tests/test_form_extraction.py
@@ -162,16 +162,26 @@ def test_field_mapping_assembly_and_materialization_preserve_regions_and_order()
         3,
         None,
     ]
+
+    # Keyless items: one value each, one item per widget -- flat shape preserved.
+    def _region_values(region):
+        return [value for item in region.items for value in item.values]
+
     assert [
-        [value.text for value in region.values]
+        [value.text for value in _region_values(region)]
         for region in page.predictions.field_regions
     ] == [["first", "third", "tie"], ["second"], [""], [""]]
     assert [
-        [value.checkbox for value in region.values]
+        [value.checkbox for value in _region_values(region)]
         for region in page.predictions.field_regions
     ] == [[None, None, None], [None], ["selected"], ["unselected"]]
-    assert page.predictions.field_regions[2].values[0].orig == "/On"
-    assert page.predictions.field_regions[3].values[0].orig == "/Off"
+    assert all(
+        item.key_text == ""
+        for region in page.predictions.field_regions
+        for item in region.items
+    )
+    assert page.predictions.field_regions[2].items[0].values[0].orig == "/On"
+    assert page.predictions.field_regions[3].items[0].values[0].orig == "/Off"
 
     visible_child = Cluster(
         id=4,
@@ -330,7 +340,7 @@ def test_checkbox_widget_lifts_cluster_label_and_lets_as_override_classifier() -
 
     list(PdfFormFieldModel(enabled=True)(conv_res, [page]))
 
-    value = page.predictions.field_regions[0].values[0]
+    value = page.predictions.field_regions[0].items[0].values[0]
     assert value.text == ""
     assert value.checkbox == "unselected"  # from /AS, overriding the classifier
     assert value.checkbox_label == "4797 ✔"  # cluster text lifted as-is
@@ -338,18 +348,27 @@ def test_checkbox_widget_lifts_cluster_label_and_lets_as_override_classifier() -
     assert cb_cluster not in page.predictions.layout.clusters  # promoted, not left
 
 
-def test_pipeline_materializes_keyless_format_neutral_fields() -> None:
+def test_pipeline_materializes_format_neutral_fields() -> None:
     result = _convert(extract_form_fields=True)
 
     assert result.pages[0].assembled is not None
-    assert len(result.pages[0].predictions.field_regions) == 1
-    assert result.pages[0].predictions.field_regions[0].source_container_id is None
-    assert len(result.document.field_regions) == 1
-    assert len(result.document.field_items) == 4
-    assert all(len(item.children) == 1 for item in result.document.field_items)
-    assert not any(
-        item.label == DocItemLabel.FIELD_KEY for item in result.document.texts
-    )
+    # The layout detector merges the three checkbox lines into one text cluster,
+    # so their widgets share an enclosing paragraph and group under one keyed
+    # item; the text field sits in its own keyless region. Two regions, keyed on
+    # the paragraph cluster (id 0) and the page-wide unmatched fallback.
+    assert [
+        region.source_container_id
+        for region in result.pages[0].predictions.field_regions
+    ] == [0, None]
+    assert len(result.document.field_regions) == 2
+    # One keyed item (paragraph key + three checkbox values) and one keyless
+    # single-value item for the text field.
+    assert len(result.document.field_items) == 2
+    keys = [
+        item for item in result.document.texts if item.label == DocItemLabel.FIELD_KEY
+    ]
+    assert len(keys) == 1
+    assert "I agree to the terms" in keys[0].text
 
     values = [
         item for item in result.document.texts if isinstance(item, FieldValueItem)
@@ -389,4 +408,66 @@ def test_pipeline_materializes_keyless_format_neutral_fields() -> None:
     assert disabled.pages[0].predictions.field_regions == []
     assert disabled.document.field_regions == []
     assert disabled.document.field_items == []
-    assert result.pages[0].predictions.layout == disabled.pages[0].predictions.layout
+    # Extraction promotes the paragraph that hosts the checkbox widgets out of the
+    # plain-text body (it becomes the field key), so the enabled layout is the
+    # disabled one minus that one cluster; every other cluster is untouched.
+    enabled_ids = {c.id for c in result.pages[0].predictions.layout.clusters}
+    disabled_ids = {c.id for c in disabled.pages[0].predictions.layout.clusters}
+    promoted = disabled_ids - enabled_ids
+    assert len(promoted) == 1
+    promoted_cluster = next(
+        c for c in disabled.pages[0].predictions.layout.clusters if c.id in promoted
+    )
+    assert "I agree to the terms" in " ".join(
+        cell.text for cell in promoted_cluster.cells
+    )
+
+
+def test_widgets_inlined_in_paragraph_group_into_one_keyed_item() -> None:
+    # IRS Sch.1 line 7 shape: a sentence inlines a checkbox and a fillable amount.
+    # The layout detects the whole line as one text cluster enclosing both
+    # widgets; a FORM cluster also wraps the page. The smaller text cluster is the
+    # more specific host, so both widgets group under one keyed item -- key = the
+    # paragraph, two values (checkbox + amount) -- not two keyless FORM fields.
+    paragraph = _text_cluster(
+        1,
+        BoundingBox(l=10, t=10, r=90, b=20),
+        "check here and enter amount repaid:",
+    )
+    page_form = Cluster(
+        id=2, label=DocItemLabel.FORM, bbox=BoundingBox(l=0, t=0, r=100, b=100)
+    )
+    widgets = [
+        _widget(
+            0,
+            BoundingBox(l=40, t=12, r=44, b=18),
+            "",
+            field_type="/Btn",
+            appearance_state="/Off",
+        ),
+        _widget(1, BoundingBox(l=70, t=12, r=85, b=18), "1221.00"),
+    ]
+    page = Page(page_no=1, size=Size(width=100, height=100))
+    page.parsed_page = MagicMock(widgets=widgets)
+    page.predictions.layout = LayoutPrediction(clusters=[page_form, paragraph])
+    conv_res = _conversion_result(page)
+
+    list(PdfFormFieldModel(enabled=True)(conv_res, [page]))
+
+    keyed = [
+        (region, item)
+        for region in page.predictions.field_regions
+        for item in region.items
+        if item.key_text
+    ]
+    assert len(keyed) == 1
+    region, item = keyed[0]
+    assert region.source_container_id == paragraph.id
+    assert item.key_text == "check here and enter amount repaid:"
+    assert item.key_bbox == paragraph.bbox
+    assert [(v.text, v.checkbox) for v in item.values] == [
+        ("", "unselected"),
+        ("1221.00", None),
+    ]
+    # The paragraph is promoted out of the plain-text body (becomes the key).
+    assert paragraph not in page.predictions.layout.clusters

--- a/tests/test_form_extraction.py
+++ b/tests/test_form_extraction.py
@@ -354,21 +354,28 @@ def test_pipeline_materializes_format_neutral_fields() -> None:
     assert result.pages[0].assembled is not None
     # The layout detector merges the three checkbox lines into one text cluster,
     # so their widgets share an enclosing paragraph and group under one keyed
-    # item; the text field sits in its own keyless region. Two regions, keyed on
-    # the paragraph cluster (id 0) and the page-wide unmatched fallback.
+    # field_item materialized in place of that paragraph. The text field has no
+    # enclosing paragraph and stays a keyless value in the page-wide region.
     assert [
         region.source_container_id
         for region in result.pages[0].predictions.field_regions
     ] == [0, None]
-    assert len(result.document.field_regions) == 2
-    # One keyed item (paragraph key + three checkbox values) and one keyless
-    # single-value item for the text field.
+    # Only the text field's page-wide region survives as a field_region; the
+    # paragraph item lives inline in the body, not wrapped in a region of its own.
+    assert len(result.document.field_regions) == 1
+    # One keyed inline item (paragraph key + three checkbox values) and one
+    # keyless single-value item for the text field.
     assert len(result.document.field_items) == 2
     keys = [
         item for item in result.document.texts if item.label == DocItemLabel.FIELD_KEY
     ]
     assert len(keys) == 1
     assert "I agree to the terms" in keys[0].text
+    # The keyed field_item materializes in the paragraph's own place, NOT wrapped
+    # in a field_region of its own (it would be, if pulled out into a region).
+    keyed_item = keys[0].parent.resolve(result.document)
+    assert keyed_item.label == DocItemLabel.FIELD_ITEM
+    assert keyed_item.parent.resolve(result.document).label != DocItemLabel.FIELD_REGION
 
     values = [
         item for item in result.document.texts if isinstance(item, FieldValueItem)
@@ -408,19 +415,9 @@ def test_pipeline_materializes_format_neutral_fields() -> None:
     assert disabled.pages[0].predictions.field_regions == []
     assert disabled.document.field_regions == []
     assert disabled.document.field_items == []
-    # Extraction promotes the paragraph that hosts the checkbox widgets out of the
-    # plain-text body (it becomes the field key), so the enabled layout is the
-    # disabled one minus that one cluster; every other cluster is untouched.
-    enabled_ids = {c.id for c in result.pages[0].predictions.layout.clusters}
-    disabled_ids = {c.id for c in disabled.pages[0].predictions.layout.clusters}
-    promoted = disabled_ids - enabled_ids
-    assert len(promoted) == 1
-    promoted_cluster = next(
-        c for c in disabled.pages[0].predictions.layout.clusters if c.id in promoted
-    )
-    assert "I agree to the terms" in " ".join(
-        cell.text for cell in promoted_cluster.cells
-    )
+    # The hosting paragraph is not dropped -- it is reinterpreted as a field_item
+    # at materialization -- so extraction leaves the layout clusters untouched.
+    assert result.pages[0].predictions.layout == disabled.pages[0].predictions.layout
 
 
 def test_widgets_inlined_in_paragraph_group_into_one_keyed_item() -> None:
@@ -469,5 +466,6 @@ def test_widgets_inlined_in_paragraph_group_into_one_keyed_item() -> None:
         ("", "unselected"),
         ("1221.00", None),
     ]
-    # The paragraph is promoted out of the plain-text body (becomes the key).
-    assert paragraph not in page.predictions.layout.clusters
+    # The paragraph stays in the layout -- it is reinterpreted as a field_item in
+    # place at materialization, keeping its position in its list/container.
+    assert paragraph in page.predictions.layout.clusters

--- a/tests/test_form_extraction.py
+++ b/tests/test_form_extraction.py
@@ -1,0 +1,274 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+import json
+from pathlib import Path, PurePath
+from unittest.mock import MagicMock
+
+from docling_core.types.doc import BoundingBox, DocItemLabel, Size
+from docling_core.types.doc.items.form import FieldItem, FieldValueItem
+from docling_core.types.doc.page import BoundingRectangle, PdfWidget
+
+from docling.backend.docling_parse_backend import DoclingParseDocumentBackend
+from docling.datamodel.base_models import (
+    AssembledUnit,
+    Cluster,
+    FieldRegionElement,
+    InputFormat,
+    LayoutPrediction,
+    Page,
+)
+from docling.datamodel.document import ConversionResult, InputDocument
+from docling.datamodel.pipeline_options import PdfPipelineOptions
+from docling.document_converter import DocumentConverter, PdfFormatOption
+from docling.models.stages.form_field.form_field_model import PdfFormFieldModel
+from docling.models.stages.page_assemble.page_assemble_model import (
+    PageAssembleModel,
+    PageAssembleOptions,
+)
+from docling.models.stages.reading_order.readingorder_model import (
+    ReadingOrderModel,
+    ReadingOrderOptions,
+)
+
+FORM_PDF = Path("tests/data/pdf/sources/acroform_sample.pdf")
+EXPECTED_NAMES = [
+    "applicant_name",
+    "agree_terms",
+    "newsletter",
+    "mail_optin",
+]
+
+
+def _convert(*, extract_form_fields: bool) -> ConversionResult:
+    options = PdfPipelineOptions(
+        do_ocr=False,
+        do_table_structure=False,
+        extract_form_fields=extract_form_fields,
+    )
+    return DocumentConverter(
+        format_options={
+            InputFormat.PDF: PdfFormatOption(pipeline_options=options),
+        }
+    ).convert(FORM_PDF)
+
+
+def _conversion_result(page: Page) -> ConversionResult:
+    input_doc = InputDocument.model_construct(
+        file=PurePath("input.pdf"),
+        document_hash="0" * 64,
+        valid=True,
+        format=InputFormat.PDF,
+    )
+    return ConversionResult(input=input_doc, pages=[page])
+
+
+def _widget(
+    index: int,
+    bbox: BoundingBox,
+    text: str,
+    *,
+    field_type: str = "/Tx",
+    appearance_state: str | None = None,
+) -> PdfWidget:
+    return PdfWidget(
+        index=index,
+        rect=BoundingRectangle.from_bounding_box(
+            bbox.to_bottom_left_origin(page_height=100)
+        ),
+        widget_text=text,
+        widget_field_type=field_type,
+        widget_appearance_state=appearance_state,
+    )
+
+
+def test_docling_parse_exposes_complete_widget_contract_in_native_order() -> None:
+    input_doc = InputDocument(
+        path_or_stream=FORM_PDF,
+        format=InputFormat.PDF,
+        backend=DoclingParseDocumentBackend,
+    )
+    backend = input_doc._backend
+    page = backend.load_page(0)
+    try:
+        segmented_page = page.get_segmented_page()
+        assert segmented_page is not None
+        assert [widget.widget_field_name for widget in segmented_page.widgets] == (
+            EXPECTED_NAMES
+        )
+        assert [widget.index for widget in segmented_page.widgets] == [0, 1, 2, 3]
+        assert segmented_page.widgets[0].widget_text == "Ada Lovelace"
+        assert segmented_page.widgets[0].widget_description == "Full legal name"
+        assert segmented_page.widgets[0].widget_field_type == "/Tx"
+        assert segmented_page.widgets[0].widget_field_flags == 2
+        assert segmented_page.widgets[1].widget_appearance_state == "/Yes"
+        assert segmented_page.widgets[2].widget_appearance_state == "/Off"
+        assert segmented_page.widgets[3].widget_text in {None, ""}
+        assert segmented_page.widgets[3].widget_appearance_state == "/On"
+    finally:
+        page.unload()
+        backend.unload()
+
+
+def test_field_mapping_assembly_and_materialization_preserve_regions_and_order() -> (
+    None
+):
+    form_1 = Cluster(
+        id=1,
+        label=DocItemLabel.FORM,
+        bbox=BoundingBox(l=0, t=0, r=60, b=60),
+    )
+    form_2 = Cluster(
+        id=2,
+        label=DocItemLabel.FORM,
+        bbox=BoundingBox(l=40, t=0, r=100, b=60),
+    )
+    form_3 = Cluster(
+        id=3,
+        label=DocItemLabel.FORM,
+        bbox=BoundingBox(l=45, t=30, r=55, b=45),
+    )
+    widgets = [
+        _widget(0, BoundingBox(l=10, t=10, r=20, b=20), "first"),
+        _widget(1, BoundingBox(l=80, t=10, r=90, b=20), "second"),
+        _widget(2, BoundingBox(l=20, t=30, r=30, b=40), "third"),
+        _widget(3, BoundingBox(l=45, t=10, r=55, b=20), "tie"),
+        _widget(
+            4,
+            BoundingBox(l=47, t=32, r=53, b=40),
+            "/Off",
+            field_type="/Btn",
+            appearance_state="/On",
+        ),
+        _widget(
+            5,
+            BoundingBox(l=10, t=80, r=20, b=90),
+            "/Yes",
+            field_type="/Btn",
+            appearance_state="/Off",
+        ),
+    ]
+    page = Page(page_no=1, size=Size(width=100, height=100))
+    page.parsed_page = MagicMock(widgets=widgets)
+    page.predictions.layout = LayoutPrediction(clusters=[form_1, form_2, form_3])
+    conv_res = _conversion_result(page)
+
+    assert list(PdfFormFieldModel(enabled=True)(conv_res, [page])) == [page]
+    assert [
+        region.source_container_id for region in page.predictions.field_regions
+    ] == [
+        1,
+        2,
+        3,
+        None,
+    ]
+    assert [
+        [value.text for value in region.values]
+        for region in page.predictions.field_regions
+    ] == [["first", "third", "tie"], ["second"], ["checked"], ["unchecked"]]
+    assert page.predictions.field_regions[2].values[0].orig == "/On"
+    assert page.predictions.field_regions[3].values[0].orig == "/Off"
+
+    visible_child = Cluster(
+        id=4,
+        label=DocItemLabel.TEXT,
+        bbox=BoundingBox(l=5, t=5, r=35, b=9),
+    )
+    retained_form_1 = form_1.model_copy(
+        update={
+            "bbox": BoundingBox(l=5, t=5, r=35, b=45),
+            "children": [visible_child],
+        }
+    )
+    retained_form_2 = form_2.model_copy(
+        update={"bbox": BoundingBox(l=60, t=5, r=95, b=45)}
+    )
+    page.predictions.layout = LayoutPrediction(
+        clusters=[retained_form_1, retained_form_2, visible_child]
+    )
+    layout_before_assembly = page.predictions.layout.model_copy(deep=True)
+    page._backend = MagicMock()
+    page._backend.is_valid.return_value = True
+
+    assert list(PageAssembleModel(PageAssembleOptions())(conv_res, [page])) == [page]
+    assert page.predictions.layout == layout_before_assembly
+    assert page.assembled is not None
+    region_elements = [
+        element
+        for element in page.assembled.elements
+        if isinstance(element, FieldRegionElement)
+    ]
+    assert len(region_elements) == 4
+    assert region_elements[0].id == form_1.id
+    assert region_elements[0].cluster.bbox == form_1.bbox
+    assert region_elements[0].cluster.children == [visible_child]
+    assert len({element.id for element in page.assembled.elements}) == len(
+        page.assembled.elements
+    )
+
+    conv_res.assembled = AssembledUnit(
+        elements=page.assembled.elements,
+        body=page.assembled.body,
+        headers=page.assembled.headers,
+    )
+    doc = ReadingOrderModel(ReadingOrderOptions())(conv_res)
+    assert len(doc.field_regions) == 4
+    assert len(doc.field_items) == 6
+    assert not any(item.label == DocItemLabel.FIELD_KEY for item in doc.texts)
+    values_by_region = []
+    for region in doc.field_regions:
+        field_items = [
+            child.resolve(doc)
+            for child in region.children
+            if isinstance(child.resolve(doc), FieldItem)
+        ]
+        values_by_region.append(
+            [field.children[0].resolve(doc).text for field in field_items]
+        )
+    assert ["first", "third", "tie"] in values_by_region
+    assert ["checked"] in values_by_region
+    assert ["unchecked"] in values_by_region
+    doc.validate_document()
+
+
+def test_pipeline_materializes_keyless_format_neutral_fields() -> None:
+    result = _convert(extract_form_fields=True)
+
+    assert result.pages[0].assembled is not None
+    assert len(result.pages[0].predictions.field_regions) == 1
+    assert result.pages[0].predictions.field_regions[0].source_container_id is None
+    assert len(result.document.field_regions) == 1
+    assert len(result.document.field_items) == 4
+    assert all(len(item.children) == 1 for item in result.document.field_items)
+    assert not any(
+        item.label == DocItemLabel.FIELD_KEY for item in result.document.texts
+    )
+
+    values = [
+        item for item in result.document.texts if isinstance(item, FieldValueItem)
+    ]
+    assert [value.text for value in values] == [
+        "Ada Lovelace",
+        "checked",
+        "unchecked",
+        "checked",
+    ]
+    assert [value.orig for value in values] == [
+        "Ada Lovelace",
+        "/Yes",
+        "/Off",
+        "/On",
+    ]
+    assert all(value.kind == "fillable" for value in values)
+    assert not any(
+        name in {item.text for item in result.document.texts} for name in EXPECTED_NAMES
+    )
+    serialized = json.dumps(result.document.export_to_dict())
+    assert "widget_field_name" not in serialized
+    assert "widget_appearance_state" not in serialized
+
+    disabled = _convert(extract_form_fields=False)
+    assert disabled.pages[0].predictions.field_regions == []
+    assert disabled.document.field_regions == []
+    assert disabled.document.field_items == []
+    assert result.pages[0].predictions.layout == disabled.pages[0].predictions.layout

--- a/tests/test_form_extraction.py
+++ b/tests/test_form_extraction.py
@@ -165,7 +165,11 @@ def test_field_mapping_assembly_and_materialization_preserve_regions_and_order()
     assert [
         [value.text for value in region.values]
         for region in page.predictions.field_regions
-    ] == [["first", "third", "tie"], ["second"], ["checked"], ["unchecked"]]
+    ] == [["first", "third", "tie"], ["second"], [""], [""]]
+    assert [
+        [value.checkbox for value in region.values]
+        for region in page.predictions.field_regions
+    ] == [[None, None, None], [None], ["selected"], ["unselected"]]
     assert page.predictions.field_regions[2].values[0].orig == "/On"
     assert page.predictions.field_regions[3].values[0].orig == "/Off"
 
@@ -215,6 +219,21 @@ def test_field_mapping_assembly_and_materialization_preserve_regions_and_order()
     assert len(doc.field_regions) == 4
     assert len(doc.field_items) == 6
     assert not any(item.label == DocItemLabel.FIELD_KEY for item in doc.texts)
+
+    def _value_repr(value: FieldValueItem) -> str:
+        # Text fields carry their text; a checkbox value is empty and nests a
+        # CHECKBOX_* child that carries the selection state.
+        checkbox_children = [
+            child.resolve(doc)
+            for child in value.children
+            if child.resolve(doc).label
+            in {DocItemLabel.CHECKBOX_SELECTED, DocItemLabel.CHECKBOX_UNSELECTED}
+        ]
+        if checkbox_children:
+            assert value.text == ""
+            return checkbox_children[0].label.value
+        return value.text
+
     values_by_region = []
     for region in doc.field_regions:
         field_items = [
@@ -223,11 +242,11 @@ def test_field_mapping_assembly_and_materialization_preserve_regions_and_order()
             if isinstance(child.resolve(doc), FieldItem)
         ]
         values_by_region.append(
-            [field.children[0].resolve(doc).text for field in field_items]
+            [_value_repr(field.children[0].resolve(doc)) for field in field_items]
         )
     assert ["first", "third", "tie"] in values_by_region
-    assert ["checked"] in values_by_region
-    assert ["unchecked"] in values_by_region
+    assert [DocItemLabel.CHECKBOX_SELECTED.value] in values_by_region
+    assert [DocItemLabel.CHECKBOX_UNSELECTED.value] in values_by_region
     doc.validate_document()
 
 
@@ -284,11 +303,22 @@ def test_pipeline_materializes_keyless_format_neutral_fields() -> None:
     values = [
         item for item in result.document.texts if isinstance(item, FieldValueItem)
     ]
-    assert [value.text for value in values] == [
-        "Ada Lovelace",
-        "checked",
-        "unchecked",
-        "checked",
+    # Checkbox values carry no text; their state rides on a nested CHECKBOX_* child.
+    assert [value.text for value in values] == ["Ada Lovelace", "", "", ""]
+    checkbox_labels = [
+        [
+            child.resolve(result.document).label
+            for child in value.children
+            if child.resolve(result.document).label
+            in {DocItemLabel.CHECKBOX_SELECTED, DocItemLabel.CHECKBOX_UNSELECTED}
+        ]
+        for value in values
+    ]
+    assert checkbox_labels == [
+        [],
+        [DocItemLabel.CHECKBOX_SELECTED],
+        [DocItemLabel.CHECKBOX_UNSELECTED],
+        [DocItemLabel.CHECKBOX_SELECTED],
     ]
     assert [value.orig for value in values] == [
         "Ada Lovelace",

--- a/tests/test_form_extraction.py
+++ b/tests/test_form_extraction.py
@@ -287,6 +287,57 @@ def test_suppresses_rendered_duplicate_of_filled_widget() -> None:
     assert form.children == []  # child ref pruned so assembly stays consistent
 
 
+def _checkbox_cluster(
+    cluster_id: int, bbox: BoundingBox, *, label: str, mark: str
+) -> Cluster:
+    cells = [
+        TextCell(
+            index=0,
+            rect=BoundingRectangle.from_bounding_box(bbox),
+            text=label,
+            orig=label,
+            from_ocr=False,
+        ),
+        TextCell(
+            index=1,
+            rect=BoundingRectangle.from_bounding_box(bbox),
+            text=mark,
+            orig=mark,
+            from_ocr=False,
+        ),
+    ]
+    return Cluster(
+        id=cluster_id,
+        label=DocItemLabel.CHECKBOX_SELECTED,
+        bbox=bbox,
+        cells=cells,
+    )
+
+
+def test_checkbox_widget_lifts_cluster_label_and_lets_as_override_classifier() -> None:
+    # The widget rect sits inside a CHECKBOX_SELECTED cluster that also absorbed
+    # the option label "4797" and the mark glyph. The cluster's option label is
+    # lifted onto the value and the cluster is promoted out of the plain-text
+    # stream; but /AS ("/Off") -- not the classifier's "selected" -- decides state.
+    widget_bbox = BoundingBox(l=10, t=10, r=18, b=18)
+    cb_cluster = _checkbox_cluster(
+        2, BoundingBox(l=8, t=8, r=40, b=20), label="4797", mark="✔"
+    )
+    widget = _widget(0, widget_bbox, "/Off", field_type="/Btn", appearance_state="/Off")
+    page = Page(page_no=1, size=Size(width=100, height=100))
+    page.parsed_page = MagicMock(widgets=[widget])
+    page.predictions.layout = LayoutPrediction(clusters=[cb_cluster])
+    conv_res = _conversion_result(page)
+
+    list(PdfFormFieldModel(enabled=True)(conv_res, [page]))
+
+    value = page.predictions.field_regions[0].values[0]
+    assert value.text == ""
+    assert value.checkbox == "unselected"  # from /AS, overriding the classifier
+    assert value.checkbox_label == "4797"  # mark glyph stripped
+    assert cb_cluster not in page.predictions.layout.clusters  # promoted, not left
+
+
 def test_pipeline_materializes_keyless_format_neutral_fields() -> None:
     result = _convert(extract_form_fields=True)
 

--- a/uv.lock
+++ b/uv.lock
@@ -881,7 +881,7 @@ name = "coloredlogs"
 version = "15.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "humanfriendly" },
+    { name = "humanfriendly", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
 wheels = [
@@ -919,7 +919,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/54/eb9bfc647b19f2009dd5c7f5ec51c4e6ca831725f1aea7a993034f483147/contourpy-1.3.2.tar.gz", hash = "sha256:b6945942715a034c671b7fc54f9588126b0b8bf23db2696e3ca8328f3ff0ab54", size = 13466130, upload-time = "2025-04-15T17:47:53.79Z" }
 wheels = [
@@ -1001,7 +1001,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/58/01/1253e6698a07380cd31a736d248a3f2a50a7c88779a1813da27503cadc2a/contourpy-1.3.3.tar.gz", hash = "sha256:083e12155b210502d0bca491432bb04d56dc3432f95a979b429f2848c3dbe880", size = 13466174, upload-time = "2025-07-26T12:03:12.549Z" }
@@ -1217,8 +1217,8 @@ name = "cryptography"
 version = "50.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "cffi", marker = "(platform_python_implementation != 'PyPy' and sys_platform == 'linux') or (platform_python_implementation != 'PyPy' and sys_platform == 'win32')" },
+    { name = "typing-extensions", marker = "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/bb/ad/5d6702db60b1e40b41ef513b6967ff5848f307d50f8449baf1634f5908f1/cryptography-50.0.1.tar.gz", hash = "sha256:5dd9bda1c12b4162f6ff568eeb5e0ff956c28d14406e875cfe8a63a2d414ff20", size = 880381, upload-time = "2026-08-25T19:45:45.499Z" }
 wheels = [
@@ -1309,7 +1309,7 @@ name = "cuda-bindings"
 version = "13.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/21/8464d133752951c154feafb3b65c297e7d80f301183d220bec4c830f1441/cuda_bindings-13.3.1-cp310-cp310-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:120fcc53d57903df529c3486962c56528cba5b7d6c57c99537320ed9922c8b86", size = 6073403, upload-time = "2026-05-29T23:11:36.22Z" },
@@ -1347,37 +1347,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", version = "13.1.0.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cublas", version = "13.1.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime" },
+    { name = "nvidia-cuda-runtime", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft" },
+    { name = "nvidia-cufft", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 cufile = [
-    { name = "nvidia-cufile" },
+    { name = "nvidia-cufile", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti" },
+    { name = "nvidia-cuda-cupti", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand" },
+    { name = "nvidia-curand", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver" },
+    { name = "nvidia-cusolver", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse" },
+    { name = "nvidia-cusparse", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx" },
+    { name = "nvidia-nvtx", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -1397,43 +1397,43 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", version = "13.1.1.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", version = "13.1.1.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-runtime", marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufft", marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cufile = [
-    { name = "nvidia-cufile", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cufile", marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux')" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-cupti", marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-curand", marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cusolver = [
-    { name = "nvidia-cublas", version = "13.1.1.3", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusolver", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cublas", version = "13.1.1.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusolver", marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cusparse", marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "platform_machine == 'aarch64' or platform_machine == 'x86_64'" },
+    { name = "nvidia-nvtx", marker = "(python_full_version != '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
 ]
 
 [[package]]
@@ -1718,7 +1718,7 @@ requires-dist = [{ name = "docling-slim", extras = ["service-client"], editable 
 [[package]]
 name = "docling-core"
 version = "2.92.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/docling-project/docling-core.git?branch=feat%2Facroform-widget-extraction#8942fa3b1c809278860830e23f9b99969dc76884" }
 dependencies = [
     { name = "defusedxml" },
     { name = "doclang" },
@@ -1734,10 +1734,6 @@ dependencies = [
     { name = "tabulate" },
     { name = "typer" },
     { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/47/9c/8ab960c09e501b57dda1b823dff3264bed70ab70ef60328767be38ca30f5/docling_core-2.92.0.tar.gz", hash = "sha256:33fd25e38c199336447a21925374400aca13a6b9316a032f111972c2dc0f085c", size = 360897, upload-time = "2026-08-19T10:55:21.431Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/d1/7f6d9e737ea5c41c0fd4d2819732fc43416c0a60c5870342381db149d368/docling_core-2.92.0-py3-none-any.whl", hash = "sha256:726d89c23197e53be2f7192bb4c00108ff545830cf9ab7b981fb014fa92b5c02", size = 295507, upload-time = "2026-08-19T10:55:19.992Z" },
 ]
 
 [package.optional-dependencies]
@@ -1776,40 +1772,12 @@ wheels = [
 [[package]]
 name = "docling-parse"
 version = "7.16.0"
-source = { registry = "https://pypi.org/simple" }
+source = { git = "https://github.com/docling-project/docling-parse.git?branch=feat%2Facroform-widget-extraction#78679d7928f90d8be03a864bd2eae3a656e4e61d" }
 dependencies = [
     { name = "docling-core" },
     { name = "pillow" },
     { name = "pydantic" },
     { name = "pywin32", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/99/ee/83a4fb9926b0fb0185b30797a98027a8e433284a0bf16396c11fb85a09b6/docling_parse-7.16.0.tar.gz", hash = "sha256:870e781f7b7d1403d1168bf860c19fd2ab5ddb42335c60a1927673fa8fc615e2", size = 6963225, upload-time = "2026-08-25T15:49:04.615Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/0c/1f30461c0d6b574df0c7596f79a17dbaf9c5ac79d1df759fd3c5337d21a5/docling_parse-7.16.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:2eec0297713e85076a9856ba455b546ec108b7d1d0c485a4a0260e820e722ca9", size = 9759121, upload-time = "2026-08-25T15:48:18.867Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e7/d4c6d35e7a84adbcac09f7685410939576153f61ada03902a0a20f6bc027/docling_parse-7.16.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63f161f3cfcaefef919f60ad7dba805c2eda3daac1022fbdbf3368e51ea10520", size = 10316231, upload-time = "2026-08-25T15:48:20.842Z" },
-    { url = "https://files.pythonhosted.org/packages/19/f9/d493fae93deb924f34f4d128afac52d9d95afdd64abbc3d035bf7337d50d/docling_parse-7.16.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea261b705ffd1cac97b0ca2eab656b2fe4434ff4876be38eddf0b2c9bb582133", size = 10581077, upload-time = "2026-08-25T15:48:22.727Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d0/294cadf83f4f73accf497ad443306e42bf2697e3380e086fb240b106c47c/docling_parse-7.16.0-cp310-cp310-win_amd64.whl", hash = "sha256:8d383646bd8f11969b1e45c0107ead107354e4ff20661943642091e92cffcc99", size = 11739885, upload-time = "2026-08-25T15:48:24.373Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/d6/f15f0da2583f7014d11b304535c7aab88bf7b149c167151b7cb7c27796f1/docling_parse-7.16.0-cp310-cp310-win_arm64.whl", hash = "sha256:4a80901f294579681c1f51601892b1a3068a4599986bc3a92321305b78daca59", size = 9050056, upload-time = "2026-08-25T15:48:26.352Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/d9/96c1b4a0ddfef5ce81b126a1d34aefcc1fa36cf19415626c48183f1de790/docling_parse-7.16.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:d81008264fec675bd75ddbb79ec20823dd638f3ab31d889e08991d769cc592ab", size = 9761145, upload-time = "2026-08-25T15:48:28.027Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/a9/16b21173aa41be0f922b410a96960b17940f3f1a882263b0192bc17b031e/docling_parse-7.16.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e63af02e5bcea71a407776e4f8d944f5db4ee840cb3abb9c4ecaae6768e0efb", size = 10283267, upload-time = "2026-08-25T15:48:29.745Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/bc/5665ac3ebd14af94ed08ef0ba89d1b87541c0fac64ed27dd4c853f1fd40e/docling_parse-7.16.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:96756c2205aaa958ee2930e7ded33b756c5ff663724f8aa7dce5cd241296cf1b", size = 10683338, upload-time = "2026-08-25T15:48:31.362Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/e1/9f31ca9bd22be994c6651b1e080882bb8a787a630d25e666b3523d78563c/docling_parse-7.16.0-cp311-cp311-win_amd64.whl", hash = "sha256:e6104ae8e881ddb6ed78275c662cf857dbfbb2af4853189cc1d4ba57f2a1ae1f", size = 11741343, upload-time = "2026-08-25T15:48:33.186Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/1b/1986384533c025c9e40823d303f5b1958d1730b595b02de57a7a904bef4d/docling_parse-7.16.0-cp311-cp311-win_arm64.whl", hash = "sha256:7b400182bc6de50cb7705eb7d944fe5dfe747023a5b8557adcd643a5c014880d", size = 9051339, upload-time = "2026-08-25T15:48:34.964Z" },
-    { url = "https://files.pythonhosted.org/packages/08/e3/02e6e02eef860e276587c90896dd86d897e1150bf984c6135f4ab61f9352/docling_parse-7.16.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:cb173b447806ff3a4af3c06936e9585dc201b3ecbb958aebde37a2725471675f", size = 9762630, upload-time = "2026-08-25T15:48:36.814Z" },
-    { url = "https://files.pythonhosted.org/packages/25/70/3702dd16141ac8e45548d3f09d2e66c373a96ffc871086a0bb022caa81de/docling_parse-7.16.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2c2bf844d567f729aa2a48f22b3c4f5d7e5a7db6b6b3a9ec07b45cf31d4ce3e", size = 10286523, upload-time = "2026-08-25T15:48:38.495Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/cb/cece74107282ce7cfe00d14ce5a33d2056aed689a34d20965be4779972da/docling_parse-7.16.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ab71b6b9d1085b08ca2a3529356ae3122e56a8be693a32d37e996ae88c6fe866", size = 10686779, upload-time = "2026-08-25T15:48:40.223Z" },
-    { url = "https://files.pythonhosted.org/packages/51/b3/52068732b63eae2cbae779d057c311e0010e761e5853ad233080cf201a53/docling_parse-7.16.0-cp312-cp312-win_amd64.whl", hash = "sha256:f1abfe050b670bcb25c7bcefc5d876bc3561949c1bff177e8a8a3d8d6f217314", size = 11746880, upload-time = "2026-08-25T15:48:42.089Z" },
-    { url = "https://files.pythonhosted.org/packages/23/09/2ceda924e1581c4b9fbec47d1343e0e64078ef89a314383dca2f604e6b48/docling_parse-7.16.0-cp312-cp312-win_arm64.whl", hash = "sha256:da0483decd77d9a967c54e751107c36a3c3bae186e989f81339dff5037f0a7fe", size = 9051750, upload-time = "2026-08-25T15:48:43.924Z" },
-    { url = "https://files.pythonhosted.org/packages/68/b3/1a4b65a60e0cd11d4512c55e81c03a4f5f6c7c08ed6f78fb703e983aa4b0/docling_parse-7.16.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:c3b4d67da75631a28252bf574023e4a45fdd422603ea07cf73a8e70074547436", size = 9762652, upload-time = "2026-08-25T15:48:45.716Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/fa/0b1a0ce72403002080231708f753cbbfbef22385b336bfd5f2252a96fe54/docling_parse-7.16.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e2bebe14d3ce0b6e7f256f2e4bbc7f2405dc9ddc91bbc5031dcba07bf97d9b8", size = 10286719, upload-time = "2026-08-25T15:48:47.483Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/67/fe434aeb6d58bf3a69bdbcfee7b52633ec2cfad5e28ce7862d3d910f31c7/docling_parse-7.16.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6ab9b9deefd347166d670f894d27f697bf2d213a51e526516dc9ff44e0c19b5a", size = 10686793, upload-time = "2026-08-25T15:48:49.073Z" },
-    { url = "https://files.pythonhosted.org/packages/8d/79/97d07a4a056f540d7224720eb1cbdd606fe5f825d7954b5b574cf872efb8/docling_parse-7.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:b4dc06844b775014bbf9a8f2d830d6700a47b2ec13c62a4ee61a2c9382fe4dca", size = 11746783, upload-time = "2026-08-25T15:48:50.855Z" },
-    { url = "https://files.pythonhosted.org/packages/42/eb/61492ee31917fdcc35117c0b5053626b81084b68cc1345e779e2428c6e08/docling_parse-7.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:4dad04e693ec3d120885249a097dc61b0823f01b0a99c52696828b9eb6649e0b", size = 9051766, upload-time = "2026-08-25T15:48:52.558Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/ac/9ca727496edf2a1e5f2ecf7b2736173616d4e09ae65e4f7f858f9dc5d8b3/docling_parse-7.16.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:1ed3fd24a26a2b00357cc199001e2817d70163447b456ac0c66efe1823e38404", size = 9763549, upload-time = "2026-08-25T15:48:54.258Z" },
-    { url = "https://files.pythonhosted.org/packages/13/86/84ab1b9bdc4ab0eb68bfef70b5abf871fde4f9c8f576b1e5e40ed0187c22/docling_parse-7.16.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:12a1b9d145cc44d94a7b80e4ef62ea732b00cbd7803b1dac0d803893a82c100c", size = 10287706, upload-time = "2026-08-25T15:48:57.471Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/ec/887fb066d848ed0c8ad9efb90d1fe0361ee869b0a95a55a0254e70f723f1/docling_parse-7.16.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e71584a38d8bfaaf7947557b51359a260266b348507b0682814fa39f33cb2f0b", size = 10687139, upload-time = "2026-08-25T15:48:59.394Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/39/99699251e782eb8ffdbe2c49b7454d9bab8f0bed7cea30c56a8a1c564f0f/docling_parse-7.16.0-cp314-cp314-win_amd64.whl", hash = "sha256:9c11e3c7cb509fa27de277795211bd80369a2e682ed0e3d7170e12df13ff6d05", size = 12180438, upload-time = "2026-08-25T15:49:01.006Z" },
-    { url = "https://files.pythonhosted.org/packages/95/07/fba291257e7a40f9fddfca25fccb11f26404daabb83fddacd63cee72b307/docling_parse-7.16.0-cp314-cp314-win_arm64.whl", hash = "sha256:c9d5994bdcb8b12d157871ca2fd1e399afeac4528a2343af7d82e87dfca35e82", size = 9419759, upload-time = "2026-08-25T15:49:02.827Z" },
 ]
 
 [[package]]
@@ -2180,10 +2148,10 @@ requires-dist = [
     { name = "defusedxml", marker = "extra == 'format-iwork'", specifier = ">=0.7.1,<0.8.0" },
     { name = "defusedxml", marker = "extra == 'format-xml-uspto'", specifier = ">=0.7.1,<0.8.0" },
     { name = "defusedxml", marker = "extra == 'models-local'", specifier = ">=0.7.1,<0.8.0" },
-    { name = "docling-core", specifier = ">=2.91.0,<3.0.0" },
-    { name = "docling-core", extras = ["chunking"], marker = "extra == 'feat-chunking'", specifier = ">=2.73.0,<3.0.0" },
+    { name = "docling-core", git = "https://github.com/docling-project/docling-core.git?branch=feat%2Facroform-widget-extraction" },
+    { name = "docling-core", extras = ["chunking"], marker = "extra == 'feat-chunking'", git = "https://github.com/docling-project/docling-core.git?branch=feat%2Facroform-widget-extraction" },
     { name = "docling-ibm-models", marker = "extra == 'models-local'", specifier = ">=3.13.0,<5" },
-    { name = "docling-parse", marker = "extra == 'format-pdf-docling'", specifier = ">=7.16.0,<8.0.0" },
+    { name = "docling-parse", marker = "extra == 'format-pdf-docling'", git = "https://github.com/docling-project/docling-parse.git?branch=feat%2Facroform-widget-extraction" },
     { name = "docling-slim", extras = ["convert-core"], marker = "extra == 'extract-core'" },
     { name = "docling-slim", extras = ["format-audio"], marker = "extra == 'format-video'" },
     { name = "docling-slim", extras = ["format-docx", "format-pptx", "format-xlsx"], marker = "extra == 'format-office'" },
@@ -2316,7 +2284,7 @@ examples = [
 ]
 pr-fast-checks = [
     { name = "boto3-stubs", specifier = "~=1.37" },
-    { name = "docling-core", extras = ["chunking"], specifier = ">=2.73.0,<3.0.0" },
+    { name = "docling-core", extras = ["chunking"], git = "https://github.com/docling-project/docling-core.git?branch=feat%2Facroform-widget-extraction" },
     { name = "pandas-stubs", specifier = "~=2.1" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "pydantic-settings", specifier = ">=2.3.0,<3.0.0" },
@@ -2414,7 +2382,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -2770,14 +2738,14 @@ name = "gliner"
 version = "0.2.28"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
-    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' or python_full_version >= '3.14'" },
+    { name = "huggingface-hub", marker = "python_full_version < '3.14'" },
+    { name = "onnxruntime", version = "1.23.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "onnxruntime", version = "1.29.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
-    { name = "sentencepiece" },
+    { name = "sentencepiece", marker = "python_full_version < '3.14'" },
     { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*' or platform_machine != 'x86_64' or sys_platform != 'linux'" },
-    { name = "tqdm" },
-    { name = "transformers" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.14' and platform_machine != 'x86_64') or (python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version == '3.13.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.14' and sys_platform != 'linux')" },
+    { name = "tqdm", marker = "python_full_version < '3.14'" },
+    { name = "transformers", marker = "python_full_version < '3.14'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/f4/b7/0f3e24ff0b8c1c95121532a44e09b5bb87bd771c6bed0d387d51480645c5/gliner-0.2.28.tar.gz", hash = "sha256:b1637afb5cf4235fc871f1e21498831775b7bd19cefbda6dc5fe08ee88cb07a0", size = 263394, upload-time = "2026-07-24T14:03:49.833Z" }
 wheels = [
@@ -3038,7 +3006,7 @@ name = "humanfriendly"
 version = "10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+    { name = "pyreadline3", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
 wheels = [
@@ -3134,17 +3102,17 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "decorator" },
-    { name = "exceptiongroup" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions" },
+    { name = "colorama", marker = "python_full_version < '3.11' and sys_platform == 'win32'" },
+    { name = "decorator", marker = "python_full_version < '3.11'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
+    { name = "jedi", marker = "python_full_version < '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version < '3.11'" },
+    { name = "pexpect", marker = "python_full_version < '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version < '3.11'" },
+    { name = "pygments", marker = "python_full_version < '3.11'" },
+    { name = "stack-data", marker = "python_full_version < '3.11'" },
+    { name = "traitlets", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/40/18/f8598d287006885e7136451fdea0755af4ebcbfe342836f24deefaed1164/ipython-8.39.0.tar.gz", hash = "sha256:4110ae96012c379b8b6db898a07e186c40a2a1ef5d57a7fa83166047d9da7624", size = 5513971, upload-time = "2026-03-27T10:02:13.94Z" }
 wheels = [
@@ -3171,17 +3139,17 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-    { name = "ipython-pygments-lexers" },
-    { name = "jedi" },
-    { name = "matplotlib-inline" },
-    { name = "pexpect", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
-    { name = "prompt-toolkit" },
-    { name = "psutil", marker = "sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
-    { name = "pygments" },
-    { name = "stack-data" },
-    { name = "traitlets" },
-    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+    { name = "colorama", marker = "python_full_version >= '3.11' and sys_platform == 'win32'" },
+    { name = "ipython-pygments-lexers", marker = "python_full_version >= '3.11'" },
+    { name = "jedi", marker = "python_full_version >= '3.11'" },
+    { name = "matplotlib-inline", marker = "python_full_version >= '3.11'" },
+    { name = "pexpect", marker = "python_full_version >= '3.11' and sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "prompt-toolkit", marker = "python_full_version >= '3.11'" },
+    { name = "psutil", marker = "python_full_version >= '3.11' and sys_platform != 'cygwin' and sys_platform != 'emscripten'" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
+    { name = "stack-data", marker = "python_full_version >= '3.11'" },
+    { name = "traitlets", marker = "python_full_version >= '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/bc/e05ae123712ce4e1fde4408eedca1791fc1ff832684565132ea1dc646092/ipython-9.17.0.tar.gz", hash = "sha256:1dc69e6966b270fb259f676c71a21450e63607729b14a672b942914a54e8b730", size = 4538547, upload-time = "2026-08-28T09:00:58.233Z" }
 wheels = [
@@ -3193,7 +3161,7 @@ name = "ipython-pygments-lexers"
 version = "1.1.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pygments" },
+    { name = "pygments", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ef/4c/5dd1d8af08107f88c7f741ead7a40854b8ac24ddf9ae850afbcf698aa552/ipython_pygments_lexers-1.1.1.tar.gz", hash = "sha256:09c0138009e56b6854f9535736f4171d855c8c08a563a0dcd8022f78355c7e81", size = 8393, upload-time = "2025-01-17T11:24:34.505Z" }
 wheels = [
@@ -4086,15 +4054,15 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "contourpy", version = "1.3.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "cycler", marker = "python_full_version < '3.11'" },
+    { name = "fonttools", marker = "python_full_version < '3.11'" },
+    { name = "kiwisolver", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pillow", marker = "python_full_version < '3.11'" },
+    { name = "pyparsing", marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/63/1b/4be5be87d43d327a0cf4de1a56e86f7f84c89312452406cf122efe2839e6/matplotlib-3.10.9.tar.gz", hash = "sha256:fd66508e8c6877d98e586654b608a0456db8d7e8a546eb1e2600efd957302358", size = 34811233, upload-time = "2026-04-24T00:14:13.539Z" }
 wheels = [
@@ -4174,16 +4142,16 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "cycler" },
-    { name = "fonttools" },
-    { name = "kiwisolver" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "contourpy", version = "1.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "cycler", marker = "python_full_version >= '3.11'" },
+    { name = "fonttools", marker = "python_full_version >= '3.11'" },
+    { name = "kiwisolver", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "pyparsing" },
-    { name = "python-dateutil" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pillow", marker = "python_full_version >= '3.11'" },
+    { name = "pyparsing", marker = "python_full_version >= '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/49/64/f9a391af28f518b11ad45a8a712353c94a0aefce09d3703200e5c54b610a/matplotlib-3.11.1.tar.gz", hash = "sha256:69647db5746941c793d6e445a4cd349323ffb87d9cc958c2ad84a659b4832d30", size = 32612045, upload-time = "2026-07-18T03:39:46.63Z" }
 wheels = [
@@ -4299,7 +4267,7 @@ name = "miniaudio"
 version = "1.71"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d8/d5/e5439dc08561f73656bfeb3340fc64ab63163e101426593d8fb9a025ff1e/miniaudio-1.71.tar.gz", hash = "sha256:ff51e2887bb673e2e757752b586b3dc924d59aa5fbcae9bbc45f4a111bd3262b", size = 1116480, upload-time = "2026-04-29T21:20:38.182Z" }
 wheels = [
@@ -4476,7 +4444,7 @@ name = "mlx"
 version = "0.32.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "mlx-metal" },
+    { name = "mlx-metal", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/96/315e758cb589406ca13e7ae951efa51f13b612af88244a72a6148a3cbc8e/mlx-0.32.2-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:fe8c1ecdad687259944b76d67621b00536b00194557588a4604a45efcd238d8e", size = 626316, upload-time = "2026-08-25T10:31:23.275Z" },
@@ -4507,19 +4475,19 @@ name = "mlx-audio"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
-    { name = "miniaudio" },
-    { name = "mlx" },
-    { name = "mlx-lm" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "sounddevice" },
-    { name = "tqdm" },
-    { name = "transformers" },
+    { name = "huggingface-hub", marker = "sys_platform == 'darwin'" },
+    { name = "miniaudio", marker = "sys_platform == 'darwin'" },
+    { name = "mlx", marker = "sys_platform == 'darwin'" },
+    { name = "mlx-lm", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' and sys_platform == 'darwin'" },
+    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
+    { name = "sounddevice", marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
+    { name = "transformers", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/e7/02/40b042713edf6f8f7714f711a2fc5191b871c4c39d79df6e7726de6a81e9/mlx_audio-0.4.6.tar.gz", hash = "sha256:9f377ba4c0927af06526ed2d03b2fa44eb158d83385da96422da17c926b8589f", size = 1488412, upload-time = "2026-07-25T09:07:07.729Z" }
 wheels = [
@@ -4531,15 +4499,15 @@ name = "mlx-lm"
 version = "0.31.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "jinja2" },
-    { name = "mlx" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "protobuf" },
-    { name = "pyyaml" },
-    { name = "sentencepiece" },
-    { name = "transformers" },
+    { name = "jinja2", marker = "sys_platform == 'darwin'" },
+    { name = "mlx", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
+    { name = "protobuf", marker = "sys_platform == 'darwin'" },
+    { name = "pyyaml", marker = "sys_platform == 'darwin'" },
+    { name = "sentencepiece", marker = "sys_platform == 'darwin'" },
+    { name = "transformers", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/84/94/9a38d6b0c6fcca995b9136c94eb7da1e9c5165652edf228b96b29960fa7a/mlx_lm-0.31.3.tar.gz", hash = "sha256:61eb0e3ba09444f77f874aff295401d7ccd20b39495cbbce0c782a15474ce733", size = 304318, upload-time = "2026-04-22T07:37:27.922Z" }
 wheels = [
@@ -4561,24 +4529,24 @@ name = "mlx-vlm"
 version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "datasets" },
-    { name = "fastapi" },
-    { name = "llguidance" },
-    { name = "miniaudio" },
-    { name = "mlx" },
-    { name = "mlx-audio" },
-    { name = "mlx-lm" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "opencv-python" },
-    { name = "pillow" },
-    { name = "python-multipart" },
-    { name = "requests" },
-    { name = "starlette" },
-    { name = "tqdm" },
-    { name = "transformers" },
-    { name = "uvicorn" },
+    { name = "datasets", marker = "sys_platform == 'darwin'" },
+    { name = "fastapi", marker = "sys_platform == 'darwin'" },
+    { name = "llguidance", marker = "sys_platform == 'darwin'" },
+    { name = "miniaudio", marker = "sys_platform == 'darwin'" },
+    { name = "mlx", marker = "sys_platform == 'darwin'" },
+    { name = "mlx-audio", marker = "sys_platform == 'darwin'" },
+    { name = "mlx-lm", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
+    { name = "opencv-python", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "python-multipart", marker = "sys_platform == 'darwin'" },
+    { name = "requests", marker = "sys_platform == 'darwin'" },
+    { name = "starlette", marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
+    { name = "transformers", marker = "sys_platform == 'darwin'" },
+    { name = "uvicorn", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/22/de/03810d375be44e04a0889a7709aa72d8f187ec94a5172dea3d91051032e4/mlx_vlm-0.6.4.tar.gz", hash = "sha256:2a911692aedc3861ae26f4057b1c05dcb9abfb954d50123df3ef63eab0c58e29", size = 1453442, upload-time = "2026-07-06T21:11:12.567Z" }
 wheels = [
@@ -4590,19 +4558,19 @@ name = "mlx-whisper"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
-    { name = "mlx" },
-    { name = "more-itertools" },
-    { name = "numba" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
-    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "tiktoken" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "tqdm" },
+    { name = "huggingface-hub", marker = "sys_platform == 'darwin'" },
+    { name = "mlx", marker = "sys_platform == 'darwin'" },
+    { name = "more-itertools", marker = "sys_platform == 'darwin'" },
+    { name = "numba", marker = "sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' and sys_platform == 'darwin'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11' and sys_platform == 'darwin'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*' and sys_platform == 'darwin'" },
+    { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12' and sys_platform == 'darwin'" },
+    { name = "tiktoken", marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'darwin'" },
+    { name = "tqdm", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/22/b7/a35232812a2ccfffcb7614ba96a91338551a660a0e9815cee668bf5743f0/mlx_whisper-0.4.3-py3-none-any.whl", hash = "sha256:6b82b6597a994643a3e5496c7bc229a672e5ca308458455bfe276e76ae024489", size = 890544, upload-time = "2025-08-29T14:56:13.815Z" },
@@ -5015,12 +4983,12 @@ name = "nemotron-ocr"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "huggingface-hub" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "pillow" },
-    { name = "shapely" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "torchvision", version = "0.26.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "huggingface-hub", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pillow", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "shapely", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torchvision", version = "0.26.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/8e/42/744f74d37f58c4589bda4b8c3b0477432c48ff5caa3f1e1050d8c0edafff/nemotron_ocr-2.0.2.tar.gz", hash = "sha256:703ae32bf7172da8985fca90ff22584fd9622ee04ce877d0cc6d2db4be7dce5b", size = 159827, upload-time = "2026-07-20T19:05:24.126Z" }
 wheels = [
@@ -5434,7 +5402,7 @@ resolution-markers = [
     "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')",
 ]
 dependencies = [
-    { name = "nvidia-cuda-nvrtc" },
+    { name = "nvidia-cuda-nvrtc", marker = "(python_full_version != '3.12.*' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
@@ -5476,7 +5444,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "nvidia-cublas", version = "13.1.0.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cublas", version = "13.1.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a3/22/0b4b932655d17a6da1b92fa92ab12844b053bb2ac2475e179ba6f043da1e/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:d20e1734305e9d68889a96e3f35094d733ff1f83932ebe462753973e53a572bf", size = 366066321, upload-time = "2026-02-03T20:44:52.837Z" },
@@ -5494,7 +5462,7 @@ resolution-markers = [
     "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')",
 ]
 dependencies = [
-    { name = "nvidia-cublas", version = "13.1.1.3", source = { registry = "https://pypi.org/simple" } },
+    { name = "nvidia-cublas", version = "13.1.1.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version != '3.12.*' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
@@ -5506,8 +5474,8 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*' or platform_machine != 'x86_64'" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version != '3.12.*' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -5537,11 +5505,11 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas", version = "13.1.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64'" },
-    { name = "nvidia-cublas", version = "13.1.1.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*' or platform_machine != 'x86_64'" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*' or platform_machine != 'x86_64'" },
+    { name = "nvidia-cublas", version = "13.1.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cublas", version = "13.1.1.3", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version != '3.12.*' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version != '3.12.*' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -5553,8 +5521,8 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64'" },
-    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*' or platform_machine != 'x86_64'" },
+    { name = "nvidia-nvjitlink", version = "13.0.88", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", version = "13.3.33", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version != '3.12.*' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux') or sys_platform == 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -5665,9 +5633,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "pillow" },
-    { name = "pyobjc-framework-vision" },
+    { name = "click", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-vision", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -5719,12 +5687,12 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "coloredlogs" },
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
+    { name = "coloredlogs", marker = "python_full_version < '3.11'" },
+    { name = "flatbuffers", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "protobuf", marker = "python_full_version < '3.11'" },
+    { name = "sympy", marker = "python_full_version < '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
@@ -5771,11 +5739,11 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "flatbuffers", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging" },
-    { name = "protobuf" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "protobuf", marker = "python_full_version >= '3.11'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7c/a8/0520890321b8ff40b908cf165a93eb58fbc8f85c14db637277ea866c9544/onnxruntime-1.29.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:07c5907474dec4a2792fd7626b753dc66707808385a6d9eecf993db0066a9d0f", size = 21420890, upload-time = "2026-08-17T22:53:33.429Z" },
@@ -5812,12 +5780,12 @@ resolution-markers = [
     "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')",
 ]
 dependencies = [
-    { name = "coloredlogs" },
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "protobuf" },
-    { name = "sympy" },
+    { name = "coloredlogs", marker = "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "flatbuffers", marker = "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "protobuf", marker = "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
+    { name = "sympy", marker = "(python_full_version < '3.11' and sys_platform == 'linux') or (python_full_version < '3.11' and sys_platform == 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/ae/39283748c68a96be4f5f8a9561e0e3ca92af1eae6c2b1c07fb1da5f65cd1/onnxruntime_gpu-1.23.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:18de50c6c8eea50acc405ea13d299aec593e46478d7a22cd32cdbbdf7c42899d", size = 300525411, upload-time = "2025-10-22T16:56:08.415Z" },
@@ -5843,11 +5811,11 @@ resolution-markers = [
     "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')",
 ]
 dependencies = [
-    { name = "flatbuffers" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging" },
-    { name = "protobuf" },
+    { name = "flatbuffers", marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version == '3.11.*' and sys_platform == 'linux') or (python_full_version == '3.11.*' and sys_platform == 'win32')" },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform == 'win32')" },
+    { name = "packaging", marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
+    { name = "protobuf", marker = "(python_full_version >= '3.11' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/3e/d25cf1a72cde300ef6e8f3df63e59c9cc5daa515de687a9cd9881f8b4873/onnxruntime_gpu-1.29.0-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:de3caf93887ba4ad51c7d3cab04c7b464f9dd93c51047be5bfb413fd4a191e6a", size = 202176559, upload-time = "2026-08-17T22:29:22.647Z" },
@@ -6032,10 +6000,10 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "python-dateutil" },
-    { name = "pytz" },
-    { name = "tzdata" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "python-dateutil", marker = "python_full_version < '3.11'" },
+    { name = "pytz", marker = "python_full_version < '3.11'" },
+    { name = "tzdata", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/33/01/d40b85317f86cf08d853a4f495195c73815fdf205eef3993821720274518/pandas-2.3.3.tar.gz", hash = "sha256:e05e1af93b977f7eafa636d043f9f94c7ee3ac81af99c13508215942e64c993b", size = 4495223, upload-time = "2025-09-29T23:34:51.853Z" }
 wheels = [
@@ -6108,10 +6076,10 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "python-dateutil" },
-    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+    { name = "python-dateutil", marker = "python_full_version >= '3.11'" },
+    { name = "tzdata", marker = "(python_full_version >= '3.11' and sys_platform == 'emscripten') or (python_full_version >= '3.11' and sys_platform == 'win32')" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/be/4f/5f3422a2afec5ffc46308b79e53291365a93748b498ac2e58bead0197916/pandas-3.0.5.tar.gz", hash = "sha256:dca3734d6ab7c906e6730f0788b0a1dbb9f2467731f9711f77995c8e9d62d712", size = 4658219, upload-time = "2026-07-22T22:19:28.819Z" }
 wheels = [
@@ -6995,7 +6963,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/75/76/49c6da2c6a831020b4854ba20079d5a1030474bffc776b7b73c2eeff8c15/pyobjc_framework_cocoa-12.2.2.tar.gz", hash = "sha256:c96c0ef69a71afbbb0e6a7d594b455c5fe47d62e0db376ee7a2b4b828c16ace9", size = 3132831, upload-time = "2026-08-11T19:44:02.288Z" }
 wheels = [
@@ -7015,8 +6983,8 @@ name = "pyobjc-framework-coreml"
 version = "12.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/b7/3b/c835535e7aef41afc953e5597ea41e693b7bae80d753ab74b9721e07cba5/pyobjc_framework_coreml-12.2.2.tar.gz", hash = "sha256:3e6abe134634adbcc0c1e843826e42df86e63beb3bc7e8e4a914e93179ae1e75", size = 49750, upload-time = "2026-08-11T19:44:14.011Z" }
 wheels = [
@@ -7036,8 +7004,8 @@ name = "pyobjc-framework-quartz"
 version = "12.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/35/b1/426a37c7ae37280b3ffca2571fb48f211946aee2f4ca31a603ed1943c4a7/pyobjc_framework_quartz-12.2.2.tar.gz", hash = "sha256:810f97b210cfd93704d240860286dfd6df09f9f1c52525fc5c2166723aea3f9e", size = 3218295, upload-time = "2026-08-11T19:45:15.189Z" }
 wheels = [
@@ -7057,10 +7025,10 @@ name = "pyobjc-framework-vision"
 version = "12.2.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-coreml" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-coreml", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ea/bf/31e8bcae94047b365592ab7533096a4025c0306a8a312b65bcbf57e073ec/pyobjc_framework_vision-12.2.2.tar.gz", hash = "sha256:a6bf78e8dca145c6a78fd8d5f925b6da54649a60a1464b81ff405bca4a08406b", size = 73289, upload-time = "2026-08-11T19:45:41.877Z" }
 wheels = [
@@ -8294,14 +8262,14 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "imageio" },
-    { name = "lazy-loader" },
-    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" } },
+    { name = "imageio", marker = "python_full_version < '3.11'" },
+    { name = "lazy-loader", marker = "python_full_version < '3.11'" },
+    { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "packaging", marker = "python_full_version < '3.11'" },
+    { name = "pillow", marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "tifffile", version = "2025.5.10", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c7/a8/3c0f256012b93dd2cb6fda9245e9f4bff7dc0486880b248005f15ea2255e/scikit_image-0.25.2.tar.gz", hash = "sha256:e5a37e6cd4d0c018a7a55b9d601357e3382826d3888c10d0213fc63bff977dde", size = 22693594, upload-time = "2025-02-18T18:05:24.538Z" }
 wheels = [
@@ -8348,16 +8316,16 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "imageio" },
-    { name = "lazy-loader" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "imageio", marker = "python_full_version >= '3.11'" },
+    { name = "lazy-loader", marker = "python_full_version >= '3.11'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "packaging" },
-    { name = "pillow" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "packaging", marker = "python_full_version >= '3.11'" },
+    { name = "pillow", marker = "python_full_version >= '3.11'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "tifffile", version = "2026.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "tifffile", version = "2026.8.23", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a1/b4/2528bb43c67d48053a7a649a9666432dc307d66ba02e3a6d5c40f46655df/scikit_image-0.26.0.tar.gz", hash = "sha256:f5f970ab04efad85c24714321fcc91613fcb64ef2a892a13167df2f3e59199fa", size = 22729739, upload-time = "2025-12-20T17:12:21.824Z" }
@@ -8422,10 +8390,10 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
-    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" } },
-    { name = "threadpoolctl" },
+    { name = "joblib", marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "scipy", version = "1.15.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "threadpoolctl", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/98/c2/a7855e41c9d285dfe86dc50b250978105dce513d6e459ea66a6aeb0e1e0c/scikit_learn-1.7.2.tar.gz", hash = "sha256:20e9e49ecd130598f1ca38a1d85090e1a600147b9c02fa6f15d69cb53d968fda", size = 7193136, upload-time = "2025-09-09T08:21:29.075Z" }
 wheels = [
@@ -8481,13 +8449,13 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "joblib" },
-    { name = "narwhals" },
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "joblib", marker = "python_full_version >= '3.11'" },
+    { name = "narwhals", marker = "python_full_version >= '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy", version = "1.17.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "scipy", version = "1.18.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
-    { name = "threadpoolctl" },
+    { name = "threadpoolctl", marker = "python_full_version >= '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fa/6f/37092bdb25f712817231799fc5674d8e704066a8a70c1d2d40517e18b4ab/scikit_learn-1.9.0.tar.gz", hash = "sha256:8833266989d3a5110178a9fae30783675460724d0e1efb13b14901d2c660c557", size = 7750767, upload-time = "2026-06-02T11:54:32.706Z" }
 wheels = [
@@ -8533,7 +8501,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0f/37/6964b830433e654ec7485e45a00fc9a27cf868d622838f6b6d9c5ec0d532/scipy-1.15.3.tar.gz", hash = "sha256:eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf", size = 59419214, upload-time = "2025-05-08T16:13:05.955Z" }
 wheels = [
@@ -8594,7 +8562,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7a/97/5a3609c4f8d58b039179648e62dd220f89864f56f7357f5d4f45c29eb2cc/scipy-1.17.1.tar.gz", hash = "sha256:95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0", size = 30573822, upload-time = "2026-02-23T00:26:24.851Z" }
 wheels = [
@@ -8677,7 +8645,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/7e/74/66de6258867beb2ef08f35f9f2ac017a52cacd5081714d239ff1a442d458/scipy-1.18.1.tar.gz", hash = "sha256:52c4b7422442aba924d03ad4019852b08a92e64ea187b933135687bfe2747307", size = 30781235, upload-time = "2026-08-21T23:28:50.599Z" }
 wheels = [
@@ -8748,8 +8716,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "jeepney", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
@@ -8983,7 +8951,7 @@ name = "sounddevice"
 version = "0.5.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cffi" },
+    { name = "cffi", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/ec/db/0c890e2d9aab9ba284021efc02e1d3aebfecab1b611762d7434602209bcf/sounddevice-0.5.6.tar.gz", hash = "sha256:8ec9fbfde2e32f020b167e348f3ab3bac6625a5f15af524d790108ac7147a410", size = 1120094, upload-time = "2026-08-17T07:55:05.048Z" }
 wheels = [
@@ -9075,8 +9043,8 @@ name = "standard-aifc"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts" },
-    { name = "standard-chunk" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
+    { name = "standard-chunk", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c4/53/6050dc3dde1671eb3db592c13b55a8005e5040131f7509cef0215212cb84/standard_aifc-3.13.0.tar.gz", hash = "sha256:64e249c7cb4b3daf2fdba4e95721f811bde8bdfc43ad9f936589b7bb2fae2e43", size = 15240, upload-time = "2024-10-30T16:01:31.772Z" }
 wheels = [
@@ -9097,7 +9065,7 @@ name = "standard-sunau"
 version = "3.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "audioop-lts" },
+    { name = "audioop-lts", marker = "python_full_version >= '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/66/e3/ce8d38cb2d70e05ffeddc28bb09bad77cfef979eb0a299c9117f7ed4e6a9/standard_sunau-3.13.0.tar.gz", hash = "sha256:b319a1ac95a09a2378a8442f403c66f4fd4b36616d6df6ae82b8e536ee790908", size = 9368, upload-time = "2024-10-30T16:01:41.626Z" }
 wheels = [
@@ -9242,7 +9210,7 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/44/d0/18fed0fc0916578a4463f775b0fbd9c5fed2392152d039df2fb533bfdd5d/tifffile-2025.5.10.tar.gz", hash = "sha256:018335d34283aa3fd8c263bae5c3c2b661ebc45548fde31504016fcae7bf1103", size = 365290, upload-time = "2025-05-10T19:22:34.386Z" }
 wheels = [
@@ -9259,7 +9227,7 @@ resolution-markers = [
     "python_full_version == '3.11.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c5/cb/2f6d79c7576e22c116352a801f4c3c8ace5957e9aced862012430b62e14f/tifffile-2026.3.3.tar.gz", hash = "sha256:d9a1266bed6f2ee1dd0abde2018a38b4f8b2935cb843df381d70ac4eac5458b7", size = 388745, upload-time = "2026-03-03T19:14:38.134Z" }
 wheels = [
@@ -9283,7 +9251,7 @@ resolution-markers = [
     "python_full_version == '3.12.*' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/eb/07/90078f49e60718d414d5440dc498301f11ff049458e65cf8d27c62a5c9d1/tifffile-2026.8.23.tar.gz", hash = "sha256:bd3c816f166f85c93329a54a0c9a1eccc9968a6a78f91d63b65d7b17675915f2", size = 446179, upload-time = "2026-08-23T18:45:05.976Z" }
 wheels = [
@@ -9489,20 +9457,20 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "cuda-bindings" },
-    { name = "cuda-toolkit", version = "13.0.2", source = { registry = "https://pypi.org/simple" }, extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"] },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cudnn-cu13", version = "9.19.0.56", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-cusparselt-cu13", version = "0.8.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-nccl-cu13", version = "2.28.9", source = { registry = "https://pypi.org/simple" } },
-    { name = "nvidia-nvshmem-cu13" },
-    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "sympy" },
-    { name = "triton", version = "3.6.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "typing-extensions" },
+    { name = "cuda-bindings", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "cuda-toolkit", version = "13.0.2", source = { registry = "https://pypi.org/simple" }, extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "filelock", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "fsspec", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "jinja2", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu13", version = "9.19.0.56", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", version = "0.8.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", version = "2.28.9", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "setuptools", version = "81.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "sympy", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "triton", version = "3.6.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "typing-extensions", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/1e/18a9b10b4bd34f12d4e561c52b0ae7158707b8193c6cfc0aad2b48167090/torch-2.11.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:1b32ceda909818a03b112006709b02be1877240c31750a8d9c6b7bf5f2d8a6e5", size = 530589207, upload-time = "2026-03-23T18:11:23.756Z" },
@@ -9536,21 +9504,21 @@ resolution-markers = [
     "python_full_version < '3.11' and sys_platform != 'darwin' and sys_platform != 'linux' and sys_platform != 'win32'",
 ]
 dependencies = [
-    { name = "cuda-bindings", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
-    { name = "cuda-toolkit", version = "13.0.3.0", source = { registry = "https://pypi.org/simple" }, extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
+    { name = "cuda-bindings", marker = "(python_full_version >= '3.13' and python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "cuda-toolkit", version = "13.0.3.0", source = { registry = "https://pypi.org/simple" }, extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "(python_full_version != '3.12.*' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux')" },
+    { name = "filelock", marker = "python_full_version != '3.12.*' or platform_machine != 'x86_64' or sys_platform != 'linux'" },
+    { name = "fsspec", marker = "python_full_version != '3.12.*' or platform_machine != 'x86_64' or sys_platform != 'linux'" },
+    { name = "jinja2", marker = "python_full_version != '3.12.*' or platform_machine != 'x86_64' or sys_platform != 'linux'" },
     { name = "networkx", version = "3.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "networkx", version = "3.6.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.11' and platform_machine != 'x86_64') or (python_full_version == '3.11.*' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.11' and sys_platform != 'linux')" },
-    { name = "nvidia-cudnn-cu13", version = "9.20.0.48", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu13", version = "0.8.1", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu13", version = "2.29.7", source = { registry = "https://pypi.org/simple" }, marker = "sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
-    { name = "setuptools", version = "84.0.0", source = { registry = "https://pypi.org/simple" } },
-    { name = "sympy" },
-    { name = "triton", version = "3.7.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
-    { name = "typing-extensions" },
+    { name = "nvidia-cudnn-cu13", version = "9.20.0.48", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version != '3.12.*' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-cusparselt-cu13", version = "0.8.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version != '3.12.*' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nccl-cu13", version = "2.29.7", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version != '3.12.*' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux')" },
+    { name = "nvidia-nvshmem-cu13", marker = "(python_full_version != '3.12.*' and sys_platform == 'linux') or (platform_machine != 'x86_64' and sys_platform == 'linux')" },
+    { name = "setuptools", version = "84.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*' or platform_machine != 'x86_64' or sys_platform != 'linux'" },
+    { name = "sympy", marker = "python_full_version != '3.12.*' or platform_machine != 'x86_64' or sys_platform != 'linux'" },
+    { name = "triton", version = "3.7.1", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.13' and python_full_version < '3.15' and sys_platform == 'linux') or (python_full_version < '3.15' and platform_machine != 'x86_64' and sys_platform == 'linux') or (python_full_version < '3.12' and platform_machine == 'x86_64' and sys_platform == 'linux')" },
+    { name = "typing-extensions", marker = "python_full_version != '3.12.*' or platform_machine != 'x86_64' or sys_platform != 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7f/e7/19894fdb51c7dbaf94f5a79bb0871da0992e8e4241e579cb006da46d2e58/torch-2.13.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:94f0de129916f77b8dc2c7a8eff644cfeddfe59e39c9f55e9f6e17543410281d", size = 111178962, upload-time = "2026-07-08T16:05:49.855Z" },
@@ -9587,9 +9555,9 @@ resolution-markers = [
     "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'",
 ]
 dependencies = [
-    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" } },
-    { name = "pillow" },
-    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "pillow", marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "torch", version = "2.11.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.12.*' and platform_machine == 'x86_64' and sys_platform == 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5e/00/24d8c7845c3f270153fb81395a5135b2778e2538e81d14c6aea5106c689c/torchvision-0.26.0-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:b6f9ad1ecc0eab52647298b379ee9426845f8903703e6127973f8f3d049a798b", size = 7518249, upload-time = "2026-03-23T18:12:51.743Z" },
@@ -9626,8 +9594,8 @@ dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
     { name = "numpy", version = "2.5.2", source = { registry = "https://pypi.org/simple" }, marker = "(python_full_version >= '3.12' and platform_machine != 'x86_64') or (python_full_version >= '3.13' and platform_machine == 'x86_64' and sys_platform == 'linux') or (python_full_version >= '3.12' and sys_platform != 'linux')" },
-    { name = "pillow" },
-    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" } },
+    { name = "pillow", marker = "python_full_version != '3.12.*' or platform_machine != 'x86_64' or sys_platform != 'linux'" },
+    { name = "torch", version = "2.13.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version != '3.12.*' or platform_machine != 'x86_64' or sys_platform != 'linux'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b4/df/1ba039ad6cfe6e69209c36766b9b6e8c6fe92481c6d4e4ca52296f5f699d/torchvision-0.28.0-cp310-cp310-macosx_14_0_arm64.whl", hash = "sha256:2a1ef4b6f4bf5828b48cfad97372c8982db906830884b2868ba5c3df937a7d81", size = 1856019, upload-time = "2026-07-08T16:07:59.283Z" },


### PR DESCRIPTION
## What

Extracts native interactive PDF widgets (AcroForm) from docling-parse parsed pages and materializes them as **keyless, format-neutral fillable field values** in the `DoclingDocument`.

This **supersedes and replaces #4055**. That PR extracted fields late from pypdfium2 and attached legacy `FormItem + GraphData` objects after document assembly; this change deletes that path (`docling/utils/form_utils.py`) entirely. #4055 should be closed once this lands.

## How

A small `PdfFormFieldModel` stage runs **after OCR and before layout postprocessing** — the only point in the pipeline where both inputs exist:

- raw layout `FORM` cluster bboxes have not yet been tightened, and
- parsed-page widgets (`SegmentedPdfPage.widgets`) are still available.

The stage:
1. normalizes each widget into a format-neutral `FieldValuePrediction` (`text` / `orig` / `bbox`) — checkable controls resolve from widget-local `/AS` first, then `/V`; pushbuttons are excluded;
2. binds each widget to a raw `FORM` cluster by strong coverage (deterministic tie-break on coverage → smallest container → id);
3. puts unmatched widgets into one explicit page-local fallback region;
4. never mutates the layout prediction and never infers labels.

Page assembly replaces matched `FORM` container elements with `FieldRegionElement`s (reusing the raw region bbox and the cluster's visible children) and emits fallback regions with collision-free synthetic ids. Reading order places each region by bbox and materializes it as `FieldRegionItem → FieldItem → FieldValueItem(kind="fillable")` in native widget order, with **no** `FieldKeyItem`.

## Boundaries

- `PdfWidget` and raw AcroForm state (`/Ff`, `/AS`, field names) stay on `SegmentedPdfPage.widgets`; nothing PDF-specific enters `DoclingDocument`, `FieldValueItem`, or `add_field_value()`.
- No `PdfWidget` survives past the form-field stage.
- Document schema is unchanged (1.10).
- `extract_form_fields=False` and documents without widgets are exact no-ops (layout prediction identical either way).

## Dependencies

Pins the AcroForm branches of the companion PRs (draft until they release):

- docling-core: raw widget contract on the parsed page — https://github.com/docling-project/docling-core/pull/733 (branch `feat/acroform-widget-extraction`)
- docling-parse: widget extraction (`/Ff`, `/AS`, field name/type) — https://github.com/docling-project/docling-parse/pull/334 (branch `feat/acroform-widget-extraction`)

`pyproject.toml` uses git-branch sources for these; they must be repointed to published versions before merge.

## Tests

`tests/test_form_extraction.py`:
- docling-parse exposes the complete widget contract in native order;
- field mapping / assembly / materialization preserve regions and native order across matched + fallback + overlapping-FORM cases, with no `FIELD_KEY`;
- full pipeline produces keyless format-neutral fields, and disabling the option is a no-op with an identical layout prediction.


## What this does NOT solve (yet)

Deliberately out of scope for this PR — the fields are extracted and typed, but not yet semantically labeled or optimally ordered:

- **Field name / key association.** Widgets are materialized as keyless `FieldValueItem`s. Raw AcroForm names (`/T`) and descriptions (`/TU`) are available on `SegmentedPdfPage.widgets` but are **not** associated with the value widgets as `FieldKeyItem`s. No key is inferred from geometry, proximity, or `/T`/`/TU` (an earlier reconciliation experiment that did this produced wrong keys and leaked machine names like `topmostSubform[0].Page1[0].f1_08[0]`). Authoritative key↔value association is future work.
- **Form reading order.** Field values are emitted in native widget order within each region, and regions are placed by bbox. This is not a true form-aware reading order — values are not interleaved with their visible printed labels, and multi-column / tab-order layouts are not reconstructed. Improving intra-region reading order is future work.
