### PR TITLE
fix: align transformer engine input dtype with model weights (fixes #3110)

### DIFF
--- a/docling/models/inference_engines/image_classification/transformers_engine.py
+++ b/docling/models/inference_engines/image_classification/transformers_engine.py
@@ -185,6 +185,18 @@ class TransformersImageClassificationEngine(HfImageClassificationEngineBase):
         images = [item.image.convert("RGB") for item in input_batch]
         inputs = self._processor(images=images, return_tensors="pt").to(self._device)
 
+        # Align the input tensor dtype with the model weights. When a non-default
+        # torch_dtype (e.g. bfloat16) is configured, the weights are loaded in that
+        # dtype but the preprocessor still emits float32 inputs, which crashes at
+        # inference with "mat1 and mat2 must have the same dtype". Cast only
+        # floating-point tensors so integer tensors (e.g. pixel_mask) are preserved.
+        model_dtype = self._model.dtype  # type: ignore[union-attr]
+        if model_dtype is not None:
+            inputs = {
+                k: (v.to(dtype=model_dtype) if torch.is_floating_point(v) else v)
+                for k, v in inputs.items()
+            }
+
         with torch.inference_mode():
             outputs = self._model(**inputs)  # type: ignore[operator]
             probs_batch = torch.softmax(outputs.logits, dim=-1)

--- a/docling/models/inference_engines/image_classification/transformers_engine.py
+++ b/docling/models/inference_engines/image_classification/transformers_engine.py
@@ -183,19 +183,9 @@ class TransformersImageClassificationEngine(HfImageClassificationEngineBase):
             raise RuntimeError("Engine not initialized. Call initialize() first.")
 
         images = [item.image.convert("RGB") for item in input_batch]
-        inputs = self._processor(images=images, return_tensors="pt").to(self._device)
-
-        # Align the input tensor dtype with the model weights. When a non-default
-        # torch_dtype (e.g. bfloat16) is configured, the weights are loaded in that
-        # dtype but the preprocessor still emits float32 inputs, which crashes at
-        # inference with "mat1 and mat2 must have the same dtype". Cast only
-        # floating-point tensors so integer tensors (e.g. pixel_mask) are preserved.
-        model_dtype = self._model.dtype  # type: ignore[union-attr]
-        if model_dtype is not None:
-            inputs = {
-                k: (v.to(dtype=model_dtype) if torch.is_floating_point(v) else v)
-                for k, v in inputs.items()
-            }
+        inputs = self._processor(images=images, return_tensors="pt").to(
+            self._device, self._model.dtype
+        )
 
         with torch.inference_mode():
             outputs = self._model(**inputs)  # type: ignore[operator]

--- a/docling/models/inference_engines/object_detection/transformers_engine.py
+++ b/docling/models/inference_engines/object_detection/transformers_engine.py
@@ -221,6 +221,18 @@ class TransformersObjectDetectionEngine(HfObjectDetectionEngineBase):
         images = [item.image.convert("RGB") for item in input_batch]
         inputs = self._processor(images=images, return_tensors="pt").to(self._device)
 
+        # Align the input tensor dtype with the model weights. When a non-default
+        # torch_dtype (e.g. bfloat16) is configured, the weights are loaded in that
+        # dtype but the preprocessor still emits float32 inputs, which crashes at
+        # inference with "mat1 and mat2 must have the same dtype". Cast only
+        # floating-point tensors so integer tensors (e.g. pixel_mask) are preserved.
+        model_dtype = self._model.dtype  # type: ignore[union-attr]
+        if model_dtype is not None:
+            inputs = {
+                k: (v.to(dtype=model_dtype) if torch.is_floating_point(v) else v)
+                for k, v in inputs.items()
+            }
+
         # Get target sizes for post-processing
         target_sizes = torch.tensor(
             [[img.height, img.width] for img in images], device=self._device

--- a/docling/models/inference_engines/object_detection/transformers_engine.py
+++ b/docling/models/inference_engines/object_detection/transformers_engine.py
@@ -219,19 +219,9 @@ class TransformersObjectDetectionEngine(HfObjectDetectionEngineBase):
 
         # Preprocess images using HF processor
         images = [item.image.convert("RGB") for item in input_batch]
-        inputs = self._processor(images=images, return_tensors="pt").to(self._device)
-
-        # Align the input tensor dtype with the model weights. When a non-default
-        # torch_dtype (e.g. bfloat16) is configured, the weights are loaded in that
-        # dtype but the preprocessor still emits float32 inputs, which crashes at
-        # inference with "mat1 and mat2 must have the same dtype". Cast only
-        # floating-point tensors so integer tensors (e.g. pixel_mask) are preserved.
-        model_dtype = self._model.dtype  # type: ignore[union-attr]
-        if model_dtype is not None:
-            inputs = {
-                k: (v.to(dtype=model_dtype) if torch.is_floating_point(v) else v)
-                for k, v in inputs.items()
-            }
+        inputs = self._processor(images=images, return_tensors="pt").to(
+            self._device, self._model.dtype
+        )
 
         # Get target sizes for post-processing
         target_sizes = torch.tensor(


### PR DESCRIPTION
## Problem

When a non-default `torch_dtype` (e.g. `"bfloat16"`) is configured via `picture_engine_options.torch_dtype` (or the equivalent object-detection option), the model weights are loaded in that dtype, but the HuggingFace preprocessor still emits float32 inputs. This causes a crash at inference time:

```
RuntimeError: mat1 and mat2 must have the same dtype, but got Float and BFloat16
```

This was reported in issue #3110 for the picture classifier engine.

## Root cause

In `predict_batch()`, the preprocessed inputs are moved to the target device via `.to(self._device)`, but the tensor dtype is never adjusted to match the model's weight dtype. The model weights are loaded in `torch_dtype` (e.g. bfloat16) via `from_pretrained(..., dtype=torch.bfloat16)`, while the image processor's output defaults to float32.

## Fix

After moving the preprocessed batch to the device, cast floating-point input tensors to the model's dtype (`self._model.dtype`). Integer tensors (e.g. `pixel_mask`) are left untouched since they are not consumed by matmul. The fix is applied to both the **image-classification** and **object-detection** Transformers engines, which share the identical pattern.

## Verification

- **Logic**: The fix is device-agnostic — it uses `self._model.dtype` without any `if cuda:` / `if npu:` branches.
- **Tested on Ascend NPU (torch 2.14.0a0, CANN)**: before the fix, float32 pixel tensors × bf16 weights silently consume extra memory (auto-promoted by NPU); after the fix, pixel_values are correctly cast to bf16, matching the model weights, and matmul succeeds with matching dtypes. `pixel_mask` (int64) is preserved as-is.
- The same pattern is widely used in HuggingFace transformers and other projects.

## Related

- Fixes #3110