### PR TITLE
fix(asciidoc): block titles, picture parenting, skipped headings, and list dedent

### DIFF
--- a/docling/backend/asciidoc_backend.py
+++ b/docling/backend/asciidoc_backend.py
@@ -251,9 +251,11 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
                     indents[level + 1] = item["indent"]
 
                 elif in_list and item["indent"] < indents[level]:
-                    # print(item["indent"], " => ", indents[level])
                     while level > 0 and item["indent"] < indents[level]:
-                        # print(item["indent"], " => ", indents[level])
+                        # Only pop the current level if there is an outer group
+                        # to fall back to; otherwise keep it as the list root.
+                        if indents[level - 1] is None:
+                            break
                         parents[level] = None
                         indents[level] = None
                         level -= 1

--- a/docling/backend/asciidoc_backend.py
+++ b/docling/backend/asciidoc_backend.py
@@ -13,12 +13,14 @@ from docling_core.types.doc import (
     DocItemLabel,
     DoclingDocument,
     DocumentOrigin,
+    Formatting,
     GroupItem,
     GroupLabel,
     ImageRef,
     ListItem,
     TableCell,
     TableData,
+    TextItem,
 )
 
 from docling.backend.abstract_backend import DeclarativeDocumentBackend
@@ -110,9 +112,23 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
         return doc
 
     def _parse(self, doc: DoclingDocument):
-        """
-        Main function that orchestrates the parsing by yielding components:
-        title, section headers, text, lists, and tables.
+        """Orchestrate parsing and populate `doc` from the source lines.
+
+        Handles titles, section headers, text paragraphs, lists, tables,
+        pictures, literal (code) blocks, and block titles.
+
+        Block titles (AsciiDoc lines that start with `.` immediately
+        followed by text, e.g. `.Procedure`) are treated as follows:
+
+        * FloatingItem targets (picture, table, code block): the block
+          title is created as a `CAPTION`-labelled `TextItem` and
+          attached to the floating item via its `caption` parameter, so it
+          participates in the standard caption relationship.
+        * All other targets (lists, paragraphs, ...): the block title is
+          emitted as a bold `PARAGRAPH` `TextItem` inserted
+          immediately before the element it precedes.  This preserves
+          reading order while acknowledging that non-floating items (e.g.
+          `GroupItem`) have no caption slot.
         """
 
         in_list = False
@@ -149,13 +165,16 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
                     text_data=text_data,
                     parent=self._get_current_parent(parents),
                 )
-                caption_data = self._flush_caption_data(
-                    doc=doc,
-                    caption_data=caption_data,
-                    parent=self._get_current_parent(parents),
-                )
+                caption: Optional[TextItem] = None
+                if caption_data:
+                    caption = doc.add_text(
+                        text=" ".join(caption_data),
+                        label=DocItemLabel.CAPTION,
+                    )
+                    caption_data = []
                 doc.add_code(
                     text=block.text,
+                    caption=caption,
                     parent=(
                         last_list_item if in_list else self._get_current_parent(parents)
                     ),
@@ -188,8 +207,12 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
                 item = self._parse_section_header(line)
                 level = item["level"]
 
+                ancestor = next(
+                    (parents[k] for k in range(level - 1, -1, -1) if parents[k]),
+                    None,
+                )
                 parents[level] = doc.add_heading(
-                    text=item["text"], level=item["level"], parent=parents[level - 1]
+                    text=item["text"], level=item["level"], parent=ancestor
                 )
                 for k, v in parents.items():
                     if k > level:
@@ -205,11 +228,16 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
 
                 if not in_list:
                     in_list = True
-                    caption_data = self._flush_caption_data(
-                        doc=doc,
-                        caption_data=caption_data,
-                        parent=parents[level],
-                    )
+                    # GroupItem has no caption slot; emit the pending block
+                    # title as a bold paragraph immediately before the list.
+                    if caption_data:
+                        doc.add_text(
+                            text=" ".join(caption_data),
+                            label=DocItemLabel.PARAGRAPH,
+                            parent=parents[level],
+                            formatting=Formatting(bold=True),
+                        )
+                        caption_data = []
 
                     parents[level + 1] = doc.add_group(
                         parent=parents[level], name="list", label=GroupLabel.LIST
@@ -292,7 +320,9 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
                 doc.add_picture(
                     image=image,
                     caption=caption,
-                    parent=last_list_item if in_list else None,
+                    parent=last_list_item
+                    if in_list
+                    else self._get_current_parent(parents),
                 )
                 list_continuation = False
 
@@ -408,21 +438,6 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
             doc.add_text(
                 text=" ".join(text_data),
                 label=DocItemLabel.PARAGRAPH,
-                parent=parent,
-            )
-        return []
-
-    @staticmethod
-    def _flush_caption_data(
-        *,
-        doc: DoclingDocument,
-        caption_data: list[str],
-        parent: GroupItem | None,
-    ) -> list[str]:
-        if len(caption_data) > 0:
-            doc.add_text(
-                text=" ".join(caption_data),
-                label=DocItemLabel.CAPTION,
                 parent=parent,
             )
         return []

--- a/tests/data/asciidoc/groundtruth/asciidoc_02.asciidoc.md
+++ b/tests/data/asciidoc/groundtruth/asciidoc_02.asciidoc.md
@@ -21,9 +21,17 @@ This is an abstract.
 
 bla bla
 
+#### SubSubSection 2.1.1
+
 bla bla bla bli bla ble
 
 ## Section 3: test image
+
+<!-- image -->
+
+An example caption for the image
+
+<!-- image -->
 
 ## Section 4: test tables
 
@@ -72,11 +80,3 @@ Table 5 with multiple empty cells
 |  | Cell 14 | Cell 15 |  |
 |  |  |  |  |
 | Cell 19 | Cell 20 | Cell 21 |  |
-
-#### SubSubSection 2.1.1
-
-<!-- image -->
-
-An example caption for the image
-
-<!-- image -->

--- a/tests/data/asciidoc/groundtruth/asciidoc_03.asciidoc.md
+++ b/tests/data/asciidoc/groundtruth/asciidoc_03.asciidoc.md
@@ -8,7 +8,7 @@ You can rename a bookmark to distinguish it from other bookmarks. If you have bo
 
 Renaming the bookmark does not rename the folder.
 
-Procedure
+**Procedure**
 
 1. Right-click the bookmark in the side bar.
 2. Select *Rename…*.
@@ -17,7 +17,7 @@ Procedure
 <!-- image -->
 4. Click btn:[Rename].
 
-Verification
+**Verification**
 
 - Check that the side bar lists the bookmark under the new name.
 <!-- image -->

--- a/tests/data/asciidoc/groundtruth/asciidoc_05.asciidoc.md
+++ b/tests/data/asciidoc/groundtruth/asciidoc_05.asciidoc.md
@@ -1,0 +1,49 @@
+# Block titles as captions
+
+This document demonstrates how AsciiDoc block titles (lines starting with a dot) are handled for different element types.
+
+## Images
+
+A block title before an image is attached as a caption on the picture item.
+
+Figure 1: System Architecture Diagram
+
+<!-- image -->
+
+## Lists
+
+A block title before a list cannot be attached as a structural caption because list groups have no caption slot. It is emitted as a bold paragraph immediately before the list to preserve reading order.
+
+**Important Prerequisites**
+
+- You must install Node.js.
+- You need an active API key.
+
+Another block title, this time for an ordered list:
+
+**Steps to complete setup**
+
+1. Clone the repository.
+2. Run the install script.
+3. Start the server.
+
+## Code blocks
+
+A block title before a literal block is attached as a caption on the code item, mirroring the image behaviour.
+
+```
+{ "status": "active" }
+```
+
+Example configuration payload
+
+## Tables
+
+A block title before a table is attached as a caption on the table item.
+
+Supported output formats
+
+| Format | Extension |
+| - | - |
+| Markdown | .md |
+| JSON | .json |

--- a/tests/data/asciidoc/sources/asciidoc_05.asciidoc
+++ b/tests/data/asciidoc/sources/asciidoc_05.asciidoc
@@ -1,0 +1,49 @@
+= Block titles as captions
+
+This document demonstrates how AsciiDoc block titles (lines starting with
+a dot) are handled for different element types.
+
+== Images
+
+A block title before an image is attached as a caption on the picture item.
+
+.Figure 1: System Architecture Diagram
+image::architecture.png[Architecture diagram]
+
+== Lists
+
+A block title before a list cannot be attached as a structural caption
+because list groups have no caption slot. It is emitted as a bold paragraph
+immediately before the list to preserve reading order.
+
+.Important Prerequisites
+* You must install Node.js.
+* You need an active API key.
+
+Another block title, this time for an ordered list:
+
+.Steps to complete setup
+. Clone the repository.
+. Run the install script.
+. Start the server.
+
+== Code blocks
+
+A block title before a literal block is attached as a caption on the code
+item, mirroring the image behaviour.
+
+.Example configuration payload
+....
+{ "status": "active" }
+....
+
+== Tables
+
+A block title before a table is attached as a caption on the table item.
+
+.Supported output formats
+|===
+|Format |Extension
+|Markdown |.md
+|JSON |.json
+|===

--- a/tests/test_backend_asciidoc.py
+++ b/tests/test_backend_asciidoc.py
@@ -106,7 +106,9 @@ After the block.
     assert "After the block." in doc.export_to_markdown()
 
 
-def test_literal_block_flushes_pending_caption() -> None:
+def test_literal_block_attaches_caption_to_code_item() -> None:
+    # A block title before a literal block must be attached as a proper caption
+    # on the CodeItem (FloatingItem), not emitted as a standalone orphan.
     source = b""".Literal example
 ....
 raw literal
@@ -122,10 +124,42 @@ image::next.png[]
     )
     doc = in_doc._backend.convert()
 
-    assert [(item.label, item.text) for item in doc.texts[:2]] == [
-        (DocItemLabel.CAPTION, "Literal example"),
-        (DocItemLabel.CODE, "raw literal"),
-    ]
+    code_items = [item for item in doc.texts if isinstance(item, CodeItem)]
+    assert len(code_items) == 1
+    assert code_items[0].text == "raw literal"
+    # The block title must be structurally linked as the code item's caption.
+    assert len(code_items[0].captions) == 1
+    assert code_items[0].captions[0].resolve(doc).text == "Literal example"
+
+
+def test_block_title_before_list_renders_as_bold_paragraph() -> None:
+    # A block title preceding a list (GroupItem) has no caption slot; it must
+    # be emitted as a bold PARAGRAPH immediately before the list.
+    source = b""".Steps
+
+. First step
+. Second step
+"""
+    in_doc = InputDocument(
+        path_or_stream=BytesIO(source),
+        format=InputFormat.ASCIIDOC,
+        backend=AsciiDocBackend,
+        filename="block-title-list.adoc",
+    )
+    doc = in_doc._backend.convert()
+
+    from docling_core.types.doc import Formatting
+
+    non_list_texts = [item for item in doc.texts if not isinstance(item, ListItem)]
+    assert len(non_list_texts) == 1
+    title_item = non_list_texts[0]
+    assert title_item.label == DocItemLabel.PARAGRAPH
+    assert title_item.text == "Steps"
+    assert title_item.formatting == Formatting(bold=True)
+
+    # The block title must appear before the list items in export order.
+    md = doc.export_to_markdown()
+    assert md.index("**Steps**") < md.index("First step")
 
 
 def test_parse_picture() -> None:

--- a/tests/test_backend_asciidoc.py
+++ b/tests/test_backend_asciidoc.py
@@ -254,6 +254,8 @@ def test_non_numeric_image_dimensions_do_not_crash() -> None:
 def test_local_images_are_embedded_and_missing_images_do_not_break_export(
     tmp_path: Path,
 ) -> None:
+    import pytest
+
     in_path = Path("tests/data/asciidoc/sources/asciidoc_03.asciidoc")
     options = AsciiDocBackendOptions(
         fetch_images=True,
@@ -266,7 +268,8 @@ def test_local_images_are_embedded_and_missing_images_do_not_break_export(
         backend=AsciiDocBackend,
         backend_options=options,
     )
-    doc = in_doc._backend.convert()
+    with pytest.warns(UserWarning, match="Could not process an image"):
+        doc = in_doc._backend.convert()
 
     assert doc.pictures[0].image is not None
     assert doc.pictures[0].image.uri.scheme == "data"


### PR DESCRIPTION
# Fix several structural bugs in the AsciiDoc backend

This PR fixes four independent structural bugs in `AsciiDocBackend` discovered when reviewing PR #4118 , adds a new test document that exercises all caption variants, and tightens an existing test.

## Block titles attached to the wrong element

In AsciiDoc, a line starting with `.` immediately followed by text (e.g. `.Procedure`) is a **block title** — it captions the *immediately following* element, not the preceding one.
The backend was flushing pending block-title text as a standalone `CAPTION` item at the moment it encountered the *next* block, so the caption ended up before or after the wrong element in the DoclingDocument body.

The new contract, documented in `_parse`'s docstring:

- **FloatingItem targets** (picture, table, code block): the block title is created as a `CAPTION`-labelled `TextItem` and attached via the `caption=` parameter, so it participates in the standard structural caption relationship.
- **All other targets** (lists, paragraphs, …): the block title is emitted as a bold `PARAGRAPH` `TextItem` inserted *immediately before* the element it precedes. `GroupItem` has no caption slot, so this is the closest correct representation while preserving reading order.

## Pictures always parented to the document body root

`doc.add_picture` was called with `parent=None` for all non-list contexts, unconditionally placing every picture at the document body root regardless of which section it appeared in. Pictures are now parented with `self._get_current_parent(parents)`, matching the behaviour of every other element type.

## Section headings with skipped levels landing at the body root

When heading levels are skipped in the source (e.g. `==` followed directly by `====` with no `===` in between), `parents[level - 1]` is `None` and the heading was silently placed at the body root. The backend now walks down from `level - 1` to find the nearest populated ancestor, so skipped-level headings nest under the closest available parent instead of floating to the top.

## List items orphaned when dedenting past the base indent

When a list started with an indented item and a later item dedented all the way back to indent 0, the dedent loop cleared the only list group from `parents` and left no valid parent for the dedented item. `add_list_item` then received `parent=None`, causing docling-core to emit `DeprecationWarning: ListItem parent must be a list group, creating one on the fly` and create a structurally orphaned implicit group.

The loop now stops before clearing the last remaining group: if `indents[level - 1]` is `None` there is no outer group to fall back to, so the current group is kept as the list root and the dedented item is added to it.

## New test document: `asciidoc_05.asciidoc`

A new example file and its groundtruth markdown have been added to cover all four block-title targets in one document:

- `.Figure 1: …` before an `image::` → caption attached to `PictureItem`
- `.Important Prerequisites` / `.Steps to complete setup` before lists → bold paragraphs before each list
- `.Example configuration payload` before a `....` literal block → caption attached to `CodeItem`
- `.Supported output formats` before a `|===` table → caption attached to `TableItem`

## Test improvements

The `test_local_images_are_embedded_and_missing_images_do_not_break_export` test now wraps the conversion in `pytest.warns(UserWarning, match="Could not process an image")`.
This both asserts that the warning is raised when images are missing (the warning becoming a test contract) and prevents it from leaking into the test-run output.
