### PR TITLE
fix(layout): remove wrapper picture proposals

### DIFF
--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 from docling_core.types.doc import BoundingBox, DocItemLabel, Size
 from docling_core.types.doc.page import TextCell
-from PIL import Image, ImageChops, ImageDraw
+from PIL import Image
 
 from docling.datamodel.base_models import Cluster, Page
 from docling.datamodel.pipeline_options import BaseLayoutPostprocessorOptions
@@ -448,34 +448,33 @@ class LayoutPostprocessor:
         top = min(max(top, 0), page_image.height)
         bottom = min(max(bottom, 0), page_image.height)
 
-        masked_bbox = (left - 1, top - 1, right + 1, bottom + 1)
-        corners = (
-            (0, 0),
-            (page_image.width - 1, 0),
-            (0, page_image.height - 1),
-            (page_image.width - 1, page_image.height - 1),
-        )
-        sample = next(
-            (
-                (x, y)
-                for x, y in corners
-                if not (
-                    masked_bbox[0] <= x <= masked_bbox[2]
-                    and masked_bbox[1] <= y <= masked_bbox[3]
-                )
-            ),
-            None,
-        )
-        if sample is None:
-            return False
+        # Exclude the picture and its one-pixel rasterization seam.
+        left = max(left - 1, 0)
+        top = max(top - 1, 0)
+        right = min(right + 2, page_image.width)
+        bottom = min(bottom + 2, page_image.height)
 
-        image = page_image.convert("RGB")
-        difference = ImageChops.difference(
-            image, Image.new("RGB", image.size, image.getpixel(sample))
+        image = page_image if page_image.mode == "RGB" else page_image.convert("RGB")
+        regions = (
+            (0, 0, image.width, top),
+            (0, bottom, image.width, image.height),
+            (0, top, left, bottom),
+            (right, top, image.width, bottom),
         )
-        # Mask the picture and its one-pixel rasterization seam.
-        ImageDraw.Draw(difference).rectangle(masked_bbox, fill=0)
-        return difference.getbbox() is None
+        surrounding_color = None
+        for region in regions:
+            if region[0] >= region[2] or region[1] >= region[3]:
+                continue
+            colors = image.crop(region).getcolors(maxcolors=1)
+            if colors is None:
+                return False
+            color = colors[0][1]
+            if surrounding_color is None:
+                surrounding_color = color
+            elif color != surrounding_color:
+                return False
+
+        return surrounding_color is not None
 
     def _set_cluster_children(self, cluster: Cluster, children: list[Cluster]) -> None:
         if not children:

--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -7,6 +7,7 @@ from collections import defaultdict
 
 from docling_core.types.doc import BoundingBox, DocItemLabel, Size
 from docling_core.types.doc.page import TextCell
+from PIL import Image, ImageChops, ImageDraw
 
 from docling.datamodel.base_models import Cluster, Page
 from docling.datamodel.pipeline_options import BaseLayoutPostprocessorOptions
@@ -14,6 +15,7 @@ from docling.datamodel.spatial import (
     BoundingBoxSpatialIndex,
     has_positive_area,
     ordered_bounding_box,
+    ordered_bounds,
 )
 
 _log = logging.getLogger(__name__)
@@ -281,20 +283,7 @@ class LayoutPostprocessor:
             for c in self.special_clusters
             if c.confidence >= self.CONFIDENCE_THRESHOLDS[c.label]
         ]
-
-        # Calculate page area from known page size
-        assert self.page_size is not None
-        page_area = self.page_size.width * self.page_size.height
-        if page_area > 0:
-            # Filter out full-page pictures
-            special_clusters = [
-                cluster
-                for cluster in special_clusters
-                if not (
-                    cluster.label == DocItemLabel.PICTURE
-                    and cluster.bbox.area() / page_area > 0.90
-                )
-            ]
+        special_clusters = self._remove_wrapper_pictures(special_clusters)
 
         picture_clusters = [
             c for c in special_clusters if c.label == DocItemLabel.PICTURE
@@ -394,6 +383,99 @@ class LayoutPostprocessor:
             self._set_cluster_children(container, direct_children + nested_children)
 
         return picture_clusters + table_clusters + container_clusters
+
+    def _remove_wrapper_pictures(
+        self, special_clusters: list[Cluster]
+    ) -> list[Cluster]:
+        """Remove picture proposals that wrap all detected page content."""
+        page_image = self.page.get_image(scale=1.0)
+        if (
+            page_image is None
+            or self.page_size is None
+            or self.page_size.width <= 0
+            or self.page_size.height <= 0
+        ):
+            return special_clusters
+
+        model_cluster_ids = {cluster.id for cluster in self.all_clusters}
+        detected_clusters = [
+            cluster
+            for cluster in self.regular_clusters + special_clusters
+            if cluster.id in model_cluster_ids and has_positive_area(cluster.bbox)
+        ]
+        wrapper_ids = set()
+
+        for picture in special_clusters:
+            if picture.label != DocItemLabel.PICTURE:
+                continue
+
+            others = [
+                cluster for cluster in detected_clusters if cluster.id != picture.id
+            ]
+            if not others or not all(
+                cluster.bbox.intersection_over_self(picture.bbox) == 1.0
+                for cluster in others
+            ):
+                continue
+            if not any(
+                ordered_bounds(cluster.bbox) != ordered_bounds(picture.bbox)
+                for cluster in others
+            ):
+                continue
+            if self._has_uniform_surrounding(page_image, picture.bbox):
+                wrapper_ids.add(picture.id)
+
+        return [
+            cluster for cluster in special_clusters if cluster.id not in wrapper_ids
+        ]
+
+    def _has_uniform_surrounding(
+        self, page_image: Image.Image, bbox: BoundingBox
+    ) -> bool:
+        """Return whether all pixels outside a picture have one RGB value."""
+        assert self.page_size is not None
+        bbox = ordered_bounding_box(
+            bbox.to_top_left_origin(page_height=self.page_size.height)
+        )
+        left, top, right, bottom = (
+            round(bbox.l * page_image.width / self.page_size.width),
+            round(bbox.t * page_image.height / self.page_size.height),
+            round(bbox.r * page_image.width / self.page_size.width),
+            round(bbox.b * page_image.height / self.page_size.height),
+        )
+        left = min(max(left, 0), page_image.width)
+        right = min(max(right, 0), page_image.width)
+        top = min(max(top, 0), page_image.height)
+        bottom = min(max(bottom, 0), page_image.height)
+
+        masked_bbox = (left - 1, top - 1, right + 1, bottom + 1)
+        corners = (
+            (0, 0),
+            (page_image.width - 1, 0),
+            (0, page_image.height - 1),
+            (page_image.width - 1, page_image.height - 1),
+        )
+        sample = next(
+            (
+                (x, y)
+                for x, y in corners
+                if not (
+                    masked_bbox[0] <= x <= masked_bbox[2]
+                    and masked_bbox[1] <= y <= masked_bbox[3]
+                )
+            ),
+            None,
+        )
+        if sample is None:
+            return False
+
+        image = page_image.convert("RGB")
+        difference = ImageChops.difference(
+            image, Image.new("RGB", image.size, image.getpixel(sample))
+        )
+        # Mask the picture and its one-pixel rasterization seam.
+        ImageDraw.Draw(difference).rectangle(masked_bbox, fill=0)
+        return difference.getbbox() is None
 
     def _set_cluster_children(self, cluster: Cluster, children: list[Cluster]) -> None:
         if not children:

--- a/docling/utils/layout_postprocessor.py
+++ b/docling/utils/layout_postprocessor.py
@@ -388,22 +388,13 @@ class LayoutPostprocessor:
         self, special_clusters: list[Cluster]
     ) -> list[Cluster]:
         """Remove picture proposals that wrap all detected page content."""
-        page_image = self.page.get_image(scale=1.0)
-        if (
-            page_image is None
-            or self.page_size is None
-            or self.page_size.width <= 0
-            or self.page_size.height <= 0
-        ):
-            return special_clusters
-
         model_cluster_ids = {cluster.id for cluster in self.all_clusters}
         detected_clusters = [
             cluster
             for cluster in self.regular_clusters + special_clusters
             if cluster.id in model_cluster_ids and has_positive_area(cluster.bbox)
         ]
-        wrapper_ids = set()
+        candidates = []
 
         for picture in special_clusters:
             if picture.label != DocItemLabel.PICTURE:
@@ -422,8 +413,25 @@ class LayoutPostprocessor:
                 for cluster in others
             ):
                 continue
-            if self._has_uniform_surrounding(page_image, picture.bbox):
-                wrapper_ids.add(picture.id)
+            candidates.append(picture)
+
+        if not candidates:
+            return special_clusters
+
+        page_image = self.page.get_image(scale=1.0)
+        if (
+            page_image is None
+            or self.page_size is None
+            or self.page_size.width <= 0
+            or self.page_size.height <= 0
+        ):
+            return special_clusters
+
+        wrapper_ids = {
+            picture.id
+            for picture in candidates
+            if self._has_uniform_surrounding(page_image, picture.bbox)
+        }
 
         return [
             cluster for cluster in special_clusters if cluster.id not in wrapper_ids

--- a/tests/test_layout_postprocessing_model.py
+++ b/tests/test_layout_postprocessing_model.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 from docling_core.types.doc import DocItemLabel
+from PIL import Image
 
 from docling.datamodel.base_models import (
     BoundingBox,
@@ -24,13 +25,20 @@ from docling.models.stages.layout.layout_postprocessing_model import (
 
 
 class _StubBackend:
-    """Minimal stand-in for a PdfPageBackend (only validity is queried here)."""
+    """Minimal stand-in for the PdfPageBackend methods used by this stage."""
 
     def __init__(self, valid: bool = True) -> None:
         self._valid = valid
+        self.image_requests = 0
 
     def is_valid(self) -> bool:
         return self._valid
+
+    def get_page_image(
+        self, scale: float = 1.0, cropbox: BoundingBox | None = None
+    ) -> Image.Image:
+        self.image_requests += 1
+        return Image.new("RGB", (round(600 * scale), round(800 * scale)), "white")
 
 
 def _conv_res() -> SimpleNamespace:
@@ -107,6 +115,8 @@ def test_runs_postprocessor_and_scores_processed_clusters() -> None:
     expected = float(np.mean([c.confidence for c in produced]))
     assert conv_res.confidence.pages[1].layout_score == pytest.approx(expected)
     assert conv_res.confidence.pages[1].layout_score == pytest.approx(0.7)
+    assert isinstance(page._backend, _StubBackend)
+    assert page._backend.image_requests == 0
 
 
 def test_invalid_page_passes_through_without_scoring() -> None:

--- a/tests/test_layout_postprocessor.py
+++ b/tests/test_layout_postprocessor.py
@@ -4,6 +4,7 @@
 import pytest
 from docling_core.types.doc import DocItemLabel, Size
 from docling_core.types.doc.page import BoundingRectangle, TextCell
+from PIL import Image
 
 from docling.datamodel.base_models import BoundingBox, Cluster, Page
 from docling.datamodel.pipeline_options import LayoutOptions, LayoutPostprocessorOptions
@@ -70,9 +71,14 @@ def _reference_assignments(
     return assignments
 
 
-def _postprocessor(*clusters: Cluster) -> LayoutPostprocessor:
+def _postprocessor(
+    *clusters: Cluster, page_image: Image.Image | None = None
+) -> LayoutPostprocessor:
+    page = Page(page_no=1, size=Size(width=1000, height=1000))
+    if page_image is not None:
+        page._image_cache = {1.0: page_image}
     return LayoutPostprocessor(
-        page=Page(page_no=1, size=Size(width=1000, height=1000)),
+        page=page,
         clusters=list(clusters),
         options=LayoutOptions(skip_cell_assignment=True),
     )
@@ -433,13 +439,58 @@ def test_container_does_not_wrap_nearly_identical_child(
     assert [cluster.id for cluster in result] == [2]
 
 
-def test_filtered_full_page_picture_does_not_remove_container() -> None:
-    container = _cluster(1, _bbox(0, 0, 1000, 1000), DocItemLabel.FORM, confidence=0.8)
+def test_empty_full_page_picture_is_preserved() -> None:
     picture = _cluster(2, _bbox(0, 0, 1000, 1000), DocItemLabel.PICTURE, confidence=0.8)
 
-    result = _process_special_clusters(container, picture)
+    result = _process_special_clusters(picture)
 
-    assert [cluster.id for cluster in result] == [1]
+    assert [cluster.id for cluster in result] == [picture.id]
+
+
+def test_uniform_wrapper_picture_is_removed_for_detected_text() -> None:
+    picture = _cluster(1, _bbox(100, 100, 900, 900), DocItemLabel.PICTURE)
+    text = _cluster(2, _bbox(200, 200, 800, 300), DocItemLabel.TEXT)
+
+    result = _postprocessor(
+        picture, text, page_image=Image.new("RGB", (1000, 1000), "white")
+    ).postprocess()
+
+    assert [cluster.id for cluster in result] == [text.id]
+
+
+def test_wrapper_picture_is_kept_for_nonuniform_surrounding() -> None:
+    page_image = Image.new("RGB", (1000, 1000), "white")
+    page_image.putpixel((10, 10), (0, 0, 0))
+    picture = _cluster(1, _bbox(100, 100, 900, 900), DocItemLabel.PICTURE)
+    text = _cluster(2, _bbox(200, 200, 800, 300), DocItemLabel.TEXT)
+
+    result = _postprocessor(picture, text, page_image=page_image).postprocess()
+
+    assert [cluster.id for cluster in result] == [picture.id]
+
+
+def test_wrapper_picture_is_kept_for_detected_content_outside() -> None:
+    picture = _cluster(1, _bbox(100, 100, 900, 900), DocItemLabel.PICTURE)
+    text = _cluster(2, _bbox(10, 10, 90, 50), DocItemLabel.TEXT)
+
+    result = _postprocessor(
+        picture, text, page_image=Image.new("RGB", (1000, 1000), "white")
+    ).postprocess()
+
+    assert {cluster.id for cluster in result} == {picture.id, text.id}
+
+
+def test_wrapper_picture_is_kept_for_synthesized_orphan_only() -> None:
+    picture = _cluster(1, _bbox(100, 100, 900, 900), DocItemLabel.PICTURE)
+    orphan = _cluster(2, _bbox(200, 200, 800, 300), DocItemLabel.TEXT)
+    processor = _postprocessor(
+        picture, page_image=Image.new("RGB", (1000, 1000), "white")
+    )
+    processor.regular_clusters = [orphan]
+
+    result = processor._process_special_clusters()
+
+    assert [cluster.id for cluster in result] == [picture.id]
 
 
 def test_removed_picture_does_not_remove_container() -> None:

--- a/tests/test_skip_cell_extraction.py
+++ b/tests/test_skip_cell_extraction.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 import pytest
 from docling_core.types.doc import DocItemLabel
 from docling_core.types.doc.page import BoundingRectangle, TextCell
+from PIL import Image
 
 from docling.datamodel.base_models import (
     BoundingBox,
@@ -32,6 +33,16 @@ from docling.models.base_ocr_model import BaseOcrModel
 from docling.models.stages.layout.layout_postprocessing_model import (
     LayoutPostprocessingModel,
 )
+
+
+class _StubBackend:
+    def is_valid(self) -> bool:
+        return True
+
+    def get_page_image(
+        self, scale: float = 1.0, cropbox: BoundingBox | None = None
+    ) -> Image.Image:
+        return Image.new("RGB", (round(600 * scale), round(800 * scale)), "white")
 
 
 def _page() -> Page:
@@ -76,7 +87,7 @@ def test_layout_write_back_guarded_without_parsed_page() -> None:
     # With cell assignment ENABLED and parsed_page None (skipped extraction),
     # the postprocessor previously asserted; it must now pass through.
     page = _page()
-    page._backend = SimpleNamespace(is_valid=lambda: True)  # type: ignore[assignment]
+    page._backend = _StubBackend()  # type: ignore[assignment]
     page.predictions.layout = LayoutPrediction(
         clusters=[
             Cluster(


### PR DESCRIPTION
## Summary

- Remove `PICTURE` proposals that wrap every surviving model-detected layout element when the page area outside the proposal is a single background color.
- Exclude synthesized orphan text clusters from the evidence used to remove a picture.
- Preserve lone or empty full-page pictures, pictures with non-uniform surroundings, and pictures when any detected element lies outside.

## Difference from #4047

This targets the same failure as #4047: landscape slide-like content embedded in a portrait PDF can be classified as one large picture, hiding machine-readable text and causing picture description to receive the whole slide.

#4047 computes a union from regular and special clusters and removes a picture when its bounding box equals that union. Because the candidate picture participates in the union, any picture containing the remaining clusters defines the union itself. The decision therefore reduces to containment and does not inspect the surrounding page raster.

This PR ports the fix onto current `main` and requires three independent signals:

1. Every other surviving model detection is fully inside the candidate picture.
2. At least one geometrically distinct inner element is a real layout-model detection; raw text cells and synthesized orphan clusters do not count.
3. All pixels outside the candidate share one RGB background color, ignoring a one-pixel rasterization seam.

A nested picture is deliberately not required, so text-only slide frames are handled as well.

## Result

On the reported `page28.pdf`, current `main` produces one outer picture containing all eight text items, leaving Markdown with only an image placeholder. This change exposes the eight native text items and retains the two internal picture proposals, achieving the same user-visible goal as #4047 with narrower removal conditions.

## Validation

- `28 passed` in `tests/test_layout_postprocessor.py`
- `make validate`
- CPU-only conversion of the reported PDF with `DOCLING_DEVICE=cpu`, `--device cpu`, and `--no-ocr`

Related: #4047