### PR TITLE
fix: pin RapidOCR's cuDNN algorithm search so CUDA beats the CPU

### DIFF
--- a/docling/models/stages/ocr/rapid_ocr_model.py
+++ b/docling/models/stages/ocr/rapid_ocr_model.py
@@ -412,6 +412,18 @@ class RapidOcrModel(BaseOcrModel):
                 "EngineConfig.onnxruntime.intra_op_num_threads": intra_op_num_threads,
                 "EngineConfig.onnxruntime.use_cuda": use_cuda,
                 "EngineConfig.onnxruntime.cuda_ep_cfg.device_id": gpu_id,
+                # RapidOCR defaults this to EXHAUSTIVE, which re-searches the
+                # convolution algorithms for every new input shape. Detection
+                # sees one shape per page size and amortizes that search, but
+                # recognition runs one text-line crop at a time, so its shape
+                # changes constantly and the search never pays for itself. On an
+                # L4 that is 0.12s vs 0.22s on detection against 11.3s vs 1.3s
+                # on recognition, i.e. the difference between CUDA being 4.4x
+                # slower than the CPU and 1.6x faster. HEURISTIC still searches;
+                # only DEFAULT skips it. RapidOCR shares one engine config
+                # across Det/Cls/Rec, so this cannot be chosen per model.
+                "EngineConfig.onnxruntime.cuda_ep_cfg.cudnn_conv_algo_search": "DEFAULT",
+                "EngineConfig.onnxruntime.use_dml": use_dml,
                 # Engine-level OpenVINO settings
                 "EngineConfig.openvino.inference_num_threads": intra_op_num_threads,
                 # "Global.verbose": self.options.print_verbose,

--- a/docs/usage/gpu.md
+++ b/docs/usage/gpu.md
@@ -87,6 +87,22 @@ pipeline_options = PdfPipelineOptions(
 )
 ```
 
+Recognition runs one text-line crop at a time, so its input shape changes on nearly
+every call. Docling therefore pins ONNX Runtime's `cudnn_conv_algo_search` to `DEFAULT`
+for this engine: RapidOCR's own default re-searches the convolution algorithms on every
+new shape, which costs far more than the inference it is choosing kernels for. Measured
+on an L4, one 1224x1584 page with `lang=["japan"]`:
+
+| | seconds/page |
+| --- | --- |
+| CPU | 2.7 |
+| CUDA | 1.7 |
+| CUDA, without the pinned search | 11.6 |
+
+If ONNX Runtime cannot load its CUDA execution provider — no `onnxruntime-gpu`, a
+version built against a different CUDA/cuDNN, or a host with no GPU — RapidOCR logs a
+warning and falls back to the CPU provider; conversion still succeeds.
+
 The Torch backend can be enabled instead with:
 
 ```py

--- a/tests/test_rapid_ocr_model.py
+++ b/tests/test_rapid_ocr_model.py
@@ -106,3 +106,32 @@ def test_rapidocr_pins_explicit_model_paths(
     assert params["Rec.model_path"] is not None
     assert "Det.lang_type" not in params
     assert "Rec.lang_type" not in params
+
+
+def test_rapidocr_onnxruntime_skips_the_cudnn_algorithm_search(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    params = _capture_params(
+        monkeypatch,
+        RapidOcrOptions(backend="onnxruntime"),
+        tmp_path,
+        resolved_device="cuda:0",
+    )
+    # RapidOCR defaults to EXHAUSTIVE, which re-searches convolution algorithms for
+    # every new input shape. Recognition feeds one text-line crop at a time, so the
+    # shape changes constantly and the search costs more than the inference it picks
+    # kernels for -- enough to make the GPU slower than the CPU.
+    assert (
+        params["EngineConfig.onnxruntime.cuda_ep_cfg.cudnn_conv_algo_search"]
+        == "DEFAULT"
+    )
+
+
+def test_rapidocr_onnxruntime_engine_receives_the_dml_choice(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    params = _capture_params(
+        monkeypatch, RapidOcrOptions(backend="onnxruntime"), tmp_path
+    )
+    # DirectML is selected from the engine config too, not from the per-model entries.
+    assert params["EngineConfig.onnxruntime.use_dml"] == params["Det.use_dml"]


### PR DESCRIPTION
Follow-up to #4103, which made the ONNX Runtime backend use the CUDA execution provider.
On an L4 that path currently runs OCR **4.4x slower** than the CPU it replaces.

RapidOCR defaults `cudnn_conv_algo_search` to `EXHAUSTIVE`, which re-searches the
convolution algorithms every time an input shape changes. Detection sees one shape per
page size and amortizes that search; recognition feeds one text-line crop at a time, so
its shape changes on nearly every call and the search never pays for itself.

Measured on `1c2b794b` with nothing patched, onnxruntime-gpu 1.29.0 and rapidocr 3.9.2,
one 1224x1584 page with `lang=["japan"]` (35 text lines), median of three runs after a
warm-up, spread within 0.01s:

|                            | det   | cls   | rec    | total  |
| -------------------------- | ----- | ----- | ------ | ------ |
| CPU                        | 0.96s | 0.03s | 1.66s  | 2.65s  |
| CUDA, EXHAUSTIVE (current) | 0.12s | 0.21s | 11.26s | 11.60s |
| CUDA, DEFAULT (this PR)    | 0.22s | 0.16s | 1.30s  | 1.68s  |

Detection is 8x faster on the GPU, as expected; recognition is what inverts the result.
`HEURISTIC` does not help — it still searches (11.72s); only `DEFAULT` skips it.

The trade-off is one-sided: `DEFAULT` costs detection 0.08s a page, because a fixed
algorithm is not the one `EXHAUSTIVE` would have found, while recognition saves about 10s.
Choosing per model would be better still, but RapidOCR binds one engine config to all
three (`cfg.Det.engine_cfg = cfg.EngineConfig[engine_type]`), so it cannot be set per
model from Docling.

For the record, this is not a per-node fallback to the CPU: with CUDA requested,
`session_state` reports `All nodes placed on [CUDAExecutionProvider]. Number of nodes:
190` for the detection model, with `MemcpyTransformer modified: 0`.

The PR also passes `use_dml`, which the engine config reads from the same place and which
the per-model `Det`/`Cls`/`Rec` entries do not supply, so DirectML gets selected the way
CUDA now is. I have no Windows machine, so that half is by inspection rather than
measurement.

### Fallback

These keys only matter when CUDA is actually available.
`ProviderConfig.is_cuda_available()` requires both `get_device() == "GPU"` and
`CUDAExecutionProvider` among the available providers; failing either, it logs a warning
and leaves the CUDA entry out of the provider list, so `cuda_ep_cfg` is never read.
Simulating a CPU-only onnxruntime install and a host with no GPU device both gave
`['CPUExecutionProvider']`, identical output (35 text lines), and no exception.

### Verification

`tests/test_rapid_ocr_model.py` gains two tests, both failing on `main`: the algorithm
search is pinned, and the onnxruntime engine receives the same DirectML decision as the
per-model entries. They reuse the `resolved_device` helper #4103 added, so they do not
depend on the test machine having a GPU.

End to end on the branch: 1.69s per page on CUDA against 2.66s on CPU, with the fallback
paths still landing on `['CPUExecutionProvider']`.

### Documentation

`docs/usage/gpu.md` gains the measured numbers and a note that RapidOCR falls back to the
CPU provider with a warning when ONNX Runtime cannot load the CUDA provider. The setup
instructions #4103 added are unchanged.

**Issue resolved by this Pull Request:**
Resolves #4167

**Checklist:**

- [x] Documentation has been updated, if necessary. *(`docs/usage/gpu.md`)*
- [x] Examples have been added, if necessary. *(not necessary)*
- [x] Tests have been added, if necessary.
