### PR TITLE
fix(epub): decode percent-escaped manifest hrefs

### DIFF
--- a/docling/backend/epub_backend.py
+++ b/docling/backend/epub_backend.py
@@ -7,6 +7,7 @@ import shutil
 import tempfile
 from io import BytesIO
 from pathlib import Path
+from urllib.parse import unquote
 from zipfile import ZipFile
 
 import defusedxml.ElementTree as ET
@@ -131,7 +132,9 @@ class EpubDocumentBackend(DeclarativeDocumentBackend):
                 item_id = item.get("id")
                 href = item.get("href")
                 if item_id and href:
-                    manifest_map[item_id] = href
+                    # A manifest href is a URL, while the archive stores the
+                    # literal file name, so percent-escapes are decoded here.
+                    manifest_map[item_id] = unquote(href)
 
             # Get content files in reading order
             for itemref in spine.findall("opf:itemref", ns_opf):

--- a/tests/test_backend_epub.py
+++ b/tests/test_backend_epub.py
@@ -18,6 +18,7 @@ For more information about Standard Ebooks visit: https://standardebooks.org/abo
 """
 
 import logging
+import zipfile
 from pathlib import Path
 
 import pytest
@@ -171,6 +172,76 @@ def test_epub_content_combination():
     # Check that the document has a reasonable amount of text
     total_text = "".join(item.text for item in doc.texts)
     assert len(total_text) > 100, "Combined content should have substantial text"
+
+
+def _build_epub_with_hrefs(path: Path, hrefs: list[str], names: list[str]) -> Path:
+    """Build a minimal EPUB whose manifest hrefs and ZIP entry names differ.
+
+    ``hrefs`` are written into the package document, ``names`` are the file
+    names actually stored in the archive, both relative to ``OEBPS/``.
+    """
+    container = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<container version="1.0"'
+        ' xmlns="urn:oasis:names:tc:opendocument:xmlns:container">'
+        "<rootfiles>"
+        '<rootfile full-path="OEBPS/content.opf"'
+        ' media-type="application/oebps-package+xml"/>'
+        "</rootfiles></container>"
+    )
+    items = "".join(
+        f'<item id="c{i}" href="{href}" media-type="application/xhtml+xml"/>'
+        for i, href in enumerate(hrefs)
+    )
+    itemrefs = "".join(f'<itemref idref="c{i}"/>' for i in range(len(hrefs)))
+    opf = (
+        '<?xml version="1.0" encoding="UTF-8"?>'
+        '<package xmlns="http://www.idpf.org/2007/opf" version="3.0"'
+        ' unique-identifier="uid">'
+        '<metadata xmlns:dc="http://purl.org/dc/elements/1.1/">'
+        "<dc:title>Percent Encoded</dc:title></metadata>"
+        f"<manifest>{items}</manifest>"
+        f"<spine>{itemrefs}</spine>"
+        "</package>"
+    )
+
+    with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as z:
+        zi = zipfile.ZipInfo("mimetype")
+        zi.compress_type = zipfile.ZIP_STORED
+        z.writestr(zi, "application/epub+zip")
+        z.writestr("META-INF/container.xml", container)
+        z.writestr("OEBPS/content.opf", opf)
+        for i, name in enumerate(names):
+            z.writestr(
+                f"OEBPS/{name}",
+                '<?xml version="1.0" encoding="UTF-8"?>'
+                '<html xmlns="http://www.w3.org/1999/xhtml"><body>'
+                f"<p>Chapter {i} body.</p>"
+                "</body></html>",
+            )
+    return path
+
+
+def test_epub_percent_encoded_manifest_href_is_read(tmp_path: Path):
+    """A manifest href is a URL, so its percent-escapes must be decoded.
+
+    The ZIP entry carries the literal file name, so a spine document whose
+    href escapes a space or a non-ASCII character is not found and its text
+    is dropped from the converted document while the conversion still
+    reports success.
+    """
+    epub_path = _build_epub_with_hrefs(
+        tmp_path / "percent.epub",
+        hrefs=["chapter%201.xhtml", "%C3%A9pilogue.xhtml", "plain.xhtml"],
+        names=["chapter 1.xhtml", "épilogue.xhtml", "plain.xhtml"],
+    )
+
+    doc = get_converter().convert(epub_path).document
+    text = "\n".join(item.text for item in doc.texts)
+
+    assert "Chapter 0 body." in text
+    assert "Chapter 1 body." in text
+    assert "Chapter 2 body." in text
 
 
 def test_epub_link_fixing():

--- a/tests/test_backend_epub.py
+++ b/tests/test_backend_epub.py
@@ -243,8 +243,6 @@ def test_epub_percent_encoded_manifest_href_is_read(tmp_path: Path):
 
     result = get_converter().convert(epub_path)
 
-    # The unfixed backend swallowed the lookup failure, so the dropped chapters
-    # were reported as a clean success rather than as an error.
     assert result.status == ConversionStatus.SUCCESS
     assert result.errors == []
 

--- a/tests/test_backend_epub.py
+++ b/tests/test_backend_epub.py
@@ -25,7 +25,12 @@ import pytest
 
 from docling.backend.epub_backend import EpubDocumentBackend
 from docling.datamodel.base_models import InputFormat
-from docling.datamodel.document import ConversionResult, DoclingDocument, InputDocument
+from docling.datamodel.document import (
+    ConversionResult,
+    ConversionStatus,
+    DoclingDocument,
+    InputDocument,
+)
 from docling.document_converter import DocumentConverter
 
 from .test_data_gen_flag import GEN_TEST_DATA
@@ -236,7 +241,14 @@ def test_epub_percent_encoded_manifest_href_is_read(tmp_path: Path):
         names=["chapter 1.xhtml", "épilogue.xhtml", "plain.xhtml"],
     )
 
-    doc = get_converter().convert(epub_path).document
+    result = get_converter().convert(epub_path)
+
+    # The unfixed backend swallowed the lookup failure, so the dropped chapters
+    # were reported as a clean success rather than as an error.
+    assert result.status == ConversionStatus.SUCCESS
+    assert result.errors == []
+
+    doc = result.document
     text = "\n".join(item.text for item in doc.texts)
 
     assert "Chapter 0 body." in text


### PR DESCRIPTION
An EPUB whose manifest uses percent-escaped hrefs loses whole chapters, and the conversion still reports success.

A package-document `href` is a URL, so a conforming producer writes `chapter%201.xhtml` for a ZIP entry actually named `chapter 1.xhtml`. `EpubDocumentBackend._parse_epub_structure` stores that href verbatim (`epub_backend.py:134`) and `convert()` passes it straight to `ZipFile.read()` (`:396`). The lookup misses, the `KeyError` is swallowed by the blanket `except ... continue` at `:421`, and the chapter simply is not in the output. Nothing records an error, so the result is `ConversionStatus.SUCCESS` with `errors == []`.

On a three-chapter book with two escaped hrefs, the converted document contains only the third chapter's text.

The fix percent-decodes the href when the manifest map is built. A producer that means a literal `%` writes `%25`, which round-trips, and a bare `%` is left alone by `unquote`, so non-conforming files are unaffected. This is the same normalisation `html_backend.py:614` already applies before using a URL as a path, and it matches `ebooklib`, which decodes the href for exactly this reason.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.

`tests/test_backend_epub.py` gains a case that builds a small EPUB with escaped ASCII and non-ASCII hrefs. It fails on `main` with `assert 'Chapter 0 body.' in 'Chapter 2 body.'` and the two swallowed warnings visible in the log; the file goes from 8 passing to 9. The non-model backend suites are unchanged at 10 pre-existing failures either side, all of them Windows-only groundtruth comparisons.

Two adjacent cases in the same file are deliberately left out to keep this to one behaviour, and I would rather raise them than fold them in: `container.xml`'s `full-path` is a URL too and is not decoded, though that one fails loudly rather than silently, and a UTF-16 content document hits the same swallow at `:397`. Happy to add either on request.