### PR TITLE
fix(iwork): prune sf:ghost-text-ref placeholder text

### DIFF
--- a/docling/backend/iwork/pages_xml.py
+++ b/docling/backend/iwork/pages_xml.py
@@ -58,9 +58,18 @@ SF_NAMESPACE = "http://developer.apple.com/namespaces/sf"
 
 SF_PARAGRAPH = f"{{{SF_NAMESPACE}}}p"
 
-# iWork '09 placeholder text. It is what the template shows before the author
-# types anything, so it must never be emitted as document content.
 SF_GHOST_TEXT = f"{{{SF_NAMESPACE}}}ghost-text"
+SF_GHOST_TEXT_REF = f"{{{SF_NAMESPACE}}}ghost-text-ref"
+
+SF_PLACEHOLDER_TEXT = frozenset({SF_GHOST_TEXT, SF_GHOST_TEXT_REF})
+"""Elements holding iWork '09 placeholder text.
+
+It is what the template shows before the author types anything, so it must never
+be emitted as document content. A template defines each placeholder once as an
+``sf:ghost-text`` and every later paragraph that reuses it holds an
+``sf:ghost-text-ref``, which names the original by ``sfa:IDREF`` but carries its
+own inline copy of the text — so both have to be pruned, not just the first.
+"""
 
 SF_PARAGRAPH_STYLE = f"{{{SF_NAMESPACE}}}paragraphstyle"
 
@@ -478,7 +487,7 @@ def legacy_runs(
         # outside it, so it keeps the parent's formatting.
         for child in reversed(list(element)):
             stack.append((child, formatting, link, True))
-            if child.tag == SF_GHOST_TEXT:
+            if child.tag in SF_PLACEHOLDER_TEXT:
                 continue
             inherited = formatting
             if child.tag == SF_SPAN:

--- a/tests/data/pages/groundtruth/pages_iwork09.pages.json
+++ b/tests/data/pages/groundtruth/pages_iwork09.pages.json
@@ -21,10 +21,10 @@
         "$ref": "#/texts/0"
       },
       {
-        "$ref": "#/texts/1"
+        "$ref": "#/tables/0"
       },
       {
-        "$ref": "#/tables/0"
+        "$ref": "#/texts/1"
       },
       {
         "$ref": "#/texts/2"
@@ -46,9 +46,6 @@
       },
       {
         "$ref": "#/texts/8"
-      },
-      {
-        "$ref": "#/texts/9"
       }
     ],
     "content_layer": "body",
@@ -66,23 +63,11 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Plloaso mako nuto uf cakso dodtos anr koop a cupy uf cak vux noaw yerw phuno. Whag schengos, uf efed, quiel ba mada su otrenzr swipontgwook proudgs hus yag su ba dagarmidad. Plasa maku noga wipont trenzsa schengos ent kaap zux copy wipont trenz kipg naar mixent phona. Cak pwico siructiun ruos nust apoply tyu cak UCU sisulutiun munityuw uw cak UCU-TGU jot scannow. Trens roxas eis ti Plokeing quert loppe eis yop prexs. Piy opher hawers, eit yaggles orn ti sumbloat alohe plok. Su havo loasor cakso tgu pwuructs tyu. Nunc volutpat dapibus nisi. Maecenas vel nulla. Proin et erat ac odio mattis suscipit. In hac habitasse platea dictumst. Sed tempus fermentum arcu. Cras egestas mauris cursus eros. Morbi vulputate, neque vel fermentum egestas, diam neque vestibulum risus, dapibus fermentum diam lacus et purus. In hac habitasse platea dictumst. Pellentesque id enim id tortor lacinia fermentum. Nam eu metus quis mauris ullamcorper mollis. Nullam vehicula.",
-      "text": "Plloaso mako nuto uf cakso dodtos anr koop a cupy uf cak vux noaw yerw phuno. Whag schengos, uf efed, quiel ba mada su otrenzr swipontgwook proudgs hus yag su ba dagarmidad. Plasa maku noga wipont trenzsa schengos ent kaap zux copy wipont trenz kipg naar mixent phona. Cak pwico siructiun ruos nust apoply tyu cak UCU sisulutiun munityuw uw cak UCU-TGU jot scannow. Trens roxas eis ti Plokeing quert loppe eis yop prexs. Piy opher hawers, eit yaggles orn ti sumbloat alohe plok. Su havo loasor cakso tgu pwuructs tyu. Nunc volutpat dapibus nisi. Maecenas vel nulla. Proin et erat ac odio mattis suscipit. In hac habitasse platea dictumst. Sed tempus fermentum arcu. Cras egestas mauris cursus eros. Morbi vulputate, neque vel fermentum egestas, diam neque vestibulum risus, dapibus fermentum diam lacus et purus. In hac habitasse platea dictumst. Pellentesque id enim id tortor lacinia fermentum. Nam eu metus quis mauris ullamcorper mollis. Nullam vehicula."
-    },
-    {
-      "self_ref": "#/texts/1",
-      "parent": {
-        "$ref": "#/body"
-      },
-      "children": [],
-      "content_layer": "body",
-      "label": "text",
-      "prov": [],
       "orig": "A text box with text.",
       "text": "A text box with text."
     },
     {
-      "self_ref": "#/texts/2",
+      "self_ref": "#/texts/1",
       "parent": {
         "$ref": "#/body"
       },
@@ -94,7 +79,7 @@
       "text": "Sample pages document"
     },
     {
-      "self_ref": "#/texts/3",
+      "self_ref": "#/texts/2",
       "parent": {
         "$ref": "#/body"
       },
@@ -106,7 +91,7 @@
       "text": "Some plain text to parse."
     },
     {
-      "self_ref": "#/texts/4",
+      "self_ref": "#/texts/3",
       "parent": {
         "$ref": "#/body"
       },
@@ -118,7 +103,7 @@
       "text": "Both Pages 1.x and Keynote 2.x, which form the basis of Apple’s iWork package, are powerful, yet easy to use applications that have attracted large and ever-growing customer bases. The iWork package is part of a family of iApps productivity tools."
     },
     {
-      "self_ref": "#/texts/5",
+      "self_ref": "#/texts/4",
       "parent": {
         "$ref": "#/body"
       },
@@ -130,7 +115,7 @@
       "text": "Because Keynote uses an open, easily accessible file format, developers can take advantage of its XML schema to enhance existing products or create new ones. Beginning with Keynote 1.x, it is possible to build applications that will create or change the contents of a Keynote presentation. For example, developers can use any of Keynote’s themes and build an entire presentation of their own design simply by filling out the<key:slide-list> element in a text editor of their choice."
     },
     {
-      "self_ref": "#/texts/6",
+      "self_ref": "#/texts/5",
       "parent": {
         "$ref": "#/body"
       },
@@ -142,7 +127,7 @@
       "text": "The Keynote APXL file is the engine that drives every presentation, specifying every detail of the presentation’s appearance and behavior––from master slide and each individual slide to the transitions used between slides. The APXL file also defines the state of the presentation when the user first opens it. An understanding of how the elements in an APXL file combine to create a presentation is critical to developing applications that are robust and well-behaved."
     },
     {
-      "self_ref": "#/texts/7",
+      "self_ref": "#/texts/6",
       "parent": {
         "$ref": "#/body"
       },
@@ -154,7 +139,7 @@
       "text": "Similarly, understanding the Pages document structure is important for Apple developers who want to customize their own page layouts or add value to their existing applications."
     },
     {
-      "self_ref": "#/texts/8",
+      "self_ref": "#/texts/7",
       "parent": {
         "$ref": "#/body"
       },
@@ -166,7 +151,7 @@
       "text": "A second page...."
     },
     {
-      "self_ref": "#/texts/9",
+      "self_ref": "#/texts/8",
       "parent": {
         "$ref": "#/body"
       },

--- a/tests/data/pages/groundtruth/pages_iwork09.pages.md
+++ b/tests/data/pages/groundtruth/pages_iwork09.pages.md
@@ -1,5 +1,3 @@
-Plloaso mako nuto uf cakso dodtos anr koop a cupy uf cak vux noaw yerw phuno. Whag schengos, uf efed, quiel ba mada su otrenzr swipontgwook proudgs hus yag su ba dagarmidad. Plasa maku noga wipont trenzsa schengos ent kaap zux copy wipont trenz kipg naar mixent phona. Cak pwico siructiun ruos nust apoply tyu cak UCU sisulutiun munityuw uw cak UCU-TGU jot scannow. Trens roxas eis ti Plokeing quert loppe eis yop prexs. Piy opher hawers, eit yaggles orn ti sumbloat alohe plok. Su havo loasor cakso tgu pwuructs tyu. Nunc volutpat dapibus nisi. Maecenas vel nulla. Proin et erat ac odio mattis suscipit. In hac habitasse platea dictumst. Sed tempus fermentum arcu. Cras egestas mauris cursus eros. Morbi vulputate, neque vel fermentum egestas, diam neque vestibulum risus, dapibus fermentum diam lacus et purus. In hac habitasse platea dictumst. Pellentesque id enim id tortor lacinia fermentum. Nam eu metus quis mauris ullamcorper mollis. Nullam vehicula.
-
 A text box with text.
 
 | Column one   | Column two   | Column three   |

--- a/tests/data/pages/groundtruth/pages_iwork09_comments.pages.json
+++ b/tests/data/pages/groundtruth/pages_iwork09_comments.pages.json
@@ -70,9 +70,6 @@
       },
       {
         "$ref": "#/texts/17"
-      },
-      {
-        "$ref": "#/texts/18"
       }
     ],
     "content_layer": "body",
@@ -90,23 +87,11 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Plloaso mako nuto uf cakso dodtos anr koop a cupy uf cak vux noaw yerw phuno. Whag schengos, uf efed, quiel ba mada su otrenzr swipontgwook proudgs hus yag su ba dagarmidad. Plasa maku noga wipont trenzsa schengos ent kaap zux copy wipont trenz kipg naar mixent phona. Cak pwico siructiun ruos nust apoply tyu cak UCU sisulutiun munityuw uw cak UCU-TGU jot scannow. Trens roxas eis ti Plokeing quert loppe eis yop prexs. Piy opher hawers, eit yaggles orn ti sumbloat alohe plok. Su havo loasor cakso tgu pwuructs tyu. Nunc volutpat dapibus nisi. Maecenas vel nulla. Proin et erat ac odio mattis suscipit. In hac habitasse platea dictumst. Sed tempus fermentum arcu. Cras egestas mauris cursus eros. Morbi vulputate, neque vel fermentum egestas, diam neque vestibulum risus, dapibus fermentum diam lacus et purus. In hac habitasse platea dictumst. Pellentesque id enim id tortor lacinia fermentum. Nam eu metus quis mauris ullamcorper mollis. Nullam vehicula.",
-      "text": "Plloaso mako nuto uf cakso dodtos anr koop a cupy uf cak vux noaw yerw phuno. Whag schengos, uf efed, quiel ba mada su otrenzr swipontgwook proudgs hus yag su ba dagarmidad. Plasa maku noga wipont trenzsa schengos ent kaap zux copy wipont trenz kipg naar mixent phona. Cak pwico siructiun ruos nust apoply tyu cak UCU sisulutiun munityuw uw cak UCU-TGU jot scannow. Trens roxas eis ti Plokeing quert loppe eis yop prexs. Piy opher hawers, eit yaggles orn ti sumbloat alohe plok. Su havo loasor cakso tgu pwuructs tyu. Nunc volutpat dapibus nisi. Maecenas vel nulla. Proin et erat ac odio mattis suscipit. In hac habitasse platea dictumst. Sed tempus fermentum arcu. Cras egestas mauris cursus eros. Morbi vulputate, neque vel fermentum egestas, diam neque vestibulum risus, dapibus fermentum diam lacus et purus. In hac habitasse platea dictumst. Pellentesque id enim id tortor lacinia fermentum. Nam eu metus quis mauris ullamcorper mollis. Nullam vehicula."
-    },
-    {
-      "self_ref": "#/texts/1",
-      "parent": {
-        "$ref": "#/body"
-      },
-      "children": [],
-      "content_layer": "body",
-      "label": "text",
-      "prov": [],
       "orig": "Sample pages document - this is the template document",
       "text": "Sample pages document - this is the template document"
     },
     {
-      "self_ref": "#/texts/2",
+      "self_ref": "#/texts/1",
       "parent": {
         "$ref": "#/body"
       },
@@ -118,7 +103,7 @@
       "text": "Some plain text to parse."
     },
     {
-      "self_ref": "#/texts/3",
+      "self_ref": "#/texts/2",
       "parent": {
         "$ref": "#/body"
       },
@@ -128,7 +113,7 @@
       "prov": [],
       "comments": [
         {
-          "$ref": "#/texts/18"
+          "$ref": "#/texts/17"
         }
       ],
       "orig": "Both Pages 1.x and Keynote 2.x, which form the basis of Apple’s iWork package, are powerful, yet easy to use applications that have attracted large and ever-growing customer bases. The iWork package is part of a family of iApps productivity tools.",
@@ -142,7 +127,7 @@
       }
     },
     {
-      "self_ref": "#/texts/4",
+      "self_ref": "#/texts/3",
       "parent": {
         "$ref": "#/body"
       },
@@ -154,7 +139,120 @@
       "text": "Because Keynote uses an open, easily accessible file format, developers can take advantage of its XML schema to enhance existing products or create new ones. Beginning with Keynote 1.x, it is possible to build applications that will create or change the contents of a Keynote presentation. For example, developers can use any of Keynote’s themes and build an entire presentation of their own design simply by filling out the<key:slide-list> element in a text editor of their choice."
     },
     {
+      "self_ref": "#/texts/4",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "comments": [
+        {
+          "$ref": "#/texts/15"
+        }
+      ],
+      "orig": "The Keynote APXL file is the engine that drives every presentation, specifying every detail of the presentation’s appearance and behavior––from master slide and each individual slide to the transitions used between slides. The APXL file also defines the state of the presentation when the user first opens it. An understanding of how the elements in an APXL file combine to create a presentation is critical to developing applications that are robust and well-behaved.",
+      "text": "The Keynote APXL file is the engine that drives every presentation, specifying every detail of the presentation’s appearance and behavior––from master slide and each individual slide to the transitions used between slides. The APXL file also defines the state of the presentation when the user first opens it. An understanding of how the elements in an APXL file combine to create a presentation is critical to developing applications that are robust and well-behaved."
+    },
+    {
       "self_ref": "#/texts/5",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Similarly, understanding the Pages document structure is important for Apple developers who want to customize their own page layouts or add value to their existing application.",
+      "text": "Similarly, understanding the Pages document structure is important for Apple developers who want to customize their own page layouts or add value to their existing application."
+    },
+    {
+      "self_ref": "#/texts/6",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Extensible Markup Language (XML) is a ubiquitous and flexible markup standard for processing and exchanging data. You can find XML in a wide range of categories, including property lists and file formats for various applications. XML is used extensively to specify the format of various sources of information on the Internet, including web-based services. XML is at the heart of both iWork applications, Keynote and Pages, developed by Apple.",
+      "text": "Extensible Markup Language (XML) is a ubiquitous and flexible markup standard for processing and exchanging data. You can find XML in a wide range of categories, including property lists and file formats for various applications. XML is used extensively to specify the format of various sources of information on the Internet, including web-based services. XML is at the heart of both iWork applications, Keynote and Pages, developed by Apple."
+    },
+    {
+      "self_ref": "#/texts/7",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "this should be page 2",
+      "text": "this should be page 2"
+    },
+    {
+      "self_ref": "#/texts/8",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "blah blah blah meh meh hello how are you doing today just writing a bunch of random text here nothing special move along.",
+      "text": "blah blah blah meh meh hello how are you doing today just writing a bunch of random text here nothing special move along."
+    },
+    {
+      "self_ref": "#/texts/9",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "now we’ll start a new paragraph and put in more meaningless text. LOL LOL ROFL",
+      "text": "now we’ll start a new paragraph and put in more meaningless text. LOL LOL ROFL"
+    },
+    {
+      "self_ref": "#/texts/10",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "hmmm mmmmm aaaaaarrrrrrrgggggh",
+      "text": "hmmm mmmmm aaaaaarrrrrrrgggggh"
+    },
+    {
+      "self_ref": "#/texts/11",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "Content analytics starts with the gathering of relevant enterprise content.",
+      "text": "Content analytics starts with the gathering of relevant enterprise content."
+    },
+    {
+      "self_ref": "#/texts/12",
+      "parent": {
+        "$ref": "#/body"
+      },
+      "children": [],
+      "content_layer": "body",
+      "label": "text",
+      "prov": [],
+      "orig": "IBM® Content Analytics provides crawlers for a wide variety of enterprise content sources that allow content, metadata, structured data, and unstructured data to be collected and fed into the analytics pipeline. Crawler configuration is flexible and scalable, enabling you to gather the source information that you need to intelligently answer content-based questions.",
+      "text": "IBM® Content Analytics provides crawlers for a wide variety of enterprise content sources that allow content, metadata, structured data, and unstructured data to be collected and fed into the analytics pipeline. Crawler configuration is flexible and scalable, enabling you to gather the source information that you need to intelligently answer content-based questions."
+    },
+    {
+      "self_ref": "#/texts/13",
       "parent": {
         "$ref": "#/body"
       },
@@ -167,124 +265,11 @@
           "$ref": "#/texts/16"
         }
       ],
-      "orig": "The Keynote APXL file is the engine that drives every presentation, specifying every detail of the presentation’s appearance and behavior––from master slide and each individual slide to the transitions used between slides. The APXL file also defines the state of the presentation when the user first opens it. An understanding of how the elements in an APXL file combine to create a presentation is critical to developing applications that are robust and well-behaved.",
-      "text": "The Keynote APXL file is the engine that drives every presentation, specifying every detail of the presentation’s appearance and behavior––from master slide and each individual slide to the transitions used between slides. The APXL file also defines the state of the presentation when the user first opens it. An understanding of how the elements in an APXL file combine to create a presentation is critical to developing applications that are robust and well-behaved."
-    },
-    {
-      "self_ref": "#/texts/6",
-      "parent": {
-        "$ref": "#/body"
-      },
-      "children": [],
-      "content_layer": "body",
-      "label": "text",
-      "prov": [],
-      "orig": "Similarly, understanding the Pages document structure is important for Apple developers who want to customize their own page layouts or add value to their existing application.",
-      "text": "Similarly, understanding the Pages document structure is important for Apple developers who want to customize their own page layouts or add value to their existing application."
-    },
-    {
-      "self_ref": "#/texts/7",
-      "parent": {
-        "$ref": "#/body"
-      },
-      "children": [],
-      "content_layer": "body",
-      "label": "text",
-      "prov": [],
-      "orig": "Extensible Markup Language (XML) is a ubiquitous and flexible markup standard for processing and exchanging data. You can find XML in a wide range of categories, including property lists and file formats for various applications. XML is used extensively to specify the format of various sources of information on the Internet, including web-based services. XML is at the heart of both iWork applications, Keynote and Pages, developed by Apple.",
-      "text": "Extensible Markup Language (XML) is a ubiquitous and flexible markup standard for processing and exchanging data. You can find XML in a wide range of categories, including property lists and file formats for various applications. XML is used extensively to specify the format of various sources of information on the Internet, including web-based services. XML is at the heart of both iWork applications, Keynote and Pages, developed by Apple."
-    },
-    {
-      "self_ref": "#/texts/8",
-      "parent": {
-        "$ref": "#/body"
-      },
-      "children": [],
-      "content_layer": "body",
-      "label": "text",
-      "prov": [],
-      "orig": "this should be page 2",
-      "text": "this should be page 2"
-    },
-    {
-      "self_ref": "#/texts/9",
-      "parent": {
-        "$ref": "#/body"
-      },
-      "children": [],
-      "content_layer": "body",
-      "label": "text",
-      "prov": [],
-      "orig": "blah blah blah meh meh hello how are you doing today just writing a bunch of random text here nothing special move along.",
-      "text": "blah blah blah meh meh hello how are you doing today just writing a bunch of random text here nothing special move along."
-    },
-    {
-      "self_ref": "#/texts/10",
-      "parent": {
-        "$ref": "#/body"
-      },
-      "children": [],
-      "content_layer": "body",
-      "label": "text",
-      "prov": [],
-      "orig": "now we’ll start a new paragraph and put in more meaningless text. LOL LOL ROFL",
-      "text": "now we’ll start a new paragraph and put in more meaningless text. LOL LOL ROFL"
-    },
-    {
-      "self_ref": "#/texts/11",
-      "parent": {
-        "$ref": "#/body"
-      },
-      "children": [],
-      "content_layer": "body",
-      "label": "text",
-      "prov": [],
-      "orig": "hmmm mmmmm aaaaaarrrrrrrgggggh",
-      "text": "hmmm mmmmm aaaaaarrrrrrrgggggh"
-    },
-    {
-      "self_ref": "#/texts/12",
-      "parent": {
-        "$ref": "#/body"
-      },
-      "children": [],
-      "content_layer": "body",
-      "label": "text",
-      "prov": [],
-      "orig": "Content analytics starts with the gathering of relevant enterprise content.",
-      "text": "Content analytics starts with the gathering of relevant enterprise content."
-    },
-    {
-      "self_ref": "#/texts/13",
-      "parent": {
-        "$ref": "#/body"
-      },
-      "children": [],
-      "content_layer": "body",
-      "label": "text",
-      "prov": [],
-      "orig": "IBM® Content Analytics provides crawlers for a wide variety of enterprise content sources that allow content, metadata, structured data, and unstructured data to be collected and fed into the analytics pipeline. Crawler configuration is flexible and scalable, enabling you to gather the source information that you need to intelligently answer content-based questions.",
-      "text": "IBM® Content Analytics provides crawlers for a wide variety of enterprise content sources that allow content, metadata, structured data, and unstructured data to be collected and fed into the analytics pipeline. Crawler configuration is flexible and scalable, enabling you to gather the source information that you need to intelligently answer content-based questions."
-    },
-    {
-      "self_ref": "#/texts/14",
-      "parent": {
-        "$ref": "#/body"
-      },
-      "children": [],
-      "content_layer": "body",
-      "label": "text",
-      "prov": [],
-      "comments": [
-        {
-          "$ref": "#/texts/17"
-        }
-      ],
       "orig": "Because IBM Content Analytics implements the open Unstructured Information Management Architecture (UIMA) framework, you can fully customize the processing of content and take advantage of existing UIMA annotators, both open source and commercial, to enhance your automated content analysis capabilities.",
       "text": "Because IBM Content Analytics implements the open Unstructured Information Management Architecture (UIMA) framework, you can fully customize the processing of content and take advantage of existing UIMA annotators, both open source and commercial, to enhance your automated content analysis capabilities."
     },
     {
-      "self_ref": "#/texts/15",
+      "self_ref": "#/texts/14",
       "parent": {
         "$ref": "#/body"
       },
@@ -296,7 +281,7 @@
       "text": "Deep, automated analysis of content can be a computing-intensive operation. To support fast and efficient analysis of large amounts of content, IBM Content Analytics provides a highly scalable implementation of the UIMA specification, which allows you to distribute content analysis across multiple machines."
     },
     {
-      "self_ref": "#/texts/16",
+      "self_ref": "#/texts/15",
       "parent": {
         "$ref": "#/body"
       },
@@ -308,7 +293,7 @@
       "text": "comment about the APXL file here!!"
     },
     {
-      "self_ref": "#/texts/17",
+      "self_ref": "#/texts/16",
       "parent": {
         "$ref": "#/body"
       },
@@ -320,7 +305,7 @@
       "text": "comment about UIMA annotators"
     },
     {
-      "self_ref": "#/texts/18",
+      "self_ref": "#/texts/17",
       "parent": {
         "$ref": "#/body"
       },

--- a/tests/data/pages/groundtruth/pages_iwork09_comments.pages.md
+++ b/tests/data/pages/groundtruth/pages_iwork09_comments.pages.md
@@ -1,5 +1,3 @@
-Plloaso mako nuto uf cakso dodtos anr koop a cupy uf cak vux noaw yerw phuno. Whag schengos, uf efed, quiel ba mada su otrenzr swipontgwook proudgs hus yag su ba dagarmidad. Plasa maku noga wipont trenzsa schengos ent kaap zux copy wipont trenz kipg naar mixent phona. Cak pwico siructiun ruos nust apoply tyu cak UCU sisulutiun munityuw uw cak UCU-TGU jot scannow. Trens roxas eis ti Plokeing quert loppe eis yop prexs. Piy opher hawers, eit yaggles orn ti sumbloat alohe plok. Su havo loasor cakso tgu pwuructs tyu. Nunc volutpat dapibus nisi. Maecenas vel nulla. Proin et erat ac odio mattis suscipit. In hac habitasse platea dictumst. Sed tempus fermentum arcu. Cras egestas mauris cursus eros. Morbi vulputate, neque vel fermentum egestas, diam neque vestibulum risus, dapibus fermentum diam lacus et purus. In hac habitasse platea dictumst. Pellentesque id enim id tortor lacinia fermentum. Nam eu metus quis mauris ullamcorper mollis. Nullam vehicula.
-
 Sample pages document - this is the template document
 
 Some plain text to parse.

--- a/tests/data/pages/groundtruth/pages_iwork09_formatted.pages.json
+++ b/tests/data/pages/groundtruth/pages_iwork09_formatted.pages.json
@@ -75,9 +75,6 @@
         "$ref": "#/texts/18"
       },
       {
-        "$ref": "#/texts/19"
-      },
-      {
         "$ref": "#/groups/0"
       }
     ],
@@ -93,13 +90,13 @@
       },
       "children": [
         {
+          "$ref": "#/texts/19"
+        },
+        {
           "$ref": "#/texts/20"
         },
         {
           "$ref": "#/texts/21"
-        },
-        {
-          "$ref": "#/texts/22"
         }
       ],
       "content_layer": "furniture",
@@ -117,23 +114,11 @@
       "content_layer": "body",
       "label": "text",
       "prov": [],
-      "orig": "Plloaso mako nuto uf cakso dodtos anr koop a cupy uf cak vux noaw yerw phuno. Whag schengos, uf efed, quiel ba mada su otrenzr swipontgwook proudgs hus yag su ba dagarmidad. Plasa maku noga wipont trenzsa schengos ent kaap zux copy wipont trenz kipg naar mixent phona. Cak pwico siructiun ruos nust apoply tyu cak UCU sisulutiun munityuw uw cak UCU-TGU jot scannow. Trens roxas eis ti Plokeing quert loppe eis yop prexs. Piy opher hawers, eit yaggles orn ti sumbloat alohe plok. Su havo loasor cakso tgu pwuructs tyu. Nunc volutpat dapibus nisi. Maecenas vel nulla. Proin et erat ac odio mattis suscipit. In hac habitasse platea dictumst. Sed tempus fermentum arcu. Cras egestas mauris cursus eros. Morbi vulputate, neque vel fermentum egestas, diam neque vestibulum risus, dapibus fermentum diam lacus et purus. In hac habitasse platea dictumst. Pellentesque id enim id tortor lacinia fermentum. Nam eu metus quis mauris ullamcorper mollis. Nullam vehicula.",
-      "text": "Plloaso mako nuto uf cakso dodtos anr koop a cupy uf cak vux noaw yerw phuno. Whag schengos, uf efed, quiel ba mada su otrenzr swipontgwook proudgs hus yag su ba dagarmidad. Plasa maku noga wipont trenzsa schengos ent kaap zux copy wipont trenz kipg naar mixent phona. Cak pwico siructiun ruos nust apoply tyu cak UCU sisulutiun munityuw uw cak UCU-TGU jot scannow. Trens roxas eis ti Plokeing quert loppe eis yop prexs. Piy opher hawers, eit yaggles orn ti sumbloat alohe plok. Su havo loasor cakso tgu pwuructs tyu. Nunc volutpat dapibus nisi. Maecenas vel nulla. Proin et erat ac odio mattis suscipit. In hac habitasse platea dictumst. Sed tempus fermentum arcu. Cras egestas mauris cursus eros. Morbi vulputate, neque vel fermentum egestas, diam neque vestibulum risus, dapibus fermentum diam lacus et purus. In hac habitasse platea dictumst. Pellentesque id enim id tortor lacinia fermentum. Nam eu metus quis mauris ullamcorper mollis. Nullam vehicula."
-    },
-    {
-      "self_ref": "#/texts/1",
-      "parent": {
-        "$ref": "#/body"
-      },
-      "children": [],
-      "content_layer": "body",
-      "label": "text",
-      "prov": [],
       "orig": "Sample pages document - this is the template document",
       "text": "Sample pages document - this is the template document"
     },
     {
-      "self_ref": "#/texts/2",
+      "self_ref": "#/texts/1",
       "parent": {
         "$ref": "#/body"
       },
@@ -145,7 +130,7 @@
       "text": "Some plain text to parse."
     },
     {
-      "self_ref": "#/texts/3",
+      "self_ref": "#/texts/2",
       "parent": {
         "$ref": "#/body"
       },
@@ -164,7 +149,7 @@
       }
     },
     {
-      "self_ref": "#/texts/4",
+      "self_ref": "#/texts/3",
       "parent": {
         "$ref": "#/body"
       },
@@ -176,7 +161,7 @@
       "text": "Because Keynote uses an open, easily accessible file format, developers can take advantage of its XML schema to enhance existing products or create new ones. Beginning with Keynote 1.x, it is possible to build applications that will create or change the contents of a Keynote presentation. For example, developers can use any of Keynote’s themes and build an entire presentation of their own design simply by filling out the<key:slide-list> element in a text editor of their choice."
     },
     {
-      "self_ref": "#/texts/5",
+      "self_ref": "#/texts/4",
       "parent": {
         "$ref": "#/body"
       },
@@ -188,7 +173,7 @@
       "text": "The Keynote APXL file is the engine that drives every presentation, specifying every detail of the presentation’s appearance and behavior––from master slide and each individual slide to the transitions used between slides. The APXL file also defines the state of the presentation when the user first opens it. An understanding of how the elements in an APXL file combine to create a presentation is critical to developing applications that are robust and well-behaved."
     },
     {
-      "self_ref": "#/texts/6",
+      "self_ref": "#/texts/5",
       "parent": {
         "$ref": "#/body"
       },
@@ -200,7 +185,7 @@
       "text": "Similarly, understanding the Pages document structure is important for Apple developers who want to customize their own page layouts or add value to their existing application."
     },
     {
-      "self_ref": "#/texts/7",
+      "self_ref": "#/texts/6",
       "parent": {
         "$ref": "#/body"
       },
@@ -212,7 +197,7 @@
       "text": "Extensible Markup Language (XML) is a ubiquitous and flexible markup standard for processing and exchanging data. You can find XML in a wide range of categories, including property lists and file formats for various applications. XML is used extensively to specify the format of various sources of information on the Internet, including web-based services. XML is at the heart of both iWork applications, Keynote and Pages, developed by Apple."
     },
     {
-      "self_ref": "#/texts/8",
+      "self_ref": "#/texts/7",
       "parent": {
         "$ref": "#/body"
       },
@@ -224,7 +209,7 @@
       "text": "this should be page 2"
     },
     {
-      "self_ref": "#/texts/9",
+      "self_ref": "#/texts/8",
       "parent": {
         "$ref": "#/body"
       },
@@ -236,7 +221,7 @@
       "text": "blah blah blah meh meh hello how are you doing today just writing a bunch of random text here nothing special move along."
     },
     {
-      "self_ref": "#/texts/10",
+      "self_ref": "#/texts/9",
       "parent": {
         "$ref": "#/body"
       },
@@ -248,7 +233,7 @@
       "text": "now we’ll start a new paragraph and put in more meaningless text. LOL LOL ROFL"
     },
     {
-      "self_ref": "#/texts/11",
+      "self_ref": "#/texts/10",
       "parent": {
         "$ref": "#/body"
       },
@@ -260,7 +245,7 @@
       "text": "hmmm mmmmm aaaaaarrrrrrrgggggh"
     },
     {
-      "self_ref": "#/texts/12",
+      "self_ref": "#/texts/11",
       "parent": {
         "$ref": "#/body"
       },
@@ -272,7 +257,7 @@
       "text": "Content analytics starts with the gathering of relevant enterprise content."
     },
     {
-      "self_ref": "#/texts/13",
+      "self_ref": "#/texts/12",
       "parent": {
         "$ref": "#/body"
       },
@@ -284,7 +269,7 @@
       "text": "IBM® Content Analytics provides crawlers for a wide variety of enterprise content sources that allow content, metadata, structured data, and unstructured data to be collected and fed into the analytics pipeline. Crawler configuration is flexible and scalable, enabling you to gather the source information that you need to intelligently answer content-based questions."
     },
     {
-      "self_ref": "#/texts/14",
+      "self_ref": "#/texts/13",
       "parent": {
         "$ref": "#/body"
       },
@@ -296,7 +281,7 @@
       "text": "Because IBM Content Analytics implements the open Unstructured Information Management Architecture (UIMA) framework, you can fully customize the processing of content and take advantage of existing UIMA annotators, both open source and commercial, to enhance your automated content analysis capabilities."
     },
     {
-      "self_ref": "#/texts/15",
+      "self_ref": "#/texts/14",
       "parent": {
         "$ref": "#/body"
       },
@@ -308,7 +293,7 @@
       "text": "Deep, automated analysis of content can be a computing-intensive operation. To support fast and efficient analysis of large amounts of content, IBM Content Analytics provides a highly scalable implementation of the UIMA specification, which allows you to distribute content analysis across multiple machines."
     },
     {
-      "self_ref": "#/texts/16",
+      "self_ref": "#/texts/15",
       "parent": {
         "$ref": "#/body"
       },
@@ -320,7 +305,7 @@
       "text": "THIS IS SOME HEADER TEXT"
     },
     {
-      "self_ref": "#/texts/17",
+      "self_ref": "#/texts/16",
       "parent": {
         "$ref": "#/body"
       },
@@ -332,7 +317,7 @@
       "text": "THIS IS SOME FOOTER TEXT"
     },
     {
-      "self_ref": "#/texts/18",
+      "self_ref": "#/texts/17",
       "parent": {
         "$ref": "#/body"
       },
@@ -344,7 +329,7 @@
       "text": "Footnote: Do a lot of people really use iWork?!?!"
     },
     {
-      "self_ref": "#/texts/19",
+      "self_ref": "#/texts/18",
       "parent": {
         "$ref": "#/body"
       },
@@ -356,7 +341,7 @@
       "text": "Footnote: What does APXL stand for?!?!?"
     },
     {
-      "self_ref": "#/texts/20",
+      "self_ref": "#/texts/19",
       "parent": {
         "$ref": "#/groups/0"
       },
@@ -368,7 +353,7 @@
       "text": "Footnote: UIMA spec created by OASIS. Find it at "
     },
     {
-      "self_ref": "#/texts/21",
+      "self_ref": "#/texts/20",
       "parent": {
         "$ref": "#/groups/0"
       },
@@ -388,7 +373,7 @@
       "hyperlink": "http://www.oasis-open.org/"
     },
     {
-      "self_ref": "#/texts/22",
+      "self_ref": "#/texts/21",
       "parent": {
         "$ref": "#/groups/0"
       },

--- a/tests/data/pages/groundtruth/pages_iwork09_formatted.pages.md
+++ b/tests/data/pages/groundtruth/pages_iwork09_formatted.pages.md
@@ -1,5 +1,3 @@
-Plloaso mako nuto uf cakso dodtos anr koop a cupy uf cak vux noaw yerw phuno. Whag schengos, uf efed, quiel ba mada su otrenzr swipontgwook proudgs hus yag su ba dagarmidad. Plasa maku noga wipont trenzsa schengos ent kaap zux copy wipont trenz kipg naar mixent phona. Cak pwico siructiun ruos nust apoply tyu cak UCU sisulutiun munityuw uw cak UCU-TGU jot scannow. Trens roxas eis ti Plokeing quert loppe eis yop prexs. Piy opher hawers, eit yaggles orn ti sumbloat alohe plok. Su havo loasor cakso tgu pwuructs tyu. Nunc volutpat dapibus nisi. Maecenas vel nulla. Proin et erat ac odio mattis suscipit. In hac habitasse platea dictumst. Sed tempus fermentum arcu. Cras egestas mauris cursus eros. Morbi vulputate, neque vel fermentum egestas, diam neque vestibulum risus, dapibus fermentum diam lacus et purus. In hac habitasse platea dictumst. Pellentesque id enim id tortor lacinia fermentum. Nam eu metus quis mauris ullamcorper mollis. Nullam vehicula.
-
 Sample pages document - this is the template document
 
 Some plain text to parse.

--- a/tests/test_backend_iwork_pages.py
+++ b/tests/test_backend_iwork_pages.py
@@ -146,6 +146,25 @@ def test_legacy_placeholder_text_is_not_emitted():
     assert "Lorem ipsum dolor sit amet" not in text
 
 
+@pytest.mark.parametrize(
+    "source",
+    [PAGES_IWORK09, PAGES_IWORK09_COMMENTS, PAGES_IWORK09_FORMATTED],
+    ids=lambda path: path.name,
+)
+def test_reused_placeholder_text_is_not_emitted(source: Path):
+    """A template defines each placeholder once and every later paragraph that
+    reuses it carries an sf:ghost-text-ref instead — which names the original by
+    IDREF but holds its own inline copy of the text. Pruning only sf:ghost-text
+    let that copy through as a paragraph of garbled pseudo-English that is not
+    in the document at all."""
+    raw = zipfile.ZipFile(source).read("index.xml").decode("utf-8", "replace")
+    assert "ghost-text-ref" in raw, "fixture no longer reuses a placeholder"
+
+    text = _backend(source).convert().export_to_markdown()
+    assert "Plloaso mako nuto uf cakso dodtos" not in text
+    assert "Nunc volutpat dapibus nisi" not in text
+
+
 def test_pages_backend_accepts_a_stream():
     stream = BytesIO(PAGES_2013.read_bytes())
     in_doc = InputDocument(


### PR DESCRIPTION
Fix #4062 

An iWork '09 template defines each placeholder once as an `sf:ghost-text`, and every later paragraph that reuses it holds an `sf:ghost-text-ref` instead, which names the original by `sfa:IDREF` but carries its own inline copy of the text. The body walk pruned only the first tag, so the copy was emitted as a paragraph of garbled pseudo-English that appears nowhere in the document; Pages never renders a placeholder as content.

Both tags are pruned now.

All three '09 fixtures leaked the same paragraph, they are one source document saved three ways, each with 7 `sf:ghost-text` and 2 `sf:ghost-text-ref` elements. Their reference data is regenerated with `DOCLING_GEN_TEST_DATA=1`; the only change in each file is that paragraph disappearing, with the remaining items renumbered and their order unchanged. The Pages 5+ fixture is a different
container and is untouched.


**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

