### PR TITLE
fix(pdf): preserve semantic hyphens for single-char prefixes and digit continuations

### DIFF
--- a/docling/models/stages/page_assemble/page_assemble_model.py
+++ b/docling/models/stages/page_assemble/page_assemble_model.py
@@ -143,6 +143,8 @@ class PageAssembleModel(BasePageModel):
                     and len(prev_words)
                     and len(line_words)
                     and prev_words[-1].isalnum()
+                    and len(prev_words[-1]) >= 2
+                    and not line_words[0][0].isdigit()
                     and line_words[0].isalnum()
                 ):
                     lines[ix] = prev_line[:-1]

--- a/docling/models/stages/reading_order/readingorder_model.py
+++ b/docling/models/stages/reading_order/readingorder_model.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: The Docling Contributors
 # SPDX-License-Identifier: MIT
 
+import re
 from collections.abc import Iterator
 from pathlib import Path
 from statistics import median
@@ -670,8 +671,17 @@ class ReadingOrderModel:
             bbox=merged_elem.cluster.bbox.to_bottom_left_origin(page_height),
         )
         continuation_text = merged_elem.text.lstrip()
+        prev_words = re.findall(r"\b[\w]+\b", new_item.text)
+        continuation_words = re.findall(r"\b[\w]+\b", continuation_text)
+        hyphen_attached_to_word = len(new_item.text) > 1 and new_item.text[-2].isalnum()
+
         if new_item.text.endswith("\u00ad") or (
             new_item.text.endswith("-")
+            and hyphen_attached_to_word
+            and len(prev_words) > 0
+            and len(prev_words[-1]) >= 2
+            and len(continuation_words) > 0
+            and not continuation_words[0][0].isdigit()
             and continuation_text
             and continuation_text[0].islower()
         ):
@@ -680,6 +690,18 @@ class ReadingOrderModel:
             new_item.orig = (
                 new_item.orig[:-1] + merged_elem.text
             )  # TODO: This is incomplete, we don't have the `orig` field of the merged element.
+        elif (
+            new_item.text.endswith("-")
+            and hyphen_attached_to_word
+            and len(prev_words) > 0
+            and (
+                len(prev_words[-1]) == 1
+                or (len(continuation_words) > 0 and continuation_words[0][0].isdigit())
+            )
+        ):
+            # Attached semantic hyphen (e.g. single-letter prefix "n-" or digit continuation "6-methyl-5-")
+            new_item.text = new_item.text + merged_elem.text
+            new_item.orig = new_item.orig + merged_elem.text
         else:
             new_item.text += f" {merged_elem.text}"
             new_item.orig += f" {merged_elem.text}"  # TODO: This is incomplete, we don't have the `orig` field of the merged element.

--- a/tests/test_page_assemble_model.py
+++ b/tests/test_page_assemble_model.py
@@ -165,6 +165,34 @@ class TestSanitizeTextHyphenation:
     @pytest.mark.parametrize(
         ("lines", "expected"),
         [
+            (
+                ["compounds: undecanal or n-", "tridecanal, from each blend"],
+                "compounds: undecanal or n-tridecanal, from each blend",
+            ),
+            (["i-", "butyric acid"], "i-butyric acid"),
+            (["e-", "commerce platform"], "e-commerce platform"),
+            (["X-", "ray diffraction"], "X-ray diffraction"),
+        ],
+    )
+    def test_single_character_prefix_hyphen_is_preserved(self, model, lines, expected):
+        """A single-character token before a line-final hyphen is a prefix (e.g. n-, i-, e-) and must not be merged."""
+        assert model.sanitize_text(list(lines)) == expected
+
+    @pytest.mark.parametrize(
+        ("lines", "expected"),
+        [
+            (["6-methyl-", "5-hepten-2-one"], "6-methyl-5-hepten-2-one"),
+            (["COVID-", "19 pandemic"], "COVID-19 pandemic"),
+            (["ISO-", "9001 standard"], "ISO-9001 standard"),
+        ],
+    )
+    def test_digit_continuation_hyphen_is_preserved(self, model, lines, expected):
+        """A hyphen followed by a digit continuation is not a word split and must be preserved."""
+        assert model.sanitize_text(list(lines)) == expected
+
+    @pytest.mark.parametrize(
+        ("lines", "expected"),
+        [
             # Wrapped CLI flag, as reported: the dash must not be swallowed.
             (
                 ["gsh create_diameter_peer -ip 10.0.8.72 -pn 1 -", "prio 3 -dh mme"],

--- a/tests/test_readingorder_hyphenated_merges.py
+++ b/tests/test_readingorder_hyphenated_merges.py
@@ -57,6 +57,9 @@ def _element(cluster_id: int, text: str) -> TextElement:
         ("algo-", "rithms", "algorithms"),
         ("algo\u00ad", "rithms", "algorithms"),
         ("algo-", "Rithms", "algo- Rithms"),
+        ("n-", "tridecanal", "n-tridecanal"),
+        ("i-", "butyric", "i-butyric"),
+        ("6-methyl-", "5-hepten-2-one", "6-methyl-5-hepten-2-one"),
     ],
 )
 def test_merge_elements_dehyphenates_lowercase_continuations(


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #4151

### Description
In `PageAssembleModel.sanitize_text()` and `ReadingOrderModel._merge_elements()`, line-final attached hyphens were stripped whenever followed by alphanumeric characters, regardless of whether the hyphen was semantic (e.g., single-letter chemical/technical prefix or preceding a digit).

This caused:
1. Single-character prefixes to lose their hyphen: `n-` + `tridecanal` $\rightarrow$ `ntridecanal`, `i-` + `butyric` $\rightarrow$ `ibutyric`, `e-` + `commerce` $\rightarrow$ `ecommerce`.
2. Digit continuations across line breaks to drop the hyphen: `6-methyl-` + `5-hepten-2-one` $\rightarrow$ `6-methyl5-hepten-2-one`, `COVID-` + `19` $\rightarrow$ `COVID19`.

### Changes
- **`PageAssembleModel.sanitize_text`**:
  - Require `len(prev_words[-1]) >= 2` before stripping a line-break hyphen (standard typesetting rules never hyphenate leaving a single letter).
  - Require `not line_words[0][0].isdigit()` so hyphens preceding numbers are preserved.
- **`ReadingOrderModel._merge_elements`**:
  - Enforce matching guards (`len(prev_words[-1]) >= 2` and `not continuation_words[0][0].isdigit()`).
  - Preserve attached hyphens for single-character prefixes and digit continuations without inserting a spurious space.
- **Tests**:
  - Added unit test cases to `tests/test_page_assemble_model.py` (`test_single_character_prefix_hyphen_is_preserved`, `test_digit_continuation_hyphen_is_preserved`).
  - Added test cases to `tests/test_readingorder_hyphenated_merges.py`.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.