### PR TITLE
docs: fix links to moved or out-of-tree targets

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -6,7 +6,7 @@ For each document format, the *document converter* knows which format-specific *
 
 !!! tip
 
-    While the document converter holds a default mapping, this configuration is parametrizable, so e.g. for the PDF format, different backends and different pipeline options can be used — see [Usage](../usage/index.md#adjust-pipeline-features).
+    While the document converter holds a default mapping, this configuration is parametrizable, so e.g. for the PDF format, different backends and different pipeline options can be used — see [Usage](../usage/advanced_options.md#adjust-pipeline-features).
 
 The *conversion result* contains the [*Docling document*](./docling_document.md), Docling's fundamental document representation.
 

--- a/docs/integrations/apify.md
+++ b/docs/integrations/apify.md
@@ -20,7 +20,7 @@ The Actor stores results in:
 * Processing logs (`DOCLING_LOG`)
 * Dataset record with result URL and status
 
-Read more about the [Docling Actor](.actor/README.md), including how to use it via the Apify API and CLI.
+Read more about the [Docling Actor][docs], including how to use it via the Apify API and CLI.
 
 - 💻 [GitHub][github]
 - 📖 [Docs][docs]

--- a/docs/v2.md
+++ b/docs/v2.md
@@ -230,4 +230,4 @@ leverages the new `DoclingDocument` and provides a new, richer chunk output form
 - any applicable headings for context
 - any applicable captions for context
 
-For an example, check out [Chunking usage](usage.md#chunking).
+For an example, check out [Chunking usage](concepts/chunking.md#usage-examples).


### PR DESCRIPTION
### Summary

Three dead links, each verified against the tree:

1. `docs/concepts/architecture.md`: the Usage link pointed at `../usage/index.md#adjust-pipeline-features`, but that heading lives in `usage/advanced_options.md`
2. `docs/v2.md`: the chunking example link resolved to `docs/usage.md`, which does not exist; the content moved to `concepts/chunking.md` (`#usage-examples` anchor)
3. `docs/integrations/apify.md`: linked `.actor/README.md` relatively from inside the mkdocs tree (404s on the rendered site); switched to the `[docs]`-style reference already defined in the same file

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>