### PR TITLE
feat(mhtml): add MHTML input backend

### DIFF
--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -618,7 +618,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
             path = unquote(parsed.path)
             if parsed.netloc and parsed.netloc.lower() != "localhost":
                 path = f"//{parsed.netloc}{path}"
-            if re.match(r"^/[A-Za-z]:[/\\\\]", path):
+            if re.match(r"^/[A-Za-z]:[/\\]", path):
                 path = path[1:]
             return path
         if ImageResourceLoader.is_local_path(value):

--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -527,6 +527,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
 
     @staticmethod
     def _normalize_content_id(value: str) -> str:
+        """Normalize a Content-ID value to a canonical ``cid:<id>`` string."""
         content_id = value.strip()
         if content_id.lower().startswith("cid:"):
             content_id = content_id[4:]
@@ -534,6 +535,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
 
     @staticmethod
     def _mime_children(message: Message) -> list[Message]:
+        """Return the direct child parts of a multipart MIME message."""
         payload = message.get_payload()
         if not isinstance(payload, list):
             return []
@@ -541,6 +543,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
 
     @classmethod
     def _find_html_root(cls, root_entity: Message) -> Message | None:
+        """Return the HTML part from a root entity, descending into multipart/alternative."""
         if root_entity.get_content_type().lower() == "text/html":
             return root_entity
         if root_entity.get_content_type().lower() != "multipart/alternative":
@@ -553,6 +556,16 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
 
     @classmethod
     def _find_mhtml_root(cls, message: Message) -> tuple[Message, Message]:
+        """Locate the multipart/related scope and its HTML root part.
+
+        Returns:
+            A tuple of ``(related_scope, html_root_part)``. For bare HTML
+            input (no multipart/related wrapper) both elements are the same
+            message object.
+
+        Raises:
+            ValueError: If no valid HTML root can be identified.
+        """
         related_scope = next(
             (
                 part
@@ -595,6 +608,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
 
     @staticmethod
     def _decode_mime_payload(part: Message) -> bytes:
+        """Decode the transfer encoding of a MIME part and return raw bytes."""
         payload = part.get_payload(decode=True)
         return payload if isinstance(payload, bytes) else b""
 
@@ -637,6 +651,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
 
     @staticmethod
     def _is_windows_absolute_path(value: str) -> bool:
+        """Return True if the path string is a Windows absolute path."""
         return PureWindowsPath(value).is_absolute()
 
     @classmethod
@@ -682,6 +697,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
 
     @staticmethod
     def _join_mhtml_location(base: str, location: str) -> str:
+        """Resolve a location relative to base, handling all MHTML URI schemes."""
         location = location.strip()
         location_is_local = HTMLDocumentBackend._mhtml_local_path(location) is not None
         if (not location_is_local and urlparse(location).scheme) or location.startswith(
@@ -713,6 +729,13 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
     def _resolve_mhtml_base(
         cls, root_location: str | None, configured_base: str | None
     ) -> str:
+        """Derive the effective base URL for resolving MHTML resource references.
+
+        Prefers the root part's Content-Location, falling back to the caller-supplied
+        base or the synthetic ``thismessage:/`` origin for archives with no real URL.
+        Local roots that would escape the source document's directory are remapped to
+        the synthetic base to prevent filesystem traversal.
+        """
         if not root_location:
             return configured_base or _MHTML_SYNTHETIC_BASE
 
@@ -743,6 +766,11 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
     def _collect_mhtml_resources(
         cls, related_scope: Message, effective_base: str
     ) -> dict[str, bytes]:
+        """Build a lookup map of embedded image resources keyed by location and cid.
+
+        Only image parts are collected; non-image resources (CSS, fonts, scripts)
+        are intentionally ignored since the HTML backend strips those tags.
+        """
         resources: dict[str, bytes] = {}
         for part in related_scope.walk():
             if part.is_multipart() or part.get_content_maintype().lower() != "image":
@@ -770,6 +798,22 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
     def _parse_mhtml(
         cls, raw: bytes, configured_base: str | None
     ) -> tuple[bytes, dict[str, bytes], str]:
+        """Parse an MHTML archive and extract the HTML root, image resources, and base URL.
+
+        Args:
+            raw: Raw bytes of the MHTML archive.
+            configured_base: Caller-supplied base path or URL (e.g. from
+                ``HTMLBackendOptions.source_uri``), used to resolve local roots.
+
+        Returns:
+            A tuple of ``(html_bytes, resources, effective_base)`` where
+            ``resources`` maps location keys to raw image bytes and
+            ``effective_base`` is the resolved base URL for further reference
+            resolution.
+
+        Raises:
+            ValueError: If the input cannot be parsed as a valid MHTML document.
+        """
         message = BytesParser(policy=policy.default).parsebytes(raw)
         if message.get("Content-Type") is None:
             raise ValueError("MHTML input has no MIME Content-Type header.")

--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import logging
 import math
-import mimetypes
 import ntpath
 import posixpath
 import re
@@ -93,11 +92,8 @@ _BR_SENTINEL = "\ue000"
 
 DEFAULT_IMAGE_WIDTH = 128
 DEFAULT_IMAGE_HEIGHT = 128
-
-_MHTML_MIMETYPE = FormatToMimeType[InputFormat.MHTML][0]
 _MHTML_SYNTHETIC_BASE = "thismessage:/"
-mimetypes.add_type(_MHTML_MIMETYPE, ".mhtml")
-mimetypes.add_type(_MHTML_MIMETYPE, ".mht")
+
 
 # Tags that initiate distinct Docling items
 _BLOCK_TAGS: Final = {

--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -5,15 +5,21 @@ from __future__ import annotations
 
 import logging
 import math
+import mimetypes
+import ntpath
+import posixpath
 import re
 import warnings
 from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass, field as dataclass_field
+from email import policy
+from email.message import Message
+from email.parser import BytesParser
 from io import BytesIO
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Final, Iterator, Literal, Optional, Union, cast
-from urllib.parse import urlparse
+from urllib.parse import unquote, urljoin, urlparse
 from urllib.request import url2pathname
 
 from docling_core.types.doc import (
@@ -46,7 +52,7 @@ from docling_core.types.doc import (
     TextItem,
 )
 from docling_core.types.doc.document import ContentLayer, Formatting, ImageRef, Script
-from PIL import Image
+from PIL import Image, UnidentifiedImageError
 from pydantic import AnyUrl, BaseModel, ValidationError
 from typing_extensions import Self, override
 
@@ -55,7 +61,7 @@ from docling.backend.abstract_backend import (
 )
 from docling.backend.utils.image_resource_loader import ImageResourceLoader
 from docling.datamodel.backend_options import HTMLBackendOptions
-from docling.datamodel.base_models import InputFormat
+from docling.datamodel.base_models import FormatToMimeType, InputFormat
 from docling.datamodel.document import InputDocument
 from docling.exceptions import DocumentLoadError
 from docling.utils.code_language import (
@@ -87,6 +93,11 @@ _BR_SENTINEL = "\ue000"
 
 DEFAULT_IMAGE_WIDTH = 128
 DEFAULT_IMAGE_HEIGHT = 128
+
+_MHTML_MIMETYPE = FormatToMimeType[InputFormat.MHTML][0]
+_MHTML_SYNTHETIC_BASE = "thismessage:/"
+mimetypes.add_type(_MHTML_MIMETYPE, ".mhtml")
+mimetypes.add_type(_MHTML_MIMETYPE, ".mht")
 
 # Tags that initiate distinct Docling items
 _BLOCK_TAGS: Final = {
@@ -435,9 +446,11 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         self.options: HTMLBackendOptions
         self.soup: Optional[BeautifulSoup] = None
         self.path_or_stream: Union[BytesIO, Path] = path_or_stream
-        self.base_path: Optional[str] = (
+        configured_base_path: Optional[str] = (
             str(options.source_uri) if options.source_uri is not None else None
         )
+        self.base_path = configured_base_path
+        self._mhtml_resources: dict[str, bytes] | None = None
         self._image_loader = ImageResourceLoader(
             enable_local_fetch=options.enable_local_fetch,
             enable_remote_fetch=options.enable_remote_fetch,
@@ -476,8 +489,20 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
                 if isinstance(path_or_stream, BytesIO)
                 else Path(path_or_stream).read_bytes()
             )
+            if self.input_format == InputFormat.MHTML:
+                if options.render_page:
+                    raise DocumentLoadError(
+                        "Browser rendering is not supported for MHTML input."
+                    )
+                raw, resources, root_location = self._parse_mhtml(
+                    raw, configured_base_path
+                )
+                self._mhtml_resources = resources
+                self.base_path = root_location or configured_base_path
             self._raw_html_bytes = raw
             self.soup = BeautifulSoup(raw, "html.parser")
+        except DocumentLoadError:
+            raise
         except Exception as e:
             raise DocumentLoadError(
                 "Could not initialize HTML backend for file with "
@@ -502,7 +527,257 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
     @classmethod
     @override
     def supported_formats(cls) -> set[InputFormat]:
-        return {InputFormat.HTML}
+        return {InputFormat.HTML, InputFormat.MHTML}
+
+    @staticmethod
+    def _normalize_content_id(value: str) -> str:
+        content_id = value.strip()
+        if content_id.lower().startswith("cid:"):
+            content_id = content_id[4:]
+        return f"cid:{content_id.strip('<>').casefold()}"
+
+    @staticmethod
+    def _mime_children(message: Message) -> list[Message]:
+        payload = message.get_payload()
+        if not isinstance(payload, list):
+            return []
+        return [part for part in payload if isinstance(part, Message)]
+
+    @classmethod
+    def _find_html_root(cls, root_entity: Message) -> Message | None:
+        if root_entity.get_content_type().lower() == "text/html":
+            return root_entity
+        if root_entity.get_content_type().lower() != "multipart/alternative":
+            return None
+
+        for part in reversed(cls._mime_children(root_entity)):
+            if html_part := cls._find_html_root(part):
+                return html_part
+        return None
+
+    @classmethod
+    def _find_mhtml_root(cls, message: Message) -> tuple[Message, Message]:
+        related_scope = next(
+            (
+                part
+                for part in message.walk()
+                if part.get_content_type().lower() == "multipart/related"
+            ),
+            None,
+        )
+        if related_scope is None:
+            if message.get_content_type().lower() == "text/html":
+                return message, message
+            raise ValueError("MHTML input has no multipart/related root.")
+
+        children = cls._mime_children(related_scope)
+        if not children:
+            raise ValueError("The MHTML multipart/related root is empty.")
+
+        start = related_scope.get_param("start", header="content-type")
+        if start:
+            target_id = cls._normalize_content_id(str(start))
+            root_entity = next(
+                (
+                    part
+                    for part in children
+                    if part.get("Content-ID") is not None
+                    and cls._normalize_content_id(str(part.get("Content-ID")))
+                    == target_id
+                ),
+                None,
+            )
+            if root_entity is None:
+                raise ValueError("The MHTML start part was not found.")
+        else:
+            root_entity = children[0]
+
+        root_part = cls._find_html_root(root_entity)
+        if root_part is None:
+            raise ValueError("The MHTML root entity has no HTML representation.")
+        return related_scope, root_part
+
+    @staticmethod
+    def _decode_mime_payload(part: Message) -> bytes:
+        payload = part.get_payload(decode=True)
+        return payload if isinstance(payload, bytes) else b""
+
+    @classmethod
+    def _decode_mhtml_html(cls, part: Message) -> bytes:
+        payload = cls._decode_mime_payload(part)
+        charset = part.get_content_charset()
+        if not charset:
+            return payload
+        try:
+            return payload.decode(charset, errors="replace").encode("utf-8")
+        except LookupError:
+            return payload
+
+    @staticmethod
+    def _mhtml_local_path(value: str) -> str | None:
+        """Return a filesystem spelling for local paths and file URIs."""
+        value = value.strip()
+        parsed = urlparse(value)
+        if parsed.scheme.lower() == "file":
+            path = unquote(parsed.path)
+            if parsed.netloc and parsed.netloc.lower() != "localhost":
+                path = f"//{parsed.netloc}{path}"
+            if re.match(r"^/[A-Za-z]:[/\\\\]", path):
+                path = path[1:]
+            return path
+        if ImageResourceLoader.is_local_path(value):
+            return value
+        return None
+
+    @staticmethod
+    def _is_windows_absolute_path(value: str) -> bool:
+        return PureWindowsPath(value).is_absolute()
+
+    @classmethod
+    def _resolve_confined_local_root(
+        cls, root_location: str, configured_base: str
+    ) -> str | None:
+        """Resolve a MIME root without leaving the source document directory."""
+        source = cls._mhtml_local_path(configured_base)
+        root = cls._mhtml_local_path(root_location)
+        if source is None or root is None:
+            return None
+
+        if cls._is_windows_absolute_path(source):
+            if Path(root).is_absolute() and not cls._is_windows_absolute_path(root):
+                return None
+            source_dir = ntpath.dirname(ntpath.normpath(source))
+            candidate = ntpath.normpath(
+                root
+                if cls._is_windows_absolute_path(root)
+                else ntpath.join(source_dir, root)
+            )
+            try:
+                common = ntpath.commonpath([source_dir, candidate])
+            except ValueError:
+                return None
+            if ntpath.normcase(common) != ntpath.normcase(source_dir):
+                return None
+            return candidate
+
+        if cls._is_windows_absolute_path(root):
+            return None
+        source_path = Path(source).resolve()
+        source_dir_path = source_path.parent
+        root_path = Path(root)
+        candidate_path = (
+            root_path.resolve()
+            if root_path.is_absolute()
+            else (source_dir_path / root_path).resolve()
+        )
+        if not candidate_path.is_relative_to(source_dir_path):
+            return None
+        return str(candidate_path)
+
+    @staticmethod
+    def _join_mhtml_location(base: str, location: str) -> str:
+        location = location.strip()
+        location_is_local = HTMLDocumentBackend._mhtml_local_path(location) is not None
+        if (not location_is_local and urlparse(location).scheme) or location.startswith(
+            "//"
+        ):
+            return location
+        if base.startswith(_MHTML_SYNTHETIC_BASE):
+            base_path = urlparse(base).path
+            safe_location = location.replace("\\", "/")
+            joined_path = posixpath.normpath(
+                posixpath.join(posixpath.dirname(base_path), safe_location)
+            )
+            joined_path = f"/{joined_path.lstrip('/')}"
+            return f"thismessage:{joined_path}"
+
+        base_local = HTMLDocumentBackend._mhtml_local_path(base)
+        location_local = HTMLDocumentBackend._mhtml_local_path(location)
+        if base_local is not None and location_local is not None:
+            if HTMLDocumentBackend._is_windows_absolute_path(base_local):
+                return ntpath.normpath(
+                    ntpath.join(ntpath.dirname(base_local), location_local)
+                )
+            return posixpath.normpath(
+                posixpath.join(posixpath.dirname(base_local), location_local)
+            )
+        return urljoin(base, location)
+
+    @classmethod
+    def _resolve_mhtml_base(
+        cls, root_location: str | None, configured_base: str | None
+    ) -> str:
+        if not root_location:
+            return configured_base or _MHTML_SYNTHETIC_BASE
+
+        root_location = root_location.strip()
+        if root_location.startswith("//"):
+            return f"https:{root_location}"
+        if ImageResourceLoader.is_remote_url(root_location):
+            return root_location
+
+        local_root = cls._mhtml_local_path(root_location)
+        if local_root is not None and configured_base:
+            if ImageResourceLoader.is_remote_url(configured_base):
+                if not ImageResourceLoader.is_absolute_path(local_root):
+                    return urljoin(configured_base, local_root)
+            elif confined_root := cls._resolve_confined_local_root(
+                local_root, configured_base
+            ):
+                return confined_root
+
+        if local_root is not None:
+            return cls._join_mhtml_location(_MHTML_SYNTHETIC_BASE, local_root)
+        if urlparse(root_location).scheme:
+            return root_location
+
+        return cls._join_mhtml_location(_MHTML_SYNTHETIC_BASE, root_location)
+
+    @classmethod
+    def _collect_mhtml_resources(
+        cls, related_scope: Message, effective_base: str
+    ) -> dict[str, bytes]:
+        resources: dict[str, bytes] = {}
+        for part in related_scope.walk():
+            if part.is_multipart() or part.get_content_maintype().lower() != "image":
+                continue
+            payload = cls._decode_mime_payload(part)
+            if not payload:
+                continue
+
+            content_location = part.get("Content-Location")
+            if content_location is not None:
+                location = str(content_location).strip()
+                resources.setdefault(location, payload)
+                resources.setdefault(
+                    cls._join_mhtml_location(effective_base, location), payload
+                )
+
+            content_id = part.get("Content-ID")
+            if content_id is not None:
+                resources.setdefault(
+                    cls._normalize_content_id(str(content_id)), payload
+                )
+        return resources
+
+    @classmethod
+    def _parse_mhtml(
+        cls, raw: bytes, configured_base: str | None
+    ) -> tuple[bytes, dict[str, bytes], str]:
+        message = BytesParser(policy=policy.default).parsebytes(raw)
+        if message.get("Content-Type") is None:
+            raise ValueError("MHTML input has no MIME Content-Type header.")
+
+        related_scope, root_part = cls._find_mhtml_root(message)
+        html_bytes = cls._decode_mhtml_html(root_part)
+        if not html_bytes.strip():
+            raise ValueError("The MHTML HTML root part is empty.")
+
+        root_header = root_part.get("Content-Location")
+        root_location = str(root_header).strip() if root_header else None
+        effective_base = cls._resolve_mhtml_base(root_location, configured_base)
+        resources = cls._collect_mhtml_resources(related_scope, effective_base)
+        return html_bytes, resources, effective_base
 
     @override
     def convert(self) -> DoclingDocument:
@@ -512,7 +787,7 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
 
         origin = DocumentOrigin(
             filename=self.file.name or "file",
-            mimetype="text/html",
+            mimetype=FormatToMimeType[self.input_format][0],
             binary_hash=self.document_hash,
         )
         doc = DoclingDocument(name=self.file.stem or "file", origin=origin)
@@ -1362,6 +1637,19 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
                 parent.insert(idx, n)
 
     def _resolve_relative_path(self, loc: str) -> str:
+        if self._mhtml_resources is not None:
+            archive_location = loc.strip()
+            if archive_location.lower().startswith("cid:"):
+                archive_location = self._normalize_content_id(archive_location)
+            elif self.base_path:
+                archive_location = self._join_mhtml_location(
+                    self.base_path, archive_location
+                )
+
+            if archive_location in self._mhtml_resources:
+                return archive_location
+            if self.base_path and self.base_path.startswith(_MHTML_SYNTHETIC_BASE):
+                return archive_location
         return self._image_loader.resolve_relative_path(loc, self.base_path)
 
     @staticmethod
@@ -4586,6 +4874,37 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
         return input_item.get_ref()
 
     def _create_image_ref(self, src_url: str) -> Optional[ImageRef]:
+        if self._mhtml_resources is not None:
+            resource_key = (
+                self._normalize_content_id(src_url)
+                if src_url.lower().startswith("cid:")
+                else src_url
+            )
+            image_data = self._mhtml_resources.get(resource_key)
+            if image_data is not None:
+                max_bytes = self.options.max_image_data_base64_bytes
+                if len(image_data) > max_bytes:
+                    warnings.warn(
+                        "Could not process an embedded MHTML image: "
+                        f"resource exceeds size limit of {max_bytes} bytes."
+                    )
+                    return None
+                try:
+                    image = Image.open(BytesIO(image_data))
+                    image.load()
+                    return ImageRef.from_pil(
+                        image, dpi=int(image.info.get("dpi", (72,))[0])
+                    )
+                except (UnidentifiedImageError, OSError, TypeError, ValueError) as exc:
+                    warnings.warn(
+                        f"Could not process an embedded MHTML image from {src_url}: "
+                        f"{exc}"
+                    )
+                    return None
+            if src_url.lower().startswith("cid:"):
+                return None
+            if src_url.startswith(_MHTML_SYNTHETIC_BASE):
+                return None
         return self._image_loader.create_image_ref(src_url, self.base_path)
 
     def _load_image_data(self, src_loc: str) -> Optional[bytes]:

--- a/docling/backend/html_backend.py
+++ b/docling/backend/html_backend.py
@@ -600,6 +600,16 @@ class HTMLDocumentBackend(DeclarativeDocumentBackend):
 
     @classmethod
     def _decode_mhtml_html(cls, part: Message) -> bytes:
+        """Decode the transfer encoding and re-encode the HTML payload as UTF-8.
+
+        Note:
+            Re-encoding to UTF-8 does not strip or update any ``<meta charset>``
+            or ``Content-Type`` meta tags inside the HTML. If the document declares
+            a non-UTF-8 charset internally, BeautifulSoup may attempt to re-decode
+            the already-UTF-8 bytes using that charset, which can produce corrupted
+            text. Stripping the meta charset declaration before passing the bytes to
+            the parser would fix this but is left as a future improvement.
+        """
         payload = cls._decode_mime_payload(part)
         charset = part.get_content_charset()
         if not charset:

--- a/docling/datamodel/base_models.py
+++ b/docling/datamodel/base_models.py
@@ -103,6 +103,7 @@ class InputFormat(str, Enum):
     PPTX = "pptx"
     PPT = "ppt"
     HTML = "html"
+    MHTML = "mhtml"
     IMAGE = "image"
     PDF = "pdf"
     ASCIIDOC = "asciidoc"
@@ -155,6 +156,7 @@ FormatToExtensions: dict[InputFormat, list[str]] = {
     InputFormat.PDF: ["pdf"],
     InputFormat.MD: ["md", "txt", "text", "qmd", "rmd", "Rmd"],
     InputFormat.HTML: ["html", "htm", "xhtml"],
+    InputFormat.MHTML: ["mhtml", "mht"],
     InputFormat.XML_JATS: ["xml", "nxml"],
     InputFormat.XML_XBRL: ["xml", "xbrl"],
     InputFormat.XML_DOCLANG: ["dclg", "dclg.xml"],
@@ -204,6 +206,7 @@ FormatToMimeType: dict[InputFormat, list[str]] = {
         "application/vnd.ms-powerpoint",
     ],
     InputFormat.HTML: ["text/html", "application/xhtml+xml"],
+    InputFormat.MHTML: ["application/x-mimearchive", "multipart/related"],
     InputFormat.XML_JATS: ["application/xml"],
     InputFormat.XML_XBRL: ["application/xml", "application/xhtml+xml"],
     InputFormat.XML_DOCLANG: ["application/xml"],

--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -980,6 +980,8 @@ class _DocumentConversionInput(BaseModel):
             mime = FormatToMimeType[InputFormat.ASCIIDOC][0]
         elif ext in FormatToExtensions[InputFormat.HTML]:
             mime = FormatToMimeType[InputFormat.HTML][0]
+        elif ext in FormatToExtensions[InputFormat.MHTML]:
+            mime = FormatToMimeType[InputFormat.MHTML][0]
         elif ext in FormatToExtensions[InputFormat.XML_USPTO]:
             # USPTO text files share the "txt" extension with Markdown. Leave mime=None
             # so content probing can distinguish PATN text from plain Markdown text.

--- a/docling/document_converter.py
+++ b/docling/document_converter.py
@@ -359,6 +359,7 @@ def _get_default_option(format: InputFormat) -> FormatOption:
         InputFormat.MD: MarkdownFormatOption(),
         InputFormat.ASCIIDOC: AsciiDocFormatOption(),
         InputFormat.HTML: HTMLFormatOption(),
+        InputFormat.MHTML: HTMLFormatOption(),
         InputFormat.XML_USPTO: PatentUsptoFormatOption(),
         InputFormat.XML_JATS: XMLJatsFormatOption(),
         InputFormat.XML_DOCLANG: XMLDocLangFormatOption(),

--- a/docs/usage/supported_formats.md
+++ b/docs/usage/supported_formats.md
@@ -19,6 +19,7 @@ Below you can find a listing of all supported input and output formats.
 | AsciiDoc | Human-readable, plain-text markup language for structured technical content |
 | LaTeX | Scientific document preparation system |
 | HTML, XHTML | |
+| MHTML, MHT | MIME HTML archives |
 | CSV | |
 | PNG, JPEG, TIFF, BMP, WEBP | Image formats |
 | WAV, MP3, M4A, AAC, OGG, FLAC | Audio formats (requires `asr` extra — see [Processing audio and video](processing_audio_media.md)) |

--- a/tests/data/mhtml/sources/example.mhtml
+++ b/tests/data/mhtml/sources/example.mhtml
@@ -1,0 +1,36 @@
+From: <Saved by Blink>
+Snapshot-Content-Location: https://example.com/
+Subject: Example Domain
+Date: Wed, 1 Jul 2026 14:03:05 +0200
+MIME-Version: 1.0
+Content-Type: multipart/related;
+	type="text/html";
+	boundary="----MultipartBoundary--VXUzz2TwpuJtNtLg7deUJYyCgk5PD6sFeG0QBvIbaY----"
+
+
+------MultipartBoundary--VXUzz2TwpuJtNtLg7deUJYyCgk5PD6sFeG0QBvIbaY----
+Content-Type: text/html
+Content-ID: <frame-0DFE2207A7392C068C5E6492FDC04B83@mhtml.blink>
+Content-Transfer-Encoding: quoted-printable
+Content-Location: https://example.com/
+
+<!DOCTYPE html><html lang=3D"en"><head><meta http-equiv=3D"Content-Type" co=
+ntent=3D"text/html; charset=3Dwindows-1252"><link rel=3D"stylesheet" type=
+=3D"text/css" href=3D"cid:css-21cdd020-a757-4055-a27e-c9f22deb5160@mhtml.bl=
+ink" /><title>Example Domain</title><link rel=3D"icon" href=3D"data:"><met=
+a name=3D"viewport" content=3D"width=3Ddevice-width, initial-scale=3D1"></h=
+ead><body><div><h1>Example Domain</h1><p>This domain is for use in document=
+ation examples without needing permission. Avoid use in operations.</p><p><=
+a href=3D"https://iana.org/domains/example">Learn more</a></p></div>
+</body></html>
+------MultipartBoundary--VXUzz2TwpuJtNtLg7deUJYyCgk5PD6sFeG0QBvIbaY----
+Content-Type: text/css
+Content-Transfer-Encoding: quoted-printable
+Content-Location: cid:css-21cdd020-a757-4055-a27e-c9f22deb5160@mhtml.blink
+
+@charset "windows-1252";
+
+body { background: rgb(238, 238, 238); width: 60vw; margin: 15vh auto; font=
+-family: system-ui, sans-serif; }
+
+------MultipartBoundary--VXUzz2TwpuJtNtLg7deUJYyCgk5PD6sFeG0QBvIbaY------

--- a/tests/test_backend_html.py
+++ b/tests/test_backend_html.py
@@ -763,9 +763,12 @@ def test_fetch_remote_images(monkeypatch):
             enable_remote_fetch=True, fetch_images=True, source_uri="http://example.com"
         )
     )
-    with patch(
-        "docling.backend.utils.image_resource_loader.requests.Session.get"
-    ) as mocked_session_get:
+    with (
+        patch(
+            "docling.backend.utils.image_resource_loader.requests.Session.get"
+        ) as mocked_session_get,
+        pytest.warns(UserWarning, match="Could not process an image"),
+    ):
         mocked_session_get.return_value = _create_mock_response()
         res = converter.convert(source)
         mocked_session_get.assert_called_once()
@@ -805,9 +808,12 @@ def test_fetch_remote_images_with_custom_headers():
     )
 
     converter = _create_html_converter(backend_options)
-    with patch(
-        "docling.backend.utils.image_resource_loader.requests.Session.get"
-    ) as mocked_session_get:
+    with (
+        patch(
+            "docling.backend.utils.image_resource_loader.requests.Session.get"
+        ) as mocked_session_get,
+        pytest.warns(UserWarning, match="Could not process an image"),
+    ):
         mocked_session_get.return_value = _create_mock_response()
         res = converter.convert("./tests/data/html/sources/example_01.html")
         headers_arg = mocked_session_get.call_args[1].get("headers", {})

--- a/tests/test_backend_mhtml.py
+++ b/tests/test_backend_mhtml.py
@@ -597,11 +597,3 @@ def test_path_and_stream_preserve_original_origin(tmp_path: Path, name: str):
         assert doc.origin is not None
         assert doc.origin.filename == name
         assert doc.origin.mimetype == "application/x-mimearchive"
-
-
-def test_backend_contract():
-    assert HTMLDocumentBackend.supported_formats() == {
-        InputFormat.HTML,
-        InputFormat.MHTML,
-    }
-    assert not HTMLDocumentBackend.supports_pagination()

--- a/tests/test_backend_mhtml.py
+++ b/tests/test_backend_mhtml.py
@@ -1,0 +1,607 @@
+# SPDX-FileCopyrightText: The Docling Contributors
+# SPDX-License-Identifier: MIT
+
+from __future__ import annotations
+
+import base64
+import mimetypes
+from io import BytesIO
+from pathlib import Path, PureWindowsPath
+from unittest.mock import Mock, patch
+
+import pytest
+from PIL import Image
+from pydantic import AnyUrl
+
+from docling.backend.html_backend import HTMLDocumentBackend
+from docling.datamodel.backend_options import HTMLBackendOptions
+from docling.datamodel.base_models import (
+    ConversionStatus,
+    DocumentStream,
+    InputFormat,
+)
+from docling.datamodel.document import _DocumentConversionInput
+from docling.document_converter import DocumentConverter, HTMLFormatOption
+
+MHTML_DATA_DIR = Path("tests/data/mhtml/sources")
+
+
+def _red_png() -> bytes:
+    buffer = BytesIO()
+    Image.new("RGB", (1, 1), color=(255, 0, 0)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _blue_png() -> bytes:
+    buffer = BytesIO()
+    Image.new("RGB", (1, 1), color=(0, 0, 255)).save(buffer, format="PNG")
+    return buffer.getvalue()
+
+
+def _archive(
+    html: str,
+    extra_parts: str = "",
+    related_options: str = "",
+    root_location: str = "https://example.com/docs/page.html",
+) -> bytes:
+    return (
+        "MIME-Version: 1.0\r\n"
+        f'Content-Type: multipart/related; boundary="B"{related_options}\r\n\r\n'
+        "--B\r\n"
+        "Content-Type: text/html; charset=utf-8\r\n"
+        "Content-ID: <root@example>\r\n"
+        f"Content-Location: {root_location}\r\n\r\n"
+        f"{html}\r\n"
+        f"{extra_parts}"
+        "--B--\r\n"
+    ).encode()
+
+
+def _convert_stream(
+    data: bytes,
+    name: str = "sample.mhtml",
+    options: HTMLBackendOptions | None = None,
+):
+    converter = (
+        DocumentConverter(allowed_formats=[InputFormat.MHTML])
+        if options is None
+        else DocumentConverter(
+            allowed_formats=[InputFormat.MHTML],
+            format_options={
+                InputFormat.MHTML: HTMLFormatOption(backend_options=options)
+            },
+        )
+    )
+    result = converter.convert(DocumentStream(name=name, stream=BytesIO(data)))
+    assert result.status == ConversionStatus.SUCCESS
+    return result.document
+
+
+@pytest.mark.parametrize("extension", ["mhtml", "mht"])
+def test_mhtml_extension_detection(tmp_path: Path, extension: str):
+    path = tmp_path / f"sample.{extension}"
+    path.write_bytes(_archive("<html><body><p>Detected</p></body></html>"))
+    conversion_input = _DocumentConversionInput(path_or_stream_iterator=[path])
+
+    assert conversion_input._guess_format(path) == InputFormat.MHTML
+    stream = DocumentStream(name=path.name, stream=BytesIO(path.read_bytes()))
+    assert conversion_input._guess_format(stream) == InputFormat.MHTML
+    assert mimetypes.guess_type(path.name)[0] == "application/x-mimearchive"
+
+
+def test_root_html_preserves_standard_html_semantics():
+    html = """
+    <html><body>
+      <h1>Пример</h1>
+      <p>Текст with <a href="https://example.com/details">a link</a>.</p>
+      <ul><li>One</li><li>Two</li></ul>
+      <table><tr><th>Key</th><th>Value</th></tr><tr><td>A</td><td>1</td></tr></table>
+    </body></html>
+    """
+    doc = _convert_stream(_archive(html))
+    markdown = doc.export_to_markdown()
+
+    assert "# Пример" in markdown
+    assert "[a link](https://example.com/details)" in markdown
+    assert "- One" in markdown and "- Two" in markdown
+    assert len(doc.tables) == 1
+    assert [cell.text for cell in doc.tables[0].data.table_cells] == [
+        "Key",
+        "Value",
+        "A",
+        "1",
+    ]
+
+
+def test_related_start_selects_root_inside_nested_multipart():
+    data = (
+        b"MIME-Version: 1.0\r\n"
+        b'Content-Type: multipart/mixed; boundary="OUT"\r\n\r\n'
+        b"--OUT\r\n"
+        b'Content-Type: multipart/related; boundary="IN"; start="<wanted@example>"\r\n\r\n'
+        b"--IN\r\nContent-Type: text/html\r\nContent-ID: <wrong@example>\r\n\r\n"
+        b"<p>Wrong root</p>\r\n"
+        b"--IN\r\nContent-Type: text/html\r\nContent-ID: <wanted@example>\r\n\r\n"
+        b"<h1>Selected root</h1>\r\n"
+        b"--IN--\r\n--OUT--\r\n"
+    )
+
+    markdown = _convert_stream(data).export_to_markdown()
+    assert "Selected root" in markdown
+    assert "Wrong root" not in markdown
+
+
+def test_related_start_selects_html_from_multipart_alternative():
+    data = (
+        b"MIME-Version: 1.0\r\n"
+        b'Content-Type: multipart/related; boundary="B"; start="<root@example>"\r\n\r\n'
+        b'--B\r\nContent-Type: multipart/alternative; boundary="A"\r\n'
+        b"Content-ID: <root@example>\r\n\r\n"
+        b"--A\r\nContent-Type: text/plain\r\n\r\nPlain fallback\r\n"
+        b"--A\r\nContent-Type: text/html\r\n\r\n<h1>HTML alternative</h1>\r\n"
+        b"--A--\r\n--B--\r\n"
+    )
+
+    markdown = _convert_stream(data).export_to_markdown()
+
+    assert "# HTML alternative" in markdown
+    assert "Plain fallback" not in markdown
+
+
+def test_related_without_start_does_not_select_later_html():
+    data = (
+        b"MIME-Version: 1.0\r\n"
+        b'Content-Type: multipart/related; boundary="B"\r\n\r\n'
+        b"--B\r\nContent-Type: text/plain\r\n\r\nFirst root\r\n"
+        b"--B\r\nContent-Type: text/html\r\n\r\n<h1>Wrong root</h1>\r\n"
+        b"--B--\r\n"
+    )
+    converter = DocumentConverter(allowed_formats=[InputFormat.MHTML])
+    result = converter.convert(
+        DocumentStream(name="invalid.mhtml", stream=BytesIO(data)),
+        raises_on_error=False,
+    )
+
+    assert result.status == ConversionStatus.FAILURE
+    assert result.errors
+
+
+def test_declared_non_utf8_charset_is_decoded():
+    html = "<html><body><p>Привет, мир</p></body></html>".encode("windows-1251")
+    encoded = base64.b64encode(html).decode()
+    data = (
+        "MIME-Version: 1.0\r\n"
+        "Content-Type: text/html; charset=windows-1251\r\n"
+        "Content-Transfer-Encoding: base64\r\n\r\n"
+        f"{encoded}\r\n"
+    ).encode()
+
+    assert "Привет, мир" in _convert_stream(data).export_to_markdown()
+
+
+def test_real_blink_fixture_decodes_quoted_printable_html():
+    path = MHTML_DATA_DIR / "example.mhtml"
+    converter = DocumentConverter(allowed_formats=[InputFormat.MHTML])
+    result = converter.convert(path)
+
+    assert result.status == ConversionStatus.SUCCESS
+    markdown = result.document.export_to_markdown()
+    assert "# Example Domain" in markdown
+    assert "[Learn more](https://iana.org/domains/example)" in markdown
+
+
+def test_embedded_images_resolve_by_location_and_cid():
+    png = base64.b64encode(_red_png()).decode()
+    parts = (
+        "--B\r\nContent-Type: image/png\r\n"
+        "Content-Location: https://example.com/images/location.png\r\n"
+        f"Content-Transfer-Encoding: base64\r\n\r\n{png}\r\n"
+        "--B\r\nContent-Type: image/png\r\n"
+        "Content-ID: <CID-IMAGE@EXAMPLE>\r\n"
+        f"Content-Transfer-Encoding: base64\r\n\r\n{png}\r\n"
+    )
+    html = (
+        '<html><body><img src="../images/location.png">'
+        '<img src="cid:cid-image@example"></body></html>'
+    )
+    doc = _convert_stream(
+        _archive(html, parts), options=HTMLBackendOptions(fetch_images=True)
+    )
+
+    assert len(doc.pictures) == 2
+    assert all(picture.image is not None for picture in doc.pictures)
+    assert all(picture.get_image(doc).size == (1, 1) for picture in doc.pictures)
+
+
+def test_embedded_relative_location_resolves_with_file_root():
+    png = base64.b64encode(_red_png()).decode()
+    parts = (
+        "--B\r\nContent-Type: image/png\r\n"
+        "Content-Location: images/file.png\r\n"
+        f"Content-Transfer-Encoding: base64\r\n\r\n{png}\r\n"
+    )
+    data = _archive('<html><body><img src="images/file.png"></body></html>', parts)
+    data = data.replace(
+        b"https://example.com/docs/page.html", b"file:///C:/saved/page.html"
+    )
+
+    doc = _convert_stream(data, options=HTMLBackendOptions(fetch_images=True))
+
+    assert doc.pictures[0].image is not None
+
+
+def test_default_fetch_images_leaves_archive_image_as_placeholder():
+    png = base64.b64encode(_red_png()).decode()
+    parts = (
+        "--B\r\nContent-Type: image/png\r\nContent-ID: <image@example>\r\n"
+        f"Content-Transfer-Encoding: base64\r\n\r\n{png}\r\n"
+    )
+    doc = _convert_stream(
+        _archive('<html><body><img src="cid:image@example"></body></html>', parts)
+    )
+
+    assert doc.pictures[0].image is None
+
+
+def test_archive_image_precedes_explicit_remote_fetch():
+    png = base64.b64encode(_red_png()).decode()
+    parts = (
+        "--B\r\nContent-Type: image/png\r\n"
+        "Content-Location: https://example.com/image.png\r\n"
+        f"Content-Transfer-Encoding: base64\r\n\r\n{png}\r\n"
+    )
+    html = '<html><body><img src="https://example.com/image.png"></body></html>'
+
+    with patch(
+        "docling.backend.utils.image_resource_loader.requests.Session.get"
+    ) as mocked_get:
+        doc = _convert_stream(
+            _archive(html, parts),
+            options=HTMLBackendOptions(fetch_images=True, enable_remote_fetch=True),
+        )
+
+    mocked_get.assert_not_called()
+    assert doc.pictures[0].get_image(doc).getpixel((0, 0)) == (255, 0, 0)
+
+
+def test_resources_are_limited_to_selected_related_scope():
+    red = base64.b64encode(_red_png()).decode()
+    blue = base64.b64encode(_blue_png()).decode()
+    data = (
+        "MIME-Version: 1.0\r\n"
+        'Content-Type: multipart/mixed; boundary="OUT"\r\n\r\n'
+        '--OUT\r\nContent-Type: multipart/related; boundary="ONE"\r\n\r\n'
+        "--ONE\r\nContent-Type: text/html\r\n\r\n"
+        '<html><body><img src="cid:shared@example"></body></html>\r\n'
+        "--ONE\r\nContent-Type: image/png\r\nContent-ID: <shared@example>\r\n"
+        f"Content-Transfer-Encoding: base64\r\n\r\n{red}\r\n"
+        "--ONE--\r\n"
+        '--OUT\r\nContent-Type: multipart/related; boundary="TWO"\r\n\r\n'
+        "--TWO\r\nContent-Type: text/html\r\n\r\n<p>Other scope</p>\r\n"
+        "--TWO\r\nContent-Type: image/png\r\nContent-ID: <shared@example>\r\n"
+        f"Content-Transfer-Encoding: base64\r\n\r\n{blue}\r\n"
+        "--TWO--\r\n--OUT--\r\n"
+    ).encode()
+
+    doc = _convert_stream(data, options=HTMLBackendOptions(fetch_images=True))
+
+    assert doc.pictures[0].get_image(doc).getpixel((0, 0)) == (255, 0, 0)
+
+
+def test_duplicate_resource_labels_keep_first_part():
+    red = base64.b64encode(_red_png()).decode()
+    blue = base64.b64encode(_blue_png()).decode()
+    parts = (
+        "--B\r\nContent-Type: image/png\r\nContent-ID: <same@example>\r\n"
+        f"Content-Transfer-Encoding: base64\r\n\r\n{red}\r\n"
+        "--B\r\nContent-Type: image/png\r\nContent-ID: <same@example>\r\n"
+        f"Content-Transfer-Encoding: base64\r\n\r\n{blue}\r\n"
+    )
+    html = '<html><body><img src="cid:same@example"></body></html>'
+
+    doc = _convert_stream(
+        _archive(html, parts), options=HTMLBackendOptions(fetch_images=True)
+    )
+
+    assert doc.pictures[0].get_image(doc).getpixel((0, 0)) == (255, 0, 0)
+
+
+@pytest.mark.parametrize(
+    ("root_location", "expected"),
+    [
+        (r"C:\safe\page.html", r"C:\safe\images\a.png"),
+        ("C:/safe/page.html", r"C:\safe\images\a.png"),
+    ],
+)
+def test_windows_locations_are_joined_without_urljoin(
+    root_location: str, expected: str
+):
+    first = HTMLDocumentBackend._join_mhtml_location(root_location, "images/a.png")
+    equivalent = HTMLDocumentBackend._join_mhtml_location(
+        root_location, "./images/a.png"
+    )
+
+    assert PureWindowsPath(first) == PureWindowsPath(expected)
+    assert PureWindowsPath(equivalent) == PureWindowsPath(expected)
+
+
+@pytest.mark.parametrize(
+    "root_location",
+    [r"C:\outside\page.html", "C:/outside/page.html", "file:///C:/outside/page.html"],
+)
+def test_windows_root_outside_source_directory_never_reaches_shared_loader(
+    root_location: str,
+):
+    options = HTMLBackendOptions(
+        fetch_images=True,
+        enable_local_fetch=True,
+        source_uri=PureWindowsPath(r"C:\safe\archive.mhtml"),
+    )
+    data = _archive(
+        '<html><body><img src="missing.png"></body></html>',
+        root_location=root_location,
+    )
+
+    with patch(
+        "docling.backend.html_backend.ImageResourceLoader.create_image_ref"
+    ) as shared_loader:
+        doc = _convert_stream(data, options=options)
+
+    shared_loader.assert_not_called()
+    assert doc.pictures[0].image is None
+
+
+@pytest.mark.parametrize(
+    "root_location",
+    [r"C:\safe\page.html", "C:/safe/page.html", "file:///C:/safe/page.html"],
+)
+def test_equivalent_windows_archive_locations_resolve(root_location: str):
+    png = base64.b64encode(_red_png()).decode()
+    parts = (
+        "--B\r\nContent-Type: image/png\r\nContent-Location: images/a.png\r\n"
+        f"Content-Transfer-Encoding: base64\r\n\r\n{png}\r\n"
+    )
+    options = HTMLBackendOptions(
+        fetch_images=True,
+        source_uri=PureWindowsPath(r"C:\safe\archive.mhtml"),
+    )
+    html = '<html><body><img src="./images/a.png"></body></html>'
+
+    doc = _convert_stream(
+        _archive(html, parts, root_location=root_location), options=options
+    )
+
+    assert doc.pictures[0].get_image(doc).getpixel((0, 0)) == (255, 0, 0)
+
+
+def test_missing_and_unsupported_images_remain_placeholders():
+    parts = (
+        "--B\r\nContent-Type: image/svg+xml\r\n"
+        "Content-ID: <vector@example>\r\n\r\n"
+        '<svg xmlns="http://www.w3.org/2000/svg"></svg>\r\n'
+        "--B\r\nContent-Type: image/png\r\n"
+        "Content-ID: <empty@example>\r\n"
+        "Content-Transfer-Encoding: base64\r\n\r\n\r\n"
+    )
+    html = (
+        '<html><body><img src="cid:missing@example">'
+        '<img src="cid:vector@example">'
+        '<img src="cid:empty@example"></body></html>'
+    )
+
+    with pytest.warns(UserWarning, match="embedded MHTML image"):
+        doc = _convert_stream(
+            _archive(html, parts), options=HTMLBackendOptions(fetch_images=True)
+        )
+
+    assert len(doc.pictures) == 3
+    assert all(picture.image is None for picture in doc.pictures)
+
+
+def test_archive_image_size_limit_is_enforced():
+    png = base64.b64encode(_red_png()).decode()
+    parts = (
+        "--B\r\nContent-Type: image/png\r\nContent-ID: <large@example>\r\n"
+        f"Content-Transfer-Encoding: base64\r\n\r\n{png}\r\n"
+    )
+    html = '<html><body><img src="cid:large@example"></body></html>'
+
+    with pytest.warns(UserWarning, match="exceeds size limit"):
+        doc = _convert_stream(
+            _archive(html, parts),
+            options=HTMLBackendOptions(
+                fetch_images=True, max_image_data_base64_bytes=8
+            ),
+        )
+
+    assert doc.pictures[0].image is None
+
+
+def test_missing_remote_image_respects_default_fetch_permission():
+    html = '<html><body><img src="https://example.com/missing.png"></body></html>'
+
+    with (
+        patch(
+            "docling.backend.utils.image_resource_loader.requests.Session.get"
+        ) as mocked_get,
+        pytest.warns(UserWarning, match="Fetching remote resources"),
+    ):
+        doc = _convert_stream(
+            _archive(html), options=HTMLBackendOptions(fetch_images=True)
+        )
+        mocked_get.assert_not_called()
+
+    assert len(doc.pictures) == 1
+    assert doc.pictures[0].image is None
+
+
+def test_missing_remote_image_is_fetched_when_explicitly_enabled():
+    html = '<html><body><img src="image.png"></body></html>'
+    response = Mock()
+    response.headers = {}
+    response.raise_for_status = Mock()
+    response.iter_content = Mock(return_value=[_red_png()])
+    response.is_redirect = False
+    response.is_permanent_redirect = False
+
+    with patch(
+        "docling.backend.utils.image_resource_loader.requests.Session.get",
+        return_value=response,
+    ) as mocked_get:
+        options = HTMLBackendOptions(
+            fetch_images=True,
+            enable_remote_fetch=True,
+            source_uri=AnyUrl("https://example.com/archive.mhtml"),
+        )
+        doc = _convert_stream(
+            _archive(html, root_location="page.html"), options=options
+        )
+
+    mocked_get.assert_called_once()
+    assert mocked_get.call_args.args[0] == "https://example.com/image.png"
+    assert doc.pictures[0].image is not None
+    assert str(options.source_uri) == "https://example.com/archive.mhtml"
+
+
+def test_relative_root_path_uses_archive_directory_for_local_fallback(
+    tmp_path: Path,
+):
+    (tmp_path / "fallback.png").write_bytes(_red_png())
+    archive_path = tmp_path / "archive.mhtml"
+    archive_path.write_bytes(
+        _archive(
+            '<html><body><img src="fallback.png"></body></html>',
+            root_location="page.html",
+        )
+    )
+    options = HTMLBackendOptions(fetch_images=True, enable_local_fetch=True)
+    converter = DocumentConverter(
+        allowed_formats=[InputFormat.MHTML],
+        format_options={InputFormat.MHTML: HTMLFormatOption(backend_options=options)},
+    )
+
+    doc = converter.convert(archive_path).document
+
+    image = doc.pictures[0].get_image(doc)
+    assert image is not None
+    assert image.size == (1, 1)
+    assert options.source_uri is None
+
+
+def test_relative_root_stream_uses_non_filesystem_base():
+    options = HTMLBackendOptions(fetch_images=True, enable_local_fetch=True)
+    data = _archive(
+        '<html><body><img src="fallback.png"></body></html>',
+        root_location="page.html",
+    )
+
+    with patch(
+        "docling.backend.html_backend.ImageResourceLoader.create_image_ref"
+    ) as shared_loader:
+        doc = _convert_stream(data, options=options)
+
+    shared_loader.assert_not_called()
+    assert doc.pictures[0].image is None
+    assert options.source_uri is None
+
+
+def test_data_uri_image_uses_shared_html_loader():
+    encoded = base64.b64encode(_red_png()).decode()
+    html = f'<html><body><img src="data:image/png;base64,{encoded}"></body></html>'
+    doc = _convert_stream(_archive(html), options=HTMLBackendOptions(fetch_images=True))
+
+    assert doc.pictures[0].image is not None
+    assert doc.pictures[0].get_image(doc).size == (1, 1)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"MIME-Version: 1.0\r\nContent-Type: text/plain\r\n\r\nplain text\r\n",
+        b"not a mime message",
+        b'MIME-Version: 1.0\r\nContent-Type: multipart/mixed; boundary="B"\r\n\r\n--B--\r\n',
+        _archive(""),
+    ],
+)
+def test_unusable_input_fails_cleanly(data: bytes):
+    converter = DocumentConverter(allowed_formats=[InputFormat.MHTML])
+    result = converter.convert(
+        DocumentStream(name="invalid.mhtml", stream=BytesIO(data)),
+        raises_on_error=False,
+    )
+
+    assert result.status == ConversionStatus.FAILURE
+    assert result.errors
+
+
+@pytest.mark.parametrize(
+    "related_options, extra_parts",
+    [
+        ('; start="<missing@example>"', ""),
+        (
+            '; start="<not-html@example>"',
+            "--B\r\nContent-Type: text/plain\r\n"
+            "Content-ID: <not-html@example>\r\n\r\nnot html\r\n",
+        ),
+    ],
+)
+def test_invalid_related_start_fails_cleanly(related_options: str, extra_parts: str):
+    data = _archive(
+        "<p>Fallback must not be selected</p>", extra_parts, related_options
+    )
+    converter = DocumentConverter(allowed_formats=[InputFormat.MHTML])
+    result = converter.convert(
+        DocumentStream(name="invalid.mhtml", stream=BytesIO(data)),
+        raises_on_error=False,
+    )
+
+    assert result.status == ConversionStatus.FAILURE
+    assert result.errors
+
+
+def test_browser_rendering_is_rejected_for_mhtml():
+    converter = DocumentConverter(
+        allowed_formats=[InputFormat.MHTML],
+        format_options={
+            InputFormat.MHTML: HTMLFormatOption(
+                backend_options=HTMLBackendOptions(render_page=True)
+            )
+        },
+    )
+    result = converter.convert(
+        DocumentStream(
+            name="render.mhtml",
+            stream=BytesIO(_archive("<p>Render</p>")),
+        ),
+        raises_on_error=False,
+    )
+
+    assert result.status == ConversionStatus.FAILURE
+    assert any("not supported for MHTML" in err.error_message for err in result.errors)
+
+
+@pytest.mark.parametrize("name", ["original.mhtml", "original.mht"])
+def test_path_and_stream_preserve_original_origin(tmp_path: Path, name: str):
+    data = _archive("<html><body><p>Origin</p></body></html>")
+    path = tmp_path / name
+    path.write_bytes(data)
+    converter = DocumentConverter(allowed_formats=[InputFormat.MHTML])
+
+    path_doc = converter.convert(path).document
+    stream_doc = converter.convert(
+        DocumentStream(name=name, stream=BytesIO(data))
+    ).document
+
+    for doc in (path_doc, stream_doc):
+        assert doc.name == Path(name).stem
+        assert doc.origin is not None
+        assert doc.origin.filename == name
+        assert doc.origin.mimetype == "application/x-mimearchive"
+
+
+def test_backend_contract():
+    assert HTMLDocumentBackend.supported_formats() == {
+        InputFormat.HTML,
+        InputFormat.MHTML,
+    }
+    assert not HTMLDocumentBackend.supports_pagination()

--- a/tests/test_backend_mhtml.py
+++ b/tests/test_backend_mhtml.py
@@ -86,7 +86,7 @@ def test_mhtml_extension_detection(tmp_path: Path, extension: str):
     assert conversion_input._guess_format(path) == InputFormat.MHTML
     stream = DocumentStream(name=path.name, stream=BytesIO(path.read_bytes()))
     assert conversion_input._guess_format(stream) == InputFormat.MHTML
-    assert mimetypes.guess_type(path.name)[0] == "application/x-mimearchive"
+    assert mimetypes.guess_type(path.name)[0] == "message/rfc822"
 
 
 def test_root_html_preserves_standard_html_semantics():


### PR DESCRIPTION
Resolves #659.

Adds a thin MHTML adapter based on Python's standard-library MIME parser.
The backend selects the root HTML part, resolves embedded raster images from
Content-Location and cid: MIME parts without network/filesystem access, then
delegates document semantics to HTMLDocumentBackend.

The design follows docling.rs's established MHTML architecture while adapting
to Python Docling's backend and safety conventions.

Tests cover .mhtml/.mht detection, root/start selection, nested MIME,
quoted-printable and base64 HTML, Unicode, HTML structure, Content-Location
and cid images, missing/unsupported images, text-only/unusable input,
path/stream input, origin preservation, image-size limits, and no outbound
network access.