### PR TITLE
fix(webvtt): accept CRLF and CR line terminators from a stream

### DIFF
--- a/docling/backend/webvtt_backend.py
+++ b/docling/backend/webvtt_backend.py
@@ -3,7 +3,7 @@
 
 import logging
 from dataclasses import dataclass, field
-from io import BytesIO
+from io import BytesIO, TextIOWrapper
 from pathlib import Path
 
 from docling_core.types.doc import (
@@ -73,14 +73,12 @@ class WebVTTDocumentBackend(DeclarativeDocumentBackend):
         # verify_signature() reject the file. Equivalent to utf-8 without a BOM.
         try:
             if isinstance(self.path_or_stream, BytesIO):
-                # bytes.decode() keeps CR and CRLF while the text-mode read below
-                # translates them, and WebVTT allows all three line terminators.
-                self.content = (
-                    self.path_or_stream.getvalue()
-                    .decode("utf-8-sig")
-                    .replace("\r\n", "\n")
-                    .replace("\r", "\n")
-                )
+                # TextIOWrapper gives the same universal newline translation as
+                # the text-mode read below. It reads from the current position,
+                # which is EOF here, so it wraps a copy rather than the input.
+                self.content = TextIOWrapper(
+                    BytesIO(self.path_or_stream.getvalue()), encoding="utf-8-sig"
+                ).read()
             if isinstance(self.path_or_stream, Path):
                 with open(self.path_or_stream, encoding="utf-8-sig") as f:
                     self.content = f.read()

--- a/docling/backend/webvtt_backend.py
+++ b/docling/backend/webvtt_backend.py
@@ -73,7 +73,14 @@ class WebVTTDocumentBackend(DeclarativeDocumentBackend):
         # verify_signature() reject the file. Equivalent to utf-8 without a BOM.
         try:
             if isinstance(self.path_or_stream, BytesIO):
-                self.content = self.path_or_stream.getvalue().decode("utf-8-sig")
+                # bytes.decode() keeps CR and CRLF while the text-mode read below
+                # translates them, and WebVTT allows all three line terminators.
+                self.content = (
+                    self.path_or_stream.getvalue()
+                    .decode("utf-8-sig")
+                    .replace("\r\n", "\n")
+                    .replace("\r", "\n")
+                )
             if isinstance(self.path_or_stream, Path):
                 with open(self.path_or_stream, encoding="utf-8-sig") as f:
                     self.content = f.read()

--- a/docling/backend/webvtt_backend.py
+++ b/docling/backend/webvtt_backend.py
@@ -73,9 +73,6 @@ class WebVTTDocumentBackend(DeclarativeDocumentBackend):
         # verify_signature() reject the file. Equivalent to utf-8 without a BOM.
         try:
             if isinstance(self.path_or_stream, BytesIO):
-                # TextIOWrapper gives the same universal newline translation as
-                # the text-mode read below. It reads from the current position,
-                # which is EOF here, so it wraps a copy rather than the input.
                 self.content = TextIOWrapper(
                     BytesIO(self.path_or_stream.getvalue()), encoding="utf-8-sig"
                 ).read()

--- a/tests/test_backend_vtt.py
+++ b/tests/test_backend_vtt.py
@@ -332,3 +332,28 @@ def test_utf8_bom_does_not_invalidate_the_signature(converter, tmp_path):
 
     for doc in (stream_doc, file_doc):
         assert _process_vtt_doc(doc) == "Hello there"
+
+
+@pytest.mark.parametrize("terminator", ["\r\n", "\r"])
+def test_crlf_and_cr_line_terminators(converter, terminator, tmp_path):
+    """WebVTT counts CRLF, LF and a lone CR as line terminators.
+
+    WebVTTFile.parse() normalizes them, but is_valid() calls verify_signature()
+    on the content as decoded, and that rejects a CR after "WEBVTT". Only the
+    stream arrives with the CR still in it, since a path is read in text mode.
+    """
+    vtt_bytes = (
+        "WEBVTT\n\n00:00:01.000 --> 00:00:05.000\nHello there\n".replace(
+            "\n", terminator
+        )
+    ).encode()
+
+    stream = DocumentStream(name="eol.vtt", stream=BytesIO(vtt_bytes))
+    stream_doc = converter.convert(stream, raises_on_error=True).document
+
+    vtt_file = tmp_path / "eol.vtt"
+    vtt_file.write_bytes(vtt_bytes)
+    file_doc = converter.convert(vtt_file, raises_on_error=True).document
+
+    for doc in (stream_doc, file_doc):
+        assert _process_vtt_doc(doc) == "Hello there"


### PR DESCRIPTION
Same shape as #4111, in the WebVTT backend.

`WebVTTDocumentBackend.__init__` reads a `Path` with `open(..., encoding="utf-8-sig")`, which is text mode and translates CRLF and a lone CR, and reads a `BytesIO` with `.decode("utf-8-sig")`, which does not. `is_valid()` passes that string straight to `verify_signature()`, which rejects a CR right after `WEBVTT`. So the same .vtt file converts from disk and fails from a stream with "The document backend could not parse the input", which is what docling-serve and anything uploading bytes will hit on a Windows-authored file.

`WebVTTFile.parse()` normalizes all three terminators before it checks the signature, so this just makes `is_valid()` agree with it.

Added a parametrized test over CRLF and CR that covers both the stream and the path route. Both cases fail on main.
