### PR TITLE
feat: Addition of 'region' to S3Coordinates

### DIFF
--- a/docling/datamodel/service/sources.py
+++ b/docling/datamodel/service/sources.py
@@ -64,6 +64,20 @@ class S3Coordinates(BaseModel):
         ),
     ] = True
 
+    region: Annotated[
+        Optional[str],
+        Field(
+            description=(
+                "AWS region of the S3 bucket, e.g. 'us-east-2'. Required for "
+                "correctly signed requests (including presigned URLs) against "
+                "real AWS S3 buckets outside the default 'us-east-1' region. "
+                "Optional, defaults to unset for S3-compatible services "
+                "(e.g. IBM COS, MinIO) that don't require it."
+            ),
+            examples=["us-east-2", "eu-de"],
+        ),
+    ] = None
+
     access_key: Annotated[
         StrictStr,
         Field(


### PR DESCRIPTION
Adds 'region' to S3Coordinates, which is necessary for making pre-signed urls, in non-default s3 region. Currently, this propagates to docling-jobkit and docling-serve, locking users from using anything but a default us-east1 region.

Relevant PRs:
https://github.com/docling-project/docling-jobkit/pull/248
https://github.com/docling-project/docling-serve/pull/694