### PR TITLE
fix(iwork): drop mimetypes.add_type workaround for Pages MIME type

### DIFF
--- a/docling/backend/iwork_backend.py
+++ b/docling/backend/iwork_backend.py
@@ -59,12 +59,6 @@ _log = logging.getLogger(__name__)
 
 _PAGES_MIMETYPE = "application/vnd.apple.pages"
 
-# DocumentOrigin only accepts a mimetype that the stdlib knows or that
-# docling-core allow-lists, and Python ships no mapping for ".pages". Teaching
-# the stdlib the real Apple type keeps the origin honest without waiting on a
-# docling-core release; it also makes mimetypes.guess_type() correct for callers.
-mimetypes.add_type(_PAGES_MIMETYPE, ".pages")
-
 _MODERN_INDEX_PREFIX = "Index/"
 
 _LEGACY_INDEX_MEMBERS = ("index.xml", "index.xml.gz")


### PR DESCRIPTION
In the Apple Pages backend, `application/vnd.apple.pages` is now allow-listed in **docling-core**, so `DocumentOrigin` accepts it without any help from the stdlib's MIME registry.
The `mimetypes.add_type()` call — which was a temporary shim to avoid a `DocumentOrigin` validation error — is therefore no longer needed and is removed.

**Checklist:**

- [x] Documentation has been updated, if necessary.
- [x] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.
