### PR TITLE
fix(asciidoc): remove dead max_image_data_base64_bytes option

### DIFF
--- a/docling/backend/asciidoc_backend.py
+++ b/docling/backend/asciidoc_backend.py
@@ -57,7 +57,6 @@ class AsciiDocBackend(DeclarativeDocumentBackend):
         self._image_loader = ImageResourceLoader(
             enable_local_fetch=options.enable_local_fetch,
             enable_remote_fetch=options.enable_remote_fetch,
-            max_image_data_base64_bytes=options.max_image_data_base64_bytes,
         )
 
         # utf-8-sig drops a leading BOM. Kept, it prefixes the first line, so a

--- a/docling/datamodel/backend_options.py
+++ b/docling/datamodel/backend_options.py
@@ -58,12 +58,6 @@ class AsciiDocBackendOptions(BaseBackendOptions):
             ),
         ),
     ] = None
-    max_image_data_base64_bytes: Annotated[
-        PositiveInt,
-        Field(
-            description="The maximum number of base64 data bytes that the backend will accept.",
-        ),
-    ] = 20 * 1024 * 1024  # 20 MB
 
 
 class HTMLBackendOptions(BaseBackendOptions):


### PR DESCRIPTION
The AsciiDoc `image::` macro syntax only supports file paths and URLs — there is no `data:` URI form in the AsciiDoc spec. `ImageResourceLoader.load_image_data` only applies `max_image_data_base64_bytes` inside the `src_loc.startswith("data:")` branch, which the AsciiDoc backend can never reach. The field in `AsciiDocBackendOptions` and its corresponding constructor argument were therefore dead code.

### Changes

- Removed `max_image_data_base64_bytes` from `AsciiDocBackendOptions` in `docling/datamodel/backend_options.py`.
- Removed the `max_image_data_base64_bytes=options.max_image_data_base64_bytes` keyword argument from the `ImageResourceLoader` constructor call in `AsciiDocBackend.__init__`. The loader retains its own default of 20 MB, which is consistent with other backends.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
