### PR TITLE
fix(docx): avoid per-figure document reload and use bulk body reset

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -3143,17 +3143,17 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             return None
 
         try:
-            # Load once; del body[:] resets cheaply on every call
+            # Loaded once per backend instance; del body[:] clears cheaply on every call.
             if self._empty_docx_template is None:
                 self._empty_docx_template = self.load_msword_file(
                     self.path_or_stream, self.document_hash
                 )
-            temp_doc = self._empty_docx_template
-            body = temp_doc._element.body
+            render_doc = self._empty_docx_template
+            body = render_doc._element.body
             del body[:]
 
-            # Add elements to empty document
-            new_para = temp_doc.add_paragraph()
+            # Populate the now-empty body with the element(s) to render.
+            new_para = render_doc.add_paragraph()
             new_r = new_para.add_run()
 
             # Handle list of elements (e.g., multiple DrawingML elements)
@@ -3182,7 +3182,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
 
             # Convert DOCX->PDF->PNG
             pil_image = get_pil_from_dml_docx(
-                temp_doc, converter=self.docx_to_pdf_converter
+                render_doc, converter=self.docx_to_pdf_converter
             )
             return pil_image
         except Exception as e:

--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -476,6 +476,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         self.docx_to_pdf_converter: Callable | None = None
         self.docx_to_pdf_converter_init = False
         self.display_drawingml_warning = True
+        self._empty_docx_template: DocxDocument | None = None
 
         for i in range(-1, self.max_levels):
             self.parents[i] = None
@@ -3142,11 +3143,14 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             return None
 
         try:
-            # Create a temporary document with just these elements
-            temp_doc = self.load_msword_file(self.path_or_stream, self.document_hash)
+            # Load once; del body[:] resets cheaply on every call
+            if self._empty_docx_template is None:
+                self._empty_docx_template = self.load_msword_file(
+                    self.path_or_stream, self.document_hash
+                )
+            temp_doc = self._empty_docx_template
             body = temp_doc._element.body
-            for child in list(body):
-                body.remove(child)
+            del body[:]
 
             # Add elements to empty document
             new_para = temp_doc.add_paragraph()


### PR DESCRIPTION
## Problem

`MsWordDocumentBackend._convert_elements_via_docx` was called once per figure in
figure-bearing DOCX files. Each call reloaded the source document from disk and then
emptied its body with an element-by-element `remove()` loop. The `lxml`
`Element.remove()` call triggers `moveNodeToDocument` → `_fixCNs`, which reconciles
namespace declarations across the moved subtree on every removal. On large documents
this teardown alone could take tens of seconds per figure, making the overall parse
time grow proportionally to the figure count.

## Changes

- **Load once:** `_empty_docx_template` is a new lazy instance attribute that holds the
loaded `DocxDocument`. `load_msword_file` is called at most once per backend instance
instead of once per figure.
- **Bulk reset:** `del body[:]` replaces the `for child in list(body): body.remove(child)`
loop. The slice deletion is a bulk C-level operation that avoids all per-element lxml
namespace fixup, and is several orders of magnitude faster on large documents.

## Memory trade-off

`_empty_docx_template` holds a second in-memory copy of the source document's OPC
package (styles, theme, font table, and embedded image blobs). This duplicates the
same data already held by `self.docx_obj`.

The overhead is **constant** — independent of figure count — and bounded by the
size of the source file. After the first figure render `del body[:]` frees the body
XML, so what remains is essentially the package parts: the embedded image blobs
(which must be retained so LibreOffice can resolve `r:id` references) plus the
structural XML parts (styles, theme, settings), typically a few hundred kilobytes.

This is an acceptable trade-off: the original cost was `O(figures × body_size)` CPU
time; the new cost is one constant allocation in RAM that lives for the lifetime of
the backend instance, the same scope as `self.docx_obj` itself.

## Testing

All existing tests pass (`make validate`). Output is byte-identical to the unpatched
version: same markdown content and same rasterized figure images.

**Issue resolved by this Pull Request:**
Resolves #4192

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
