### PR TITLE
fix(xlsx): add missing openpyxl template formats

### DIFF
--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -160,7 +160,7 @@ FormatToExtensions: dict[InputFormat, list[str]] = {
     InputFormat.IMAGE: ["jpg", "jpeg", "png", "tif", "tiff", "bmp", "webp"],
     InputFormat.ASCIIDOC: ["adoc", "asciidoc", "asc"],
     InputFormat.CSV: ["csv"],
-    InputFormat.XLSX: ["xlsx", "xlsm"],
+    InputFormat.XLSX: ["xlsx", "xlsm", "xltx", "xltm"],
     InputFormat.XLS: ["xls", "xlt"],
     InputFormat.ODT: ["odt", "ott"],
     InputFormat.ODS: ["ods", "ots"],


### PR DESCRIPTION
<!-- Thank you for contributing to Docling! -->

<!-- STEPS TO FOLLOW:
  1. Add a description of the changes (frequently the same as the commit description)
  2. Enter the issue number next to "Resolves #" below (if there is no tracking issue resolved, **remove that section**)
  3. Make sure the PR title follows the **Commit Message Formatting**: https://www.conventionalcommits.org/en/v1.0.0/#summary.
  4. Follow the steps in the checklist below, starting with the **Commit Message Formatting**.
-->

<!-- Uncomment this section with the issue number if an issue is being resolved
**Issue resolved by this Pull Request:**
Resolves #
--->

adds `xltx` and `xltm` to the input formats for XLSX. These are listed as supported by `openpyxl` so don't require any additional downstream logic. we get these for free!

tested with real world files to validate anyway:

- [Spider_etc_2022-02.xltx - zenodo.org](https://zenodo.org/records/5985208)
- [Excel template for process mapping and FMEA.xltm - zenodo.org](https://zenodo.org/records/8256459)

Both converted successfully.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

^ considered each of these in turn - there's a number of office formats missing from the docs so I thought best to leave for brevity.
