### PR TITLE
docs: remove Label Studio integration entries pending the page

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -9,8 +9,7 @@ Here some of our picks to get you started:
 - [🧠 Semantica](./semantica.md)
 - [🌾 Haystack](./haystack.md)
 - [🇨 Crew AI](./crewai.md)
-- [🏷️ Label Studio](./labelstudio.md)
-
+- 
 👈 ... and there is much more: explore all integrations using the navigation menu on the side
 
 <div class="grid" style="text-align: center">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,8 +176,7 @@ nav:
       - "Apify": integrations/apify.md
       - "Data Prep Kit": integrations/data_prep_kit.md
       - "InstructLab": integrations/instructlab.md
-      - "Label Studio": integrations/labelstudio.md
-      - "NVIDIA": integrations/nvidia.md
+          - "NVIDIA": integrations/nvidia.md
       - "Prodigy": integrations/prodigy.md
       - "RHEL AI": integrations/rhel_ai.md
       - "spaCy": integrations/spacy.md


### PR DESCRIPTION
### Summary

#4072 added a nav entry and an integrations card for `integrations/labelstudio.md`, but the target page was never committed (`2 files changed` in that PR touched only `docs/integrations/index.md` and `mkdocs.yml`). The docs site therefore has a dead nav entry and card.

This removes both entries until the actual page lands.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>