### PR TITLE
fix(docx): retain list items when list starts above indent level 0 (#4185)

### DIFF
--- a/docling/backend/msword_backend.py
+++ b/docling/backend/msword_backend.py
@@ -468,6 +468,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         # Initialise the parents for the hierarchy
         self.max_levels: int = 10
         self.level_at_new_list: int | None = None
+        self.base_indent_at_new_list: int | None = None
         self.parents: dict[int, NodeItem | None] = {}
         self.numbered_headers: dict[int, int] = {}
         self.equation_bookends: str = "<eq>{EQ}</eq>"
@@ -728,6 +729,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             "indents": self.history["indents"].copy(),
         }
         saved_level_at_new_list = self.level_at_new_list
+        saved_base_indent_at_new_list = self.base_indent_at_new_list
         saved_parents = self.parents.copy()
         # Save and clear list group cache to prevent reuse across table cells
         saved_last_list_group = self.last_list_group
@@ -740,6 +742,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         finally:
             self.history = saved_history
             self.level_at_new_list = saved_level_at_new_list
+            self.base_indent_at_new_list = saved_base_indent_at_new_list
             self.parents = saved_parents
             self.last_list_group = saved_last_list_group
             self.last_list_group_numid = saved_last_list_group_numid
@@ -2240,10 +2243,12 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                         self.parents[key] = None
                 self.level = self.level_at_new_list - 1
                 self.level_at_new_list = None
+                self.base_indent_at_new_list = None
             else:
                 for key in range(len(self.parents)):
                     self.parents[key] = None
                 self.level = 0
+                self.base_indent_at_new_list = None
 
         if p_style_id in ["Title"]:
             for key in range(len(self.parents)):
@@ -2630,6 +2635,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             self._prev_numid() == numid and self.level_at_new_list is None
         ):  # Open new list
             self.level_at_new_list = level
+            self.base_indent_at_new_list = ilevel
             # Only reset counters the first time a numId is opened. A numId
             # that reappears after an intervening list of a different numId is
             # the same Word list resuming, and must keep its numbering.
@@ -2654,9 +2660,16 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             and prev_indent is not None
             and prev_indent < ilevel
         ):  # Open indented list
+            base_indent = (
+                self.base_indent_at_new_list
+                if self.base_indent_at_new_list is not None
+                else 0
+            )
+            rel_prev = max(0, prev_indent - base_indent)
+            rel_indent = max(0, ilevel - base_indent)
             for i in range(
-                self.level_at_new_list + prev_indent + 1,
-                self.level_at_new_list + ilevel + 1,
+                self.level_at_new_list + rel_prev + 1,
+                self.level_at_new_list + rel_indent + 1,
             ):
                 list_gr1 = doc.add_list_group(
                     name="list",
@@ -2665,7 +2678,7 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
                 )
                 self.parents[i] = list_gr1
                 elem_ref.append(list_gr1.get_ref())
-            use_level = self.level_at_new_list + ilevel
+            use_level = self.level_at_new_list + rel_indent
 
         elif (
             self._prev_numid() == numid
@@ -2673,10 +2686,16 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
             and prev_indent is not None
             and ilevel < prev_indent
         ):  # Close list
-            for k in self.parents:
-                if k > self.level_at_new_list + ilevel:
+            base_indent = (
+                self.base_indent_at_new_list
+                if self.base_indent_at_new_list is not None
+                else 0
+            )
+            rel_indent = max(0, ilevel - base_indent)
+            for k in list(self.parents.keys()):
+                if k > self.level_at_new_list + rel_indent:
                     self.parents[k] = None
-            use_level = self.level_at_new_list + ilevel
+            use_level = self.level_at_new_list + rel_indent
 
         elif self._prev_numid() == numid and isinstance(
             self.parents.get(level - 1), ListGroup
@@ -2689,13 +2708,20 @@ class MsWordDocumentBackend(DeclarativeDocumentBackend):
         ):
             # New list sequence
             if self.level_at_new_list is not None:
-                use_level = self.level_at_new_list + ilevel
+                base_indent = (
+                    self.base_indent_at_new_list
+                    if self.base_indent_at_new_list is not None
+                    else 0
+                )
+                rel_indent = max(0, ilevel - base_indent)
+                use_level = self.level_at_new_list + rel_indent
                 for k in list(self.parents.keys()):
                     if k > use_level:
                         self.parents[k] = None
             else:
                 use_level = level
                 self.level_at_new_list = use_level
+                self.base_indent_at_new_list = ilevel
 
             # Only reset counters the first time a numId is opened. A numId
             # that reappears after an intervening list of a different numId is

--- a/tests/test_backend_msword_lists.py
+++ b/tests/test_backend_msword_lists.py
@@ -320,6 +320,80 @@ def test_list_markers_follow_num_fmt_end_to_end(tmp_path):
     ]
 
 
+def test_list_starting_above_indent_level_zero_retains_all_items(tmp_path):
+    """A list starting at ilevel > 0 must not drop items returning to the start level.
+
+    See issue #4185: when a list has items at ilevels 1 -> 2 -> 1, Docling used to
+    drop the third item with 'Parent element of the list item is not a ListGroup'
+    because _manage_list_structure() assumed the list started at ilevel 0.
+    """
+    doc = Document()
+    numbering = doc.part.numbering_part.element
+
+    def add_numbering(abstract_id: str, num_id: str):
+        abstract_num = OxmlElement("w:abstractNum")
+        abstract_num.set(qn("w:abstractNumId"), abstract_id)
+        for ilvl in range(3):
+            lvl = OxmlElement("w:lvl")
+            lvl.set(qn("w:ilvl"), str(ilvl))
+            start = OxmlElement("w:start")
+            start.set(qn("w:val"), "1")
+            lvl.append(start)
+            fmt = OxmlElement("w:numFmt")
+            fmt.set(qn("w:val"), "bullet")
+            lvl.append(fmt)
+            text_el = OxmlElement("w:lvlText")
+            text_el.set(qn("w:val"), "•")
+            lvl.append(text_el)
+            abstract_num.append(lvl)
+        numbering.append(abstract_num)
+
+        num = OxmlElement("w:num")
+        num.set(qn("w:numId"), num_id)
+        ref = OxmlElement("w:abstractNumId")
+        ref.set(qn("w:val"), abstract_id)
+        num.append(ref)
+        numbering.append(num)
+
+    add_numbering("1100", "1101")
+
+    def add_item(text: str, num_id: str, ilvl_val: int):
+        paragraph = doc.add_paragraph(text, style="List Paragraph")
+        num_pr = OxmlElement("w:numPr")
+        ilvl = OxmlElement("w:ilvl")
+        ilvl.set(qn("w:val"), str(ilvl_val))
+        num_pr.append(ilvl)
+        num_id_elem = OxmlElement("w:numId")
+        num_id_elem.set(qn("w:val"), num_id)
+        num_pr.append(num_id_elem)
+        paragraph._element.get_or_add_pPr().append(num_pr)
+
+    add_item("Item A at indent level 1", "1101", 1)
+    add_item("Item B at indent level 2", "1101", 2)
+    add_item("Item C at indent level 1", "1101", 1)
+
+    docx_path = tmp_path / "list_indent_repro.docx"
+    doc.save(str(docx_path))
+
+    in_doc = InputDocument(
+        path_or_stream=docx_path,
+        format=InputFormat.DOCX,
+        backend=MsWordDocumentBackend,
+        filename=docx_path.name,
+    )
+    converted = MsWordDocumentBackend(in_doc=in_doc, path_or_stream=docx_path).convert()
+
+    items = [
+        item.text for item, _ in converted.iterate_items() if isinstance(item, ListItem)
+    ]
+
+    assert items == [
+        "Item A at indent level 1",
+        "Item B at indent level 2",
+        "Item C at indent level 1",
+    ]
+
+
 def _make_empty_docx():
     """Return an in-memory .docx with no content."""
 


### PR DESCRIPTION
### Summary of Changes

Closes #4185.

#### Problem
When a Word list starts at an indent level greater than 0 (e.g., `ilevels: 1 -> 2 -> 1` or `3 -> 5 -> 3`), list items that return to the list's starting indent level were silently discarded with:
`Parent element of the list item is not a ListGroup. The list item will be ignored.`

This occurred because `_manage_list_structure()` in `msword_backend.py` assumed all Word lists start at `ilevel = 0`, causing an index mismatch when computing `use_level = self.level_at_new_list + ilevel`.

#### Solution
1. Track `self.base_indent_at_new_list: int | None` on the backend:
   - Initialized in `__init__`.
   - Saved/restored in `_isolated_list_context()` to ensure table cell lists remain isolated.
   - Cleared in `_walk_linear()` when closing lists.
2. In `_manage_list_structure()`, normalize `ilevel` and `prev_indent` relative to `base_indent_at_new_list` across open, indent, and de-indent branches.
3. Added regression test `test_list_starting_above_indent_level_zero_retains_all_items` in `tests/test_backend_msword_lists.py`.

#### Testing
- `uv run pytest tests/test_backend_msword_lists.py` (Failing before fix, passing after fix)
- `uv run pytest tests/test_backend_msword*.py` (All 68 MS Word backend tests passing)
- `uv run ruff check` & `uv run ruff format --check` (All passing)