### PR TITLE
fix(office): harden the LibreOffice profile, flags, and timeout kill

### DIFF
--- a/docling/backend/docx/drawingml/utils.py
+++ b/docling/backend/docx/drawingml/utils.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import os
 import shutil
+import signal
 import subprocess
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -26,12 +27,150 @@ Without this, a hung ``soffice`` process (e.g. a modal dialog it can't
 show in headless mode) blocks the calling thread forever.
 """
 
+LIBREOFFICE_HARDENING_FLAGS: Final[tuple[str, ...]] = (
+    "--headless",
+    "--norestore",
+    "--nologo",
+    "--nolockcheck",
+    "--nodefault",
+)
+"""Flags that constrain a throwaway ``soffice`` invocation.
+
+``--headless`` avoids any GUI/dialogs; ``--norestore`` stops LibreOffice
+from trying to reopen documents from a previous crashed session (which can
+include attacker files); ``--nologo``/``--nodefault`` suppress the start
+splash and the empty default document; ``--nolockcheck`` avoids stalling on
+a stale lock file inside the throwaway profile.
+"""
+
+
+def _registrymodifications_xcu() -> str:
+    """Return the contents of a hardening ``registrymodifications.xcu``.
+
+    The file is seeded into the throwaway user profile so that the very
+    first (and only) ``soffice`` launch already runs with a locked-down
+    configuration instead of relying on the build's implicit defaults:
+
+    * ``MacroSecurityLevel = 3`` (Very High / maximum) and
+      ``DisableMacrosExecution = true`` prevent document macros from
+      running during conversion.
+    * ``.../Writer/Content/Update/Link = 0`` and the Calc equivalent set
+      "update links when loading" to *never*, so opening an attacker file
+      does not fetch external/DDE-linked content (an SSRF / file-inclusion
+      vector via e.g. ``TargetMode="External"`` relationships).
+
+    Registry nodes deliberately *not* set here (see module notes): explicit
+    DDE, OLE-object and remote-image resolution toggles do not have a single
+    well-documented registry key across LibreOffice versions; macro-security
+    High plus disabled link updates covers the primary vectors, and the rest
+    is tracked as follow-up rather than guessed at.
+    """
+    return (
+        '<?xml version="1.0" encoding="UTF-8"?>\n'
+        "<oor:items "
+        'xmlns:oor="http://openoffice.org/2001/registry" '
+        'xmlns:xs="http://www.w3.org/2001/XMLSchema" '
+        'xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">\n'
+        ' <item oor:path="/org.openoffice.Office.Common/Security/Scripting">\n'
+        '  <prop oor:name="MacroSecurityLevel" oor:op="fuse">\n'
+        "   <value>3</value>\n"
+        "  </prop>\n"
+        " </item>\n"
+        ' <item oor:path="/org.openoffice.Office.Common/Security/Scripting">\n'
+        '  <prop oor:name="DisableMacrosExecution" oor:op="fuse">\n'
+        "   <value>true</value>\n"
+        "  </prop>\n"
+        " </item>\n"
+        ' <item oor:path="/org.openoffice.Office.Writer/Content/Update">\n'
+        '  <prop oor:name="Link" oor:op="fuse">\n'
+        "   <value>0</value>\n"
+        "  </prop>\n"
+        " </item>\n"
+        ' <item oor:path="/org.openoffice.Office.Calc/Content/Update">\n'
+        '  <prop oor:name="Link" oor:op="fuse">\n'
+        "   <value>0</value>\n"
+        "  </prop>\n"
+        " </item>\n"
+        "</oor:items>\n"
+    )
+
+
+def _build_soffice_command(
+    libreoffice_cmd: str,
+    profile_arg: str,
+    *,
+    target_format: str,
+    outdir: str,
+    input_path: str,
+) -> list[str]:
+    """Assemble a hardened ``soffice`` argv for a single conversion.
+
+    Kept as a pure function so the exact flags can be asserted in unit
+    tests without a LibreOffice binary present.
+    """
+    return [
+        libreoffice_cmd,
+        profile_arg,
+        *LIBREOFFICE_HARDENING_FLAGS,
+        "--convert-to",
+        target_format,
+        "--outdir",
+        outdir,
+        str(input_path),
+    ]
+
+
+def _kill_soffice_process_group(proc: subprocess.Popen) -> None:
+    """Best-effort SIGKILL of the whole ``soffice`` process group.
+
+    ``soffice`` is a thin wrapper that forks ``soffice.bin``; killing only
+    the wrapper (as ``subprocess.run(timeout=...)`` does) can leave the real
+    worker alive to accumulate. Launching with ``start_new_session=True``
+    puts the wrapper in its own process group so the whole tree can be
+    signalled here.
+    """
+    if hasattr(os, "killpg") and hasattr(os, "getpgid"):
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError, OSError):
+            proc.kill()
+    else:  # pragma: no cover - Windows has no process groups
+        proc.kill()
+    try:
+        proc.wait(timeout=5)
+    except Exception:
+        pass
+
+
+def _run_hardened_soffice(args: list[str], timeout_s: int) -> None:
+    """Run ``soffice`` in its own process group with a hard timeout.
+
+    Mirrors the previous ``subprocess.run(check=True, timeout=...)``
+    contract (raising :class:`subprocess.CalledProcessError` on a non-zero
+    exit and :class:`subprocess.TimeoutExpired` on timeout) but, on timeout,
+    kills the entire process group so ``soffice.bin`` cannot survive.
+    """
+    proc = subprocess.Popen(
+        args,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    try:
+        returncode = proc.wait(timeout=timeout_s)
+    except subprocess.TimeoutExpired:
+        _kill_soffice_process_group(proc)
+        raise
+    if returncode != 0:
+        raise subprocess.CalledProcessError(returncode, args)
+
 
 def get_libreoffice_cmd(raise_if_unavailable: bool = False) -> Optional[str]:
     """Return the libreoffice cmd and optionally test it."""
 
     libreoffice_cmd = (
-        shutil.which("libreoffice")
+        os.environ.get("DOCLING_LIBREOFFICE_CMD")
+        or shutil.which("libreoffice")
         or shutil.which("soffice")
         or (
             "/Applications/LibreOffice.app/Contents/MacOS/soffice"
@@ -67,6 +206,10 @@ def _isolated_libreoffice_profile() -> Iterator[str]:
     handling simultaneous requests) share the default profile and collide
     on that lock, causing conversions to fail intermittently and silently.
 
+    The profile is also seeded with a hardening ``registrymodifications.xcu``
+    (see :func:`_registrymodifications_xcu`) so the conversion runs with
+    macros disabled and external link updates turned off.
+
     Yields:
         A ``-env:UserInstallation=<uri>`` CLI argument pointing at a freshly
         created, empty profile directory. The directory is removed again
@@ -74,6 +217,11 @@ def _isolated_libreoffice_profile() -> Iterator[str]:
     """
     profile_dir = Path(mkdtemp(prefix="docling_lo_profile_"))
     try:
+        user_dir = profile_dir / "user"
+        user_dir.mkdir(parents=True, exist_ok=True)
+        (user_dir / "registrymodifications.xcu").write_text(
+            _registrymodifications_xcu(), encoding="utf-8"
+        )
         yield f"-env:UserInstallation={profile_dir.as_uri()}"
     finally:
         shutil.rmtree(profile_dir, ignore_errors=True)
@@ -127,21 +275,15 @@ def convert_to_modern_format(
             input_path = source
 
         with _isolated_libreoffice_profile() as profile_arg:
-            subprocess.run(
-                [
+            _run_hardened_soffice(
+                _build_soffice_command(
                     libreoffice_cmd,
                     profile_arg,
-                    "--headless",
-                    "--convert-to",
-                    target_suffix,
-                    "--outdir",
-                    str(tmp_dir),
-                    str(input_path),
-                ],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                check=True,
-                timeout=timeout_s,
+                    target_format=target_suffix,
+                    outdir=str(tmp_dir),
+                    input_path=str(input_path),
+                ),
+                timeout_s=timeout_s,
             )
 
         converted_path = tmp_dir / (input_path.stem + "." + target_suffix)
@@ -183,21 +325,15 @@ def get_docx_to_pdf_converter() -> Optional[Callable]:
                 output_path: Desired path for the converted PDF.
             """
             with _isolated_libreoffice_profile() as profile_arg:
-                subprocess.run(
-                    [
+                _run_hardened_soffice(
+                    _build_soffice_command(
                         libreoffice_cmd,
                         profile_arg,
-                        "--headless",
-                        "--convert-to",
-                        "pdf",
-                        "--outdir",
-                        os.path.dirname(output_path),
-                        input_path,
-                    ],
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    check=True,
-                    timeout=LIBREOFFICE_TIMEOUT_S,
+                        target_format="pdf",
+                        outdir=os.path.dirname(output_path),
+                        input_path=str(input_path),
+                    ),
+                    timeout_s=LIBREOFFICE_TIMEOUT_S,
                 )
 
             expected_output = os.path.join(

--- a/tests/test_drawingml_utils.py
+++ b/tests/test_drawingml_utils.py
@@ -4,7 +4,6 @@
 import subprocess
 from io import BytesIO
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -24,6 +23,135 @@ def _track_mkdtemp(monkeypatch) -> list[Path]:
     return created_dirs
 
 
+class _FakePopen:
+    """Minimal stand-in for ``subprocess.Popen`` used by ``_run_hardened_soffice``.
+
+    ``side_effect`` mirrors LibreOffice's real behavior of writing the output
+    file into ``--outdir`` while the "conversion" runs.
+    """
+
+    def __init__(self, args, side_effect=None, returncode=0, wait_exc=None, **kwargs):
+        self.args = list(args)
+        self.kwargs = kwargs
+        self.pid = 4242
+        self._returncode = returncode
+        self._wait_exc = wait_exc
+        self.wait_timeout = None
+        self.wait_calls = 0
+        if side_effect is not None:
+            side_effect(self.args)
+
+    def wait(self, timeout=None):
+        self.wait_calls += 1
+        # The first wait is the timeout-bounded one; a killpg cleanup wait
+        # (timeout=5) may follow.
+        if self.wait_calls == 1:
+            self.wait_timeout = timeout
+            if self._wait_exc is not None:
+                raise self._wait_exc
+        return self._returncode
+
+    def kill(self):  # pragma: no cover - only on the no-killpg fallback path
+        pass
+
+
+def _install_fake_popen(monkeypatch, *, side_effect=None, returncode=0, wait_exc=None):
+    instances: list[_FakePopen] = []
+
+    def factory(args, **kwargs):
+        proc = _FakePopen(
+            args,
+            side_effect=side_effect,
+            returncode=returncode,
+            wait_exc=wait_exc,
+            **kwargs,
+        )
+        instances.append(proc)
+        return proc
+
+    monkeypatch.setattr(drawingml_utils.subprocess, "Popen", factory)
+    return instances
+
+
+# ---------------------------------------------------------------------------
+# Pure-helper unit tests (no LibreOffice binary required)
+# ---------------------------------------------------------------------------
+
+
+def test_build_soffice_command_contains_hardening_flags():
+    args = drawingml_utils._build_soffice_command(
+        "/usr/bin/soffice",
+        "-env:UserInstallation=file:///tmp/p",
+        target_format="pdf",
+        outdir="/tmp/out",
+        input_path="/tmp/in.docx",
+    )
+
+    # Every hardening flag is present.
+    for flag in (
+        "--headless",
+        "--norestore",
+        "--nologo",
+        "--nolockcheck",
+        "--nodefault",
+    ):
+        assert flag in args, f"missing hardening flag {flag}"
+
+    # The isolated-profile env argument and the conversion request survive.
+    assert "-env:UserInstallation=file:///tmp/p" in args
+    assert args[args.index("--convert-to") + 1] == "pdf"
+    assert args[args.index("--outdir") + 1] == "/tmp/out"
+    assert args[0] == "/usr/bin/soffice"
+    assert args[-1] == "/tmp/in.docx"
+
+
+def test_registrymodifications_xcu_locks_down_security():
+    xcu = drawingml_utils._registrymodifications_xcu()
+
+    # Well-formed XML.
+    import xml.etree.ElementTree as ET
+
+    ET.fromstring(xcu)
+
+    # Macros: maximum security level and execution disabled.
+    assert 'oor:name="MacroSecurityLevel"' in xcu
+    assert "<value>3</value>" in xcu
+    assert 'oor:name="DisableMacrosExecution"' in xcu
+    assert "<value>true</value>" in xcu
+
+    # External link updates disabled for Writer and Calc.
+    assert "/org.openoffice.Office.Writer/Content/Update" in xcu
+    assert "/org.openoffice.Office.Calc/Content/Update" in xcu
+    assert 'oor:name="Link"' in xcu
+    assert "<value>0</value>" in xcu
+
+
+def test_isolated_profile_seeds_registrymodifications(monkeypatch):
+    created = _track_mkdtemp(monkeypatch)
+
+    with drawingml_utils._isolated_libreoffice_profile() as profile_arg:
+        profile_dir = created[-1]
+        xcu_path = profile_dir / "user" / "registrymodifications.xcu"
+        assert xcu_path.exists()
+        assert profile_dir.as_uri() in profile_arg
+        assert xcu_path.read_text(encoding="utf-8") == (
+            drawingml_utils._registrymodifications_xcu()
+        )
+
+    # Cleaned up afterwards.
+    assert not profile_dir.exists()
+
+
+def test_get_libreoffice_cmd_honors_env_var(monkeypatch):
+    monkeypatch.setenv("DOCLING_LIBREOFFICE_CMD", "/opt/custom/soffice")
+    assert drawingml_utils.get_libreoffice_cmd() == "/opt/custom/soffice"
+
+
+# ---------------------------------------------------------------------------
+# Integration of helpers via the public conversion entry points
+# ---------------------------------------------------------------------------
+
+
 def test_convert_with_libreoffice_uses_timeout_and_isolated_profile(
     monkeypatch, tmp_path
 ):
@@ -32,20 +160,12 @@ def test_convert_with_libreoffice_uses_timeout_and_isolated_profile(
     )
     created_profile_dirs = _track_mkdtemp(monkeypatch)
 
-    captured_args: list[str] = []
-    captured_kwargs: dict = {}
-
-    def fake_run(args, **kwargs):
-        captured_args.extend(args)
-        captured_kwargs.update(kwargs)
+    def side_effect(args):
         # The isolated profile dir must exist while the "conversion" runs.
         assert created_profile_dirs[-1].exists()
-        # Mirror LibreOffice's real behavior of writing the PDF next to the
-        # input, named after the input's stem.
         (tmp_path / "drawing_only.pdf").write_bytes(b"%PDF-1.4")
-        return MagicMock(returncode=0)
 
-    monkeypatch.setattr(drawingml_utils.subprocess, "run", fake_run)
+    instances = _install_fake_popen(monkeypatch, side_effect=side_effect)
 
     converter = drawingml_utils.get_docx_to_pdf_converter()
     assert converter is not None
@@ -56,10 +176,14 @@ def test_convert_with_libreoffice_uses_timeout_and_isolated_profile(
 
     converter(input_path, output_path)
 
-    assert captured_kwargs["timeout"] == drawingml_utils.LIBREOFFICE_TIMEOUT_S
+    # Launched with a bounded wait, its own session, and the hardening flags.
+    assert instances[-1].wait_timeout == drawingml_utils.LIBREOFFICE_TIMEOUT_S
+    assert instances[-1].kwargs.get("start_new_session") is True
+    for flag in drawingml_utils.LIBREOFFICE_HARDENING_FLAGS:
+        assert flag in instances[-1].args
 
     profile_flag = next(
-        a for a in captured_args if str(a).startswith("-env:UserInstallation=")
+        a for a in instances[-1].args if str(a).startswith("-env:UserInstallation=")
     )
     assert created_profile_dirs[-1].as_uri() in profile_flag
 
@@ -67,16 +191,24 @@ def test_convert_with_libreoffice_uses_timeout_and_isolated_profile(
     assert not created_profile_dirs[-1].exists()
 
 
-def test_convert_with_libreoffice_cleans_up_profile_on_timeout(monkeypatch, tmp_path):
+def test_convert_with_libreoffice_kills_process_group_on_timeout(monkeypatch, tmp_path):
     monkeypatch.setattr(
         drawingml_utils, "get_libreoffice_cmd", lambda: "/usr/bin/soffice"
     )
     created_profile_dirs = _track_mkdtemp(monkeypatch)
 
-    def fake_run(args, **kwargs):
-        raise subprocess.TimeoutExpired(cmd=args, timeout=kwargs.get("timeout"))
+    timeout_exc = subprocess.TimeoutExpired(cmd="soffice", timeout=5)
+    _install_fake_popen(monkeypatch, wait_exc=timeout_exc)
 
-    monkeypatch.setattr(drawingml_utils.subprocess, "run", fake_run)
+    killed: dict = {}
+
+    monkeypatch.setattr(drawingml_utils.os, "getpgid", lambda pid: pid)
+
+    def fake_killpg(pgid, sig):
+        killed["pgid"] = pgid
+        killed["sig"] = sig
+
+    monkeypatch.setattr(drawingml_utils.os, "killpg", fake_killpg)
 
     converter = drawingml_utils.get_docx_to_pdf_converter()
     assert converter is not None
@@ -88,6 +220,10 @@ def test_convert_with_libreoffice_cleans_up_profile_on_timeout(monkeypatch, tmp_
     with pytest.raises(subprocess.TimeoutExpired):
         converter(input_path, output_path)
 
+    # The whole process group was SIGKILLed, not just the wrapper.
+    assert killed["pgid"] == 4242
+    assert killed["sig"] == drawingml_utils.signal.SIGKILL
+
     # A hung/killed conversion must not leak its profile directory.
     assert not created_profile_dirs[-1].exists()
 
@@ -98,27 +234,32 @@ def test_convert_to_modern_format_uses_isolated_profile(monkeypatch):
     )
     created_profile_dirs = _track_mkdtemp(monkeypatch)
 
-    captured_kwargs: dict = {}
-
-    def fake_run(args, **kwargs):
-        captured_kwargs.update(kwargs)
+    def side_effect(args):
         # The isolated profile dir (most recently created) must exist while
         # the "conversion" runs, separate from the outer working tmp_dir.
         assert created_profile_dirs[-1].exists()
         outdir = Path(args[args.index("--outdir") + 1])
         (outdir / "input.docx").write_bytes(b"PK\x03\x04")
-        return MagicMock(returncode=0)
 
-    monkeypatch.setattr(drawingml_utils.subprocess, "run", fake_run)
+    instances = _install_fake_popen(monkeypatch, side_effect=side_effect)
 
     result = drawingml_utils.convert_to_modern_format(
         BytesIO(b"legacy doc bytes"), "doc", "docx", timeout_s=5
     )
 
     assert isinstance(result, BytesIO)
-    assert captured_kwargs["timeout"] == 5
+    assert instances[-1].wait_timeout == 5
+    for flag in drawingml_utils.LIBREOFFICE_HARDENING_FLAGS:
+        assert flag in instances[-1].args
 
     # Both the outer working directory and the isolated profile directory
     # are cleaned up once the conversion completes.
     assert not created_profile_dirs[0].exists()
     assert not created_profile_dirs[-1].exists()
+
+
+def test_run_hardened_soffice_raises_on_nonzero_exit(monkeypatch):
+    _install_fake_popen(monkeypatch, returncode=1)
+
+    with pytest.raises(subprocess.CalledProcessError):
+        drawingml_utils._run_hardened_soffice(["/usr/bin/soffice"], timeout_s=5)


### PR DESCRIPTION
**Issue resolved by this Pull Request:**
Resolves #4225

### Description

Hardens the LibreOffice subprocess used to render legacy Office formats and DrawingML/EMF/chart content:

- seeds the throwaway profile's `registrymodifications.xcu` with macro security at maximum, macros disabled, and link-update off;
- adds `--norestore --nologo --nolockcheck --nodefault`;
- launches in a new process group and kills the whole group on `TimeoutExpired` (so a hung `soffice.bin` cannot survive on Linux);
- wires up the documented `DOCLING_LIBREOFFICE_CMD` env var, which was referenced in a message but never read.

Command and profile construction are split into pure helpers with unit tests; the LibreOffice binary itself is not required for the tests.

**Checklist:**

- [ ] Documentation has been updated, if necessary.
- [ ] Examples have been added, if necessary.
- [x] Tests have been added, if necessary.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019srdYs3e1HdpZJprNgcNxR
