### PR TITLE
feat(pdf): key form fields by their /TU description and skip artifact widgets

### DIFF
--- a/docling/.agents/skills/docling/references/python-sdk.md
+++ b/docling/.agents/skills/docling/references/python-sdk.md
@@ -61,7 +61,7 @@ Useful `PdfPipelineOptions` / base fields:
 |---|---|
 | `do_ocr` | Run OCR (default engine EasyOCR) |
 | `do_table_structure` | Detect table structure |
-| `extract_form_fields` | Convert docling-parse PDF widgets into keyless, format-neutral fillable fields |
+| `extract_form_fields` | Convert docling-parse PDF widgets into format-neutral fillable fields, keyed by the inlining paragraph or the field's `/TU` description |
 | `do_code_enrichment` / `do_formula_enrichment` | Enrich code / formulas |
 | `ocr_options` | Choose/parametrize the OCR engine (see below) |
 | `table_structure_options` | e.g. `TableFormerMode.ACCURATE` vs `FAST` |
@@ -71,10 +71,12 @@ Useful `PdfPipelineOptions` / base fields:
 | `artifacts_path` | Use pre-downloaded model artifacts (offline) |
 | `enable_remote_services` | Gate all outbound HTTP (required for any remote model) |
 
-`extract_form_fields=True` does not infer visible labels or store PDF-specific
-widget metadata in the `DoclingDocument`. Use `generate_parsed_pages=True` to
-retain raw widgets on parsed pages when needed. Backends without page-local
-widgets produce no fields.
+`extract_form_fields=True` keys a field by the paragraph that inlines it, else
+by its `/TU` description when present; it never uses field names (`/T`).
+Zero-size widgets and push buttons are skipped. No PDF-specific widget metadata
+is stored in the `DoclingDocument`; use `generate_parsed_pages=True` to retain
+raw widgets on parsed pages when needed. Backends without page-local widgets
+produce no fields.
 
 ### Choosing an OCR engine
 

--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -412,13 +412,25 @@ class FieldValuePrediction(BaseModel):
     checkbox_label: str = ""
 
 
+FieldKeySource = Literal["layout", "tooltip"]
+"""Where a field item's key came from.
+
+``layout`` is the text of the paragraph cluster that inlines the widget(s);
+``tooltip`` is the field's ``/TU`` entry, one of the context sources listed in
+Well-Tagged PDF 1.0, 8.10.2.1 (the field name ``/T`` is explicitly not one).
+Structure-tree labels and ``/Contents`` are reserved for follow-up work.
+"""
+
+
 class FieldItemPrediction(BaseModel):
     # A keyed item groups several values under one key (e.g. an inline checkbox
     # and a fillable amount that share a sentence). key_bbox is the prov of the
-    # key -- the enclosing text cluster. Keyless items (key_text == "") carry a
-    # single value and reproduce the flat field_item shape.
+    # key -- the enclosing text cluster -- and is None for a key that is
+    # dictionary metadata rather than page text. Keyless items (key_text == "")
+    # carry a single value and reproduce the flat field_item shape.
     key_text: str = ""
     key_bbox: BoundingBox | None = None
+    key_source: FieldKeySource | None = None
     values: list[FieldValuePrediction] = []
 
 

--- a/docling/datamodel/pipeline_options.py
+++ b/docling/datamodel/pipeline_options.py
@@ -1952,10 +1952,11 @@ class PdfPipelineOptions(PaginatedPipelineOptions):
         bool,
         Field(
             description=(
-                "Extract native interactive PDF widgets as keyless, format-neutral fillable field values. "
-                "The docling-parse backend currently supplies page widgets; labels are not inferred. Raw widget "
-                "metadata remains available only on retained parsed pages. Scanned or flattened forms and backends "
-                "without page widgets are unaffected."
+                "Extract native interactive PDF widgets as format-neutral fillable field values. A widget inlined "
+                "in a text paragraph is keyed by that paragraph; otherwise the field's accessible description (/TU) "
+                "is the key when present. Keys are never inferred from field names. The docling-parse backend "
+                "currently supplies page widgets. Raw widget metadata remains available only on retained parsed "
+                "pages. Scanned or flattened forms and backends without page widgets are unaffected."
             )
         ),
     ] = False

--- a/docling/models/stages/form_field/form_field_model.py
+++ b/docling/models/stages/form_field/form_field_model.py
@@ -18,6 +18,8 @@ from docling.models.base_layout_model import TEXT_ELEM_LABELS
 from docling.models.base_model import BasePageModel
 from docling.utils.profiling import TimeRecorder
 
+_CHECKBOX_LABELS = {DocItemLabel.CHECKBOX_SELECTED, DocItemLabel.CHECKBOX_UNSELECTED}
+
 
 class PdfFormFieldModel(BasePageModel):
     _FORM_COVERAGE_THRESHOLD = 0.8
@@ -177,16 +179,18 @@ class PdfFormFieldModel(BasePageModel):
                 checkbox_clusters = [
                     cluster
                     for cluster in page.predictions.layout.clusters
-                    if cluster.label
-                    in {
-                        DocItemLabel.CHECKBOX_SELECTED,
-                        DocItemLabel.CHECKBOX_UNSELECTED,
-                    }
+                    if cluster.label in _CHECKBOX_LABELS
                 ]
+                # A CHECKBOX_* cluster is a control's own option label, not a
+                # paragraph that hosts controls: it is lifted onto the checkbox
+                # child above, never used as a key container. Admitting it would
+                # key the widget by its own label (duplicating it) and point the
+                # region at a cluster that promotion drops before assembly.
                 text_clusters = [
                     cluster
                     for cluster in page.predictions.layout.clusters
                     if cluster.label in TEXT_ELEM_LABELS
+                    and cluster.label not in _CHECKBOX_LABELS
                 ]
                 matched_values: dict[int, list[FieldValuePrediction]] = {}
                 matched_forms: dict[int, Cluster] = {}

--- a/docling/models/stages/form_field/form_field_model.py
+++ b/docling/models/stages/form_field/form_field_model.py
@@ -114,6 +114,22 @@ class PdfFormFieldModel(BasePageModel):
                 best = (ios, cluster)
         return best[1] if best else None
 
+    @staticmethod
+    def _tooltip_keyed_item(
+        widget: PdfWidget, value: FieldValuePrediction
+    ) -> FieldItemPrediction:
+        """Single-value item keyed by the field's ``/TU`` description, if any.
+
+        ``/TU`` is the field's accessible description and one of the context
+        sources listed in Well-Tagged PDF 1.0, 8.10.2.1; the field name ``/T``
+        is explicitly not one and never becomes document text. The key is
+        dictionary metadata, not page text, so it carries no bbox.
+        """
+        key = (widget.widget_description or "").strip()
+        return FieldItemPrediction(
+            key_text=key, key_source="tooltip" if key else None, values=[value]
+        )
+
     @classmethod
     def _match_form(
         cls, widget_bbox: BoundingBox, forms: list[Cluster]
@@ -192,11 +208,11 @@ class PdfFormFieldModel(BasePageModel):
                     if cluster.label in TEXT_ELEM_LABELS
                     and cluster.label not in _CHECKBOX_LABELS
                 ]
-                matched_values: dict[int, list[FieldValuePrediction]] = {}
+                matched_items: dict[int, list[FieldItemPrediction]] = {}
                 matched_forms: dict[int, Cluster] = {}
                 text_values: dict[int, list[FieldValuePrediction]] = {}
                 text_containers: dict[int, Cluster] = {}
-                unmatched_values: list[FieldValuePrediction] = []
+                unmatched_items: list[FieldItemPrediction] = []
                 promoted_cluster_ids: set[int] = set()
 
                 for widget in page.parsed_page.widgets:
@@ -241,19 +257,22 @@ class PdfFormFieldModel(BasePageModel):
                         # widgets), keeping its position in its list/container.
                         # page_assemble attaches the item onto the text element.
                         continue
+                    # Not inlined in a paragraph: the item stands alone, keyed by
+                    # the field's /TU description when the PDF carries one.
+                    item = self._tooltip_keyed_item(widget, value)
                     if form is not None:
                         matched_forms[form.id] = form
-                        matched_values.setdefault(form.id, []).append(value)
+                        matched_items.setdefault(form.id, []).append(item)
                         continue
-                    unmatched_values.append(value)
+                    unmatched_items.append(item)
 
                 regions = [
                     FieldRegionPrediction(
                         source_container_id=form_id,
                         bbox=matched_forms[form_id].bbox,
-                        items=[FieldItemPrediction(values=[value]) for value in values],
+                        items=items,
                     )
-                    for form_id, values in matched_values.items()
+                    for form_id, items in matched_items.items()
                 ]
                 # Widgets sharing one enclosing paragraph accumulate into a single
                 # keyed item; the key text/bbox is the paragraph cluster.
@@ -267,31 +286,34 @@ class PdfFormFieldModel(BasePageModel):
                                     text_containers[cluster_id]
                                 ),
                                 key_bbox=text_containers[cluster_id].bbox,
+                                key_source="layout",
                                 values=values,
                             )
                         ],
                     )
                     for cluster_id, values in text_values.items()
                 )
-                if unmatched_values:
+                if unmatched_items:
                     regions.append(
                         FieldRegionPrediction(
                             bbox=BoundingBox.enclosing_bbox(
-                                [value.bbox for value in unmatched_values]
+                                [
+                                    value.bbox
+                                    for item in unmatched_items
+                                    for value in item.values
+                                ]
                             ),
-                            items=[
-                                FieldItemPrediction(values=[value])
-                                for value in unmatched_values
-                            ],
+                            items=unmatched_items,
                         )
                     )
                 page.predictions.field_regions = regions
 
-                all_values = (
-                    [value for values in matched_values.values() for value in values]
-                    + [value for values in text_values.values() for value in values]
-                    + unmatched_values
-                )
+                all_values = [
+                    value
+                    for region in regions
+                    for item in region.items
+                    for value in item.values
+                ]
                 # Promote matched checkbox clusters (now hosted inside a field
                 # item) out of the body before suppressing raster duplicates.
                 self._drop_clusters(page, promoted_cluster_ids)

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -572,17 +572,21 @@ class ReadingOrderModel:
                     materialize_siblings(rel.ref.cref, field_region)
                     for item in element.items:
                         field_item = out_doc.add_field_item(parent=field_region)
-                        if item.key_text and item.key_bbox is not None:
-                            out_doc.add_field_key(
-                                text=item.key_text,
-                                prov=ProvenanceItem(
+                        if item.key_text:
+                            # A key with a bbox is page text (the enclosing
+                            # paragraph); one without is dictionary metadata
+                            # (/TU) and gets no provenance.
+                            key_prov = None
+                            if item.key_bbox is not None:
+                                key_prov = ProvenanceItem(
                                     page_no=element.page_no,
                                     charspan=(0, len(item.key_text)),
                                     bbox=item.key_bbox.to_bottom_left_origin(
                                         page_height
                                     ),
-                                ),
-                                parent=field_item,
+                                )
+                            out_doc.add_field_key(
+                                text=item.key_text, prov=key_prov, parent=field_item
                             )
                         for value in item.values:
                             self._add_field_value(

--- a/docs/usage/advanced_options.md
+++ b/docs/usage/advanced_options.md
@@ -106,13 +106,20 @@ one can adjust the conversion pipeline and features.
 ### Extract native PDF form fields
 
 Set `PdfPipelineOptions(extract_form_fields=True)` to convert native PDF widgets
-into keyless, format-neutral `FieldItem` and fillable `FieldValueItem` objects.
-The docling-parse backend currently supplies this data. Scanned or flattened
-forms and backends without page widgets produce no field items.
+into format-neutral `FieldItem` objects holding fillable `FieldValueItem`
+objects. A widget inlined in a text paragraph (for example "check here [ ] and
+enter the amount: ____") is grouped with its siblings under a `FieldKeyItem`
+carrying the paragraph text. Any other field gets a `FieldKeyItem` from its
+accessible description (`/TU`) when the PDF carries one, and no key otherwise.
+Checkbox and radio state is a nested `CHECKBOX_SELECTED` / `CHECKBOX_UNSELECTED`
+child of the value. The docling-parse backend currently supplies this data.
+Scanned or flattened forms and backends without page widgets produce no field
+items. Zero-size widgets and push buttons are skipped.
 
-This option does not infer labels from layout geometry or PDF field names. Raw
-widget metadata is not stored in the `DoclingDocument`; keep parsed pages with
-`generate_parsed_pages=True` when that PDF-specific data is needed.
+Keys are never taken from PDF field names (`/T`), which Well-Tagged PDF 1.0
+explicitly excludes as a source of context. Raw widget metadata is not stored in
+the `DoclingDocument`; keep parsed pages with `generate_parsed_pages=True` when
+that PDF-specific data is needed.
 
 ### Image resolution and scale
 

--- a/tests/test_form_extraction.py
+++ b/tests/test_form_extraction.py
@@ -71,6 +71,7 @@ def _widget(
     field_type: str = "/Tx",
     appearance_state: str | None = None,
     field_flags: int = 0,
+    description: str | None = None,
 ) -> PdfWidget:
     return PdfWidget(
         index=index,
@@ -80,6 +81,7 @@ def _widget(
         widget_text=text,
         widget_field_type=field_type,
         widget_appearance_state=appearance_state,
+        widget_description=description,
         widget_field_flags=field_flags,
     )
 
@@ -131,7 +133,9 @@ def test_field_mapping_assembly_and_materialization_preserve_regions_and_order()
         bbox=BoundingBox(l=45, t=30, r=55, b=45),
     )
     widgets = [
-        _widget(0, BoundingBox(l=10, t=10, r=20, b=20), "first"),
+        _widget(
+            0, BoundingBox(l=10, t=10, r=20, b=20), "first", description="First name"
+        ),
         _widget(1, BoundingBox(l=80, t=10, r=90, b=20), "second"),
         _widget(2, BoundingBox(l=20, t=30, r=30, b=40), "third"),
         _widget(3, BoundingBox(l=45, t=10, r=55, b=20), "tie"),
@@ -187,11 +191,17 @@ def test_field_mapping_assembly_and_materialization_preserve_regions_and_order()
         [value.checkbox for value in _region_values(region)]
         for region in page.predictions.field_regions
     ] == [[None, None, None], [None], ["selected"], ["unselected"]]
-    assert all(
-        item.key_text == ""
+    # Only the widget carrying a /TU gets a key, sourced from the tooltip and
+    # without a bbox (dictionary metadata, not page text).
+    assert [
+        [(item.key_text, item.key_source, item.key_bbox) for item in region.items]
         for region in page.predictions.field_regions
-        for item in region.items
-    )
+    ] == [
+        [("First name", "tooltip", None), ("", None, None), ("", None, None)],
+        [("", None, None)],
+        [("", None, None)],
+        [("", None, None)],
+    ]
     assert page.predictions.field_regions[2].items[0].values[0].orig == "/On"
     assert page.predictions.field_regions[3].items[0].values[0].orig == "/Off"
     # The zero-size and push-button widgets are dropped: no extra region and
@@ -247,7 +257,8 @@ def test_field_mapping_assembly_and_materialization_preserve_regions_and_order()
     doc = ReadingOrderModel(ReadingOrderOptions())(conv_res)
     assert len(doc.field_regions) == 4
     assert len(doc.field_items) == 6
-    assert not any(item.label == DocItemLabel.FIELD_KEY for item in doc.texts)
+    keys = [item for item in doc.texts if item.label == DocItemLabel.FIELD_KEY]
+    assert [(key.text, key.prov) for key in keys] == [("First name", [])]
 
     def _value_repr(value: FieldValueItem) -> str:
         # Text fields carry their text; a checkbox value is empty and nests a
@@ -271,7 +282,14 @@ def test_field_mapping_assembly_and_materialization_preserve_regions_and_order()
             if isinstance(child.resolve(doc), FieldItem)
         ]
         values_by_region.append(
-            [_value_repr(field.children[0].resolve(doc)) for field in field_items]
+            [
+                next(
+                    _value_repr(child.resolve(doc))
+                    for child in field.children
+                    if isinstance(child.resolve(doc), FieldValueItem)
+                )
+                for field in field_items
+            ]
         )
     assert ["first", "third", "tie"] in values_by_region
     assert [DocItemLabel.CHECKBOX_SELECTED.value] in values_by_region
@@ -392,18 +410,30 @@ def test_pipeline_materializes_format_neutral_fields() -> None:
     # paragraph item lives inline in the body, not wrapped in a region of its own.
     assert len(result.document.field_regions) == 1
     # One keyed inline item (paragraph key + three checkbox values) and one
-    # keyless single-value item for the text field.
+    # single-value item for the text field, keyed by its /TU description.
     assert len(result.document.field_items) == 2
     keys = [
         item for item in result.document.texts if item.label == DocItemLabel.FIELD_KEY
     ]
-    assert len(keys) == 1
-    assert "I agree to the terms" in keys[0].text
+    keys_by_text = {key.text: key for key in keys}
+    assert len(keys) == 2
+    paragraph_key = next(key for key in keys if "I agree to the terms" in key.text)
+    # The paragraph key is page text and carries provenance; the /TU key is
+    # dictionary metadata and carries none. The first checkbox also has a /TU
+    # ("I agree to the terms") but is inlined in the paragraph, so the paragraph
+    # wins and its /TU never becomes a second key.
+    assert paragraph_key.prov != []
+    assert keys_by_text["Full legal name"].prov == []
     # The keyed field_item materializes in the paragraph's own place, NOT wrapped
     # in a field_region of its own (it would be, if pulled out into a region).
-    keyed_item = keys[0].parent.resolve(result.document)
+    keyed_item = paragraph_key.parent.resolve(result.document)
     assert keyed_item.label == DocItemLabel.FIELD_ITEM
     assert keyed_item.parent.resolve(result.document).label != DocItemLabel.FIELD_REGION
+    # The /TU-keyed item sits in the page-wide field_region.
+    tooltip_item = keys_by_text["Full legal name"].parent.resolve(result.document)
+    assert (
+        tooltip_item.parent.resolve(result.document).label == DocItemLabel.FIELD_REGION
+    )
 
     values = [
         item for item in result.document.texts if isinstance(item, FieldValueItem)

--- a/tests/test_form_extraction.py
+++ b/tests/test_form_extraction.py
@@ -359,7 +359,16 @@ def test_checkbox_widget_lifts_cluster_label_and_lets_as_override_classifier() -
 
     list(PdfFormFieldModel(enabled=True)(conv_res, [page]))
 
-    value = page.predictions.field_regions[0].items[0].values[0]
+    # The widget sits entirely inside the checkbox cluster, which would also
+    # qualify it as a "paragraph" key container. It must not: the label rides on
+    # the checkbox child only, and the region is a fallback region rather than
+    # one sourced from the (promoted, dropped) cluster.
+    assert [
+        region.source_container_id for region in page.predictions.field_regions
+    ] == [None]
+    item = page.predictions.field_regions[0].items[0]
+    assert item.key_text == ""
+    value = item.values[0]
     assert value.text == ""
     assert value.checkbox == "unselected"  # from /AS, overriding the classifier
     assert value.checkbox_label == "4797 ✔"  # cluster text lifted as-is


### PR DESCRIPTION
Stacked on #4140 (base branch `feat/acroform-native-fields`, rebased onto 505a96be). Phase 2 of the follow-on proposal in #4143: the smallest docling-only step that aligns the form stage with Well-Tagged PDF 1.0 (the basis of PDF/UA-2) without touching the docling-core schema.

Since the first version of this PR, #4140 itself absorbed the zero-size and push-button skips, so those are gone from here. Two commits remain:

**1. `fix(acroform)`: never key a checkbox widget by its own layout cluster** (cherry-pickable into #4140)

`CHECKBOX_SELECTED` / `CHECKBOX_UNSELECTED` are in `TEXT_ELEM_LABELS`, so `_match_text_container` could pick the checkbox cluster the widget sits in as its "paragraph" key container. The option label then appeared twice (as the key and on the nested checkbox child) and the region's `source_container_id` pointed at a cluster that promotion had already dropped, so assembly emitted a stray `field_region`. Checkbox clusters are now excluded from key-container candidates; the label rides on the checkbox child only. The existing checkbox test is tightened to assert a keyless fallback region.

**2. `feat(pdf)`: key standalone form fields by their `/TU` description**

WTPDF 8.10.2.1 lists the sources of context for a widget (structure-tree `Lbl`, the field's `TU`, the widget's `Contents`) and states that the field name (`T`) does not contribute. So:

- A widget inlined in a text paragraph keeps #4140's paragraph key (`key_source="layout"`, with provenance).
- Any other widget (FORM-matched or fallback) gets a `FieldKeyItem` from its `/TU` when present (`key_source="tooltip"`, no provenance, since it is dictionary metadata rather than page text). Nothing is inferred from geometry or from `/T`.
- `FieldItemPrediction.key_source` records where the key came from so structure-tree labels and `/Contents` can be added later without changing the contract.

**What does not change**

Layout prediction handling, region binding, fallback regions, duplicate suppression, reading-order placement, and the `extract_form_fields=False` no-op are untouched. Document schema unchanged; `FieldKeyItem` already exists in docling-core.

**Tests**

`tests/test_form_extraction.py`: the unit test gives one widget a `/TU` and asserts the key, its source, and the absence of a bbox through mapping, assembly, and materialization. The pipeline test now asserts two keys on `acroform_sample.pdf`: the paragraph key (with provenance) for the three inlined checkboxes, and `Full legal name` (no provenance) for the text field in the page-wide region. The first checkbox also carries a `/TU` but is inlined, so the paragraph wins and no second key appears.

**Docs**

Option description, `docs/usage/advanced_options.md`, and the packaged usage skill reference no longer describe fields as keyless; they now state the paragraph-then-`/TU` rule, the nested checkbox child, and the skipped widgets.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
