### PR TITLE
fix(pypdfium2): build the page object index once to avoid quadratic scans

### DIFF
--- a/docling/backend/pypdfium2_backend.py
+++ b/docling/backend/pypdfium2_backend.py
@@ -271,6 +271,11 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
             self.valid = False
         self.text_page: Optional[PdfTextPage] = None
         self._seg_page: Optional[SegmentedPdfPage] = None
+        # Page-object bboxes, bucketed by FPDF_PAGEOBJ_* type and built once per
+        # page (see ``_get_object_index``). ``has_content_in`` is called per layout
+        # cluster (2-3x each), and each call previously re-walked every page object
+        # per object type -- O(clusters x objects). Caching the walk removes that.
+        self._object_index: Optional[dict[int, List[tuple[BoundingBox, bool]]]] = None
 
     def is_valid(self) -> bool:
         return self.valid
@@ -424,27 +429,51 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
 
         return merge_horizontal_cells(cells)
 
-    def _object_rects(
-        self, obj_type: int, *, skip_invisible_text: bool = False
-    ) -> Iterable[BoundingBox]:
-        """Yield the bboxes of the page objects of ``obj_type``, in top-left origin.
+    # Page-object types this backend ever queries; walking them together lets a
+    # single traversal serve shapes, bitmaps and chars.
+    _INDEXED_OBJECT_TYPES = (
+        pdfium_c.FPDF_PAGEOBJ_PATH,
+        pdfium_c.FPDF_PAGEOBJ_IMAGE,
+        pdfium_c.FPDF_PAGEOBJ_TEXT,
+    )
 
-        With ``skip_invisible_text``, text objects drawn in a rendering mode that paints no
-        ink are left out, matching what docling-parse does natively.
+    def _get_object_index(self) -> dict[int, List[tuple[BoundingBox, bool]]]:
+        """Build (once per page) and return the page-object bbox index.
+
+        The index maps each queried ``FPDF_PAGEOBJ_*`` type to a list of
+        ``(bbox, invisible_text)`` pairs, where ``bbox`` is already in the rotated
+        display frame with a top-left origin and ``invisible_text`` flags text
+        objects drawn in a no-ink rendering mode. Because page rotation and size are
+        fixed for a loaded page, the index is valid for the page's whole lifetime;
+        it is cleared in ``_close_native_page``.
+
+        Lock safety: the ``pypdfium2_lock`` (a plain, non-reentrant lock) is taken
+        only for the single object walk, and never while ``get_size`` is called
+        (which takes the lock itself). Unlike the previous generator -- which held
+        the lock across its ``yield`` while callers ran overlap tests -- callers now
+        iterate the cached pure-Python lists with the lock released.
         """
-        page_size = self.get_size()
+        if self._object_index is not None:
+            return self._object_index
 
+        page_size = self.get_size()  # acquires the lock; must be outside the block
+
+        index: dict[int, List[tuple[BoundingBox, bool]]] = {
+            obj_type: [] for obj_type in self._INDEXED_OBJECT_TYPES
+        }
         with pypdfium2_lock:
             page = self._require_page()
             rotation = page.get_rotation()
-            for obj in page.get_objects(filter=[obj_type]):
-                if (
-                    skip_invisible_text
-                    and obj_type == pdfium_c.FPDF_PAGEOBJ_TEXT
+            for obj in page.get_objects(filter=list(self._INDEXED_OBJECT_TYPES)):
+                bucket = index.get(obj.type)
+                if bucket is None:
+                    continue
+
+                invisible = (
+                    obj.type == pdfium_c.FPDF_PAGEOBJ_TEXT
                     and pdfium_c.FPDFTextObj_GetTextRenderMode(obj.raw)
                     in _INVISIBLE_TEXT_RENDER_MODES
-                ):
-                    continue
+                )
 
                 if _PYPDFIUM2_MAJOR_VERSION >= 5:
                     pos = obj.get_bounds()  # pypdfium2 >= 5.x
@@ -452,9 +481,28 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
                     pos = obj.get_pos()  # pypdfium2 <= 4.x
                 pos = _rect_to_display_frame(pos, rotation, page_size)
 
-                yield BoundingBox.from_tuple(
+                bbox = BoundingBox.from_tuple(
                     pos, origin=CoordOrigin.BOTTOMLEFT
                 ).to_top_left_origin(page_height=page_size.height)
+                bucket.append((bbox, invisible))
+
+        self._object_index = index
+        return index
+
+    def _object_rects(
+        self, obj_type: int, *, skip_invisible_text: bool = False
+    ) -> Iterable[BoundingBox]:
+        """Yield the bboxes of the page objects of ``obj_type``, in top-left origin.
+
+        Served from the per-page object index (:meth:`_get_object_index`) so repeated
+        calls do not re-walk the page. With ``skip_invisible_text``, text objects
+        drawn in a rendering mode that paints no ink are left out, matching what
+        docling-parse does natively.
+        """
+        for bbox, invisible in self._get_object_index().get(obj_type, ()):
+            if skip_invisible_text and invisible:
+                continue
+            yield bbox
 
     def get_bitmap_rects(self, scale: float = 1) -> Iterable[BoundingBox]:
         AREA_THRESHOLD = 0  # 32 * 32
@@ -619,6 +667,7 @@ class PyPdfiumPageBackend(ManagedPdfiumPageBackend):
         self.text_page = None
         self._ppage = None
         self._seg_page = None
+        self._object_index = None
 
 
 class PyPdfiumDocumentBackend(ManagedPdfiumDocumentBackend):

--- a/tests/test_backend_pdfium.py
+++ b/tests/test_backend_pdfium.py
@@ -191,3 +191,81 @@ def test_pdfium_intersects_ignores_invisible_text():
         }
     finally:
         doc_backend.unload()
+
+
+def _build_multi_object_pdf(n_paths: int = 40) -> bytes:
+    """A minimal single-page PDF whose content stream draws ``n_paths`` stroked
+    rectangles, i.e. ``n_paths`` separate PATH page objects, laid out in a grid
+    inside the region (10, 10)-(250, 250) of a 300x300 MediaBox."""
+    objs = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 300] /Contents 4 0 R >>",
+    ]
+    parts = [b"1 0 0 RG 2 w"]
+    for i in range(n_paths):
+        x = 10 + (i % 8) * 30
+        y = 10 + (i // 8) * 30
+        parts.append(f"{x} {y} 20 20 re S".encode())
+    stream = b"\n".join(parts)
+    objs.append(b"<< /Length %d >>\nstream\n%s\nendstream" % (len(stream), stream))
+
+    out = b"%PDF-1.7\n"
+    offsets = []
+    for i, o in enumerate(objs, 1):
+        offsets.append(len(out))
+        out += b"%d 0 obj\n%s\nendobj\n" % (i, o)
+    xref_off = len(out)
+    out += b"xref\n0 %d\n" % (len(objs) + 1)
+    out += b"0000000000 65535 f \n"
+    for off in offsets:
+        out += b"%010d 00000 n \n" % off
+    out += b"trailer\n<< /Size %d /Root 1 0 R >>\nstartxref\n%d\n%%%%EOF" % (
+        len(objs) + 1,
+        xref_off,
+    )
+    return out
+
+
+def test_pdfium_object_index_built_once(tmp_path, monkeypatch):
+    """The page-object walk must run once per page even when ``has_content_in`` is
+    called repeatedly (once per layout cluster) -- otherwise the backend is
+    O(clusters x objects). Count the underlying pypdfium2 object enumeration."""
+    import pypdfium2 as pdfium
+
+    pdf_path = tmp_path / "multi_object.pdf"
+    pdf_path.write_bytes(_build_multi_object_pdf(40))
+
+    original_get_objects = pdfium.PdfPage.get_objects
+    calls = {"n": 0}
+
+    def counting_get_objects(self, *args, **kwargs):
+        calls["n"] += 1
+        return original_get_objects(self, *args, **kwargs)
+
+    monkeypatch.setattr(pdfium.PdfPage, "get_objects", counting_get_objects)
+
+    doc_backend = _get_backend(pdf_path)
+    try:
+        page_backend: PyPdfiumPageBackend = doc_backend.load_page(0)
+
+        content = BoundingBox(
+            l=10, t=50, r=250, b=250, coord_origin=CoordOrigin.TOPLEFT
+        )
+        blank = BoundingBox(
+            l=260, t=260, r=299, b=299, coord_origin=CoordOrigin.TOPLEFT
+        )
+
+        # Emulate the per-cluster query pattern (2-3 calls per cluster, many clusters).
+        for _ in range(5):
+            assert page_backend.has_content_in(bbox=content) is True
+            assert page_backend.has_content_in(bbox=blank) is False
+        # These reuse the same index too.
+        list(page_backend.get_bitmap_rects())
+        page_backend.get_connected_shape_bounding_boxes()
+
+        assert calls["n"] == 1, (
+            f"page objects were enumerated {calls['n']} times; expected exactly 1"
+        )
+    finally:
+        doc_backend.unload()


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #4223

### Description

In the `pypdfium2` backend, page objects were re-enumerated on every `_object_rects`/`has_content_in` call (invoked per layout cluster), giving O(clusters × objects) behavior on object-heavy pages. This builds the page object index once per page and reuses it, and clears it when the native page closes.

`get_objects` already recurses into form XObjects and filters by type in Python, so a single combined walk yields the identical object set and order as the previous per-type walks; output is unchanged. It also removes a pre-existing hazard where the old generator held the global `pypdfium2_lock` across its `yield`.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019srdYs3e1HdpZJprNgcNxR
