### PR TITLE
fix(reading-order): keep a detached hyphen when merging elements

### DIFF
--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -670,11 +670,18 @@ class ReadingOrderModel:
             bbox=merged_elem.cluster.bbox.to_bottom_left_origin(page_height),
         )
         continuation_text = merged_elem.text.lstrip()
-        if new_item.text.endswith("\u00ad") or (
+        # A hard hyphen only splits a word when it is attached to that word
+        # ("algo-" / "rithms"). A hyphen following whitespace is a literal
+        # character -- a dangling dash, a wrapped flag or a minus sign -- and
+        # must not be swallowed. A soft hyphen (U+00AD) is always a split marker.
+        hard_hyphen_split = (
             new_item.text.endswith("-")
+            and len(new_item.text) > 1
+            and new_item.text[-2].isalnum()
             and continuation_text
             and continuation_text[0].islower()
-        ):
+        )
+        if new_item.text.endswith("\u00ad") or hard_hyphen_split:
             # A soft hyphen or hard-hyphenated lowercase continuation is a split word.
             new_item.text = new_item.text[:-1] + merged_elem.text
             new_item.orig = (

--- a/tests/test_readingorder_hyphenated_merges.py
+++ b/tests/test_readingorder_hyphenated_merges.py
@@ -57,6 +57,10 @@ def _element(cluster_id: int, text: str) -> TextElement:
         ("algo-", "rithms", "algorithms"),
         ("algo\u00ad", "rithms", "algorithms"),
         ("algo-", "Rithms", "algo- Rithms"),
+        # A hyphen following whitespace is a literal character, not a word split,
+        # so it is kept and the elements are joined with a space.
+        ("run -", "prio now", "run - prio now"),
+        ("the value is -", "five units", "the value is - five units"),
     ],
 )
 def test_merge_elements_dehyphenates_lowercase_continuations(


### PR DESCRIPTION
### What

Follow-up to #4052, which fixed the same defect in `PageAssembleModel.sanitize_text`.
As noted there, `ReadingOrderModel._merge_elements` has the parallel bug for merges
across cluster boundaries.

When two elements are merged, a trailing hyphen on the first is treated as a word
split and dropped whenever the continuation starts lowercase:

```python
if new_item.text.endswith("\u00ad") or (
    new_item.text.endswith("-")
    and continuation_text
    and continuation_text[0].islower()
):
    new_item.text = new_item.text[:-1] + merged_elem.text
```

But a hyphen only splits a word when it is *attached* to that word (`"algo-"` /
`"rithms"`). A hyphen that follows whitespace is a literal character -- a dangling
dash, a wrapped CLI flag, a minus sign -- and dropping it silently corrupts the
text.

### Fix

Require the character before the trailing hyphen to be alphanumeric before treating
it as a word split. The soft-hyphen (U+00AD) branch is unchanged -- a soft hyphen is
always a split marker. When the hyphen is detached the elements are joined with a
space, exactly as the existing `else` branch already does, so the character is kept.

This only narrows the existing condition, so nothing de-hyphenated today stops being
de-hyphenated.

### Tests

Extended `tests/test_readingorder_hyphenated_merges.py` with two detached-hyphen
cases (`"run -"` + `"prio now"`, `"the value is -"` + `"five units"`). Both fail on
`main` and pass with this change; the three existing cases pass either way.

No reference data changes: this only affects cross-element merges where a detached
hyphen meets a lowercase continuation, which none of the e2e fixtures exercise.
