### PR TITLE
docs(datamodel): fix two pydantic field descriptions

### DIFF
--- a/docling/datamodel/document.py
+++ b/docling/datamodel/document.py
@@ -129,13 +129,13 @@ class InputDocument(BaseModel):
     """A document as an input of a Docling conversion."""
 
     file: Annotated[
-        PurePath, Field(description="A path representation the input document.")
+        PurePath, Field(description="A path representation of the input document.")
     ]
     document_hash: Annotated[
         str,
         Field(description="A stable hash of the path or stream of the input document."),
     ]
-    valid: bool = Field(True, description="Whether this is is a valid input document.")
+    valid: bool = Field(True, description="Whether this is a valid input document.")
     backend_options: Optional[BackendOptions] = Field(
         None, description="Custom options for backends."
     )


### PR DESCRIPTION
Two `Field(description=…)` strings in `docling/datamodel/document.py`:

- `InputDocument.valid`: "Whether this **is is** a valid input document." → single "is"
- `InputDocument.source`: "A path representation **the** input document." → "representation **of** the input document."

These descriptions surface in the generated JSON schema and API docs. String-literals only.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>