### PR TITLE
feat: honour a reading order supplied by an upstream stage

### DIFF
--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -344,6 +344,12 @@ class Cluster(BaseModel):
     confidence: float = 1.0
     cells: list[TextCell] = []
     children: list["Cluster"] = []  # Add child cluster support
+    # Position of this cluster in a reading order supplied by an upstream stage
+    # (a layout model that predicts one, or the tagged-PDF structure tree). When
+    # every element on a page carries an index, the reading-order stage sorts
+    # that page by it instead of running the predictor; pages with any element
+    # lacking one are predicted as before.
+    reading_order: int | None = None
 
     @field_serializer("confidence")
     def _serialize(self, value: float, info: FieldSerializationInfo) -> float:

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -269,6 +269,61 @@ class ReadingOrderModel:
             orientation=element.orientation,
         )
 
+    def _order_siblings(
+        self,
+        siblings: list[ReadingOrderPageElement],
+        assembled_by_ref: dict[str, PageElement],
+    ) -> list[ReadingOrderPageElement]:
+        """Order one sibling group: supplied order per page, predictor elsewhere.
+
+        A page whose every sibling carries ``Cluster.reading_order`` is sorted
+        by that index; an upstream stage (a layout model that predicts reading
+        order, the tagged-PDF structure tree) already knows the order and the
+        predictor would only second-guess it. A page with any sibling lacking
+        an index goes through the predictor together with the other such
+        pages, exactly as before. Pages are then concatenated in page order,
+        which is also how the predictor lays out its result.
+        """
+        if len(siblings) <= 1:
+            return siblings
+
+        def supplied_index(element: ReadingOrderPageElement) -> int | None:
+            return assembled_by_ref[element.ref.cref].cluster.reading_order
+
+        by_page: dict[int, list[ReadingOrderPageElement]] = {}
+        for element in siblings:
+            by_page.setdefault(element.page_no, []).append(element)
+        supplied_pages = {
+            page_no
+            for page_no, elements in by_page.items()
+            if all(supplied_index(element) is not None for element in elements)
+        }
+        if not supplied_pages:
+            return self.ro_model.predict_reading_order(page_elements=siblings)
+
+        predicted = [
+            element for element in siblings if element.page_no not in supplied_pages
+        ]
+        if len(predicted) > 1:
+            predicted = self.ro_model.predict_reading_order(page_elements=predicted)
+        predicted_by_page: dict[int, list[ReadingOrderPageElement]] = {}
+        for element in predicted:
+            predicted_by_page.setdefault(element.page_no, []).append(element)
+
+        ordered: list[ReadingOrderPageElement] = []
+        for page_no in sorted(by_page):
+            if page_no in supplied_pages:
+                # cid (assembled order) breaks ties between equal indices.
+                ordered.extend(
+                    sorted(
+                        by_page[page_no],
+                        key=lambda element: (supplied_index(element), element.cid),
+                    )
+                )
+            else:
+                ordered.extend(predicted_by_page.get(page_no, []))
+        return ordered
+
     @staticmethod
     def _element_ref(element: BasePageElement) -> str:
         return f"#/{element.page_no}/{element.cluster.id}"
@@ -722,11 +777,7 @@ class ReadingOrderModel:
                 )
 
             ordered_siblings = {
-                parent_ref: (
-                    self.ro_model.predict_reading_order(page_elements=siblings)
-                    if len(siblings) > 1
-                    else siblings
-                )
+                parent_ref: self._order_siblings(siblings, assembled_by_ref)
                 for parent_ref, siblings in siblings_by_parent.items()
             }
 

--- a/tests/test_readingorder_supplied_order.py
+++ b/tests/test_readingorder_supplied_order.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+"""A stage upstream of reading order may already know the order of a page.
+
+A layout model can predict reading order (docling issue #3958) and the
+structure tree of a tagged PDF defines it (ISO 32000-2, 14.7). The reading-order
+stage honours ``Cluster.reading_order`` on any page where every element carries
+an index, and runs the predictor on every other page as before.
+"""
+
+from pathlib import PurePath
+
+from docling_core.types.doc import BoundingBox, DocItemLabel, GroupLabel, Size
+from docling_core.types.doc.document import GroupItem
+
+from docling.datamodel.base_models import (
+    AssembledUnit,
+    Cluster,
+    ContainerElement,
+    InputFormat,
+    Page,
+    PageElement,
+    TextElement,
+)
+from docling.datamodel.document import ConversionResult, InputDocument
+from docling.models.stages.reading_order.readingorder_model import (
+    ReadingOrderModel,
+    ReadingOrderOptions,
+)
+
+PAGE = Size(width=500, height=500)
+
+
+def _text(
+    cid: int,
+    text: str,
+    top: float,
+    *,
+    page_no: int = 1,
+    order: int | None = None,
+    label: DocItemLabel = DocItemLabel.TEXT,
+) -> TextElement:
+    cluster = Cluster(
+        id=cid,
+        label=label,
+        bbox=BoundingBox(l=50, t=top, r=450, b=top + 40),
+        reading_order=order,
+    )
+    return TextElement(label=label, id=cid, text=text, page_no=page_no, cluster=cluster)
+
+
+def _conversion_result(elements: list[PageElement], pages: int = 1) -> ConversionResult:
+    input_doc = InputDocument.model_construct(
+        file=PurePath("input.pdf"),
+        document_hash="0" * 64,
+        valid=True,
+        format=InputFormat.PDF,
+    )
+    return ConversionResult(
+        input=input_doc,
+        pages=[Page(page_no=no, size=PAGE) for no in range(1, pages + 1)],
+        assembled=AssembledUnit(elements=elements, body=elements),
+    )
+
+
+def _texts(elements: list[PageElement], pages: int = 1) -> list[str]:
+    doc = ReadingOrderModel(ReadingOrderOptions())(_conversion_result(elements, pages))
+    return [item.text for item in doc.texts]
+
+
+def test_supplied_order_replaces_the_predictor_on_a_fully_indexed_page() -> None:
+    # Three paragraphs stacked top to bottom. The predictor reads them in
+    # geometric order; a supplied order that contradicts geometry must win.
+    def page(order: tuple[int | None, int | None, int | None]) -> list[PageElement]:
+        return [
+            _text(1, "top", 50, order=order[0]),
+            _text(2, "middle", 200, order=order[1]),
+            _text(3, "bottom", 350, order=order[2]),
+        ]
+
+    assert _texts(page((None, None, None))) == ["top", "middle", "bottom"]
+    assert _texts(page((1, 2, 0))) == ["bottom", "top", "middle"]
+
+
+def test_page_with_any_unindexed_element_is_predicted_whole() -> None:
+    # One element without an index disqualifies the page: the indices that are
+    # present are ignored rather than interleaved with predicted positions.
+    elements = [
+        _text(1, "top", 50, order=2),
+        _text(2, "middle", 200, order=None),
+        _text(3, "bottom", 350, order=0),
+    ]
+    assert _texts(elements) == ["top", "middle", "bottom"]
+
+
+def test_supplied_and_predicted_pages_keep_page_order() -> None:
+    # Page 1 is fully indexed (reverse of geometry); page 2 is not indexed and
+    # goes through the predictor. Pages still follow one another in order.
+    # Full stops keep the predictor's paragraph-merge heuristic from joining
+    # fragments across pages, which would hide the ordering under test.
+    elements = [
+        _text(1, "p1 top.", 50, page_no=1, order=1),
+        _text(2, "p1 bottom.", 350, page_no=1, order=0),
+        _text(3, "p2 top.", 50, page_no=2),
+        _text(4, "p2 bottom.", 350, page_no=2),
+    ]
+    assert _texts(elements, pages=2) == [
+        "p1 bottom.",
+        "p1 top.",
+        "p2 top.",
+        "p2 bottom.",
+    ]
+
+
+def test_supplied_order_applies_within_a_container() -> None:
+    # Siblings are ordered per parent. Children of a form container carry their
+    # own indices and are sorted among themselves, independently of the page's
+    # top-level elements.
+    child_top = _text(2, "child top", 100, order=1)
+    child_bottom = _text(3, "child bottom", 200, order=0)
+    container_cluster = Cluster(
+        id=1,
+        label=DocItemLabel.FORM,
+        bbox=BoundingBox(l=0, t=80, r=500, b=260),
+        reading_order=1,
+        children=[child_top.cluster, child_bottom.cluster],
+    )
+    container = ContainerElement(
+        label=DocItemLabel.FORM, id=1, page_no=1, cluster=container_cluster
+    )
+    after = _text(4, "after form", 400, order=0)
+    elements: list[PageElement] = [container, child_top, child_bottom, after]
+
+    doc = ReadingOrderModel(ReadingOrderOptions())(_conversion_result(elements))
+
+    form = next(
+        item
+        for item in doc.groups
+        if isinstance(item, GroupItem) and item.label == GroupLabel.FORM_AREA
+    )
+    assert [child.resolve(doc).text for child in form.children] == [
+        "child bottom",
+        "child top",
+    ]
+    # At the top level the paragraph (index 0) precedes the form (index 1)
+    # although it sits lower on the page.
+    top_level = [child.resolve(doc) for child in doc.body.children]
+    assert [getattr(item, "text", "form") for item in top_level] == [
+        "after form",
+        "form",
+    ]


### PR DESCRIPTION
Implements the mechanism proposed in #3958: let a stage upstream of reading order supply the order of a page, instead of the reading-order stage recomputing it.

## What

- `Cluster.reading_order: int | None = None`. Any stage that knows the order of a page sets it: a layout model that predicts reading order (PP-DocLayoutV3, #3958, #3224), the structure tree of a tagged PDF (#4146, #4148), native form widgets inside a field region (#4140).
- `ReadingOrderModel._order_siblings`: within each sibling group (top level or the children of a container), a page whose every element carries an index is sorted by it; every other page goes through the predictor together, as before. Pages are concatenated in page order, which is also how the predictor lays out its result.
- Caption, footnote and merge mapping run on the combined result unchanged, so a supplied order does not skip them (the concern raised on #3233).

## Rules

- A page is all-or-nothing. One element without an index on a page disqualifies the page and the indices that are present are ignored, rather than interleaving two orderings. A finer merge can come later if a real case needs it.
- No index anywhere means no behaviour change: the predictor is called exactly as before with the same input.
- Ties between equal indices break on assembled order.

## Relation to #3233

`reorder_elements=False` there is the degenerate case where postprocessor order is the supplied order for every page. This PR does not add that flag; it can be layered on top, or #3233 rebased onto this.

## Tests

`tests/test_readingorder_supplied_order.py`:

- a fully indexed page follows the supplied order even when it contradicts geometry, and the same fixture without indices follows the predictor;
- a page with one unindexed element is predicted whole;
- a supplied page and a predicted page keep page order;
- children of a container are ordered among themselves by their indices, independently of the page's top-level elements.

No in-tree producer sets the index yet; the tagged-structure stage in #4148 is the first consumer and will be rebased onto this once the field name and the per-page rule are agreed.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
