### PR TITLE
fix: read the pdfium outline on pypdfium2 4.x and beyond 15 levels

### DIFF
--- a/docling/utils/pdf_outline.py
+++ b/docling/utils/pdf_outline.py
@@ -56,6 +56,16 @@ class _PdfOutlineItem(BaseModel):
     y_top: float | None = None
 
 
+# pypdfium2 walks the outline recursively and stops at 15 levels by default,
+# silently dropping every entry below that. Real outlines are nowhere near this
+# deep; the bound exists only so a malformed document cannot exhaust the
+# interpreter stack, which a recursive walk otherwise would. Raise it to a depth
+# no genuine table of contents reaches while staying far inside the recursion
+# limit. (`extract_outline_from_docling_parse` walks iteratively and needs no
+# such bound.)
+_PDFIUM_OUTLINE_MAX_DEPTH = 128
+
+
 @cache
 def _view_top_index() -> dict[int, int]:
     """Destination view modes whose coordinates carry a usable vertical (top) position.
@@ -135,7 +145,7 @@ def extract_outline_from_pdfium(pdoc: pdfium.PdfDocument) -> list[_PdfOutlineIte
 
     with pypdfium2_lock:
         try:
-            toc = list(pdoc.get_toc())
+            toc = list(pdoc.get_toc(max_depth=_PDFIUM_OUTLINE_MAX_DEPTH))
         except PdfiumError as exc:
             _log.debug("Could not read PDF outline: %s", exc)
             return []

--- a/docling/utils/pdf_outline.py
+++ b/docling/utils/pdf_outline.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 
 import logging
 from functools import cache
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel
 
@@ -83,6 +83,31 @@ def _view_top_index() -> dict[int, int]:
     }
 
 
+def _outline_entry(bm: Any) -> tuple[str, int, int | None, float | None]:
+    """Read one bookmark as ``(title, level, 0-based page index, top in PDF coords)``.
+
+    docling supports ``pypdfium2>=4.30,<6`` and the two majors expose the outline
+    differently: 5 yields bookmark objects carrying ``get_title()``/``get_dest()``, while 4.30
+    yields a ``PdfOutlineItem`` namedtuple that already holds the destination fields. Accept
+    either, so the outline is not silently lost on a supported version.
+    """
+    # lazy import (see module docstring)
+    from pypdfium2._helpers.misc import PdfiumError
+
+    if hasattr(bm, "get_title"):
+        try:
+            dest = bm.get_dest()
+        except PdfiumError:
+            dest = None
+        page_index, y_pdf = _dest_top_pdf(dest) if dest is not None else (None, None)
+        return (bm.get_title() or ""), int(bm.level), page_index, y_pdf
+
+    pos = bm.view_pos or ()
+    idx = _view_top_index().get(bm.view_mode)
+    y_pdf = pos[idx] if idx is not None and idx < len(pos) else None
+    return (bm.title or ""), int(bm.level), bm.page_index, y_pdf
+
+
 def _dest_top_pdf(dest: pdfium.PdfDest) -> tuple[int | None, float | None]:
     """Return ``(0-based page index, vertical top in PDF bottom-left coords)`` for a dest.
 
@@ -116,31 +141,24 @@ def extract_outline_from_pdfium(pdoc: pdfium.PdfDocument) -> list[_PdfOutlineIte
             return []
 
         for bm in toc:
-            title = (bm.get_title() or "").strip()
+            raw_title, level, page_index, y_pdf = _outline_entry(bm)
+            title = raw_title.strip()
             if not title:
                 continue
 
             page_no: int | None = None
             y_top: float | None = None
-            try:
-                dest = bm.get_dest()
-            except PdfiumError:
-                dest = None
-            if dest is not None:
-                page_index, y_pdf = _dest_top_pdf(dest)
-                if page_index is not None:
-                    page_no = page_index + 1
-                    if y_pdf is not None:
-                        if page_index not in page_heights:
-                            page = pdoc[page_index]
-                            page_heights[page_index] = page.get_height()
-                            page.close()
-                        y_top = page_heights[page_index] - y_pdf
+            if page_index is not None:
+                page_no = page_index + 1
+                if y_pdf is not None:
+                    if page_index not in page_heights:
+                        page = pdoc[page_index]
+                        page_heights[page_index] = page.get_height()
+                        page.close()
+                    y_top = page_heights[page_index] - y_pdf
 
             items.append(
-                _PdfOutlineItem(
-                    title=title, level=int(bm.level), page_no=page_no, y_top=y_top
-                )
+                _PdfOutlineItem(title=title, level=level, page_no=page_no, y_top=y_top)
             )
 
     return items

--- a/tests/test_pdf_outline.py
+++ b/tests/test_pdf_outline.py
@@ -136,9 +136,12 @@ class _MockPdfiumDocument:
         self._toc = toc
         self._page_height = page_height
         self.pages_opened: list[int] = []
+        self.max_depth_used: int | None = None
 
-    def get_toc(self):
-        return iter(self._toc)
+    def get_toc(self, max_depth: int = 15):
+        # Mirrors pypdfium2: entries below the depth bound are dropped silently.
+        self.max_depth_used = max_depth
+        return iter([bm for bm in self._toc if bm.level < max_depth])
 
     def __getitem__(self, index: int) -> _MockPdfiumPage:
         self.pages_opened.append(index)
@@ -291,3 +294,68 @@ def test_outline_pdfium_reuses_one_page_height_per_page():
 
     assert [i.y_top for i in items] == [100.0, 200.0]
     assert doc.pages_opened == [7]
+
+
+def _deep_outline_pdf(depth: int) -> bytes:
+    """A one-page PDF whose outline is a single chain `depth` levels deep.
+
+    Written out by hand rather than with a PDF library: nothing that can author an
+    outline is a dependency of this project, and this test has to run everywhere.
+    """
+    catalog, pages, page, outlines = 1, 2, 3, 4
+    first_item = outlines + 1
+    objects: dict[int, str] = {
+        catalog: f"<< /Type /Catalog /Pages {pages} 0 R /Outlines {outlines} 0 R >>",
+        pages: f"<< /Type /Pages /Kids [{page} 0 R] /Count 1 >>",
+        page: f"<< /Type /Page /Parent {pages} 0 R /MediaBox [0 0 612 792] >>",
+        outlines: (
+            f"<< /Type /Outlines /First {first_item} 0 R "
+            f"/Last {first_item} 0 R /Count {depth} >>"
+        ),
+    }
+    for i in range(depth):
+        num = first_item + i
+        parent = outlines if i == 0 else num - 1
+        entry = (
+            f"<< /Title (level {i}) /Parent {parent} 0 R "
+            f"/Dest [{page} 0 R /XYZ 0 {700 - i} 0]"
+        )
+        if i + 1 < depth:
+            entry += f" /First {num + 1} 0 R /Last {num + 1} 0 R /Count 1"
+        objects[num] = entry + " >>"
+
+    out = bytearray(b"%PDF-1.7\n")
+    offsets: dict[int, int] = {}
+    for num in sorted(objects):
+        offsets[num] = len(out)
+        out += f"{num} 0 obj\n{objects[num]}\nendobj\n".encode()
+    xref_offset = len(out)
+    size = max(objects) + 1
+    out += f"xref\n0 {size}\n0000000000 65535 f \n".encode()
+    for num in range(1, size):
+        out += f"{offsets[num]:010d} 00000 n \n".encode()
+    out += (
+        f"trailer\n<< /Size {size} /Root {catalog} 0 R >>\n"
+        f"startxref\n{xref_offset}\n%%EOF\n"
+    ).encode()
+    return bytes(out)
+
+
+def test_outline_pdfium_reads_past_the_default_depth_limit():
+    """Regression test: pypdfium2's `get_toc()` stops at 15 levels unless told
+    otherwise, so a deeper outline came back silently truncated -- unlike the
+    docling-parse walker, which is unbounded."""
+    from io import BytesIO
+
+    import pypdfium2 as pdfium
+
+    from docling.utils.pdf_outline import extract_outline_from_pdfium
+
+    depth = 20
+    pdoc = pdfium.PdfDocument(BytesIO(_deep_outline_pdf(depth)))
+
+    items = extract_outline_from_pdfium(pdoc)
+
+    assert [item.title for item in items] == [f"level {i}" for i in range(depth)]
+    assert [item.level for item in items] == list(range(depth))
+    assert all(item.page_no == 1 for item in items)

--- a/tests/test_pdf_outline.py
+++ b/tests/test_pdf_outline.py
@@ -112,3 +112,182 @@ def test_outline_deep_chain_does_not_raise_recursion_error():
     assert items[0].level == 0
     assert items[-1].title == f"level_{depth - 1}"
     assert items[-1].level == depth - 2
+
+
+class _MockPdfiumPage:
+    """Stand-in for a pypdfium2 page: extract_outline_from_pdfium only reads the
+    height and closes it."""
+
+    def __init__(self, height: float):
+        self._height = height
+        self.closed = False
+
+    def get_height(self) -> float:
+        return self._height
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _MockPdfiumDocument:
+    """Stand-in for a pypdfium2 PdfDocument holding an outline and page heights."""
+
+    def __init__(self, toc, page_height: float = 800.0):
+        self._toc = toc
+        self._page_height = page_height
+        self.pages_opened: list[int] = []
+
+    def get_toc(self):
+        return iter(self._toc)
+
+    def __getitem__(self, index: int) -> _MockPdfiumPage:
+        self.pages_opened.append(index)
+        return _MockPdfiumPage(self._page_height)
+
+
+class _Pypdfium4Bookmark:
+    """pypdfium2 4.30's ``PdfOutlineItem``: a namedtuple carrying the destination
+    fields directly, with no ``get_title``/``get_dest`` methods."""
+
+    def __init__(self, title, level, page_index, view_mode, view_pos):
+        self.title = title
+        self.level = level
+        self.page_index = page_index
+        self.view_mode = view_mode
+        self.view_pos = view_pos
+
+
+class _Pypdfium5Dest:
+    def __init__(self, index, view):
+        self._index = index
+        self._view = view
+
+    def get_index(self):
+        return self._index
+
+    def get_view(self):
+        return self._view
+
+
+class _Pypdfium5Bookmark:
+    """pypdfium2 5's bookmark object, which reaches the destination through
+    accessor methods."""
+
+    def __init__(self, title, level, dest):
+        self._title = title
+        self.level = level
+        self._dest = dest
+
+    def get_title(self):
+        return self._title
+
+    def get_dest(self):
+        return self._dest
+
+
+def _xyz_mode() -> int:
+    import pypdfium2.raw as pdfium_c
+
+    return pdfium_c.PDFDEST_VIEW_XYZ
+
+
+def test_outline_pdfium_reads_the_pypdfium2_4x_namedtuple():
+    """Regression test: on pypdfium2 4.x the bookmarks have no ``get_title()``,
+    so reaching for it lost the whole outline on a supported version."""
+    from docling.utils.pdf_outline import extract_outline_from_pdfium
+
+    doc = _MockPdfiumDocument(
+        [
+            _Pypdfium4Bookmark("Contents", 0, 2, _xyz_mode(), [0.0, 736.0, 0.0]),
+            _Pypdfium4Bookmark("Chapter 1", 1, 9, _xyz_mode(), [0.0, 700.0, 0.0]),
+        ]
+    )
+
+    items = extract_outline_from_pdfium(doc)
+
+    assert [(i.title, i.level, i.page_no, i.y_top) for i in items] == [
+        ("Contents", 0, 3, 64.0),
+        ("Chapter 1", 1, 10, 100.0),
+    ]
+
+
+def test_outline_pdfium_reads_the_pypdfium2_5x_bookmark_objects():
+    """The 5.x shape must keep working: both majors are supported."""
+    from docling.utils.pdf_outline import extract_outline_from_pdfium
+
+    doc = _MockPdfiumDocument(
+        [
+            _Pypdfium5Bookmark(
+                "Contents", 0, _Pypdfium5Dest(2, (_xyz_mode(), [0.0, 736.0, 0.0]))
+            ),
+        ]
+    )
+
+    items = extract_outline_from_pdfium(doc)
+
+    assert [(i.title, i.level, i.page_no, i.y_top) for i in items] == [
+        ("Contents", 0, 3, 64.0)
+    ]
+
+
+def test_outline_pdfium_entry_without_a_target_page():
+    """An entry whose destination carries no page keeps ``page_no`` unset, and no
+    page is opened to look up a height."""
+    from docling.utils.pdf_outline import extract_outline_from_pdfium
+
+    doc = _MockPdfiumDocument(
+        [_Pypdfium4Bookmark("Dangling", 0, None, _xyz_mode(), [0.0, 736.0, 0.0])]
+    )
+
+    items = extract_outline_from_pdfium(doc)
+
+    assert [(i.title, i.page_no, i.y_top) for i in items] == [("Dangling", None, None)]
+    assert doc.pages_opened == []
+
+
+def test_outline_pdfium_view_mode_without_a_vertical_position():
+    """FIT carries no top coordinate, so the page survives but ``y_top`` does not."""
+    import pypdfium2.raw as pdfium_c
+
+    from docling.utils.pdf_outline import extract_outline_from_pdfium
+
+    doc = _MockPdfiumDocument(
+        [_Pypdfium4Bookmark("Fitted", 0, 4, pdfium_c.PDFDEST_VIEW_FIT, [])]
+    )
+
+    items = extract_outline_from_pdfium(doc)
+
+    assert [(i.title, i.page_no, i.y_top) for i in items] == [("Fitted", 5, None)]
+    assert doc.pages_opened == []
+
+
+def test_outline_pdfium_blank_titles_are_excluded():
+    from docling.utils.pdf_outline import extract_outline_from_pdfium
+
+    doc = _MockPdfiumDocument(
+        [
+            _Pypdfium4Bookmark("   ", 0, 1, _xyz_mode(), [0.0, 736.0, 0.0]),
+            _Pypdfium4Bookmark("  Real  ", 0, 1, _xyz_mode(), [0.0, 736.0, 0.0]),
+        ]
+    )
+
+    items = extract_outline_from_pdfium(doc)
+
+    assert [(i.title, i.page_no) for i in items] == [("Real", 2)]
+
+
+def test_outline_pdfium_reuses_one_page_height_per_page():
+    """The height lookup is cached: several bookmarks on a page open it once."""
+    from docling.utils.pdf_outline import extract_outline_from_pdfium
+
+    doc = _MockPdfiumDocument(
+        [
+            _Pypdfium4Bookmark("A", 0, 7, _xyz_mode(), [0.0, 700.0, 0.0]),
+            _Pypdfium4Bookmark("B", 1, 7, _xyz_mode(), [0.0, 600.0, 0.0]),
+        ]
+    )
+
+    items = extract_outline_from_pdfium(doc)
+
+    assert [i.y_top for i in items] == [100.0, 200.0]
+    assert doc.pages_opened == [7]


### PR DESCRIPTION
Two independent defects in `extract_outline_from_pdfium()`, one commit each.

**1. It only spoke the pypdfium2 5 bookmark API.** `bm.get_title()` / `bm.get_dest()`
do not exist on 4.30, where `get_toc()` yields a `PdfOutlineItem` namedtuple, so the
call raised `AttributeError` and the outline was lost on a version this project
supports. The namedtuple already carries what the 5 API reaches through the destination
object, so a small `_outline_entry()` helper reads either shape and the view-mode
handling stays in one place.

**2. It truncated the outline at 15 levels.** `get_toc()` walks recursively and defaults
to `max_depth=15`, dropping deeper entries with only a debug log, while the
docling-parse extractor next to it is iterative and unbounded. The bound is now passed
explicitly. It stays finite — the traversal is recursive, so a malformed document should
not exhaust the interpreter stack — but 128 is far past anything a real table of
contents reaches.

### Verification

`tests/test_pdf_outline.py` gains seven tests: both bookmark shapes, entries without a
destination, a view mode that carries no vertical position, blank titles, the page-height
cache, and a 20-level outline. Six of them fail on `v2.124.0`.

The deep-outline test builds its PDF from bytes rather than with a PDF library: nothing
that can author an outline is a dependency of this project, and the test should run
everywhere rather than skip.

Checked on a 2252-page manual under pypdfium2 4.30.0: 1531 bookmarks, all with a
resolved page and vertical position, where `v2.124.0` raised.

**Issue resolved by this Pull Request:**
Resolves #4160
Resolves #4161

**Checklist:**

- [x] Documentation has been updated, if necessary. *(not necessary — internal helper, no
      user-facing behaviour or option changes)*
- [x] Examples have been added, if necessary. *(not necessary)*
- [x] Tests have been added, if necessary.
