### PR TITLE
feat: allow ambient credentials for S3

### DIFF
--- a/docling/datamodel/service/sources.py
+++ b/docling/datamodel/service/sources.py
@@ -65,18 +65,24 @@ class S3Coordinates(BaseModel):
     ] = True
 
     access_key: Annotated[
-        StrictStr,
+        StrictStr | None,
         Field(
-            description=("S3 access key. Required."),
+            description=(
+                "S3 access key. Optional; provide together with secret_key, or omit "
+                "both to use ambient credentials."
+            ),
         ),
-    ]
+    ] = None
 
     secret_key: Annotated[
-        StrictStr,
+        StrictStr | None,
         Field(
-            description=("S3 secret key. Required."),
+            description=(
+                "S3 secret key. Optional; provide together with access_key, or omit "
+                "both to use ambient credentials."
+            ),
         ),
-    ]
+    ] = None
 
     bucket: Annotated[
         str,
@@ -104,6 +110,14 @@ class S3Coordinates(BaseModel):
             ge=1,
         ),
     ] = None
+
+    @model_validator(mode="after")
+    def validate_credentials(self) -> "S3Coordinates":
+        has_access_key = self.access_key is not None
+        has_secret_key = self.secret_key is not None
+        if has_access_key != has_secret_key:
+            raise ValueError("access_key and secret_key must be provided together")
+        return self
 
 
 class AzureBlobCoordinates(BaseModel):

--- a/docs/usage/jobkit.md
+++ b/docs/usage/jobkit.md
@@ -51,6 +51,12 @@ The currently supported connectors are:
 - Google Drive
 - Google Cloud Storage
 
+### S3
+
+For S3-compatible services, provide `access_key` and `secret_key` together. On
+AWS, omit both to use the default credential provider chain (for example, an
+ECS task role, EKS workload identity, or EC2 instance profile).
+
 ### Google Drive
 
 To use Google Drive as a source or target, you need to enable the API and set up credentials.

--- a/tests/test_service_datamodels.py
+++ b/tests/test_service_datamodels.py
@@ -28,6 +28,7 @@ from docling.datamodel.service.responses import (
     TaskFailureResult,
     TaskStatusResponse,
 )
+from docling.datamodel.service.sources import S3Coordinates
 from docling.datamodel.service.targets import (
     AzureBlobTarget,
     GoogleCloudStorageTarget,
@@ -36,6 +37,74 @@ from docling.datamodel.service.targets import (
     S3Target,
     ZipTarget,
 )
+
+S3_MODEL_TYPES = (S3Coordinates, S3SourceRequest, S3Target)
+FAKE_S3_CREDENTIALS = {
+    "access_key": "fake-access-key-for-testing-only",
+    "secret_key": "fake-secret-key-for-testing-only",
+}
+
+
+def test_s3_source_and_target_inherit_coordinates() -> None:
+    assert issubclass(S3SourceRequest, S3Coordinates)
+    assert issubclass(S3Target, S3Coordinates)
+
+
+@pytest.mark.parametrize("model_type", S3_MODEL_TYPES)
+def test_s3_coordinates_allow_ambient_credentials(
+    model_type: type[S3Coordinates],
+) -> None:
+    coordinates = model_type(endpoint="s3.example.com", bucket="documents")
+
+    assert coordinates.access_key is None
+    assert coordinates.secret_key is None
+
+
+@pytest.mark.parametrize("model_type", S3_MODEL_TYPES)
+def test_s3_coordinates_preserve_explicit_string_credentials(
+    model_type: type[S3Coordinates],
+) -> None:
+    coordinates = model_type(
+        endpoint="s3.example.com",
+        bucket="documents",
+        **FAKE_S3_CREDENTIALS,
+    )
+
+    assert coordinates.access_key == FAKE_S3_CREDENTIALS["access_key"]
+    assert coordinates.secret_key == FAKE_S3_CREDENTIALS["secret_key"]
+    assert isinstance(coordinates.access_key, str)
+    assert isinstance(coordinates.secret_key, str)
+
+
+@pytest.mark.parametrize("model_type", S3_MODEL_TYPES)
+@pytest.mark.parametrize(
+    "credentials",
+    [
+        {"access_key": "fake-access-key-for-testing-only"},
+        {"secret_key": "fake-secret-key-for-testing-only"},
+    ],
+)
+def test_s3_coordinates_reject_incomplete_explicit_credentials(
+    model_type: type[S3Coordinates], credentials: dict[str, str]
+) -> None:
+    with pytest.raises(ValidationError, match="access_key and secret_key"):
+        model_type(endpoint="s3.example.com", bucket="documents", **credentials)
+
+
+@pytest.mark.parametrize("model_type", S3_MODEL_TYPES)
+def test_s3_coordinates_credential_schema_is_optional_string(
+    model_type: type[S3Coordinates],
+) -> None:
+    schema = model_type.model_json_schema()
+
+    assert not {"access_key", "secret_key"} & set(schema["required"])
+    for field_name in ("access_key", "secret_key"):
+        field_schema = schema["properties"][field_name]
+        assert {item.get("type") for item in field_schema["anyOf"]} == {
+            "null",
+            "string",
+        }
+        assert "Optional" in field_schema["description"]
 
 
 def test_http_source_request_rejects_zip_urls() -> None:


### PR DESCRIPTION
## Summary

- make S3 `access_key` and `secret_key` optional as a pair
- reject partial explicit credentials during model validation
- preserve explicit string credentials for S3-compatible services
- document using the standard AWS credential provider chain when both fields are omitted

## Motivation

This is the canonical request-model half of docling-project/docling-jobkit#245. It allows AWS deployments to omit credentials from API payloads so runtime connectors can use ECS task roles, EKS Pod Identity/IRSA, EC2 instance profiles, or other standard boto3 credential providers.

The corresponding docling-jobkit runtime PR omits boto3 credential kwargs when these fields are absent.

## Validation

- 201 focused service-model/client tests passed
- Ruff lint and format checks passed
- scoped type checks passed (existing diagnostics only outside the changed source)
- Tach, module coverage, scoped max-lines, and `git diff --check` passed

No session-token support is included in this change.

Fixes docling-project/docling-jobkit#245 (model portion)
