### PR TITLE
fix(vlm): handle text labeled as forms by Chandra

### DIFF
--- a/docling/utils/chandra_utils.py
+++ b/docling/utils/chandra_utils.py
@@ -310,9 +310,16 @@ def parse_chandra_html(
         if label_str == "Table":
             table_data = _parse_table_html(inner_html)
             doc.add_table(data=table_data, prov=prov)
-        elif label_str == "Form" and "<table" in inner_html.lower():
-            table_data = _parse_table_html(inner_html)
-            doc.add_table(data=table_data, prov=prov)
+        elif label_str == "Form":
+            if "<table" in inner_html.lower():
+                table_data = _parse_table_html(inner_html)
+                doc.add_table(data=table_data, prov=prov)
+            else:
+                doc.add_text(
+                    label=DocItemLabel.TEXT,
+                    text=_strip_tags(inner_html),
+                    prov=prov,
+                )
         elif label_str == "List-Group":
             list_group = doc.add_list_group()
             list_items = _parse_list_html(inner_html) or [_strip_tags(inner_html)]

--- a/tests/data/html_chandra/sources/chandra_form_text.html
+++ b/tests/data/html_chandra/sources/chandra_form_text.html
@@ -1,0 +1,10 @@
+<div data-bbox="470 69 593 104" data-label="Section-Header">
+    <p style="text-align: center;"><b>PROXY FORM</b></p>
+</div>
+
+<div data-bbox="160 160 853 255" data-label="Form" style="border: 1px solid black; padding: 10px;">
+    <p>Name of the member(s):<br/>
+        Registered address:<br/>
+        E-mail ID:<br/>
+        Folio/DPID-Client ID No:</p>
+</div>

--- a/tests/test_chandra_vlm.py
+++ b/tests/test_chandra_vlm.py
@@ -183,6 +183,26 @@ def test_chandra_form_table_parsing():
     assert len(doc.tables) == 4
 
 
+def test_chandra_form_text_parsing():
+    """Test a saved Chandra prediction containing text labeled as Form."""
+    path = Path("./tests/data/html_chandra/sources/chandra_form_text.html")
+    content = path.read_text()
+
+    doc = parse_chandra_html(
+        content=content,
+        original_page_size=Size(width=612, height=792),
+        page_no=1,
+        filename=path.name,
+    )
+
+    assert len(doc.texts) == 2
+    labels = [
+        t.label.value if hasattr(t.label, "value") else str(t.label) for t in doc.texts
+    ]
+    assert "section_header" in labels
+    assert "text" in labels
+
+
 def test_chandra_list_group_prediction_sample():
     """Test a saved chandra prediction containing list groups."""
     path = Path("./tests/data/html_chandra/sources/chandra_list_group.html")


### PR DESCRIPTION
## Summary

Handle text content labeled as `Form` in Chandra OCR HTML output.

## Changes

- Preserve the existing handling of `Form` blocks containing HTML `<table>` elements.
- Parse non-table `Form` blocks as Docling `TEXT` elements.
- Add a regression fixture and test for text-based `Form` blocks.

## Testing

Tested with the Chandra HTML parser.

Verified that:

- `Form` blocks containing tables continue to be parsed as Docling tables.
- Text-based `Form` blocks are parsed as Docling `TEXT` elements.
- Existing Chandra VLM tests continue to pass.
- Ruff checks and formatting pass.

## Checklist

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.