### PR TITLE
docs: fix notebook links that resolve above docs/

### DIFF
--- a/docs/examples/backend_xml_rag.ipynb
+++ b/docs/examples/backend_xml_rag.ipynb
@@ -48,9 +48,9 @@
     "  - [Setup](#setup) the API access for generative AI\n",
     "  - [Fetch the data](#fetch-the-data) from USPTO and PubMed Central® sites, using Docling custom backends\n",
     "  - [Parse, chunk, and index](#parse-chunk-and-index) the documents in a vector database\n",
-    "  - [Perform RAG](#question-answering-with-rag) using [LlamaIndex Docling extension](../../integrations/llamaindex/)\n",
+    "  - [Perform RAG](#question-answering-with-rag) using [LlamaIndex Docling extension](../integrations/llamaindex/)\n",
     "\n",
-    "For more details on document chunking with Docling, refer to the [Chunking](../../concepts/chunking/) documentation. For RAG with Docling and LlamaIndex, also check the example [RAG with LlamaIndex](../rag_llamaindex/)."
+    "For more details on document chunking with Docling, refer to the [Chunking](../concepts/chunking/) documentation. For RAG with Docling and LlamaIndex, also check the example [RAG with LlamaIndex](../rag_llamaindex/)."
    ]
   },
   {
@@ -448,7 +448,7 @@
     "- The LlamaIndex extensions, `DoclingReader` and `DoclingNodeParser`, to ingest the patent chunks into a Milvus vector store.\n",
     "- The `HierarchicalChunker` implementation, which applies a document-based hierarchical chunking, to leverage the patent structures like sections and paragraphs within sections.\n",
     "\n",
-    "Refer to other possible implementations and usage patterns in the [Chunking](../../concepts/chunking/) documentation and the [RAG with LlamaIndex](../rag_llamaindex/) notebook."
+    "Refer to other possible implementations and usage patterns in the [Chunking](../concepts/chunking/) documentation and the [RAG with LlamaIndex](../rag_llamaindex/) notebook."
    ]
   },
   {

--- a/docs/examples/rag_haystack.ipynb
+++ b/docs/examples/rag_haystack.ipynb
@@ -37,7 +37,7 @@
    "metadata": {},
    "source": [
     "This example leverages the\n",
-    "[Haystack Docling extension](../../integrations/haystack/), along with\n",
+    "[Haystack Docling extension](../integrations/haystack/), along with\n",
     "Milvus-based document store and retriever instances, as well as sentence-transformers\n",
     "embeddings.\n",
     "\n",

--- a/docs/examples/rag_langchain.ipynb
+++ b/docs/examples/rag_langchain.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "source": [
     "This example leverages the\n",
-    "[LangChain Docling integration](../../integrations/langchain/), along with a Milvus\n",
+    "[LangChain Docling integration](../integrations/langchain/), along with a Milvus\n",
     "vector store, as well as sentence-transformers embeddings.\n",
     "\n",
     "The presented `DoclingLoader` component enables you to:\n",

--- a/docs/examples/rag_llamaindex.ipynb
+++ b/docs/examples/rag_llamaindex.ipynb
@@ -36,7 +36,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This example leverages the official [LlamaIndex Docling extension](../../integrations/llamaindex/).\n",
+    "This example leverages the official [LlamaIndex Docling extension](../integrations/llamaindex/).\n",
     "\n",
     "Presented extensions `DoclingReader` and `DoclingNodeParser` enable you to:\n",
     "- use various document types in your LLM applications with ease and speed, and\n",

--- a/docs/examples/serialization.ipynb
+++ b/docs/examples/serialization.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this notebook we showcase the usage of Docling [serializers](../../concepts/serialization)."
+    "In this notebook we showcase the usage of Docling [serializers](../concepts/serialization)."
    ]
   },
   {

--- a/docs/examples/visual_grounding.ipynb
+++ b/docs/examples/visual_grounding.ipynb
@@ -33,7 +33,7 @@
     "with any agentic AI / RAG framework.\n",
     "\n",
     "In this instance, we illustrate these capabilities leveraging the\n",
-    "[LangChain Docling integration](../../integrations/langchain/), along with a Milvus\n",
+    "[LangChain Docling integration](../integrations/langchain/), along with a Milvus\n",
     "vector store, as well as sentence-transformers embeddings."
    ]
   },


### PR DESCRIPTION
Six example notebooks (`serialization`, `rag_langchain`, `rag_llamaindex`, `rag_haystack`, `visual_grounding`, `backend_xml_rag`) link concepts/integration pages as `../../concepts/…` / `../../integrations/…` — from `docs/examples/` that resolves above `docs/` and 404s on GitHub. All now use the single `../` level (targets verified to exist).

Docs-only.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>