### PR TITLE
docs: drop the Label Studio integration entries

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -9,7 +9,6 @@ Here some of our picks to get you started:
 - [🧠 Semantica](./semantica.md)
 - [🌾 Haystack](./haystack.md)
 - [🇨 Crew AI](./crewai.md)
-- [🏷️ Label Studio](./labelstudio.md)
 
 👈 ... and there is much more: explore all integrations using the navigation menu on the side
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -176,7 +176,6 @@ nav:
       - "Apify": integrations/apify.md
       - "Data Prep Kit": integrations/data_prep_kit.md
       - "InstructLab": integrations/instructlab.md
-      - "Label Studio": integrations/labelstudio.md
       - "NVIDIA": integrations/nvidia.md
       - "Prodigy": integrations/prodigy.md
       - "RHEL AI": integrations/rhel_ai.md


### PR DESCRIPTION
The integrations index (`docs/integrations/index.md`) and the mkdocs nav (`mkdocs.yml`) both link `integrations/labelstudio.md` — a page that has never existed in any branch (verified with `git log --all`). Users clicking the Label Studio card get a 404, and mkdocs ships the dead link silently (strict mode off).

Removed both entries. If the integration page was intended, happy to see it land with the page instead.

Signed-off-by: simpleqt <89645338+simpleqt@users.noreply.github.com>