### PR TITLE
feat: expose per-page confidence breakdown in ConfidenceScores

### DIFF
--- a/docling/datamodel/service/responses.py
+++ b/docling/datamodel/service/responses.py
@@ -47,11 +47,13 @@ class ConfidenceScores(BaseModel):
     low_score: Optional[float] = None
     mean_grade: QualityGrade = QualityGrade.UNSPECIFIED
     low_grade: QualityGrade = QualityGrade.UNSPECIFIED
+    pages: Optional[dict[int, "ConfidenceScores"]] = None
 
     @classmethod
     def from_scores(
         cls, scores: "PageConfidenceScores | ConfidenceReport"
     ) -> "ConfidenceScores":
+        pages = getattr(scores, "pages", None)
         return cls(
             parse_score=_nan_to_none(scores.parse_score),
             layout_score=_nan_to_none(scores.layout_score),
@@ -61,6 +63,14 @@ class ConfidenceScores(BaseModel):
             low_score=_nan_to_none(scores.low_score),
             mean_grade=scores.mean_grade,
             low_grade=scores.low_grade,
+            pages=(
+                {
+                    page_no: cls.from_scores(page_scores)
+                    for page_no, page_scores in pages.items()
+                }
+                if pages
+                else None
+            ),
         )
 
 


### PR DESCRIPTION
ConfidenceScores currently only carries document-level scores, even though the docstring notes a per-page breakdown "can be added later as an optional pages field without breaking this shape."

This PR adds that field: from_scores() now checks if the source ConfidenceReport has a pages map and, if so, recursively converts each PageConfidenceScores into a ConfidenceScores, exposing the same per-page detail (parse_score, layout_score, ocr_score, table_score, mean_score/low_score, grades) that's already computed during conversion but currently discarded before reaching API consumers (docling-serve).

Non-breaking: pages defaults to None, existing document-level behavior unchanged.
No extra compute: reuses scores already present on conv_res.confidence.pages.
No changes needed in docling-jobkit or docling-serve — they already pass the full ConfidenceReport into from_scores.
Motivation: docling-serve users doing large-scale automated ingestion need per-page confidence to flag low-quality pages without re-running the full conversion pipeline locally just to get this detail.
